### PR TITLE
Add classical 2D Ising exact partition function (Tier 0a)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]
@@ -12,7 +12,11 @@ julia = "1.10"
 QuadGK = "2.11.2"
 
 [extras]
+Lattice2D = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Lattice2D"]
+
+[sources]
+Lattice2D = {url = "https://github.com/sotashimozono/Lattice2D.jl.git", rev = "v0.2.4"}

--- a/Project.toml
+++ b/Project.toml
@@ -20,3 +20,4 @@ test = ["Test", "Lattice2D"]
 
 [sources]
 Lattice2D = {url = "https://github.com/sotashimozono/Lattice2D.jl.git", rev = "v0.2.4"}
+LatticeCore = {url = "https://github.com/sotashimozono/LatticeCore.jl.git", rev = "v0.8.1"}

--- a/Project.toml
+++ b/Project.toml
@@ -13,10 +13,11 @@ QuadGK = "2.11.2"
 
 [extras]
 Lattice2D = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
+LatticeCore = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Lattice2D"]
+test = ["Test", "Lattice2D", "LatticeCore"]
 
 [sources]
 Lattice2D = {url = "https://github.com/sotashimozono/Lattice2D.jl.git", rev = "v0.2.4"}

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -5,6 +5,9 @@ export BoundaryCondition, Infinite, PBC, OBC
 export AbstractQuantity, Quantity
 export fetch
 
+# --- Classical Models ---
+export IsingSquare, PartitionFunction
+
 # --- Core Implementation ---
 include("core/alias.jl")
 include("core/type.jl")
@@ -17,5 +20,6 @@ include("universalities/E8.jl")
 include("models/TFIM.jl")
 include("models/TFIM_dynamics.jl")
 include("models/TFIM_thermal.jl")
+include("models/classical/IsingSquare.jl")
 
 end # module QAtlas

--- a/src/models/classical/IsingSquare.jl
+++ b/src/models/classical/IsingSquare.jl
@@ -136,7 +136,9 @@ consistent under this convention.
     L. Onsager, Phys. Rev. 65, 117 (1944).
     B. M. McCoy and T. T. Wu, "The Two-Dimensional Ising Model" (1973).
 """
-function fetch(::IsingSquare, ::PartitionFunction; Lx::Int, Ly::Int, β::Float64, J::Float64=1.0)
+function fetch(
+    ::IsingSquare, ::PartitionFunction; Lx::Int, Ly::Int, β::Float64, J::Float64=1.0
+)
     T = _ising_sq_transfer_matrix(Ly, β, J)
     λs = eigvals(Symmetric(T))
     return sum(λ^Lx for λ in λs)

--- a/src/models/classical/IsingSquare.jl
+++ b/src/models/classical/IsingSquare.jl
@@ -1,0 +1,143 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Classical 2D Ising model on the square lattice — exact partition function
+#
+# Hamiltonian:
+#   H = -J Σ_{⟨i,j⟩} σᵢ σⱼ,   σᵢ ∈ {−1, +1}
+#
+# Solved exactly via the transfer-matrix method. For an Lx × Ly torus
+# the partition function is Z = Tr(T^Lx) where T is the 2^Ly × 2^Ly
+# transfer matrix.
+#
+# References:
+#   L. Onsager, "Crystal Statistics. I. A Two-Dimensional Model with an
+#   Order-Disorder Transition", Phys. Rev. 65, 117 (1944).
+#   B. M. McCoy and T. T. Wu, "The Two-Dimensional Ising Model",
+#   Harvard University Press (1973).
+# ─────────────────────────────────────────────────────────────────────────────
+
+using LinearAlgebra: Symmetric, eigvals
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Dispatch tags
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    IsingSquare
+
+Dispatch tag for the classical 2D Ising model on a square lattice with
+periodic boundary conditions (PBC) in both directions.
+
+Hamiltonian: H = -J Σ_{⟨i,j⟩} σᵢ σⱼ, σᵢ ∈ {-1, +1}.
+
+See also: [`PartitionFunction`](@ref), [`fetch(::IsingSquare, ::PartitionFunction)`](@ref).
+"""
+struct IsingSquare end
+
+"""
+    PartitionFunction
+
+Dispatch tag for the canonical partition function Z = Σ_σ exp(-β H(σ)).
+
+See also: [`IsingSquare`](@ref).
+"""
+struct PartitionFunction end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Internal: transfer matrix for a row of Ly spins (PBC in y)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    _ising_sq_transfer_matrix(Ly, β, J) -> Matrix{Float64}
+
+Return the 2^Ly × 2^Ly symmetric transfer matrix for a row of `Ly` Ising
+spins with PBC along the row direction.
+
+The symmetric (Hermitian) form ensures real eigenvalues and is defined by:
+
+    T_{σ,σ'} = exp(βJ/2 · Eₕ(σ)) · exp(βJ · Eᵥ(σ,σ')) · exp(βJ/2 · Eₕ(σ'))
+
+where
+    Eₕ(σ) = Σⱼ₌₁^Ly σⱼ σ_{(j mod Ly)+1}   (horizontal bonds within row, PBC)
+    Eᵥ(σ,σ') = Σⱼ₌₁^Ly σⱼ σ'ⱼ             (vertical bonds between rows)
+
+Note: for Ly = 2, each horizontal bond is counted twice by the PBC sum
+(σ₁σ₂ + σ₂σ₁ = 2σ₁σ₂). This is consistent with the convention used by
+`Lattice2D`'s bond list, which also lists each bond of a 2-site periodic
+row twice.
+"""
+function _ising_sq_transfer_matrix(Ly::Int, β::Float64, J::Float64)
+    dim = 2^Ly
+
+    # Precompute spin vectors for each row state index (0-based binary encoding)
+    spins_of = Vector{Vector{Int}}(undef, dim)
+    for σ_idx in 0:(dim - 1)
+        spins_of[σ_idx + 1] = Int[((σ_idx >> j) & 1) == 1 ? 1 : -1 for j in 0:(Ly - 1)]
+    end
+
+    # Diagonal weight: exp(βJ/2 · Eₕ(σ))
+    h_weight = Vector{Float64}(undef, dim)
+    for σ_idx in 0:(dim - 1)
+        σ = spins_of[σ_idx + 1]
+        e_h = sum(σ[j] * σ[(j % Ly) + 1] for j in 1:Ly)
+        h_weight[σ_idx + 1] = exp(β * J / 2 * e_h)
+    end
+
+    # Build transfer matrix
+    T = Matrix{Float64}(undef, dim, dim)
+    for σ_idx in 0:(dim - 1)
+        σ = spins_of[σ_idx + 1]
+        wσ = h_weight[σ_idx + 1]
+        for σp_idx in 0:(dim - 1)
+            σp = spins_of[σp_idx + 1]
+            e_v = sum(σ[j] * σp[j] for j in 1:Ly)
+            T[σ_idx + 1, σp_idx + 1] = wσ * exp(β * J * e_v) * h_weight[σp_idx + 1]
+        end
+    end
+    return T
+end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# fetch: partition function via transfer matrix
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    fetch(::IsingSquare, ::PartitionFunction; Lx, Ly, β, J=1.0) -> Float64
+
+Exact partition function Z = Tr(T^Lx) for the classical 2D Ising model on an
+Lx × Ly square lattice with periodic boundary conditions in both directions.
+
+The transfer matrix T acts along the Lx direction (row-to-row transfer), with
+each row containing Ly spins and PBC along the Ly direction. Explicitly:
+
+    Z = Σᵢ λᵢ^Lx
+
+where λᵢ are the eigenvalues of the 2^Ly × 2^Ly symmetric transfer matrix.
+
+# Bond-counting convention
+
+This function adopts the same bond-counting convention as `Lattice2D`'s
+pre-computed bond list: for small PBC systems where Lx = 2 or Ly = 2, each
+unique physical bond appears twice in the enumeration. Both the transfer-matrix
+result and the brute-force enumeration via `Lattice2D.bonds` are internally
+consistent under this convention.
+
+# Special values
+
+- β = 0 (any Lx, Ly, J): Z = 2^(Lx·Ly)  — all configurations equally weighted
+- J = 0 (any β, Lx, Ly): Z = 2^(Lx·Ly)  — no interactions, same as β = 0
+
+# Arguments
+- `Lx::Int`: number of rows (transfer direction)
+- `Ly::Int`: number of columns (row length, PBC)
+- `β::Float64`: inverse temperature (β = 1/(k_B T))
+- `J::Float64`: Ising coupling constant (default 1.0; J > 0 ferromagnetic)
+
+# References
+    L. Onsager, Phys. Rev. 65, 117 (1944).
+    B. M. McCoy and T. T. Wu, "The Two-Dimensional Ising Model" (1973).
+"""
+function fetch(::IsingSquare, ::PartitionFunction; Lx::Int, Ly::Int, β::Float64, J::Float64=1.0)
+    T = _ising_sq_transfer_matrix(Ly, β, J)
+    λs = eigvals(Symmetric(T))
+    return sum(λ^Lx for λ in λs)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 ENV["GKSwstype"] = "100"
 
 using QAtlas, Test
-const dirs = ["core/", "universalities/", "models/"]
+const dirs = ["core/", "universalities/", "models/", "standalone/", "verification/"]
 
 const FIG_BASE = joinpath(pkgdir(QAtlas), "docs", "src", "assets")
 const PATHS = Dict()

--- a/test/standalone/test_ising_square_pfaffian.jl
+++ b/test/standalone/test_ising_square_pfaffian.jl
@@ -1,0 +1,65 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Lattice 非依存の standalone test for IsingSquare partition function.
+#
+# Tests special values that can be verified without building a lattice:
+#   β = 0 → Z = 2^N  (all configurations equally weighted)
+#   J = 0 → Z = 2^N  (no interactions, Z is independent of β)
+#   positivity + finiteness checks
+#
+# No Lattice2D dependency.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Test
+
+@testset "IsingSquare special values (Lattice 非依存)" begin
+
+    @testset "β = 0 → Z = 2^N for various (Lx, Ly)" begin
+        for (Lx, Ly) in [(2, 2), (2, 3), (3, 3), (3, 4), (4, 4)]
+            N = Lx * Ly
+            Z = fetch(IsingSquare(), PartitionFunction(); Lx=Lx, Ly=Ly, β=0.0)
+            @test Z ≈ 2.0^N atol = 1e-8
+        end
+    end
+
+    @testset "J = 0 → Z = 2^N (no interactions, any β)" begin
+        for β in [0.1, 0.5, 1.0, 5.0]
+            for (Lx, Ly) in [(2, 2), (2, 3), (3, 3)]
+                N = Lx * Ly
+                Z = fetch(IsingSquare(), PartitionFunction(); Lx=Lx, Ly=Ly, β=β, J=0.0)
+                @test Z ≈ 2.0^N atol = 1e-8
+            end
+        end
+    end
+
+    @testset "Z > 0 and finite for standard parameters" begin
+        for (Lx, Ly) in [(2, 2), (2, 3), (3, 3)]
+            for β in [0.0, 0.2, 0.44, 1.0, 2.0]
+                Z = fetch(IsingSquare(), PartitionFunction(); Lx=Lx, Ly=Ly, β=β)
+                @test Z > 0
+                @test isfinite(Z)
+            end
+        end
+    end
+
+    @testset "Z monotone decreasing in β (ferromagnetic J > 0)" begin
+        # As β increases from 0, configurations with low energy are favoured
+        # while high-energy ones are suppressed → Z decreases.
+        for (Lx, Ly) in [(2, 2), (3, 3)]
+            betas = [0.0, 0.1, 0.5, 1.0, 2.0]
+            Zs = [fetch(IsingSquare(), PartitionFunction(); Lx=Lx, Ly=Ly, β=β) for β in betas]
+            for k in 1:(length(Zs) - 1)
+                @test Zs[k] >= Zs[k + 1]
+            end
+        end
+    end
+
+    @testset "Symmetry: swap Lx ↔ Ly gives same Z" begin
+        # Z is symmetric under transposing the lattice (same model).
+        for β in [0.0, 0.3, 1.0]
+            Z_23 = fetch(IsingSquare(), PartitionFunction(); Lx=2, Ly=3, β=β)
+            Z_32 = fetch(IsingSquare(), PartitionFunction(); Lx=3, Ly=2, β=β)
+            @test Z_23 ≈ Z_32 rtol = 1e-10
+        end
+    end
+
+end

--- a/test/standalone/test_ising_square_pfaffian.jl
+++ b/test/standalone/test_ising_square_pfaffian.jl
@@ -15,7 +15,7 @@ using QAtlas, Test
     @testset "β = 0 → Z = 2^N for various (Lx, Ly)" begin
         for (Lx, Ly) in [(2, 2), (2, 3), (3, 3), (3, 4), (4, 4)]
             N = Lx * Ly
-            Z = fetch(IsingSquare(), PartitionFunction(); Lx=Lx, Ly=Ly, β=0.0)
+            Z = QAtlas.fetch(IsingSquare(), PartitionFunction(); Lx=Lx, Ly=Ly, β=0.0)
             @test Z ≈ 2.0^N atol = 1e-8
         end
     end
@@ -24,7 +24,7 @@ using QAtlas, Test
         for β in [0.1, 0.5, 1.0, 5.0]
             for (Lx, Ly) in [(2, 2), (2, 3), (3, 3)]
                 N = Lx * Ly
-                Z = fetch(IsingSquare(), PartitionFunction(); Lx=Lx, Ly=Ly, β=β, J=0.0)
+                Z = QAtlas.fetch(IsingSquare(), PartitionFunction(); Lx=Lx, Ly=Ly, β=β, J=0.0)
                 @test Z ≈ 2.0^N atol = 1e-8
             end
         end
@@ -33,23 +33,24 @@ using QAtlas, Test
     @testset "Z > 0 and finite for standard parameters" begin
         for (Lx, Ly) in [(2, 2), (2, 3), (3, 3)]
             for β in [0.0, 0.2, 0.44, 1.0, 2.0]
-                Z = fetch(IsingSquare(), PartitionFunction(); Lx=Lx, Ly=Ly, β=β)
+                Z = QAtlas.fetch(IsingSquare(), PartitionFunction(); Lx=Lx, Ly=Ly, β=β)
                 @test Z > 0
                 @test isfinite(Z)
             end
         end
     end
 
-    @testset "Z monotone decreasing in β (ferromagnetic J > 0)" begin
-        # As β increases from 0, configurations with low energy are favoured
-        # while high-energy ones are suppressed → Z decreases.
+    @testset "Z monotone increasing in β (ferromagnetic J > 0)" begin
+        # For J > 0 the ground state has E_gs < 0, so Z ≥ 2·exp(β|E_gs|)
+        # grows with β. The Boltzmann sum is dominated by the two
+        # all-up/all-down configurations as β → ∞.
         for (Lx, Ly) in [(2, 2), (3, 3)]
             betas = [0.0, 0.1, 0.5, 1.0, 2.0]
             Zs = [
-                fetch(IsingSquare(), PartitionFunction(); Lx=Lx, Ly=Ly, β=β) for β in betas
+                QAtlas.fetch(IsingSquare(), PartitionFunction(); Lx=Lx, Ly=Ly, β=β) for β in betas
             ]
             for k in 1:(length(Zs) - 1)
-                @test Zs[k] >= Zs[k + 1]
+                @test Zs[k] <= Zs[k + 1]
             end
         end
     end
@@ -57,8 +58,8 @@ using QAtlas, Test
     @testset "Symmetry: swap Lx ↔ Ly gives same Z" begin
         # Z is symmetric under transposing the lattice (same model).
         for β in [0.0, 0.3, 1.0]
-            Z_23 = fetch(IsingSquare(), PartitionFunction(); Lx=2, Ly=3, β=β)
-            Z_32 = fetch(IsingSquare(), PartitionFunction(); Lx=3, Ly=2, β=β)
+            Z_23 = QAtlas.fetch(IsingSquare(), PartitionFunction(); Lx=2, Ly=3, β=β)
+            Z_32 = QAtlas.fetch(IsingSquare(), PartitionFunction(); Lx=3, Ly=2, β=β)
             @test Z_23 ≈ Z_32 rtol = 1e-10
         end
     end

--- a/test/standalone/test_ising_square_pfaffian.jl
+++ b/test/standalone/test_ising_square_pfaffian.jl
@@ -24,7 +24,9 @@ using QAtlas, Test
         for β in [0.1, 0.5, 1.0, 5.0]
             for (Lx, Ly) in [(2, 2), (2, 3), (3, 3)]
                 N = Lx * Ly
-                Z = QAtlas.fetch(IsingSquare(), PartitionFunction(); Lx=Lx, Ly=Ly, β=β, J=0.0)
+                Z = QAtlas.fetch(
+                    IsingSquare(), PartitionFunction(); Lx=Lx, Ly=Ly, β=β, J=0.0
+                )
                 @test Z ≈ 2.0^N atol = 1e-8
             end
         end
@@ -47,7 +49,8 @@ using QAtlas, Test
         for (Lx, Ly) in [(2, 2), (3, 3)]
             betas = [0.0, 0.1, 0.5, 1.0, 2.0]
             Zs = [
-                QAtlas.fetch(IsingSquare(), PartitionFunction(); Lx=Lx, Ly=Ly, β=β) for β in betas
+                QAtlas.fetch(IsingSquare(), PartitionFunction(); Lx=Lx, Ly=Ly, β=β) for
+                β in betas
             ]
             for k in 1:(length(Zs) - 1)
                 @test Zs[k] <= Zs[k + 1]

--- a/test/standalone/test_ising_square_pfaffian.jl
+++ b/test/standalone/test_ising_square_pfaffian.jl
@@ -12,7 +12,6 @@
 using QAtlas, Test
 
 @testset "IsingSquare special values (Lattice 非依存)" begin
-
     @testset "β = 0 → Z = 2^N for various (Lx, Ly)" begin
         for (Lx, Ly) in [(2, 2), (2, 3), (3, 3), (3, 4), (4, 4)]
             N = Lx * Ly
@@ -46,7 +45,9 @@ using QAtlas, Test
         # while high-energy ones are suppressed → Z decreases.
         for (Lx, Ly) in [(2, 2), (3, 3)]
             betas = [0.0, 0.1, 0.5, 1.0, 2.0]
-            Zs = [fetch(IsingSquare(), PartitionFunction(); Lx=Lx, Ly=Ly, β=β) for β in betas]
+            Zs = [
+                fetch(IsingSquare(), PartitionFunction(); Lx=Lx, Ly=Ly, β=β) for β in betas
+            ]
             for k in 1:(length(Zs) - 1)
                 @test Zs[k] >= Zs[k + 1]
             end
@@ -61,5 +62,4 @@ using QAtlas, Test
             @test Z_23 ≈ Z_32 rtol = 1e-10
         end
     end
-
 end

--- a/test/util/classical_partition.jl
+++ b/test/util/classical_partition.jl
@@ -1,0 +1,43 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# test/util/classical_partition.jl
+#
+# Brute-force exact partition function for classical Ising models.
+#
+# Dependencies (expected to be `using`'d by the including test file):
+#   Lattice2D  — provides `bonds(lat)`, `num_sites(lat)`
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    exact_partition(lat, J::Float64, β::Float64) -> Float64
+
+Exactly compute Z = Σ_σ exp(-β E(σ)) by enumerating all 2^N Ising spin
+configurations on `lat`.
+
+The energy is E(σ) = -J Σ_{b ∈ bonds(lat)} σ_{b.i} σ_{b.j}, using the
+pre-computed bond list from `Lattice2D`. This adopts the same bond-counting
+convention as `IsingSquare`'s transfer matrix: for PBC lattices where
+Lx = 2 or Ly = 2, each unique physical bond appears twice in the bond list,
+which doubles the effective coupling relative to an Lx,Ly ≥ 3 lattice.
+
+Both `exact_partition` and `fetch(IsingSquare(), PartitionFunction(); ...)`
+are internally consistent under this convention.
+
+# Arguments
+- `lat`: a finite `AbstractLattice` from `Lattice2D` (e.g., `build_lattice(Square, Lx, Ly)`)
+- `J::Float64`: Ising coupling constant (J > 0 ferromagnetic)
+- `β::Float64`: inverse temperature
+
+# Complexity
+O(2^N) — exact for any finite lattice; practical for N ≤ 20.
+"""
+function exact_partition(lat, J::Float64, β::Float64)
+    N = num_sites(lat)
+    bond_pairs = [(b.i, b.j) for b in bonds(lat)]
+    Z = 0.0
+    for σ_idx in 0:(2^N - 1)
+        σ = Int[((σ_idx >> j) & 1) == 1 ? 1 : -1 for j in 0:(N - 1)]
+        E = -J * sum(σ[i] * σ[j] for (i, j) in bond_pairs)
+        Z += exp(-β * E)
+    end
+    return Z
+end

--- a/test/util/classical_partition.jl
+++ b/test/util/classical_partition.jl
@@ -34,7 +34,7 @@ function exact_partition(lat, J::Float64, β::Float64)
     N = num_sites(lat)
     bond_pairs = [(b.i, b.j) for b in bonds(lat)]
     Z = 0.0
-    for σ_idx in 0:(2^N - 1)
+    for σ_idx in 0:(2 ^ N - 1)
         σ = Int[((σ_idx >> j) & 1) == 1 ? 1 : -1 for j in 0:(N - 1)]
         E = -J * sum(σ[i] * σ[j] for (i, j) in bond_pairs)
         Z += exp(-β * E)

--- a/test/verification/test_ising_2x2_classical.jl
+++ b/test/verification/test_ising_2x2_classical.jl
@@ -22,7 +22,7 @@ const J_ISING = 1.0
         @testset "$(Lx)×$(Ly) square PBC" begin
             for β in [0.0, 0.1, 0.2, 0.44, 1.0, 2.0]
                 Z_bf = exact_partition(lat, J_ISING, β)
-                Z_tm = fetch(
+                Z_tm = QAtlas.fetch(
                     IsingSquare(), PartitionFunction(); Lx=Lx, Ly=Ly, β=β, J=J_ISING
                 )
                 @test Z_tm ≈ Z_bf rtol = 1e-10

--- a/test/verification/test_ising_2x2_classical.jl
+++ b/test/verification/test_ising_2x2_classical.jl
@@ -1,0 +1,30 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Verification: classical 2D Ising partition function
+#
+# Cross-validate QAtlas's transfer-matrix result against a brute-force
+# 2^N enumeration built on Lattice2D's pre-computed bond list.
+#
+# Test sizes: 2×2, 2×3, 3×3 (up to 9 sites = 512 configurations).
+# β values: sweep from 0 through a value near the infinite-volume Tc
+#            (βc = ln(1 + √2)/2 ≈ 0.4407) and into the ordered phase.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Lattice2D, Test
+
+include("../util/classical_partition.jl")
+
+const J_ISING = 1.0
+
+@testset "IsingSquare — transfer-matrix vs brute-force" begin
+    for (Lx, Ly) in [(2, 2), (2, 3), (3, 3)]
+        lat = build_lattice(Square, Lx, Ly)
+
+        @testset "$(Lx)×$(Ly) square PBC" begin
+            for β in [0.0, 0.1, 0.2, 0.44, 1.0, 2.0]
+                Z_bf = exact_partition(lat, J_ISING, β)
+                Z_tm = fetch(IsingSquare(), PartitionFunction(); Lx=Lx, Ly=Ly, β=β, J=J_ISING)
+                @test Z_tm ≈ Z_bf rtol = 1e-10
+            end
+        end
+    end
+end

--- a/test/verification/test_ising_2x2_classical.jl
+++ b/test/verification/test_ising_2x2_classical.jl
@@ -22,7 +22,9 @@ const J_ISING = 1.0
         @testset "$(Lx)×$(Ly) square PBC" begin
             for β in [0.0, 0.1, 0.2, 0.44, 1.0, 2.0]
                 Z_bf = exact_partition(lat, J_ISING, β)
-                Z_tm = fetch(IsingSquare(), PartitionFunction(); Lx=Lx, Ly=Ly, β=β, J=J_ISING)
+                Z_tm = fetch(
+                    IsingSquare(), PartitionFunction(); Lx=Lx, Ly=Ly, β=β, J=J_ISING
+                )
                 @test Z_tm ≈ Z_bf rtol = 1e-10
             end
         end


### PR DESCRIPTION
## Summary

- `src/models/classical/IsingSquare.jl`: `IsingSquare` / `PartitionFunction` dispatch tags + `fetch(::IsingSquare, ::PartitionFunction; Lx, Ly, β, J)` — 転送行列固有値分解で Z = Σᵢ λᵢ^Lx を返す純粋関数 (Onsager 1944 参照)
- `test/util/classical_partition.jl`: `exact_partition(lat, J, β)` — `Lattice2D.bonds(lat)` ベースの 2^N 全列挙ヘルパー
- `test/standalone/test_ising_square_pfaffian.jl`: Lattice 非依存の special-value テスト (β=0, J=0, 対称性等)
- `test/verification/test_ising_2x2_classical.jl`: 転送行列 vs 全列挙の end-to-end cross-validation (2×2, 2×3, 3×3 PBC, `rtol=1e-10`)
- `Project.toml`: Lattice2D v0.2.4 を test-only dep として追加
- バージョン 0.4.0 → 0.5.0

## Test plan

- [ ] `standalone/test_ising_square_pfaffian.jl` が Lattice2D なしで通ること
- [ ] `verification/test_ising_2x2_classical.jl` が `pkg> test` で通ること (Lattice2D の解決が必要)
- [ ] 既存の `core/`, `universalities/`, `models/` テストが壊れていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)