### PR TITLE
Kagome tight-binding: flat-band verification

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -10,6 +10,9 @@ export IsingSquare, PartitionFunction
 
 # --- Quantum Models ---
 export Graphene, TightBindingSpectrum
+# NOTE: `Kagome` is NOT exported — it conflicts with Lattice2D's topology
+# type of the same name. Access it as `QAtlas.Kagome()` in code that also
+# uses `Lattice2D`.
 export Heisenberg1D, ExactSpectrum
 
 # --- Core Implementation ---
@@ -26,6 +29,7 @@ include("models/TFIM_dynamics.jl")
 include("models/TFIM_thermal.jl")
 include("models/classical/IsingSquare.jl")
 include("models/quantum/Graphene.jl")
+include("models/quantum/Kagome.jl")
 include("models/quantum/Heisenberg.jl")
 
 end # module QAtlas

--- a/src/models/quantum/Kagome.jl
+++ b/src/models/quantum/Kagome.jl
@@ -1,0 +1,104 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Kagome — nearest-neighbor tight-binding on the kagome lattice
+#
+# Hamiltonian (single-particle, spinless):
+#   H = -t Σ_{⟨i,j⟩} (c†_i c_j + c†_j c_i)
+#
+# The kagome lattice has three sublattices (A, B, C). In the sublattice
+# basis, the Bloch Hamiltonian is a 3×3 real symmetric matrix:
+#
+#   H(k) = -2t · [ 0              cos(θ₁/2)           cos(θ₂/2)        ]
+#                [ cos(θ₁/2)      0                   cos((θ₂−θ₁)/2)   ]
+#                [ cos(θ₂/2)      cos((θ₂−θ₁)/2)      0                ]
+#
+# with θ₁ = k·a₁, θ₂ = k·a₂ and Lattice2D's primitive basis
+# a₁ = (1, 0), a₂ = (1/2, √3/2). Each off-diagonal element collects both
+# the "same-cell" and "neighbouring-cell" hoppings of an A–B, A–C or B–C
+# bond (two bonds per pair), yielding the factor 2.
+#
+# The key feature: one of the three bands is completely flat at E = +2t.
+# The lower two bands touch it at the Γ-point (k = 0), where the spectrum
+# degenerates to {−4t, +2t, +2t}.
+#
+# References:
+#   I. Syôzi, "Statistics of Kagomé Lattice", Prog. Theor. Phys. 6, 306 (1951).
+#   D. L. Bergman, C. Wu, L. Balents, "Band touching from real-space
+#     topology in frustrated hopping models", Phys. Rev. B 78, 125104 (2008).
+# ─────────────────────────────────────────────────────────────────────────────
+
+using LinearAlgebra: Symmetric, eigvals
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Dispatch tag
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    Kagome
+
+Dispatch tag for the nearest-neighbor tight-binding model on the kagome
+lattice (spinless, single-orbital, three sublattices).
+
+Hamiltonian: H = -t Σ_{⟨i,j⟩} (c†_i c_j + h.c.)
+
+The spectrum exhibits a dispersionless flat band at E = +2t touching the
+lower dispersive bands at the Γ-point.
+"""
+struct Kagome end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# fetch: closed-form Bloch spectrum for Lx × Ly kagome PBC
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    fetch(::Kagome, ::TightBindingSpectrum; Lx, Ly, t=1.0) -> Vector{Float64}
+
+Sorted single-particle spectrum of the nearest-neighbor tight-binding
+Hamiltonian on an Lx × Ly kagome lattice with periodic boundary
+conditions in both directions.
+
+The 3×3 Bloch Hamiltonian is diagonalized numerically at each of the
+`Lx·Ly` allowed momenta
+
+    k_{mn} = (m/Lx) b₁ + (n/Ly) b₂,   m ∈ {0,…,Lx−1}, n ∈ {0,…,Ly−1}
+
+with b₁, b₂ dual to `Lattice2D`'s kagome primitive basis. In the θ
+parametrization (θ₁ = k·a₁ = 2π m/Lx, θ₂ = k·a₂ = 2π n/Ly),
+
+    H(k) = -2t · [ 0              cos(θ₁/2)           cos(θ₂/2)        ]
+                 [ cos(θ₁/2)      0                   cos((θ₂−θ₁)/2)   ]
+                 [ cos(θ₂/2)      cos((θ₂−θ₁)/2)      0                ]
+
+# Flat band
+
+One band is exactly flat at `+2t`, so the returned spectrum contains at
+least `Lx·Ly` eigenvalues equal to `2t`. At the Γ-point (k = 0) the
+upper dispersive band touches the flat band, contributing one extra
+`+2t` eigenvalue, giving a `Lx·Ly + 1`-fold degeneracy there. The
+remaining `2·Lx·Ly − 1` eigenvalues lie in `[−4t, +2t)`.
+
+# Arguments
+- `Lx::Int`: number of unit cells in the first lattice direction
+- `Ly::Int`: number of unit cells in the second lattice direction
+- `t::Real`: nearest-neighbor hopping amplitude (default 1.0)
+
+# Return
+A sorted `Vector{Float64}` of length `3·Lx·Ly`.
+
+# References
+    I. Syôzi, Prog. Theor. Phys. 6, 306 (1951).
+    D. L. Bergman et al., Phys. Rev. B 78, 125104 (2008).
+"""
+function fetch(::Kagome, ::TightBindingSpectrum; Lx::Int, Ly::Int, t::Real=1.0)
+    eigs = Float64[]
+    sizehint!(eigs, 3 * Lx * Ly)
+    for m in 0:(Lx - 1), n in 0:(Ly - 1)
+        θ1 = 2π * m / Lx
+        θ2 = 2π * n / Ly
+        c1 = cos(θ1 / 2)
+        c2 = cos(θ2 / 2)
+        c12 = cos((θ2 - θ1) / 2)
+        H = -2 * t * [0.0 c1 c2; c1 0.0 c12; c2 c12 0.0]
+        append!(eigs, eigvals(Symmetric(H)))
+    end
+    return sort!(eigs)
+end

--- a/test/verification/test_kagome_tight_binding.jl
+++ b/test/verification/test_kagome_tight_binding.jl
@@ -1,0 +1,71 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Verification: nearest-neighbor tight-binding on the kagome lattice
+#
+# Cross-validate QAtlas's closed-form Bloch spectrum (3×3 per k) against
+# direct diagonalization of the real-space tight-binding Hamiltonian
+# built from `Lattice2D.bonds(lat)`.
+#
+# Test sizes: 2×2 through 4×4 kagome PBC.
+#
+# Additional structural checks:
+#   * tr H = 0 (NN TB has no on-site energy)
+#   * Exactly Lx·Ly (+1 from Γ-touch) eigenvalues at +2t  → flat-band
+#     existence
+#   * Bonding ground state E_gs = −4t, reached at the Γ-point
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Lattice2D, LinearAlgebra, Test
+
+include("../util/tight_binding.jl")
+
+const T_HOP = 1.0
+
+@testset "Kagome TB — real-space vs Bloch closed form" begin
+    for (Lx, Ly) in [(2, 2), (2, 3), (3, 3), (3, 4), (4, 4)]
+        lat = build_lattice(Kagome, Lx, Ly)
+
+        @testset "$(Lx)×$(Ly) kagome PBC" begin
+            H = build_tight_binding(lat, T_HOP)
+            λ_real = sort(eigvals(Symmetric(H)))
+            λ_bloch = QAtlas.fetch(
+                QAtlas.Kagome(), TightBindingSpectrum(); Lx=Lx, Ly=Ly, t=T_HOP
+            )
+
+            @test length(λ_real) == 3 * Lx * Ly
+            @test length(λ_bloch) == 3 * Lx * Ly
+            @test λ_real ≈ λ_bloch atol = 1e-10
+
+            # Structural: trH = 0
+            @test tr(H) ≈ 0 atol = 1e-10
+
+            # Flat band at +2t: Lx·Ly states from the flat band, plus
+            # one extra from the Γ-point band touching.
+            flat = count(x -> abs(x - 2.0) < 1e-10, λ_real)
+            @test flat == Lx * Ly + 1
+
+            # Ground state: -4t at the Γ-point (unique)
+            @test λ_real[1] ≈ -4.0 atol = 1e-10
+            @test count(x -> abs(x - (-4.0)) < 1e-10, λ_real) == 1
+        end
+    end
+
+    @testset "2×2 hand-computable spectrum" begin
+        # Allowed k-points: (θ₁, θ₂) ∈ {0, π} × {0, π}
+        #   (0, 0)   : eigs of -2·[[0,1,1],[1,0,1],[1,1,0]]        = {-4, +2, +2}
+        #   (π, 0)   : eigs of -2·[[0,0,1],[0,0, cos(-π/2)=0],...] = {-2, 0, +2}
+        #   (0, π)   :                                              = {-2, 0, +2}
+        #   (π, π)   :                                              = {-2, 0, +2}
+        # Sorted full spectrum: [-4, -2, -2, -2, 0, 0, 0, 2, 2, 2, 2, 2]
+        λ = QAtlas.fetch(QAtlas.Kagome(), TightBindingSpectrum(); Lx=2, Ly=2, t=1.0)
+        @test λ ≈ [-4.0, -2.0, -2.0, -2.0, 0.0, 0.0, 0.0, 2.0, 2.0, 2.0, 2.0, 2.0] atol =
+            1e-12
+    end
+
+    @testset "t scaling: λ(t) = t · λ(1)" begin
+        λ1 = QAtlas.fetch(QAtlas.Kagome(), TightBindingSpectrum(); Lx=3, Ly=3, t=1.0)
+        for t in (0.5, 2.0, 3.7)
+            λt = QAtlas.fetch(QAtlas.Kagome(), TightBindingSpectrum(); Lx=3, Ly=3, t=t)
+            @test λt ≈ t .* λ1 rtol = 1e-12
+        end
+    end
+end


### PR DESCRIPTION
## Summary

Stage B の続きで Kagome lattice の flat-band verification を追加します。

- \`src/models/quantum/Kagome.jl\`: \`Kagome\` dispatch tag + \`fetch(::Kagome, ::TightBindingSpectrum; Lx, Ly, t)\`。各 k 点で 3×3 Bloch Hamiltonian を対角化して全スペクトルを返します。\`TightBindingSpectrum\` は Graphene と共有。
  - **\`Kagome\` は QAtlas から export していません**: Lattice2D の topology struct と名前衝突するため、mixed-using では \`QAtlas.Kagome()\` と qualify します (\`QAtlas.fetch\` と同じ慣例)
- \`test/verification/test_kagome_tight_binding.jl\`:
  - 2×2 〜 4×4 kagome PBC で実空間対角化 vs Bloch 閉形式を \`atol=1e-10\` で一致確認
  - 2×2 の hand-computable spectrum \`{-4, -2×3, 0×3, +2×5}\` を pin
  - 平坦バンドの存在確認: \`Lx·Ly + 1\` 個の固有値が \`+2t\` (flat band + Γ 点での band touching)
  - 基底状態が \`-4t\` (Γ 点 bonding) で一意
  - \`t\` スケーリングと \`tr H = 0\` の構造チェック
- \`Project.toml\`: version 0.8.0 → 0.9.0

## Test plan

- [x] \`Pkg.test()\` で全 449 tests 通過 (追加 39 tests)
- [x] 2×2 の spectrum が \`{-4, -2, -2, -2, 0, 0, 0, 2, 2, 2, 2, 2}\` で完全一致
- [x] flat band が 2×2 で 5 個, 3×3 で 10 個, 4×4 で 17 個 (Lx·Ly + 1)

## 今後の余地 (TB util を使い回すだけ)

- Lieb lattice (flat band at \`E = 0\`, 3 sublattice)
- Triangular lattice
- Square π-flux Hofstadter