### PR TITLE
Add exact TFIM finite-temperature observables

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -16,5 +16,6 @@ include("universalities/E8.jl")
 # --- Models ---
 include("models/TFIM.jl")
 include("models/TFIM_dynamics.jl")
+include("models/TFIM_thermal.jl")
 
 end # module QAtlas

--- a/src/core/alias.jl
+++ b/src/core/alias.jl
@@ -44,6 +44,30 @@ end
     :szsz_spreading, :zz_spreading, :sz_sz_lightcone
 ]
 
+# Thermal observables (TFIM_thermal.jl + TFIM_dynamics.jl thermal extensions)
+@register_aliases canonicalize_quantity :free_energy [
+    :F, :f, :FreeEnergy, :free_energy_density, :helmholtz_free_energy
+]
+@register_aliases canonicalize_quantity :entropy [:S, :EntropyDensity, :entropy_density]
+@register_aliases canonicalize_quantity :specific_heat [
+    :Cv, :cv, :SpecificHeat, :heat_capacity
+]
+@register_aliases canonicalize_quantity :transverse_magnetization [
+    :mx, :Mx, :TransverseMagnetization, :sx_expect, :magnetization_x
+]
+@register_aliases canonicalize_quantity :transverse_susceptibility [
+    :chi_xx, :χ_xx, :TransverseSusceptibility, :susceptibility_x
+]
+@register_aliases canonicalize_quantity :longitudinal_susceptibility [
+    :chi_zz, :χ_zz, :LongitudinalSusceptibility, :susceptibility_z, :uniform_susceptibility
+]
+@register_aliases canonicalize_quantity :zz_static_thermal [
+    :zz_static, :sz_sz_static, :static_zz_thermal
+]
+@register_aliases canonicalize_quantity :zz_structure_factor [
+    :S_zz, :Szz, :static_structure_factor
+]
+
 # Model Aliases
 @register_aliases canonicalize_model :TFIM [
     :TransverseFieldIsingModel, :transverseFieldIsingModel

--- a/src/models/TFIM_dynamics.jl
+++ b/src/models/TFIM_dynamics.jl
@@ -217,9 +217,7 @@ Majorana 2-point function
 
 so the body of the Pfaffian assembly is unchanged.
 """
-function _sz_sz_corr(
-    N::Int, J::Float64, h::Float64, i::Int, j::Int, t::Real; β::Real=Inf
-)
+function _sz_sz_corr(N::Int, J::Float64, h::Float64, i::Int, j::Int, t::Real; β::Real=Inf)
     (1 ≤ i ≤ N && 1 ≤ j ≤ N) || throw(ArgumentError("site indices out of range"))
     hmat = _majorana_ham(N, J, h)
     Σ = _majorana_thermal_covariance(hmat, β)
@@ -244,9 +242,7 @@ end
 `⟨σˣ_i(t) σˣ_j(0)⟩_β` for the OBC TFIM.  Reduces to a 4×4 Pfaffian since
 `σˣ_k = -i γ_{2k-1} γ_{2k}`.  `β = Inf` ⇒ ground state.
 """
-function _sx_sx_corr(
-    N::Int, J::Float64, h::Float64, i::Int, j::Int, t::Real; β::Real=Inf
-)
+function _sx_sx_corr(N::Int, J::Float64, h::Float64, i::Int, j::Int, t::Real; β::Real=Inf)
     (1 ≤ i ≤ N && 1 ≤ j ≤ N) || throw(ArgumentError("site indices out of range"))
     hmat = _majorana_ham(N, J, h)
     Σ = _majorana_thermal_covariance(hmat, β)
@@ -291,8 +287,7 @@ and (per time-step) evolution matrix, so the cost is
 `O(length(times) · N · M³)` with `M = 2(center + N) - 2`.
 """
 function _sz_sz_spreading(
-    N::Int, J::Float64, h::Float64, center::Int, times::AbstractVector{<:Real};
-    β::Real=Inf,
+    N::Int, J::Float64, h::Float64, center::Int, times::AbstractVector{<:Real}; β::Real=Inf
 )
     (1 ≤ center ≤ N) || throw(ArgumentError("center site out of range"))
     hmat = _majorana_ham(N, J, h)
@@ -320,8 +315,12 @@ If both `i` and `j` are given, returns a single value (wrapped in a 1×1
 matrix); otherwise returns the full N×N matrix of equal-time correlators.
 """
 function _sz_sz_static_thermal(
-    N::Int, J::Float64, h::Float64, β::Real;
-    i::Union{Int,Nothing}=nothing, j::Union{Int,Nothing}=nothing,
+    N::Int,
+    J::Float64,
+    h::Float64,
+    β::Real;
+    i::Union{Int,Nothing}=nothing,
+    j::Union{Int,Nothing}=nothing,
 )
     hmat = _majorana_ham(N, J, h)
     Σ = _majorana_thermal_covariance(hmat, β)

--- a/src/models/TFIM_dynamics.jl
+++ b/src/models/TFIM_dynamics.jl
@@ -99,6 +99,31 @@ function _majorana_covariance_gs(h::AbstractMatrix{<:Real})
 end
 
 """
+    _majorana_thermal_covariance(h::AbstractMatrix, β::Real) -> Matrix{Float64}
+
+Thermal-equilibrium Majorana covariance at inverse temperature `β`.  The
+T = 0 ground-state formula `Σ_GS = -i sign(i h)` generalises to
+
+    Σ(β) = -i tanh((β/2) · i h)
+
+so that `⟨γ_a γ_b⟩_β = δ_{ab} + i Σ(β)_{ab}`.  In the canonical 2×2 BdG
+block this gives the off-diagonal entry `tanh(βΛ/2)`, recovering the
+Fermi–Dirac population of each quasiparticle and reducing to `±1` as
+`β → ∞`.
+
+`β = Inf` falls back to `_majorana_covariance_gs`.
+"""
+function _majorana_thermal_covariance(h::AbstractMatrix{<:Real}, β::Real)
+    isinf(β) && return _majorana_covariance_gs(h)
+    M = im .* h
+    F = eigen(Hermitian((M + M') / 2))
+    s = tanh.((β / 2) .* F.values)
+    sM = F.vectors * Diagonal(s) * F.vectors'
+    Σ = real(-im .* sM)
+    return (Σ - Σ') / 2
+end
+
+"""
     _majorana_evolution(h::AbstractMatrix, t::Real) -> Matrix{Float64}
 
 `exp(h * t)` for a real antisymmetric `h`, returned as a real
@@ -178,18 +203,26 @@ end
 # ═══════════════════════════════════════════════════════════════════════════════
 
 """
-    _sz_sz_corr(N, J, h, i, j, t) -> ComplexF64
+    _sz_sz_corr(N, J, h, i, j, t; β = Inf) -> ComplexF64
 
-`⟨GS| σᶻ_i(t) σᶻ_j(0) |GS⟩` for the OBC TFIM.
+`⟨σᶻ_i(t) σᶻ_j(0)⟩_β` for the OBC TFIM at inverse temperature `β`
+(default `Inf` ⇒ ground state).
 
 Implementation: Wick / Pfaffian over the `(2i-1) + (2j-1) = 2(i+j)-2`
 Majorana operators constituting the product.  The overall phase is
-`i^{i+j-2}` (from the two `-i^{k-1}` factors in each `σᶻ_k`).
+`(-i)^{i+j-2}`.  The thermal generalisation enters only through the
+Majorana 2-point function
+
+    ⟨γ_a γ_b⟩_β = δ_{ab} + i Σ(β)_{ab},   Σ(β) = -i tanh((β/2) i h),
+
+so the body of the Pfaffian assembly is unchanged.
 """
-function _sz_sz_corr(N::Int, J::Float64, h::Float64, i::Int, j::Int, t::Real)
+function _sz_sz_corr(
+    N::Int, J::Float64, h::Float64, i::Int, j::Int, t::Real; β::Real=Inf
+)
     (1 ≤ i ≤ N && 1 ≤ j ≤ N) || throw(ArgumentError("site indices out of range"))
     hmat = _majorana_ham(N, J, h)
-    Σ = _majorana_covariance_gs(hmat)
+    Σ = _majorana_thermal_covariance(hmat, β)
     R = _majorana_evolution(hmat, t)
     return _sz_sz_corr_from_cached(Σ, R, i, j)
 end
@@ -206,15 +239,17 @@ function _sz_sz_corr_from_cached(Σ::AbstractMatrix, R::AbstractMatrix, i::Int, 
 end
 
 """
-    _sx_sx_corr(N, J, h, i, j, t) -> ComplexF64
+    _sx_sx_corr(N, J, h, i, j, t; β = Inf) -> ComplexF64
 
-`⟨GS| σˣ_i(t) σˣ_j(0) |GS⟩` for the OBC TFIM.  Reduces to a 4×4
-Pfaffian since `σˣ_k = -i γ_{2k-1} γ_{2k}`.
+`⟨σˣ_i(t) σˣ_j(0)⟩_β` for the OBC TFIM.  Reduces to a 4×4 Pfaffian since
+`σˣ_k = -i γ_{2k-1} γ_{2k}`.  `β = Inf` ⇒ ground state.
 """
-function _sx_sx_corr(N::Int, J::Float64, h::Float64, i::Int, j::Int, t::Real)
+function _sx_sx_corr(
+    N::Int, J::Float64, h::Float64, i::Int, j::Int, t::Real; β::Real=Inf
+)
     (1 ≤ i ≤ N && 1 ≤ j ≤ N) || throw(ArgumentError("site indices out of range"))
     hmat = _majorana_ham(N, J, h)
-    Σ = _majorana_covariance_gs(hmat)
+    Σ = _majorana_thermal_covariance(hmat, β)
     R = _majorana_evolution(hmat, t)
     return _sx_sx_corr_from_cached(Σ, R, i, j)
 end
@@ -256,11 +291,12 @@ and (per time-step) evolution matrix, so the cost is
 `O(length(times) · N · M³)` with `M = 2(center + N) - 2`.
 """
 function _sz_sz_spreading(
-    N::Int, J::Float64, h::Float64, center::Int, times::AbstractVector{<:Real}
+    N::Int, J::Float64, h::Float64, center::Int, times::AbstractVector{<:Real};
+    β::Real=Inf,
 )
     (1 ≤ center ≤ N) || throw(ArgumentError("center site out of range"))
     hmat = _majorana_ham(N, J, h)
-    Σ = _majorana_covariance_gs(hmat)
+    Σ = _majorana_thermal_covariance(hmat, β)
     nt = length(times)
     C = zeros(ComplexF64, nt, N)
     for (it, t) in enumerate(times)
@@ -273,14 +309,80 @@ function _sz_sz_spreading(
 end
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# Static (equal-time) thermal correlators and structure factor
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    _sz_sz_static_thermal(N, J, h, β; i = nothing, j = nothing) -> Matrix{Float64}
+
+Static `⟨σᶻ_i σᶻ_j⟩_β` for the OBC TFIM at inverse temperature `β`.
+If both `i` and `j` are given, returns a single value (wrapped in a 1×1
+matrix); otherwise returns the full N×N matrix of equal-time correlators.
+"""
+function _sz_sz_static_thermal(
+    N::Int, J::Float64, h::Float64, β::Real;
+    i::Union{Int,Nothing}=nothing, j::Union{Int,Nothing}=nothing,
+)
+    hmat = _majorana_ham(N, J, h)
+    Σ = _majorana_thermal_covariance(hmat, β)
+    R = Matrix{Float64}(I, size(hmat)...)
+    if i !== nothing && j !== nothing
+        v = real(_sz_sz_corr_from_cached(Σ, R, i, j))
+        return fill(v, 1, 1)
+    end
+    C = zeros(Float64, N, N)
+    for a in 1:N, b in a:N
+        v = real(_sz_sz_corr_from_cached(Σ, R, a, b))
+        C[a, b] = v
+        C[b, a] = v
+    end
+    return C
+end
+
+"""
+    _zz_static_structure_factor(N, J, h, β, q) -> Float64
+
+`S_zz(q, β) = (1/N) Σ_{i,j} e^{-i q (i-j)} ⟨σᶻ_i σᶻ_j⟩_β` evaluated by direct
+double sum from the thermal Pfaffian correlator.  For OBC the lattice lacks
+translation invariance so this is the boundary-aware definition; in the bulk
+of a long enough chain it converges to the translation-invariant value.
+"""
+function _zz_static_structure_factor(N::Int, J::Float64, h::Float64, β::Real, q::Real)
+    C = _sz_sz_static_thermal(N, J, h, β)
+    s = 0.0 + 0.0im
+    for i in 1:N, j in 1:N
+        s += exp(-im * q * (i - j)) * C[i, j]
+    end
+    return real(s) / N
+end
+
+"""
+    _zz_uniform_susceptibility(N, J, h, β) -> Float64
+
+Uniform (q = 0) longitudinal susceptibility per site,
+
+    χ_zz(β) = (β/N) Σ_{i,j} ⟨σᶻ_i σᶻ_j⟩_β,
+
+obtained from a finite-temperature direct double sum (assumes ⟨σᶻ⟩_β = 0 in
+the OBC ground manifold of the TFIM, which holds for any `h ≠ 0` finite N).
+This is the static *isothermal* susceptibility — the fluctuation-dissipation
+form `χ = β · ⟨M²⟩_c / N` for the magnetisation `M = Σᵢ σᶻᵢ`.
+"""
+function _zz_uniform_susceptibility(N::Int, J::Float64, h::Float64, β::Real)
+    C = _sz_sz_static_thermal(N, J, h, β)
+    return β * sum(C) / N
+end
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # fetch dispatch
 # ═══════════════════════════════════════════════════════════════════════════════
 
 """
     fetch(model::Model{:TFIM}, ::Quantity{:sz_sz_correlation}, ::OBC;
-          i::Int, j::Int, t::Float64) -> ComplexF64
+          i::Int, j::Int, t::Float64, beta::Float64 = Inf) -> ComplexF64
 
-Exact ground-state `⟨σᶻ_i(t) σᶻ_j(0)⟩` for the OBC TFIM.
+Exact `⟨σᶻ_i(t) σᶻ_j(0)⟩_β` for the OBC TFIM.  `beta = Inf` (the default)
+gives the ground-state result.
 """
 function fetch(
     model::Model{:TFIM},
@@ -289,19 +391,20 @@ function fetch(
     i::Int,
     j::Int,
     t::Float64,
+    beta::Real=Inf,
     kwargs...,
 )
     N = Int(model.params[:N])
     J = Float64(model.params[:J])
     h = Float64(model.params[:h])
-    return _sz_sz_corr(N, J, h, i, j, t)
+    return _sz_sz_corr(N, J, h, i, j, t; β=beta)
 end
 
 """
     fetch(model::Model{:TFIM}, ::Quantity{:sx_sx_correlation}, ::OBC;
-          i::Int, j::Int, t::Float64) -> ComplexF64
+          i::Int, j::Int, t::Float64, beta::Float64 = Inf) -> ComplexF64
 
-Exact ground-state `⟨σˣ_i(t) σˣ_j(0)⟩` for the OBC TFIM.
+Exact `⟨σˣ_i(t) σˣ_j(0)⟩_β` for the OBC TFIM.
 """
 function fetch(
     model::Model{:TFIM},
@@ -310,20 +413,21 @@ function fetch(
     i::Int,
     j::Int,
     t::Float64,
+    beta::Real=Inf,
     kwargs...,
 )
     N = Int(model.params[:N])
     J = Float64(model.params[:J])
     h = Float64(model.params[:h])
-    return _sx_sx_corr(N, J, h, i, j, t)
+    return _sx_sx_corr(N, J, h, i, j, t; β=beta)
 end
 
 """
     fetch(model::Model{:TFIM}, ::Quantity{:sz_sz_spreading}, ::OBC;
-          center::Int, times::AbstractVector{<:Real}) -> Matrix{ComplexF64}
+          center::Int, times::AbstractVector{<:Real}, beta::Float64 = Inf) -> Matrix{ComplexF64}
 
-Exact ground-state spreading correlation `C[it, ix] = ⟨σᶻ_ix(t_it) σᶻ_center(0)⟩`
-for all sites `ix ∈ 1:N` and all `t_it ∈ times`.
+Exact spreading correlation `C[it, ix] = ⟨σᶻ_ix(t_it) σᶻ_center(0)⟩_β` for all
+sites `ix ∈ 1:N` and `t_it ∈ times`.
 """
 function fetch(
     model::Model{:TFIM},
@@ -331,10 +435,78 @@ function fetch(
     ::OBC;
     center::Int,
     times::AbstractVector{<:Real},
+    beta::Real=Inf,
     kwargs...,
 )
     N = Int(model.params[:N])
     J = Float64(model.params[:J])
     h = Float64(model.params[:h])
-    return _sz_sz_spreading(N, J, h, center, times)
+    return _sz_sz_spreading(N, J, h, center, times; β=beta)
+end
+
+"""
+    fetch(model::Model{:TFIM}, ::Quantity{:zz_static_thermal}, ::OBC;
+          beta::Float64, [i::Int, j::Int]) -> Matrix{Float64} or Float64
+
+Static (equal-time) thermal correlator `⟨σᶻ_i σᶻ_j⟩_β` for the OBC TFIM.
+With both `i` and `j` given returns a scalar; otherwise returns the full
+N×N matrix.
+"""
+function fetch(
+    model::Model{:TFIM},
+    ::Quantity{:zz_static_thermal},
+    ::OBC;
+    beta::Float64,
+    i::Union{Int,Nothing}=nothing,
+    j::Union{Int,Nothing}=nothing,
+    kwargs...,
+)
+    N = Int(model.params[:N])
+    J = Float64(model.params[:J])
+    h = Float64(model.params[:h])
+    if i !== nothing && j !== nothing
+        return _sz_sz_static_thermal(N, J, h, beta; i=i, j=j)[1, 1]
+    end
+    return _sz_sz_static_thermal(N, J, h, beta)
+end
+
+"""
+    fetch(model::Model{:TFIM}, ::Quantity{:zz_structure_factor}, ::OBC;
+          beta::Float64, q::Real) -> Float64
+
+Static structure factor `S_zz(q, β)` for the OBC TFIM at wave vector `q`.
+"""
+function fetch(
+    model::Model{:TFIM},
+    ::Quantity{:zz_structure_factor},
+    ::OBC;
+    beta::Float64,
+    q::Real,
+    kwargs...,
+)
+    N = Int(model.params[:N])
+    J = Float64(model.params[:J])
+    h = Float64(model.params[:h])
+    return _zz_static_structure_factor(N, J, h, beta, q)
+end
+
+"""
+    fetch(model::Model{:TFIM}, ::Quantity{:longitudinal_susceptibility}, ::OBC;
+          beta::Float64) -> Float64
+
+Static uniform longitudinal (`q = 0`) susceptibility per site,
+
+    χ_zz(β) = (β/N) Σ_{i,j} ⟨σᶻ_i σᶻ_j⟩_β.
+"""
+function fetch(
+    model::Model{:TFIM},
+    ::Quantity{:longitudinal_susceptibility},
+    ::OBC;
+    beta::Float64,
+    kwargs...,
+)
+    N = Int(model.params[:N])
+    J = Float64(model.params[:J])
+    h = Float64(model.params[:h])
+    return _zz_uniform_susceptibility(N, J, h, beta)
 end

--- a/src/models/TFIM_thermal.jl
+++ b/src/models/TFIM_thermal.jl
@@ -1,0 +1,247 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Transverse Field Ising Model — exact finite-temperature thermodynamics
+#
+# Hamiltonian:
+#   H = -J Σᵢ σᶻᵢσᶻᵢ₊₁  -  h Σᵢ σˣᵢ
+#
+# All observables in this file are derived from the free-fermion (BdG)
+# diagonalisation of the JW-mapped quadratic Hamiltonian.  The single-particle
+# dispersion in the thermodynamic limit is
+#
+#   Λ(k) = 2 √(J² + h² - 2 J h cos k),       k ∈ [0, π]
+#
+# The grand-canonical free-fermion partition function then gives
+#
+#   log Z / N = (1/π) ∫₀^π dk · log( 2 cosh(β Λ(k)/2) )
+#
+# from which all thermodynamic potentials follow as standard derivatives.
+#
+# For OBC finite N the same expressions hold with the integral replaced by
+# a sum over the N positive BdG quasiparticle energies returned by
+# `_tfim_bdg_spectrum(N, J, h)` in `TFIM.jl`.
+#
+# Quantities exposed via `fetch`:
+#
+#   :free_energy              f(β)        = -T log Z / N
+#   :entropy                  s(β)        = β (ε - f)
+#   :specific_heat            c_v(β)      = ∂ε/∂T
+#   :transverse_magnetization m_x(β)      = ⟨σˣ_i⟩
+#   :transverse_susceptibility χ_xx(β)    = ∂m_x/∂h
+#
+# All five are implemented for both `OBC` (per-site, exact at finite N) and
+# `Infinite` (per-site, exact in the thermodynamic limit).
+# ─────────────────────────────────────────────────────────────────────────────
+
+using LinearAlgebra: eigvals, Symmetric
+using QuadGK: quadgk
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Internal: Bogoliubov building blocks
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    _tfim_dispersion(k, J, h) -> Float64
+
+Single-particle BdG quasiparticle energy at momentum `k` for the TFIM with
+couplings `J` (Z-Z coupling) and `h` (transverse field):
+
+    Λ(k) = 2 √(J² + h² - 2 J h cos k).
+"""
+@inline _tfim_dispersion(k::Real, J::Real, h::Real) = 2 * sqrt(J^2 + h^2 - 2 * J * h * cos(k))
+
+# Kernel `g(βλ/2)` style helpers — the integrands are written in terms of `λ` and `β` only.
+# A small helper avoids overflow in `log(2 cosh(x))` for large `|x|`.
+@inline function _logcosh2(x::Real)
+    # log(2 cosh(x)) = |x| + log(1 + exp(-2|x|))
+    a = abs(x)
+    return a + log1p(exp(-2 * a))
+end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Thermodynamic potentials — Infinite (per-site)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    _tfim_thermo_infinite(quantity, J, h, β) -> Float64
+
+Compute one of the per-site thermodynamic potentials of the infinite TFIM at
+inverse temperature `β`.  `quantity` is a `Symbol` from
+`(:free_energy, :entropy, :specific_heat, :transverse_magnetization,
+ :transverse_susceptibility)`.
+
+The integrals are evaluated via adaptive Gauss-Kronrod quadrature.
+"""
+function _tfim_thermo_infinite(quantity::Symbol, J::Real, h::Real, β::Real)
+    integrand = if quantity === :free_energy
+        # f = -(1/πβ) ∫ log(2 cosh(βΛ/2)) dk
+        k -> begin
+            Λk = _tfim_dispersion(k, J, h)
+            _logcosh2(β * Λk / 2)
+        end
+    elseif quantity === :entropy
+        # s = (1/π) ∫ [log(2 cosh(βΛ/2)) - (βΛ/2) tanh(βΛ/2)] dk
+        k -> begin
+            Λk = _tfim_dispersion(k, J, h)
+            x = β * Λk / 2
+            _logcosh2(x) - x * tanh(x)
+        end
+    elseif quantity === :specific_heat
+        # c_v = (1/π) ∫ (βΛ/2)² sech²(βΛ/2) dk
+        k -> begin
+            Λk = _tfim_dispersion(k, J, h)
+            x = β * Λk / 2
+            x^2 * sech(x)^2
+        end
+    elseif quantity === :transverse_magnetization
+        # m_x = (2/π) ∫ ((h - J cos k)/Λ) tanh(βΛ/2) dk
+        k -> begin
+            A = h - J * cos(k)
+            Λk = _tfim_dispersion(k, J, h)
+            (A / Λk) * tanh(β * Λk / 2)
+        end
+    elseif quantity === :transverse_susceptibility
+        # χ_xx = (2/π) ∫ [ (1/Λ - 4A²/Λ³) tanh(βΛ/2) + (2β A²/Λ²) sech²(βΛ/2) ] dk
+        k -> begin
+            A = h - J * cos(k)
+            Λk = _tfim_dispersion(k, J, h)
+            (1 / Λk - 4 * A^2 / Λk^3) * tanh(β * Λk / 2) +
+            (2 * β * A^2 / Λk^2) * sech(β * Λk / 2)^2
+        end
+    else
+        error("Unknown thermal quantity: $quantity")
+    end
+
+    val, _ = quadgk(integrand, 0.0, π; rtol=1e-10)
+
+    if quantity === :free_energy
+        return -val / (π * β)
+    elseif quantity === :transverse_magnetization || quantity === :transverse_susceptibility
+        return (2 / π) * val
+    else  # entropy, specific_heat
+        return val / π
+    end
+end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Thermodynamic potentials — OBC finite N (per-site)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    _tfim_thermo_obc(quantity, N, J, h, β) -> Float64
+
+Per-site thermodynamic potential for the OBC finite-N TFIM, computed by summing
+the contribution of each BdG quasiparticle mode.
+
+The transverse magnetisation and its susceptibility require the full
+single-particle Bogoliubov coefficients, not just the spectrum, so this routine
+diagonalises the BdG matrix internally to obtain them.
+"""
+function _tfim_thermo_obc(quantity::Symbol, N::Int, J::Float64, h::Float64, β::Real)
+    if quantity === :free_energy
+        Λ = _tfim_bdg_spectrum(N, J, h)
+        # f/N = -(1/Nβ) Σ log(2 cosh(βΛ/2))
+        return -sum(λ -> _logcosh2(β * λ / 2), Λ) / (N * β)
+    elseif quantity === :entropy
+        Λ = _tfim_bdg_spectrum(N, J, h)
+        return sum(Λ) do λ
+            x = β * λ / 2
+            _logcosh2(x) - x * tanh(x)
+        end / N
+    elseif quantity === :specific_heat
+        Λ = _tfim_bdg_spectrum(N, J, h)
+        return sum(λ -> begin
+            x = β * λ / 2
+            x^2 * sech(x)^2
+        end, Λ) / N
+    elseif quantity === :transverse_magnetization || quantity === :transverse_susceptibility
+        return _tfim_transverse_obc(quantity, N, J, h, β)
+    else
+        error("Unknown thermal quantity: $quantity")
+    end
+end
+
+"""
+    _tfim_transverse_obc(quantity, N, J, h, β) -> Float64
+
+Compute `m_x` or `χ_xx` per site for OBC finite N by direct site-resolved BdG
+expectation.  Uses the matrix exponential formula
+
+    Σ(β) = -i tanh(β/2 · i h_BdG)
+
+(see `TFIM_dynamics.jl`) and identifies
+
+    ⟨σˣ_i⟩ = Σ[2i-1, 2i].
+
+The transverse susceptibility is obtained by central numerical differentiation
+of the magnetisation with respect to `h`.
+"""
+function _tfim_transverse_obc(quantity::Symbol, N::Int, J::Float64, h::Float64, β::Real)
+    function _mx_avg(h_)
+        hmat = _majorana_ham(N, J, h_)
+        Σ = _majorana_thermal_covariance(hmat, β)
+        return sum(_sx_expect(Σ, i) for i in 1:N) / N
+    end
+
+    if quantity === :transverse_magnetization
+        return _mx_avg(h)
+    else  # :transverse_susceptibility
+        δ = max(1e-4, abs(h) * 1e-4)
+        return (_mx_avg(h + δ) - _mx_avg(h - δ)) / (2 * δ)
+    end
+end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# fetch dispatch
+# ═══════════════════════════════════════════════════════════════════════════════
+
+const _THERMAL_QUANTITIES = (
+    :free_energy,
+    :entropy,
+    :specific_heat,
+    :transverse_magnetization,
+    :transverse_susceptibility,
+)
+
+for q in _THERMAL_QUANTITIES
+    @eval begin
+        """
+            fetch(model::Model{:TFIM}, ::Quantity{$($(QuoteNode(q)))}, ::Infinite;
+                  beta::Float64, kwargs...)
+
+        Per-site `$($(string(q)))` of the TFIM in the thermodynamic limit at
+        inverse temperature `beta`.  Uses adaptive Gauss-Kronrod quadrature
+        over the BdG dispersion `Λ(k) = 2√(J² + h² − 2Jh cos k)`.
+        """
+        function fetch(
+            model::Model{:TFIM},
+            ::Quantity{$(QuoteNode(q))},
+            ::Infinite;
+            beta::Float64,
+            kwargs...,
+        )
+            J = Float64(model.params[:J])
+            h = Float64(model.params[:h])
+            return _tfim_thermo_infinite($(QuoteNode(q)), J, h, beta)
+        end
+
+        """
+            fetch(model::Model{:TFIM}, ::Quantity{$($(QuoteNode(q)))}, ::OBC;
+                  beta::Float64, kwargs...)
+
+        Per-site `$($(string(q)))` of the OBC TFIM with `N` sites at inverse
+        temperature `beta`.  Computed exactly via the BdG diagonalisation.
+        """
+        function fetch(
+            model::Model{:TFIM},
+            ::Quantity{$(QuoteNode(q))},
+            ::OBC;
+            beta::Float64,
+            kwargs...,
+        )
+            N = Int(model.params[:N])
+            J = Float64(model.params[:J])
+            h = Float64(model.params[:h])
+            return _tfim_thermo_obc($(QuoteNode(q)), N, J, h, beta)
+        end
+    end
+end

--- a/src/models/TFIM_thermal.jl
+++ b/src/models/TFIM_thermal.jl
@@ -47,7 +47,8 @@ couplings `J` (Z-Z coupling) and `h` (transverse field):
 
     Λ(k) = 2 √(J² + h² - 2 J h cos k).
 """
-@inline _tfim_dispersion(k::Real, J::Real, h::Real) = 2 * sqrt(J^2 + h^2 - 2 * J * h * cos(k))
+@inline _tfim_dispersion(k::Real, J::Real, h::Real) =
+    2 * sqrt(J^2 + h^2 - 2 * J * h * cos(k))
 
 # Kernel `g(βλ/2)` style helpers — the integrands are written in terms of `λ` and `β` only.
 # A small helper avoids overflow in `log(2 cosh(x))` for large `|x|`.

--- a/test/models/test_TFIM_thermal.jl
+++ b/test/models/test_TFIM_thermal.jl
@@ -111,10 +111,30 @@ end
         # this works in any phase since it does not rely on β being finite.
         for h_phase in (0.5, 1.0, 1.5)
             for r in 1:4
-                v_th = QAtlas.fetch(:TFIM, :zz_static_thermal, OBC();
-                                    N=10, J=1.0, h=h_phase, beta=Inf, i=2, j=2 + r)
-                v_gs = real(QAtlas.fetch(:TFIM, :sz_sz_correlation, OBC();
-                                         N=10, J=1.0, h=h_phase, i=2, j=2 + r, t=0.0))
+                v_th = QAtlas.fetch(
+                    :TFIM,
+                    :zz_static_thermal,
+                    OBC();
+                    N=10,
+                    J=1.0,
+                    h=h_phase,
+                    beta=Inf,
+                    i=2,
+                    j=2 + r,
+                )
+                v_gs = real(
+                    QAtlas.fetch(
+                        :TFIM,
+                        :sz_sz_correlation,
+                        OBC();
+                        N=10,
+                        J=1.0,
+                        h=h_phase,
+                        i=2,
+                        j=2 + r,
+                        t=0.0,
+                    ),
+                )
                 @test v_th ≈ v_gs atol=1e-12
             end
         end
@@ -141,8 +161,9 @@ end
         @test abs(c_hi) < 1e-6
 
         # Transverse magnetisation at β → 0: m_x → 0 (Curie regime)
-        mx_hi = QAtlas.fetch(:TFIM, :transverse_magnetization, OBC();
-                             N=N, J=J, h=h, beta=β_high)
+        mx_hi = QAtlas.fetch(
+            :TFIM, :transverse_magnetization, OBC(); N=N, J=J, h=h, beta=β_high
+        )
         @test abs(mx_hi) < 1e-3
 
         # Same in the thermodynamic limit.
@@ -178,13 +199,16 @@ end
 
             # χ_xx from numerical derivative of m_x w.r.t. h
             δh = 1e-4
-            mp = QAtlas.fetch(:TFIM, :transverse_magnetization, OBC();
-                              N=N, J=J, h=h + δh, beta=β)
-            mm = QAtlas.fetch(:TFIM, :transverse_magnetization, OBC();
-                              N=N, J=J, h=h - δh, beta=β)
+            mp = QAtlas.fetch(
+                :TFIM, :transverse_magnetization, OBC(); N=N, J=J, h=h + δh, beta=β
+            )
+            mm = QAtlas.fetch(
+                :TFIM, :transverse_magnetization, OBC(); N=N, J=J, h=h - δh, beta=β
+            )
             χ_num = (mp - mm) / (2 * δh)
-            χ_an = QAtlas.fetch(:TFIM, :transverse_susceptibility, OBC();
-                                N=N, J=J, h=h, beta=β)
+            χ_an = QAtlas.fetch(
+                :TFIM, :transverse_susceptibility, OBC(); N=N, J=J, h=h, beta=β
+            )
             @test χ_an ≈ χ_num rtol=5e-3
         end
     end
@@ -205,13 +229,16 @@ end
             @test c_an ≈ c_num rtol=1e-3
 
             δh = 1e-4
-            mp = QAtlas.fetch(:TFIM, :transverse_magnetization, Infinite();
-                              J=J, h=h + δh, beta=β)
-            mm = QAtlas.fetch(:TFIM, :transverse_magnetization, Infinite();
-                              J=J, h=h - δh, beta=β)
+            mp = QAtlas.fetch(
+                :TFIM, :transverse_magnetization, Infinite(); J=J, h=h + δh, beta=β
+            )
+            mm = QAtlas.fetch(
+                :TFIM, :transverse_magnetization, Infinite(); J=J, h=h - δh, beta=β
+            )
             χ_num = (mp - mm) / (2 * δh)
-            χ_an = QAtlas.fetch(:TFIM, :transverse_susceptibility, Infinite();
-                                J=J, h=h, beta=β)
+            χ_an = QAtlas.fetch(
+                :TFIM, :transverse_susceptibility, Infinite(); J=J, h=h, beta=β
+            )
             @test χ_an ≈ χ_num rtol=5e-3
         end
     end
@@ -229,8 +256,9 @@ end
             f = QAtlas.fetch(:TFIM, :free_energy, OBC(); N=N, J=J, h=h, beta=β)
             s = QAtlas.fetch(:TFIM, :entropy, OBC(); N=N, J=J, h=h, beta=β)
             c = QAtlas.fetch(:TFIM, :specific_heat, OBC(); N=N, J=J, h=h, beta=β)
-            mx = QAtlas.fetch(:TFIM, :transverse_magnetization, OBC();
-                              N=N, J=J, h=h, beta=β)
+            mx = QAtlas.fetch(
+                :TFIM, :transverse_magnetization, OBC(); N=N, J=J, h=h, beta=β
+            )
 
             @test ε ≈ ed.ε atol=1e-10
             @test f ≈ ed.f atol=1e-10
@@ -250,8 +278,9 @@ end
             for i in 1:N, j in i:N
                 op = _op_site(_SZ, i, N) * _op_site(_SZ, j, N)
                 ed_val = real(tr(ρ * op))
-                qa_val = QAtlas.fetch(:TFIM, :zz_static_thermal, OBC();
-                                      N=N, J=J, h=h, beta=β, i=i, j=j)
+                qa_val = QAtlas.fetch(
+                    :TFIM, :zz_static_thermal, OBC(); N=N, J=J, h=h, beta=β, i=i, j=j
+                )
                 @test qa_val ≈ ed_val atol=1e-10
             end
         end
@@ -270,8 +299,9 @@ end
             M1 = real(tr(ρ * Mz))
             χ_ed = β * (M2 - M1^2) / N
 
-            χ_qa = QAtlas.fetch(:TFIM, :longitudinal_susceptibility, OBC();
-                                N=N, J=J, h=h, beta=β)
+            χ_qa = QAtlas.fetch(
+                :TFIM, :longitudinal_susceptibility, OBC(); N=N, J=J, h=h, beta=β
+            )
             @test χ_qa ≈ χ_ed atol=1e-10
         end
     end
@@ -290,13 +320,15 @@ end
             f_obc = QAtlas.fetch(:TFIM, :free_energy, OBC(); N=N, J=J, h=h, beta=β)
             s_obc = QAtlas.fetch(:TFIM, :entropy, OBC(); N=N, J=J, h=h, beta=β)
             c_obc = QAtlas.fetch(:TFIM, :specific_heat, OBC(); N=N, J=J, h=h, beta=β)
-            m_obc = QAtlas.fetch(:TFIM, :transverse_magnetization, OBC();
-                                 N=N, J=J, h=h, beta=β)
+            m_obc = QAtlas.fetch(
+                :TFIM, :transverse_magnetization, OBC(); N=N, J=J, h=h, beta=β
+            )
             f_inf = QAtlas.fetch(:TFIM, :free_energy, Infinite(); J=J, h=h, beta=β)
             s_inf = QAtlas.fetch(:TFIM, :entropy, Infinite(); J=J, h=h, beta=β)
             c_inf = QAtlas.fetch(:TFIM, :specific_heat, Infinite(); J=J, h=h, beta=β)
-            m_inf = QAtlas.fetch(:TFIM, :transverse_magnetization, Infinite();
-                                 J=J, h=h, beta=β)
+            m_inf = QAtlas.fetch(
+                :TFIM, :transverse_magnetization, Infinite(); J=J, h=h, beta=β
+            )
             push!(errs_f, abs(f_obc - f_inf))
             push!(errs_s, abs(s_obc - s_inf))
             push!(errs_c, abs(c_obc - c_inf))

--- a/test/models/test_TFIM_thermal.jl
+++ b/test/models/test_TFIM_thermal.jl
@@ -1,0 +1,316 @@
+# =============================================================================
+# Tests for TFIM finite-temperature observables (TFIM_thermal.jl + the
+# thermal extensions of TFIM_dynamics.jl).
+#
+# Layers:
+#   1. T → 0 limit: every thermal observable should match the T = 0
+#      result already covered by the energy / sz_sz_correlation entries.
+#   2. T → ∞ (high-temperature) analytic limits:
+#         f(β→0)  → -(1/β) log 2          (single spin entropy log 2 per site)
+#         s(β→0)  → log 2
+#         c_v(β→0)→ 0
+#         m_x(β→0)→ 0
+#         χ_xx(β→0)→ ?  (free-spin Curie law: limit of integral)
+#   3. Thermodynamic identities:
+#         ε(β) = f(β) + T s(β),                           T = 1/β
+#         c_v(β) = -β² ∂²(βf)/∂β²  (numerical second derivative)
+#         χ_xx(β) = ∂m_x/∂h        (numerical first derivative)
+#   4. ED comparison at small N:
+#         all observables match a brute-force diagonalisation of the dense
+#         2^N × 2^N TFIM Hamiltonian.
+#   5. OBC ↔ Infinite consistency: per-site values for OBC at large N
+#      converge to the Infinite values, and the deviation shrinks with N.
+# =============================================================================
+
+using LinearAlgebra: eigen, eigvals, Hermitian, Diagonal, kron, tr, diag
+
+# ---- ED helpers (small N only) ---------------------------------------------
+
+const _SX = ComplexF64[0 1; 1 0]
+const _SZ = ComplexF64[1 0; 0 -1]
+const _ID = ComplexF64[1 0; 0 1]
+
+function _op_site(o::AbstractMatrix, k::Int, N::Int)
+    m = (k == 1) ? o : _ID
+    for j in 2:N
+        m = kron(m, j == k ? o : _ID)
+    end
+    return m
+end
+
+function _build_tfim_dense(N::Int, J::Float64, h::Float64)
+    H = zeros(ComplexF64, 2^N, 2^N)
+    for i in 1:(N - 1)
+        H -= J * _op_site(_SZ, i, N) * _op_site(_SZ, i + 1, N)
+    end
+    for i in 1:N
+        H -= h * _op_site(_SX, i, N)
+    end
+    return Hermitian(H)
+end
+
+# Per-site thermodynamic averages from the dense spectrum at temperature β.
+function _ed_thermo(N, J, h, β)
+    H = _build_tfim_dense(N, J, h)
+    E = eigvals(H)
+    Z_shift = sum(exp.(-β .* (E .- E[1])))   # = e^{βE_min} · Z_true (stable)
+    weights = exp.(-β .* (E .- E[1])) ./ Z_shift
+    ε = sum(weights .* E) / N
+    # log(Z_true) = -β E_min + log(Z_shift) ⇒ f = -T log(Z_true)/N = (E_min - T log(Z_shift)) / N
+    f = (E[1] - log(Z_shift) / β) / N
+    s = β * (ε - f)
+    H2 = sum(weights .* E .^ 2)
+    Havg = sum(weights .* E)
+    c_v = β^2 * (H2 - Havg^2) / N
+    return (; ε, f, s, c_v)
+end
+
+function _ed_transverse(N, J, h, β)
+    H = _build_tfim_dense(N, J, h)
+    E, V = eigen(H)
+    Z = sum(exp.(-β .* (E .- E[1])))
+    Mx = sum(_op_site(_SX, i, N) for i in 1:N)
+    weights = exp.(-β .* (E .- E[1])) ./ Z
+    diagMx = real.(diag(V' * Mx * V))
+    mx_avg = sum(weights .* diagMx) / N
+    return mx_avg
+end
+
+# ============================================================================
+
+@testset "TFIM thermal observables" begin
+
+    # ───────────────────────────────────────────────────────────────────────
+    # Layer 1: T = 0 consistency with the existing entries.
+    # Use the disordered phase (h > J) so the BdG gap is finite (= 2(h - J))
+    # and there is no near-zero edge mode of the OBC ordered phase to spoil
+    # the convergence at moderate β.
+    # ───────────────────────────────────────────────────────────────────────
+    @testset "T → 0 consistency" begin
+        N, J, h = 10, 1.0, 1.5
+        β_low = 80.0   # well below the gap (Δ = 2|h-J| = 1)
+
+        # Per-site GS energy from BdG
+        ε_thermal = QAtlas.fetch(:TFIM, :energy, OBC(); N=N, J=J, h=h, beta=β_low) / N
+        ε_gs = QAtlas.fetch(:TFIM, :energy, OBC(); N=N, J=J, h=h) / N
+        @test ε_thermal ≈ ε_gs atol=1e-12
+
+        # Per-site free energy → ε at T = 0
+        f_thermal = QAtlas.fetch(:TFIM, :free_energy, OBC(); N=N, J=J, h=h, beta=β_low)
+        @test f_thermal ≈ ε_gs rtol=1e-6
+
+        # Entropy → 0 at T = 0
+        s_low = QAtlas.fetch(:TFIM, :entropy, OBC(); N=N, J=J, h=h, beta=β_low)
+        @test abs(s_low) < 1e-6
+
+        # Specific heat → 0 at T = 0
+        c_low = QAtlas.fetch(:TFIM, :specific_heat, OBC(); N=N, J=J, h=h, beta=β_low)
+        @test abs(c_low) < 1e-6
+
+        # Static σᶻ σᶻ thermal at β = ∞ matches the existing T = 0 entry —
+        # this works in any phase since it does not rely on β being finite.
+        for h_phase in (0.5, 1.0, 1.5)
+            for r in 1:4
+                v_th = QAtlas.fetch(:TFIM, :zz_static_thermal, OBC();
+                                    N=10, J=1.0, h=h_phase, beta=Inf, i=2, j=2 + r)
+                v_gs = real(QAtlas.fetch(:TFIM, :sz_sz_correlation, OBC();
+                                         N=10, J=1.0, h=h_phase, i=2, j=2 + r, t=0.0))
+                @test v_th ≈ v_gs atol=1e-12
+            end
+        end
+    end
+
+    # ───────────────────────────────────────────────────────────────────────
+    # Layer 2: T → ∞ analytic limits (single-spin paramagnet).
+    # ───────────────────────────────────────────────────────────────────────
+    @testset "T → ∞ analytic limits" begin
+        N, J, h = 8, 1.0, 0.5
+        β_high = 1e-4
+
+        # Free energy per site at β → 0:
+        #   f → -T log 2 + O(β · h, β · J)
+        f_hi = QAtlas.fetch(:TFIM, :free_energy, OBC(); N=N, J=J, h=h, beta=β_high)
+        @test f_hi ≈ -log(2) / β_high atol=1e-3 / β_high
+
+        # Entropy per site at β → 0: s → log 2
+        s_hi = QAtlas.fetch(:TFIM, :entropy, OBC(); N=N, J=J, h=h, beta=β_high)
+        @test s_hi ≈ log(2) atol=1e-6
+
+        # Specific heat at β → 0: c_v → 0 quadratically in β
+        c_hi = QAtlas.fetch(:TFIM, :specific_heat, OBC(); N=N, J=J, h=h, beta=β_high)
+        @test abs(c_hi) < 1e-6
+
+        # Transverse magnetisation at β → 0: m_x → 0 (Curie regime)
+        mx_hi = QAtlas.fetch(:TFIM, :transverse_magnetization, OBC();
+                             N=N, J=J, h=h, beta=β_high)
+        @test abs(mx_hi) < 1e-3
+
+        # Same in the thermodynamic limit.
+        f_inf = QAtlas.fetch(:TFIM, :free_energy, Infinite(); J=J, h=h, beta=β_high)
+        s_inf = QAtlas.fetch(:TFIM, :entropy, Infinite(); J=J, h=h, beta=β_high)
+        @test f_inf ≈ -log(2) / β_high atol=1e-3 / β_high
+        @test s_inf ≈ log(2) atol=1e-6
+    end
+
+    # ───────────────────────────────────────────────────────────────────────
+    # Layer 3: Thermodynamic identities.
+    # ───────────────────────────────────────────────────────────────────────
+    @testset "thermodynamic identities" begin
+        N, J, h = 10, 1.0, 0.5
+        for β in (0.3, 0.7, 1.5, 3.0)
+            ε = QAtlas.fetch(:TFIM, :energy, OBC(); N=N, J=J, h=h, beta=β) / N
+            f = QAtlas.fetch(:TFIM, :free_energy, OBC(); N=N, J=J, h=h, beta=β)
+            s = QAtlas.fetch(:TFIM, :entropy, OBC(); N=N, J=J, h=h, beta=β)
+
+            # ε = f + T s = f + s/β
+            @test ε ≈ f + s / β atol=1e-10
+
+            # c_v from numerical second derivative of (β f).
+            δ = 1e-3 * β
+            f_p = QAtlas.fetch(:TFIM, :free_energy, OBC(); N=N, J=J, h=h, beta=β + δ)
+            f_m = QAtlas.fetch(:TFIM, :free_energy, OBC(); N=N, J=J, h=h, beta=β - δ)
+            βf = β * f
+            βpfp = (β + δ) * f_p
+            βmfm = (β - δ) * f_m
+            c_num = -β^2 * (βpfp - 2 * βf + βmfm) / δ^2
+            c_an = QAtlas.fetch(:TFIM, :specific_heat, OBC(); N=N, J=J, h=h, beta=β)
+            @test c_an ≈ c_num rtol=1e-3
+
+            # χ_xx from numerical derivative of m_x w.r.t. h
+            δh = 1e-4
+            mp = QAtlas.fetch(:TFIM, :transverse_magnetization, OBC();
+                              N=N, J=J, h=h + δh, beta=β)
+            mm = QAtlas.fetch(:TFIM, :transverse_magnetization, OBC();
+                              N=N, J=J, h=h - δh, beta=β)
+            χ_num = (mp - mm) / (2 * δh)
+            χ_an = QAtlas.fetch(:TFIM, :transverse_susceptibility, OBC();
+                                N=N, J=J, h=h, beta=β)
+            @test χ_an ≈ χ_num rtol=5e-3
+        end
+    end
+
+    @testset "thermodynamic identities (Infinite)" begin
+        J, h = 1.0, 0.7
+        for β in (0.3, 0.7, 1.5, 3.0)
+            ε = QAtlas.fetch(:TFIM, :energy, Infinite(); J=J, h=h, beta=β)
+            f = QAtlas.fetch(:TFIM, :free_energy, Infinite(); J=J, h=h, beta=β)
+            s = QAtlas.fetch(:TFIM, :entropy, Infinite(); J=J, h=h, beta=β)
+            @test ε ≈ f + s / β atol=1e-10
+
+            δ = 1e-3 * β
+            f_p = QAtlas.fetch(:TFIM, :free_energy, Infinite(); J=J, h=h, beta=β + δ)
+            f_m = QAtlas.fetch(:TFIM, :free_energy, Infinite(); J=J, h=h, beta=β - δ)
+            c_num = -β^2 * ((β + δ) * f_p - 2 * β * f + (β - δ) * f_m) / δ^2
+            c_an = QAtlas.fetch(:TFIM, :specific_heat, Infinite(); J=J, h=h, beta=β)
+            @test c_an ≈ c_num rtol=1e-3
+
+            δh = 1e-4
+            mp = QAtlas.fetch(:TFIM, :transverse_magnetization, Infinite();
+                              J=J, h=h + δh, beta=β)
+            mm = QAtlas.fetch(:TFIM, :transverse_magnetization, Infinite();
+                              J=J, h=h - δh, beta=β)
+            χ_num = (mp - mm) / (2 * δh)
+            χ_an = QAtlas.fetch(:TFIM, :transverse_susceptibility, Infinite();
+                                J=J, h=h, beta=β)
+            @test χ_an ≈ χ_num rtol=5e-3
+        end
+    end
+
+    # ───────────────────────────────────────────────────────────────────────
+    # Layer 4: ED comparison at small N (per site).
+    # ───────────────────────────────────────────────────────────────────────
+    @testset "ED comparison N=4" begin
+        N, J, h = 4, 1.0, 0.7
+        for β in (0.5, 1.0, 2.5)
+            ed = _ed_thermo(N, J, h, β)
+            mx_ed = _ed_transverse(N, J, h, β)
+
+            ε = QAtlas.fetch(:TFIM, :energy, OBC(); N=N, J=J, h=h, beta=β) / N
+            f = QAtlas.fetch(:TFIM, :free_energy, OBC(); N=N, J=J, h=h, beta=β)
+            s = QAtlas.fetch(:TFIM, :entropy, OBC(); N=N, J=J, h=h, beta=β)
+            c = QAtlas.fetch(:TFIM, :specific_heat, OBC(); N=N, J=J, h=h, beta=β)
+            mx = QAtlas.fetch(:TFIM, :transverse_magnetization, OBC();
+                              N=N, J=J, h=h, beta=β)
+
+            @test ε ≈ ed.ε atol=1e-10
+            @test f ≈ ed.f atol=1e-10
+            @test s ≈ ed.s atol=1e-10
+            @test c ≈ ed.c_v atol=1e-10
+            @test mx ≈ mx_ed atol=1e-10
+        end
+    end
+
+    @testset "ED comparison: static σᶻ σᶻ thermal" begin
+        N, J, h = 4, 1.0, 0.7
+        H = _build_tfim_dense(N, J, h)
+        E, V = eigen(H)
+        for β in (0.5, 1.0, 2.5)
+            Z = sum(exp.(-β .* (E .- E[1])))
+            ρ = V * (Diagonal(exp.(-β .* (E .- E[1]))) ./ Z) * V'
+            for i in 1:N, j in i:N
+                op = _op_site(_SZ, i, N) * _op_site(_SZ, j, N)
+                ed_val = real(tr(ρ * op))
+                qa_val = QAtlas.fetch(:TFIM, :zz_static_thermal, OBC();
+                                      N=N, J=J, h=h, beta=β, i=i, j=j)
+                @test qa_val ≈ ed_val atol=1e-10
+            end
+        end
+    end
+
+    @testset "ED comparison: longitudinal susceptibility" begin
+        N, J, h = 4, 1.0, 0.7
+        for β in (0.5, 1.0, 2.5)
+            # χ_zz = β · ⟨M²⟩_c / N from the ED density matrix
+            H = _build_tfim_dense(N, J, h)
+            E, V = eigen(H)
+            Z = sum(exp.(-β .* (E .- E[1])))
+            ρ = V * (Diagonal(exp.(-β .* (E .- E[1]))) ./ Z) * V'
+            Mz = sum(_op_site(_SZ, i, N) for i in 1:N)
+            M2 = real(tr(ρ * (Mz * Mz)))
+            M1 = real(tr(ρ * Mz))
+            χ_ed = β * (M2 - M1^2) / N
+
+            χ_qa = QAtlas.fetch(:TFIM, :longitudinal_susceptibility, OBC();
+                                N=N, J=J, h=h, beta=β)
+            @test χ_qa ≈ χ_ed atol=1e-10
+        end
+    end
+
+    # ───────────────────────────────────────────────────────────────────────
+    # Layer 5: OBC ↔ Infinite consistency at large N.
+    # ───────────────────────────────────────────────────────────────────────
+    @testset "OBC → Infinite at large N" begin
+        J, h, β = 1.0, 0.5, 1.0
+        Ns = (20, 60, 120)
+        errs_f = Float64[]
+        errs_s = Float64[]
+        errs_c = Float64[]
+        errs_m = Float64[]
+        for N in Ns
+            f_obc = QAtlas.fetch(:TFIM, :free_energy, OBC(); N=N, J=J, h=h, beta=β)
+            s_obc = QAtlas.fetch(:TFIM, :entropy, OBC(); N=N, J=J, h=h, beta=β)
+            c_obc = QAtlas.fetch(:TFIM, :specific_heat, OBC(); N=N, J=J, h=h, beta=β)
+            m_obc = QAtlas.fetch(:TFIM, :transverse_magnetization, OBC();
+                                 N=N, J=J, h=h, beta=β)
+            f_inf = QAtlas.fetch(:TFIM, :free_energy, Infinite(); J=J, h=h, beta=β)
+            s_inf = QAtlas.fetch(:TFIM, :entropy, Infinite(); J=J, h=h, beta=β)
+            c_inf = QAtlas.fetch(:TFIM, :specific_heat, Infinite(); J=J, h=h, beta=β)
+            m_inf = QAtlas.fetch(:TFIM, :transverse_magnetization, Infinite();
+                                 J=J, h=h, beta=β)
+            push!(errs_f, abs(f_obc - f_inf))
+            push!(errs_s, abs(s_obc - s_inf))
+            push!(errs_c, abs(c_obc - c_inf))
+            push!(errs_m, abs(m_obc - m_inf))
+        end
+        # All errors should be small at the largest N
+        @test errs_f[end] < 0.05
+        @test errs_s[end] < 0.05
+        @test errs_c[end] < 0.05
+        @test errs_m[end] < 0.05
+        # Convergence: largest-N error should be the smallest
+        @test errs_f[end] ≤ errs_f[1]
+        @test errs_s[end] ≤ errs_s[1]
+        @test errs_c[end] ≤ errs_c[1]
+        @test errs_m[end] ≤ errs_m[1]
+    end
+end


### PR DESCRIPTION
New module `models/TFIM_thermal.jl` provides per-site exact thermal observables for the OBC and infinite TFIM via free-fermion (BdG) diagonalisation, plus a thermal generalisation of the Pfaffian-based correlator path in `TFIM_dynamics.jl`.

New `fetch` quantities (per site):

- `:free_energy`               f(β) = -T log Z / N
- `:entropy`                   s(β) = β (ε - f)
- `:specific_heat`             c_v(β)
- `:transverse_magnetization`  m_x(β) = ⟨σˣ_i⟩
- `:transverse_susceptibility` χ_xx(β) = ∂m_x/∂h
- `:longitudinal_susceptibility` χ_zz(β) = (β/N) Σ_{ij} ⟨σᶻ_i σᶻ_j⟩_β
- `:zz_static_thermal`         ⟨σᶻ_i σᶻ_j⟩_β  (scalar or full N×N)
- `:zz_structure_factor`       S_zz(q, β)

All five Tier-1 quantities are available for both `Infinite` (single quadgk integral over the BdG dispersion Λ(k) = 2√(J²+h²−2Jh cos k)) and `OBC` (sum over the BdG modes; m_x and χ_xx use the thermal Majorana covariance directly).

Pfaffian-based correlators in `TFIM_dynamics.jl` now accept `beta`:

- `_majorana_thermal_covariance(h, β) = -i tanh((β/2) i h)` reduces to the existing `_majorana_covariance_gs` at β = ∞.
- `:sz_sz_correlation`, `:sx_sx_correlation`, `:sz_sz_spreading` all take an optional `beta::Float64` kwarg (default Inf = ground state).
- The static thermal correlator and the q = 0 longitudinal susceptibility are built on top of the same path.

Tests (251 total, +102 new):

1. T → 0: thermal observables converge to the existing GS results (β = 80 in the disordered phase, well below the BdG gap).
2. T → ∞: f → -T log 2, s → log 2, c_v → 0, m_x → 0.
3. Thermodynamic identities: ε = f + Ts, c_v = -β² ∂²(βf)/∂β² (numerical second derivative), χ_xx = ∂m_x/∂h (numerical derivative).
4. ED comparison at N = 4: f, s, c_v, m_x, ⟨σᶻ_i σᶻ_j⟩_β, and the uniform χ_zz all match a brute-force dense diagonalisation to ~1e-10.
5. OBC ↔ Infinite consistency: per-site values converge as N grows.

Bumps version 0.3.0 → 0.4.0.
