### PR TITLE
Verify thermodynamic observables from log Z via ForwardDiff

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]
@@ -12,12 +12,13 @@ julia = "1.10"
 QuadGK = "2.11.2"
 
 [extras]
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Lattice2D = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
 LatticeCore = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Lattice2D", "LatticeCore"]
+test = ["Test", "Lattice2D", "LatticeCore", "ForwardDiff"]
 
 [sources]
 Lattice2D = {url = "https://github.com/sotashimozono/Lattice2D.jl.git", rev = "v0.2.4"}

--- a/src/models/classical/IsingSquare.jl
+++ b/src/models/classical/IsingSquare.jl
@@ -15,7 +15,7 @@
 #   Harvard University Press (1973).
 # ─────────────────────────────────────────────────────────────────────────────
 
-using LinearAlgebra: Symmetric, eigvals
+using LinearAlgebra: tr
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Dispatch tags
@@ -47,12 +47,12 @@ struct PartitionFunction end
 # ═══════════════════════════════════════════════════════════════════════════════
 
 """
-    _ising_sq_transfer_matrix(Ly, β, J) -> Matrix{Float64}
+    _ising_sq_transfer_matrix(Ly, β, J) -> Matrix
 
 Return the 2^Ly × 2^Ly symmetric transfer matrix for a row of `Ly` Ising
 spins with PBC along the row direction.
 
-The symmetric (Hermitian) form ensures real eigenvalues and is defined by:
+The symmetric (Hermitian) form is defined by:
 
     T_{σ,σ'} = exp(βJ/2 · Eₕ(σ)) · exp(βJ · Eᵥ(σ,σ')) · exp(βJ/2 · Eₕ(σ'))
 
@@ -64,9 +64,17 @@ Note: for Ly = 2, each horizontal bond is counted twice by the PBC sum
 (σ₁σ₂ + σ₂σ₁ = 2σ₁σ₂). This is consistent with the convention used by
 `Lattice2D`'s bond list, which also lists each bond of a 2-site periodic
 row twice.
+
+The function is generic in `β` and `J` so that automatic-differentiation
+dual numbers (e.g. `ForwardDiff.Dual`) propagate through the matrix
+elements. The element type of the returned matrix is inferred from
+`typeof(exp(β * J))`.
 """
-function _ising_sq_transfer_matrix(Ly::Int, β::Float64, J::Float64)
+function _ising_sq_transfer_matrix(Ly::Int, β::Real, J::Real)
     dim = 2^Ly
+
+    # Element type of Boltzmann weights — propagates Dual numbers for AD.
+    TT = typeof(exp(β * J))
 
     # Precompute spin vectors for each row state index (0-based binary encoding)
     spins_of = Vector{Vector{Int}}(undef, dim)
@@ -75,7 +83,7 @@ function _ising_sq_transfer_matrix(Ly::Int, β::Float64, J::Float64)
     end
 
     # Diagonal weight: exp(βJ/2 · Eₕ(σ))
-    h_weight = Vector{Float64}(undef, dim)
+    h_weight = Vector{TT}(undef, dim)
     for σ_idx in 0:(dim - 1)
         σ = spins_of[σ_idx + 1]
         e_h = sum(σ[j] * σ[(j % Ly) + 1] for j in 1:Ly)
@@ -83,7 +91,7 @@ function _ising_sq_transfer_matrix(Ly::Int, β::Float64, J::Float64)
     end
 
     # Build transfer matrix
-    T = Matrix{Float64}(undef, dim, dim)
+    T = Matrix{TT}(undef, dim, dim)
     for σ_idx in 0:(dim - 1)
         σ = spins_of[σ_idx + 1]
         wσ = h_weight[σ_idx + 1]
@@ -101,17 +109,13 @@ end
 # ═══════════════════════════════════════════════════════════════════════════════
 
 """
-    fetch(::IsingSquare, ::PartitionFunction; Lx, Ly, β, J=1.0) -> Float64
+    fetch(::IsingSquare, ::PartitionFunction; Lx, Ly, β, J=1.0) -> Real
 
 Exact partition function Z = Tr(T^Lx) for the classical 2D Ising model on an
 Lx × Ly square lattice with periodic boundary conditions in both directions.
 
 The transfer matrix T acts along the Lx direction (row-to-row transfer), with
-each row containing Ly spins and PBC along the Ly direction. Explicitly:
-
-    Z = Σᵢ λᵢ^Lx
-
-where λᵢ are the eigenvalues of the 2^Ly × 2^Ly symmetric transfer matrix.
+each row containing Ly spins and PBC along the Ly direction.
 
 # Bond-counting convention
 
@@ -126,20 +130,31 @@ consistent under this convention.
 - β = 0 (any Lx, Ly, J): Z = 2^(Lx·Ly)  — all configurations equally weighted
 - J = 0 (any β, Lx, Ly): Z = 2^(Lx·Ly)  — no interactions, same as β = 0
 
+# Automatic differentiation
+
+`fetch` is generic in `β` and `J` so that `ForwardDiff.Dual` numbers
+propagate through it. This allows macroscopic thermodynamic quantities
+to be recovered from Z by differentiation — e.g.
+
+    ⟨E⟩ = -∂(log Z)/∂β
+    C_v = β² · ∂²(log Z)/∂β²
+
+See `test/verification/test_ising_ad_thermodynamics.jl` for a cross-check
+against direct ensemble averages.
+
 # Arguments
 - `Lx::Int`: number of rows (transfer direction)
 - `Ly::Int`: number of columns (row length, PBC)
-- `β::Float64`: inverse temperature (β = 1/(k_B T))
-- `J::Float64`: Ising coupling constant (default 1.0; J > 0 ferromagnetic)
+- `β::Real`: inverse temperature (β = 1/(k_B T))
+- `J::Real`: Ising coupling constant (default 1.0; J > 0 ferromagnetic)
 
 # References
     L. Onsager, Phys. Rev. 65, 117 (1944).
     B. M. McCoy and T. T. Wu, "The Two-Dimensional Ising Model" (1973).
 """
 function fetch(
-    ::IsingSquare, ::PartitionFunction; Lx::Int, Ly::Int, β::Float64, J::Float64=1.0
+    ::IsingSquare, ::PartitionFunction; Lx::Int, Ly::Int, β::Real, J::Real=1.0
 )
     T = _ising_sq_transfer_matrix(Ly, β, J)
-    λs = eigvals(Symmetric(T))
-    return sum(λ^Lx for λ in λs)
+    return tr(T^Lx)
 end

--- a/src/models/classical/IsingSquare.jl
+++ b/src/models/classical/IsingSquare.jl
@@ -152,9 +152,7 @@ against direct ensemble averages.
     L. Onsager, Phys. Rev. 65, 117 (1944).
     B. M. McCoy and T. T. Wu, "The Two-Dimensional Ising Model" (1973).
 """
-function fetch(
-    ::IsingSquare, ::PartitionFunction; Lx::Int, Ly::Int, β::Real, J::Real=1.0
-)
+function fetch(::IsingSquare, ::PartitionFunction; Lx::Int, Ly::Int, β::Real, J::Real=1.0)
     T = _ising_sq_transfer_matrix(Ly, β, J)
     return tr(T^Lx)
 end

--- a/test/verification/test_ising_ad_thermodynamics.jl
+++ b/test/verification/test_ising_ad_thermodynamics.jl
@@ -1,0 +1,94 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Verification: thermodynamic quantities from the partition function via AD
+#
+# Check that macroscopic observables (internal energy, heat capacity, average
+# bond energy) obtained by automatic differentiation of the transfer-matrix
+# log Z agree with direct Boltzmann ensemble averages computed by brute-force
+# enumeration of all 2^N spin configurations.
+#
+# Identities being verified:
+#
+#   ⟨E⟩   = -∂(log Z)/∂β
+#   C_v   =  β² · ∂²(log Z)/∂β²  =  β² · (⟨E²⟩ − ⟨E⟩²)
+#   ⟨ΣJσσ⟩ = (1/β) · ∂(log Z)/∂J
+#
+# Every equality must hold to machine precision because Z is the same
+# mathematical object on both sides — the AD path exercises QAtlas's
+# transfer-matrix Z, while the direct path uses `Lattice2D.bonds(lat)`.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Lattice2D, ForwardDiff, Test
+
+include("../util/classical_partition.jl")
+
+# log Z as a generic function of (β, J) so ForwardDiff.Dual propagates.
+function _log_Z_tm(Lx::Int, Ly::Int, β, J)
+    return log(QAtlas.fetch(IsingSquare(), PartitionFunction(); Lx=Lx, Ly=Ly, β=β, J=J))
+end
+
+"""
+    _direct_moments(lat, J, β) -> (⟨E⟩, ⟨E²⟩, ⟨Σσσ⟩)
+
+Directly compute the ensemble averages needed for the thermodynamic
+identities by brute-force enumeration. Uses `Lattice2D.bonds(lat)` and
+the same bond-counting convention as `exact_partition`.
+"""
+function _direct_moments(lat, J::Float64, β::Float64)
+    N = num_sites(lat)
+    bond_pairs = [(b.i, b.j) for b in bonds(lat)]
+    Z = 0.0
+    E1 = 0.0
+    E2 = 0.0
+    S1 = 0.0  # ⟨Σ σ_i σ_j⟩ (no J factor)
+    for σ_idx in 0:(2^N - 1)
+        σ = Int[((σ_idx >> j) & 1) == 1 ? 1 : -1 for j in 0:(N - 1)]
+        bond_sum = sum(σ[i] * σ[j] for (i, j) in bond_pairs)
+        E = -J * bond_sum
+        w = exp(-β * E)
+        Z += w
+        E1 += E * w
+        E2 += E^2 * w
+        S1 += bond_sum * w
+    end
+    return (E1 / Z, E2 / Z, S1 / Z)
+end
+
+const J_ISING = 1.0
+
+@testset "IsingSquare — thermodynamics from log Z (ForwardDiff)" begin
+    for (Lx, Ly) in [(2, 2), (2, 3), (3, 3)]
+        lat = build_lattice(Square, Lx, Ly)
+
+        @testset "$(Lx)×$(Ly) square PBC" begin
+            for β in [0.1, 0.3, 0.5, 1.0]
+                # --- AD from transfer matrix ---
+                #   E = -∂(log Z)/∂β
+                E_ad = -ForwardDiff.derivative(
+                    βv -> _log_Z_tm(Lx, Ly, βv, J_ISING), β
+                )
+
+                #   C_v = β² · ∂²(log Z)/∂β²
+                d2logZ_dβ2 = ForwardDiff.derivative(
+                    βo -> ForwardDiff.derivative(
+                        βi -> _log_Z_tm(Lx, Ly, βi, J_ISING), βo
+                    ),
+                    β,
+                )
+                Cv_ad = β^2 * d2logZ_dβ2
+
+                #   ⟨Σ σσ⟩ = (1/β) · ∂(log Z)/∂J
+                bond_sum_ad = (1 / β) * ForwardDiff.derivative(
+                    Jv -> _log_Z_tm(Lx, Ly, β, Jv), J_ISING
+                )
+
+                # --- Direct ensemble averages ---
+                E_direct, E2_direct, bond_sum_direct = _direct_moments(lat, J_ISING, β)
+                Cv_direct = β^2 * (E2_direct - E_direct^2)
+
+                @test E_ad ≈ E_direct rtol = 1e-10
+                @test Cv_ad ≈ Cv_direct rtol = 1e-10
+                @test bond_sum_ad ≈ bond_sum_direct rtol = 1e-10
+            end
+        end
+    end
+end

--- a/test/verification/test_ising_ad_thermodynamics.jl
+++ b/test/verification/test_ising_ad_thermodynamics.jl
@@ -40,7 +40,7 @@ function _direct_moments(lat, J::Float64, β::Float64)
     E1 = 0.0
     E2 = 0.0
     S1 = 0.0  # ⟨Σ σ_i σ_j⟩ (no J factor)
-    for σ_idx in 0:(2^N - 1)
+    for σ_idx in 0:(2 ^ N - 1)
         σ = Int[((σ_idx >> j) & 1) == 1 ? 1 : -1 for j in 0:(N - 1)]
         bond_sum = sum(σ[i] * σ[j] for (i, j) in bond_pairs)
         E = -J * bond_sum
@@ -63,23 +63,19 @@ const J_ISING = 1.0
             for β in [0.1, 0.3, 0.5, 1.0]
                 # --- AD from transfer matrix ---
                 #   E = -∂(log Z)/∂β
-                E_ad = -ForwardDiff.derivative(
-                    βv -> _log_Z_tm(Lx, Ly, βv, J_ISING), β
-                )
+                E_ad = -ForwardDiff.derivative(βv -> _log_Z_tm(Lx, Ly, βv, J_ISING), β)
 
                 #   C_v = β² · ∂²(log Z)/∂β²
                 d2logZ_dβ2 = ForwardDiff.derivative(
-                    βo -> ForwardDiff.derivative(
-                        βi -> _log_Z_tm(Lx, Ly, βi, J_ISING), βo
-                    ),
+                    βo -> ForwardDiff.derivative(βi -> _log_Z_tm(Lx, Ly, βi, J_ISING), βo),
                     β,
                 )
                 Cv_ad = β^2 * d2logZ_dβ2
 
                 #   ⟨Σ σσ⟩ = (1/β) · ∂(log Z)/∂J
-                bond_sum_ad = (1 / β) * ForwardDiff.derivative(
-                    Jv -> _log_Z_tm(Lx, Ly, β, Jv), J_ISING
-                )
+                bond_sum_ad =
+                    (1 / β) *
+                    ForwardDiff.derivative(Jv -> _log_Z_tm(Lx, Ly, β, Jv), J_ISING)
 
                 # --- Direct ensemble averages ---
                 E_direct, E2_direct, bond_sum_direct = _direct_moments(lat, J_ISING, β)


### PR DESCRIPTION
## Summary

分配関数 Z から自動微分でマクロ物理量を再現し、brute-force ensemble 平均と一致することを確認する verification を追加しました。

- `src/models/classical/IsingSquare.jl`: `fetch` / `_ising_sq_transfer_matrix` を `Real` 型で generic 化し、`ForwardDiff.Dual` が通るようにしました。`eigvals(Symmetric(T))` は LAPACK 経由で Dual を受け付けないため、`tr(T^Lx)` に差し替えています (2^Ly × 2^Ly の転送行列を累乗するだけで、サイズ的に数値的にも問題なし)。
- `test/verification/test_ising_ad_thermodynamics.jl`: `log Z` を ForwardDiff で β / J 微分し、以下の熱力学関係を cross-validate:
  - `⟨E⟩ = -∂(log Z)/∂β`
  - `C_v = β² · ∂²(log Z)/∂β²`
  - `⟨Σσσ⟩ = (1/β) · ∂(log Z)/∂J`
- `Project.toml`: `ForwardDiff` を test-only dep として追加、バージョン 0.5.0 → 0.6.0。

テスト対象は 2×2, 2×3, 3×3 の PBC square lattice で β ∈ {0.1, 0.3, 0.5, 1.0}、いずれも `rtol=1e-10` で一致。

## Test plan

- [x] `Pkg.test()` で全 363 tests 通過 (追加分 36 tests を含む)
- [x] `E_ad ≈ E_direct` が 16 桁精度で一致 (ローカル確認済)
- [x] CI で ForwardDiff の precompile が通ること