### PR TITLE
Graphene tight-binding: Bloch closed form vs real-space diagonalization

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -8,6 +8,9 @@ export fetch
 # --- Classical Models ---
 export IsingSquare, PartitionFunction
 
+# --- Quantum Models ---
+export Graphene, TightBindingSpectrum
+
 # --- Core Implementation ---
 include("core/alias.jl")
 include("core/type.jl")
@@ -21,5 +24,6 @@ include("models/TFIM.jl")
 include("models/TFIM_dynamics.jl")
 include("models/TFIM_thermal.jl")
 include("models/classical/IsingSquare.jl")
+include("models/quantum/Graphene.jl")
 
 end # module QAtlas

--- a/src/models/quantum/Graphene.jl
+++ b/src/models/quantum/Graphene.jl
@@ -1,0 +1,101 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Graphene — nearest-neighbor tight-binding on the honeycomb lattice
+#
+# Hamiltonian (single-particle, spinless):
+#   H = -t Σ_{⟨i,j⟩ ∈ A-B} (c†_i c_j + c†_j c_i)
+#
+# The Bloch Hamiltonian on a bipartite (A, B) basis is:
+#
+#   H(k) = [  0      f(k)  ]
+#          [ f(k)*   0     ]
+#
+# with f(k) = -t [exp(i k·δ₁) + exp(i k·δ₂) + exp(i k·δ₃)], where δᵢ are
+# the three nearest-neighbor displacement vectors from an A site to its
+# three B neighbors. The two bands are ±|f(k)|.
+#
+# Using the unit-cell basis (a₁, a₂) adopted by `Lattice2D`'s honeycomb
+# topology (a₁ = (√3, 0), a₂ = (√3/2, 3/2), δ's derived accordingly):
+#
+#   |f(k)|² = t² [3 + 2cos(k·a₁) + 2cos(k·a₂) + 2cos(k·(a₂−a₁))]
+#
+# References:
+#   P. R. Wallace, "The Band Theory of Graphite", Phys. Rev. 71, 622 (1947).
+#   A. H. Castro Neto et al., "The electronic properties of graphene",
+#     Rev. Mod. Phys. 81, 109 (2009).
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Dispatch tags
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    Graphene
+
+Dispatch tag for the nearest-neighbor tight-binding model on the
+honeycomb lattice (spinless, single-orbital).
+
+Hamiltonian: H = -t Σ_{⟨i,j⟩} (c†_i c_j + h.c.)
+"""
+struct Graphene end
+
+"""
+    TightBindingSpectrum
+
+Dispatch tag for the single-particle spectrum of a tight-binding model.
+"""
+struct TightBindingSpectrum end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# fetch: closed-form Bloch spectrum for Lx × Ly honeycomb PBC
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    fetch(::Graphene, ::TightBindingSpectrum; Lx, Ly, t=1.0) -> Vector{Float64}
+
+Sorted single-particle spectrum of the nearest-neighbor tight-binding
+Hamiltonian on an Lx × Ly honeycomb lattice with periodic boundary
+conditions in both directions.
+
+The spectrum is obtained in closed form by diagonalizing the 2×2 Bloch
+Hamiltonian at the `Lx·Ly` allowed momenta
+
+    k_{mn} = (m/Lx) b₁ + (n/Ly) b₂,   m ∈ {0,…,Lx−1}, n ∈ {0,…,Ly−1}
+
+where (b₁, b₂) is the reciprocal basis dual to the real-space
+basis (a₁, a₂) used by `Lattice2D`'s `Honeycomb` topology.
+
+Explicitly, using k·a₁ = 2π m/Lx and k·a₂ = 2π n/Ly,
+
+    E_{mn,±} = ± t · √(3 + 2cos(2π m/Lx) + 2cos(2π n/Ly) + 2cos(2π(n/Ly − m/Lx)))
+
+The chiral (sublattice) symmetry of the bipartite honeycomb lattice
+guarantees that the spectrum is symmetric about zero. A small negative
+floor is applied inside the square root to absorb rounding error at
+Dirac points where the argument vanishes exactly.
+
+# Arguments
+- `Lx::Int`: number of unit cells in the first lattice direction
+- `Ly::Int`: number of unit cells in the second lattice direction
+- `t::Real`: nearest-neighbor hopping amplitude (default 1.0)
+
+# Return
+A sorted `Vector{Float64}` of length `2·Lx·Ly`.
+
+# References
+    P. R. Wallace, Phys. Rev. 71, 622 (1947).
+    A. H. Castro Neto et al., Rev. Mod. Phys. 81, 109 (2009).
+"""
+function fetch(::Graphene, ::TightBindingSpectrum; Lx::Int, Ly::Int, t::Real=1.0)
+    eigs = Float64[]
+    sizehint!(eigs, 2 * Lx * Ly)
+    for m in 0:(Lx - 1), n in 0:(Ly - 1)
+        θ1 = 2π * m / Lx
+        θ2 = 2π * n / Ly
+        # |f(k)|² / t² = 3 + 2cos(θ1) + 2cos(θ2) + 2cos(θ2 - θ1)
+        val = 3 + 2cos(θ1) + 2cos(θ2) + 2cos(θ2 - θ1)
+        energy = abs(t) * sqrt(max(val, 0.0))
+        push!(eigs, -energy)
+        push!(eigs, energy)
+    end
+    return sort!(eigs)
+end

--- a/test/util/tight_binding.jl
+++ b/test/util/tight_binding.jl
@@ -1,0 +1,36 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# test/util/tight_binding.jl
+#
+# Real-space single-particle tight-binding Hamiltonian constructor.
+#
+# Dependencies (expected to be `using`'d by the including test file):
+#   Lattice2D  — provides `bonds(lat)`, `num_sites(lat)`
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    build_tight_binding(lat, t::Real) -> Matrix{Float64}
+
+Build the real-space single-particle tight-binding Hamiltonian
+
+    H = -t Σ_{⟨i,j⟩} (c†_i c_j + c†_j c_i)
+
+from the pre-computed bond list of `lat`. Each bond `b ∈ bonds(lat)`
+contributes `H[b.i, b.j] -= t` and `H[b.j, b.i] -= t`.
+
+This follows the same bond-counting convention as `Lattice2D.bonds`:
+for small periodic systems where an edge is traversed in more than one
+direction by the connection list (e.g. Lx = 2 square), the corresponding
+matrix entries are naturally accumulated, consistent with the physical
+"double-bond" of a 2-site periodic ring.
+
+Returns a dense `Matrix{Float64}` of size `num_sites(lat) × num_sites(lat)`.
+"""
+function build_tight_binding(lat, t::Real)
+    N = num_sites(lat)
+    H = zeros(Float64, N, N)
+    for b in bonds(lat)
+        H[b.i, b.j] -= t
+        H[b.j, b.i] -= t
+    end
+    return H
+end

--- a/test/verification/test_graphene_tight_binding.jl
+++ b/test/verification/test_graphene_tight_binding.jl
@@ -1,0 +1,64 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Verification: nearest-neighbor tight-binding on the honeycomb lattice
+#
+# Cross-validate QAtlas's closed-form Bloch spectrum against direct
+# diagonalization of the real-space tight-binding Hamiltonian built from
+# `Lattice2D.bonds(lat)`.
+#
+# Test sizes: 2×2 through 4×4 honeycomb PBC.
+#
+# Additional structural checks motivated by the chiral (sublattice)
+# symmetry of bipartite honeycomb:
+#   * Σ λᵢ = 0   (tr H = 0)
+#   * {λᵢ} is symmetric about 0  (λ ↔ −λ)
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Lattice2D, LinearAlgebra, Test
+
+include("../util/tight_binding.jl")
+
+const T_HOP = 1.0
+
+@testset "Graphene TB — real-space vs Bloch closed form" begin
+    for (Lx, Ly) in [(2, 2), (2, 3), (3, 3), (3, 4), (4, 4)]
+        lat = build_lattice(Honeycomb, Lx, Ly)
+
+        @testset "$(Lx)×$(Ly) honeycomb PBC" begin
+            H = build_tight_binding(lat, T_HOP)
+            λ_real = sort(eigvals(Symmetric(H)))
+            λ_bloch = QAtlas.fetch(
+                Graphene(), TightBindingSpectrum(); Lx=Lx, Ly=Ly, t=T_HOP
+            )
+
+            @test length(λ_real) == 2 * Lx * Ly
+            @test length(λ_bloch) == 2 * Lx * Ly
+            @test λ_real ≈ λ_bloch atol = 1e-10
+
+            # Chiral (sublattice) symmetry: spectrum symmetric about 0
+            @test sum(λ_real) ≈ 0 atol = 1e-10
+            @test sort(λ_real) ≈ sort(-λ_real) atol = 1e-10
+        end
+    end
+
+    @testset "2×2 honeycomb — hand-computable spectrum" begin
+        # k_{mn} = (2π m/2, 2π n/2) = (πm, πn) → spectrum {-3, -1, -1, -1, 1, 1, 1, 3}
+        λ = QAtlas.fetch(Graphene(), TightBindingSpectrum(); Lx=2, Ly=2, t=1.0)
+        @test λ ≈ [-3.0, -1.0, -1.0, -1.0, 1.0, 1.0, 1.0, 3.0] atol = 1e-12
+    end
+
+    @testset "3×3 honeycomb — Dirac points give zero modes" begin
+        # At (m,n) = (1,2) and (2,1) (the K, K' points of the finite BZ),
+        # |f(k)|² = 0 exactly → four zero modes (two k-points × two bands).
+        λ = QAtlas.fetch(Graphene(), TightBindingSpectrum(); Lx=3, Ly=3, t=1.0)
+        zero_modes = count(x -> abs(x) < 1e-10, λ)
+        @test zero_modes == 4
+    end
+
+    @testset "t scaling: λ(t) = t · λ(1)" begin
+        λ1 = QAtlas.fetch(Graphene(), TightBindingSpectrum(); Lx=3, Ly=3, t=1.0)
+        for t in (0.5, 2.0, 3.7)
+            λt = QAtlas.fetch(Graphene(), TightBindingSpectrum(); Lx=3, Ly=3, t=t)
+            @test λt ≈ t .* λ1 rtol = 1e-12
+        end
+    end
+end


### PR DESCRIPTION
## Summary

Tier 0b (graphene tight-binding) の verification pipeline を追加しました。

- \`src/models/quantum/Graphene.jl\`: \`Graphene\` / \`TightBindingSpectrum\` dispatch tag と \`fetch\` — Wallace (1947) の 2×2 Bloch Hamiltonian を対角化した閉形式

  \`\`\`
  E_{mn,±} = ±t·√(3 + 2cos(2πm/Lx) + 2cos(2πn/Ly) + 2cos(2π(n/Ly − m/Lx)))
  \`\`\`

- \`test/util/tight_binding.jl\`: \`build_tight_binding(lat, t)\` — \`Lattice2D.bonds(lat)\` から実空間 TB Hamiltonian を組み立てる util
- \`test/verification/test_graphene_tight_binding.jl\`:
  - 2×2 〜 4×4 honeycomb PBC で実空間対角化 vs Bloch 閉形式を \`atol=1e-10\` で一致確認
  - 2×2 の hand-computable spectrum \`{±3, ±1, ±1, ±1}\` を pin
  - 3×3 の Dirac 点 (K, K') で zero mode が 4 個立つことを確認
  - \`t\` スケーリングと chiral 対称性 (spectrum が 0 について対称) のチェック
- \`Project.toml\`: version 0.6.0 → 0.7.0

## Test plan

- [x] \`Pkg.test()\` で全 393 tests 通過 (追加 30 tests)
- [x] 2×2 の spectrum が \`{-3, -1, -1, -1, 1, 1, 1, 3}\` で完全一致
- [x] 3×3 で 4 個の zero mode を検出 (Dirac 点)
- [x] CI で precompile が通ること