### PR TITLE
Heisenberg dimer (Tier 0c): spinhalf ED util + exact spectrum

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -10,6 +10,7 @@ export IsingSquare, PartitionFunction
 
 # --- Quantum Models ---
 export Graphene, TightBindingSpectrum
+export Heisenberg1D, ExactSpectrum
 
 # --- Core Implementation ---
 include("core/alias.jl")
@@ -25,5 +26,6 @@ include("models/TFIM_dynamics.jl")
 include("models/TFIM_thermal.jl")
 include("models/classical/IsingSquare.jl")
 include("models/quantum/Graphene.jl")
+include("models/quantum/Heisenberg.jl")
 
 end # module QAtlas

--- a/src/models/quantum/Heisenberg.jl
+++ b/src/models/quantum/Heisenberg.jl
@@ -1,0 +1,85 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Heisenberg — spin-1/2 antiferromagnetic Heisenberg model
+#
+# Hamiltonian:
+#   H = J Σ_{⟨i,j⟩} S_i · S_j
+#
+# where S_i are spin-1/2 operators and ⟨i,j⟩ runs over nearest-neighbor
+# pairs. For J > 0 the ground state is a singlet.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# Dimer (N = 2) — total-spin analysis
+#
+#   Two spin-1/2 degrees of freedom combine into S_tot = 0 ⊕ S_tot = 1.
+#   The dimer Hamiltonian is
+#
+#     H = J S_1 · S_2 = (J/2)·[(S_1 + S_2)² − S_1² − S_2²]
+#       = (J/2)·[S_tot² − 3/2]
+#
+#   giving eigenvalues
+#
+#     S_tot = 0 (singlet):   E_s = −3J/4
+#     S_tot = 1 (triplet):   E_t = +J/4  (three-fold degenerate)
+#
+#   Singlet–triplet gap: Δ = E_t − E_s = J.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Dispatch tags
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    Heisenberg1D
+
+Dispatch tag for the spin-1/2 antiferromagnetic Heisenberg model on a 1D
+chain (or more generally any finite spin-1/2 cluster). Hamiltonian:
+
+    H = J Σ_{⟨i,j⟩} S_i · S_j,   spin-1/2, J > 0 antiferromagnetic
+"""
+struct Heisenberg1D end
+
+"""
+    ExactSpectrum
+
+Dispatch tag for the full sorted eigenvalue spectrum of a finite model.
+"""
+struct ExactSpectrum end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# fetch: exact spectrum for small N
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    fetch(::Heisenberg1D, ::ExactSpectrum; N, J=1.0) -> Vector{Float64}
+
+Return the sorted exact spectrum of the spin-1/2 Heisenberg Hamiltonian
+on an N-site cluster with a single nearest-neighbor bond per pair.
+
+Currently only `N = 2` (the dimer) is implemented, with the
+closed-form spectrum
+
+    [-3J/4, J/4, J/4, J/4]
+
+corresponding to one singlet (S_tot = 0) and a three-fold degenerate
+triplet (S_tot = 1).
+
+Longer chains (4-site PBC with E₀ = −2J, etc.) are tracked as future
+additions in `dev/1_physical-verification/todo.md`.
+
+# Arguments
+- `N::Int`: number of spin-1/2 sites (only `N = 2` supported for now)
+- `J::Real`: Heisenberg coupling constant (default 1.0; J > 0 AFM)
+
+# References
+    For the dimer derivation see any standard textbook, e.g.
+    A. Auerbach, "Interacting Electrons and Quantum Magnetism" (1994), §2.
+"""
+function fetch(::Heisenberg1D, ::ExactSpectrum; N::Int, J::Real=1.0)
+    if N == 2
+        return sort([-3J / 4, J / 4, J / 4, J / 4])
+    end
+    return error(
+        "Heisenberg1D exact spectrum: only N=2 (dimer) implemented; got N=$N. " *
+        "Longer chains are tracked in dev/1_physical-verification/todo.md.",
+    )
+end

--- a/test/util/spinhalf_ed.jl
+++ b/test/util/spinhalf_ed.jl
@@ -1,0 +1,74 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# test/util/spinhalf_ed.jl
+#
+# Dense exact-diagonalization helpers for spin-1/2 many-body Hamiltonians.
+# Each site carries a 2-dimensional local Hilbert space; the total space is
+# 2^N-dimensional. Basis ordering: Julia `kron` convention, i.e. site 1 is
+# the outermost (most significant) factor in the tensor product.
+#
+# Dependencies (expected to be `using`'d by the including test file):
+#   LinearAlgebra  — `I`, `kron`
+#   Lattice2D      — `num_sites(lat)`, `bonds(lat)`
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    embed_two_site(A, B, i, j, N) -> Matrix{Float64}
+
+Embed a tensor-product two-site operator `A_i ⊗ B_j` into the full 2^N
+Hilbert space of `N` spin-1/2 sites. Both `A` and `B` are 2×2 operators
+acting on a single site; all other sites carry identity.
+
+If `i > j`, the arguments are swapped (including the operators) so that
+the smaller index is handled first. This is correct for Hermitian
+bilinears such as `S_i · S_j` which are symmetric under `i ↔ j`:
+`(Sp, Sm, i, j)` with `i > j` is silently reinterpreted as
+`(Sm, Sp, j, i)`, which is the same bond contribution.
+"""
+function embed_two_site(A::AbstractMatrix, B::AbstractMatrix, i::Int, j::Int, N::Int)
+    @assert 1 <= i <= N && 1 <= j <= N "site indices out of range"
+    @assert i != j "two-site embed requires distinct sites"
+    if i > j
+        i, j = j, i
+        A, B = B, A
+    end
+    left = Matrix{Float64}(I, 2^(i - 1), 2^(i - 1))
+    middle = Matrix{Float64}(I, 2^(j - i - 1), 2^(j - i - 1))
+    right = Matrix{Float64}(I, 2^(N - j), 2^(N - j))
+    return kron(kron(kron(kron(left, A), middle), B), right)
+end
+
+"""
+    build_spinhalf_heisenberg(lat, J) -> Matrix{Float64}
+
+Construct the full 2^N × 2^N dense Hamiltonian of the spin-1/2
+antiferromagnetic Heisenberg model
+
+    H = J Σ_{⟨i,j⟩} S_i · S_j
+      = J Σ_{⟨i,j⟩} [ Sᶻ_i Sᶻ_j + (1/2)(S⁺_i S⁻_j + S⁻_i S⁺_j) ]
+
+on the lattice `lat`, iterating over `bonds(lat)`. Uses ladder operators
+to avoid complex arithmetic — the resulting matrix is real symmetric.
+
+Each bond contributes once; no de-duplication is performed. Small PBC
+systems where `Lattice2D` lists an edge multiply (e.g. Lx = 2 ring)
+accumulate the multiplicity, matching `Lattice2DMonteCarlo`'s classical
+convention.
+"""
+function build_spinhalf_heisenberg(lat, J::Real)
+    N = num_sites(lat)
+    dim = 2^N
+    H = zeros(Float64, dim, dim)
+
+    # Spin-1/2 ladder operators and Sz in the {|↑⟩, |↓⟩} basis.
+    Sp = [0.0 1.0; 0.0 0.0]
+    Sm = [0.0 0.0; 1.0 0.0]
+    Sz = [0.5 0.0; 0.0 -0.5]
+
+    for b in bonds(lat)
+        i, j = b.i, b.j
+        H .+= J * embed_two_site(Sz, Sz, i, j, N)
+        H .+= (J / 2) * embed_two_site(Sp, Sm, i, j, N)
+        H .+= (J / 2) * embed_two_site(Sm, Sp, i, j, N)
+    end
+    return H
+end

--- a/test/verification/test_heisenberg_dimer.jl
+++ b/test/verification/test_heisenberg_dimer.jl
@@ -1,0 +1,72 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Verification: 2-site spin-1/2 Heisenberg dimer — full spectrum
+#
+# Compare Kronecker-embed ED of the real-space Hamiltonian
+#     H = J S_1 · S_2
+# built from `Lattice2D`'s `bonds(lat)` to the analytical spectrum
+#     { -3J/4, J/4, J/4, J/4 }  (singlet + three-fold triplet)
+# recorded in `src/models/quantum/Heisenberg.jl`.
+#
+# Also verifies the singlet–triplet gap Δ = J and that the low-lying
+# eigenvalue signs flip correctly under J → −J (ferromagnetic flip).
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Lattice2D, LinearAlgebra, Test
+
+include("../util/spinhalf_ed.jl")
+
+@testset "Heisenberg dimer (N=2) — ED vs exact spectrum" begin
+    # A 2-site OBC chain: build_lattice(Square, 2, 1) with OBC in y drops
+    # the (0, 1) connection; only the single (1, 0) bond survives.
+    lat = build_lattice(Square, 2, 1; boundary=OpenAxis())
+    @test num_sites(lat) == 2
+    @test length(collect(bonds(lat))) == 1
+
+    @testset "Full spectrum for various J" begin
+        for J in (1.0, 0.5, 2.0, -1.0)
+            H = build_spinhalf_heisenberg(lat, J)
+            λ_ed = sort(eigvals(Symmetric(H)))
+            λ_exact = QAtlas.fetch(Heisenberg1D(), ExactSpectrum(); N=2, J=J)
+            @test λ_ed ≈ λ_exact atol = 1e-12
+        end
+    end
+
+    @testset "Singlet-triplet gap Δ = J" begin
+        for J in (1.0, 0.5, 3.7)
+            λ = QAtlas.fetch(Heisenberg1D(), ExactSpectrum(); N=2, J=J)
+            # Sorted: J>0 → [-3J/4, J/4, J/4, J/4]; gap = λ[2] - λ[1]
+            gap = λ[2] - λ[1]
+            @test gap ≈ J rtol = 1e-12
+        end
+    end
+
+    @testset "Structural: tr H = 0 and Hermitian" begin
+        H = build_spinhalf_heisenberg(lat, 1.0)
+        @test tr(H) ≈ 0 atol = 1e-14
+        @test H ≈ H' atol = 1e-14
+    end
+
+    @testset "Singlet is the ground state for J > 0" begin
+        # Eigenvector at −3J/4 should be (|↑↓⟩ − |↓↑⟩)/√2 (up to phase).
+        # Basis ordering (kron with site 1 outermost):
+        #   1 = |↑↑⟩, 2 = |↑↓⟩, 3 = |↓↑⟩, 4 = |↓↓⟩
+        H = build_spinhalf_heisenberg(lat, 1.0)
+        F = eigen(Symmetric(H))
+        @test F.values[1] ≈ -0.75 atol = 1e-12
+        ψ0 = F.vectors[:, 1]
+        # |c(|↑↑⟩)|² = |c(|↓↓⟩)|² = 0
+        @test abs2(ψ0[1]) < 1e-20
+        @test abs2(ψ0[4]) < 1e-20
+        # ψ0 antisymmetric between |↑↓⟩ and |↓↑⟩: c[2] = -c[3] (up to sign).
+        @test ψ0[2] ≈ -ψ0[3] atol = 1e-12
+        # Singlet normalization: |c[2]| = |c[3]| = 1/√2.
+        @test abs(ψ0[2]) ≈ 1 / sqrt(2) atol = 1e-12
+    end
+
+    @testset "Ferromagnetic flip J → -J inverts ordering" begin
+        # For J < 0, the triplet becomes the ground state (E_t = J/4 < 0).
+        λ_afm = QAtlas.fetch(Heisenberg1D(), ExactSpectrum(); N=2, J=1.0)
+        λ_fm = QAtlas.fetch(Heisenberg1D(), ExactSpectrum(); N=2, J=-1.0)
+        @test λ_afm ≈ -reverse(λ_fm) atol = 1e-12
+    end
+end


### PR DESCRIPTION
## Summary

Tier 0c の 2-site quantum Heisenberg verification と、以後の量子 spin 系 ED で再利用する Kronecker embed util を追加します。

- \`test/util/spinhalf_ed.jl\`: 新規
  - \`embed_two_site(A, B, i, j, N)\`: \`A_i ⊗ B_j\` を 2^N Hilbert 空間に埋め込む (i > j の自動 swap 対応)
  - \`build_spinhalf_heisenberg(lat, J)\`: \`bonds(lat)\` から \`H = J·Σ S_i·S_j\` を ladder operator 形で構築 (実対称)
- \`src/models/quantum/Heisenberg.jl\`: \`Heisenberg1D\` / \`ExactSpectrum\` dispatch tag + \`fetch(; N=2, J)\` が dimer の closed form \`{-3J/4, J/4, J/4, J/4}\` を返す
- \`test/verification/test_heisenberg_dimer.jl\`: \`build_lattice(Square, 2, 1; boundary=OpenAxis())\` 上で ED vs 解析値を \`atol=1e-12\` で照合。singlet–triplet gap \`Δ = J\`, singlet 固有ベクトル \`(|↑↓⟩ − |↓↑⟩)/√2\`, \`tr H = 0\`, \`J → −J\` の鏡像関係もチェック
- \`Project.toml\`: version 0.7.0 → 0.8.0

## Test plan

- [x] \`Pkg.test()\` で全 410 tests 通過 (追加 17 tests)
- [x] dimer spectrum が \`{-3/4, 1/4, 1/4, 1/4}\` (J=1) で完全一致
- [x] 複数の J (1.0, 0.5, 2.0, -1.0) で ED と解析値が一致
- [x] CI で precompile が通ること

## 今後の余地

util は一般的な Kronecker embed として書いているので、以下は主に \`fetch\` 側を追加するだけで済む想定:

- 4-site 1D Heisenberg PBC (\`E₀ = -2J\` と Bethe ansatz との照合)
- TFIM small chain の gap closure  
- Heisenberg square lattice (\`E₀\` 既知数値)