### PR TITLE
Triangular lattice tight-binding: frustration & Van Hove

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -10,9 +10,10 @@ export IsingSquare, PartitionFunction
 
 # --- Quantum Models ---
 export Graphene, TightBindingSpectrum
-# NOTE: `Kagome` and `Lieb` are NOT exported — they conflict with
-# Lattice2D's topology types of the same name. Access them as
-# `QAtlas.Kagome()` / `QAtlas.Lieb()` in code that also uses `Lattice2D`.
+# NOTE: `Kagome`, `Lieb`, `Triangular` are NOT exported — they conflict
+# with Lattice2D's topology types of the same name. Access them as
+# `QAtlas.Kagome()` / `QAtlas.Lieb()` / `QAtlas.Triangular()` in code
+# that also uses `Lattice2D`.
 export Heisenberg1D, ExactSpectrum
 
 # --- Core Implementation ---
@@ -31,6 +32,7 @@ include("models/classical/IsingSquare.jl")
 include("models/quantum/tightbinding/Graphene.jl")
 include("models/quantum/tightbinding/Kagome.jl")
 include("models/quantum/tightbinding/Lieb.jl")
+include("models/quantum/tightbinding/Triangular.jl")
 include("models/quantum/Heisenberg.jl")
 
 end # module QAtlas

--- a/src/models/quantum/tightbinding/Triangular.jl
+++ b/src/models/quantum/tightbinding/Triangular.jl
@@ -1,0 +1,95 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Triangular — nearest-neighbor tight-binding on the triangular lattice
+#
+# Hamiltonian (single-particle, spinless):
+#   H = -t Σ_{⟨i,j⟩} (c†_i c_j + c†_j c_i)
+#
+# The triangular lattice has one sublattice per unit cell with six
+# nearest neighbours per site. Since there is only one band, the Bloch
+# "Hamiltonian" is a scalar:
+#
+#   E(k) = -t · Σ_{δ ∈ 6 NN} exp(i k·δ)
+#        = -2t · [ cos(k·a₁) + cos(k·a₂) + cos(k·(a₂ − a₁)) ]
+#
+# with Lattice2D's primitive basis  a₁ = (1, 0),  a₂ = (1/2, √3/2).
+#
+# Frustration: unlike the (bipartite) square or honeycomb lattice, the
+# triangular band is *not* symmetric about zero. With J ≡ t > 0,
+#
+#   minimum  E_min = -6t   at the Γ-point (unique),
+#   maximum  E_max = +3t   at the K-points (m/Lx = n/Ly = 1/3 etc.),
+#
+# i.e. the band extends from -6t to +3t, giving the hallmark
+# Van Hove singularity and the asymmetric density of states of the
+# frustrated triangular hopping problem.
+#
+# References:
+#   G. H. Wannier, "Antiferromagnetism. The Triangular Ising Net",
+#     Phys. Rev. 79, 357 (1950).
+#   T. Koretsune and M. Ogata, "Electronic structures of triangular
+#     lattice models", J. Phys. Soc. Jpn. 76, 074706 (2007) — review
+#     of the NN tight-binding spectrum and Van Hove singularity.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Dispatch tag
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    Triangular
+
+Dispatch tag for the nearest-neighbor tight-binding model on the
+triangular lattice (spinless, single-orbital, one sublattice).
+
+Hamiltonian: H = -t Σ_{⟨i,j⟩} (c†_i c_j + h.c.)
+
+The single band ranges from `-6t` (at the Γ-point) to `+3t` (at the
+K-points), reflecting geometric frustration: the absence of
+particle-hole (chiral) symmetry on a non-bipartite lattice.
+"""
+struct Triangular end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# fetch: closed-form Bloch spectrum for Lx × Ly triangular PBC
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    fetch(::Triangular, ::TightBindingSpectrum; Lx, Ly, t=1.0) -> Vector{Float64}
+
+Sorted single-particle spectrum of the nearest-neighbor tight-binding
+Hamiltonian on an `Lx × Ly` triangular lattice with periodic boundary
+conditions in both directions.
+
+Because the triangular lattice has a single sublattice per unit cell,
+each allowed momentum contributes exactly one eigenvalue
+
+    E_{mn} = -2t · [ cos(2π m/Lx) + cos(2π n/Ly) + cos(2π(n/Ly − m/Lx)) ]
+
+for m ∈ {0,…,Lx−1}, n ∈ {0,…,Ly−1}. Note the lower cut-off is `-6t`
+(at the Γ-point) but the upper cut-off is only `+3t` (at the K-points
+`(1/3, 2/3)` and `(2/3, 1/3)` — allowed when `Lx` and `Ly` are
+divisible by 3).
+
+# Arguments
+- `Lx::Int`: number of unit cells in the first lattice direction
+- `Ly::Int`: number of unit cells in the second lattice direction
+- `t::Real`: nearest-neighbor hopping amplitude (default 1.0; positive
+  convention)
+
+# Return
+A sorted `Vector{Float64}` of length `Lx·Ly`.
+
+# References
+    G. H. Wannier, Phys. Rev. 79, 357 (1950).
+"""
+function fetch(::Triangular, ::TightBindingSpectrum; Lx::Int, Ly::Int, t::Real=1.0)
+    eigs = Vector{Float64}(undef, Lx * Ly)
+    idx = 1
+    for m in 0:(Lx - 1), n in 0:(Ly - 1)
+        θ1 = 2π * m / Lx
+        θ2 = 2π * n / Ly
+        eigs[idx] = -2 * t * (cos(θ1) + cos(θ2) + cos(θ2 - θ1))
+        idx += 1
+    end
+    return sort!(eigs)
+end

--- a/test/verification/test_triangular_tight_binding.jl
+++ b/test/verification/test_triangular_tight_binding.jl
@@ -54,9 +54,7 @@ const T_HOP = 1.0
         #   (1,2)                                  → +3 (K)
         #   (2,1)                                  → +3 (K′)
         # Sorted: [-6, 0×6, 3, 3]
-        λ = QAtlas.fetch(
-            QAtlas.Triangular(), TightBindingSpectrum(); Lx=3, Ly=3, t=1.0
-        )
+        λ = QAtlas.fetch(QAtlas.Triangular(), TightBindingSpectrum(); Lx=3, Ly=3, t=1.0)
         @test λ ≈ [-6.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3.0, 3.0] atol = 1e-12
     end
 
@@ -76,22 +74,16 @@ const T_HOP = 1.0
     @testset "Frustration: spectrum NOT symmetric about zero" begin
         # Unlike honeycomb / Lieb (bipartite), the triangular band is
         # asymmetric: min = -6, max = +3 (not ±6).
-        λ = QAtlas.fetch(
-            QAtlas.Triangular(), TightBindingSpectrum(); Lx=6, Ly=6, t=1.0
-        )
+        λ = QAtlas.fetch(QAtlas.Triangular(), TightBindingSpectrum(); Lx=6, Ly=6, t=1.0)
         @test minimum(λ) ≈ -6.0 atol = 1e-10
         @test maximum(λ) ≈ +3.0 atol = 1e-10
         @test !(sort(λ) ≈ sort(-λ))  # not chiral-symmetric
     end
 
     @testset "t scaling: λ(t) = t · λ(1)" begin
-        λ1 = QAtlas.fetch(
-            QAtlas.Triangular(), TightBindingSpectrum(); Lx=4, Ly=4, t=1.0
-        )
+        λ1 = QAtlas.fetch(QAtlas.Triangular(), TightBindingSpectrum(); Lx=4, Ly=4, t=1.0)
         for t in (0.5, 2.0, 3.7)
-            λt = QAtlas.fetch(
-                QAtlas.Triangular(), TightBindingSpectrum(); Lx=4, Ly=4, t=t
-            )
+            λt = QAtlas.fetch(QAtlas.Triangular(), TightBindingSpectrum(); Lx=4, Ly=4, t=t)
             @test λt ≈ t .* λ1 rtol = 1e-12
         end
     end

--- a/test/verification/test_triangular_tight_binding.jl
+++ b/test/verification/test_triangular_tight_binding.jl
@@ -1,0 +1,98 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Verification: nearest-neighbor tight-binding on the triangular lattice
+#
+# Cross-validate QAtlas's closed-form single-band Bloch spectrum against
+# direct diagonalization of the real-space tight-binding Hamiltonian
+# built from `Lattice2D.bonds(lat)`.
+#
+# Test sizes: 3×3 through 6×6 triangular PBC. Sizes with Lx, Ly multiple
+# of 3 have the K-points in the discrete BZ, reproducing the hallmark
+# asymmetric band edge -6t / +3t.
+#
+# Additional structural checks:
+#   * tr H = 0                          (NN TB has no on-site energy)
+#   * Band edges -6t at Γ (unique) and +3t at K / K' (degeneracy 2)
+#     when both Lx and Ly are divisible by 3
+#   * Spectrum is NOT symmetric about zero (frustration, non-bipartite)
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Lattice2D, LinearAlgebra, Test
+
+include("../util/tight_binding.jl")
+
+const T_HOP = 1.0
+
+@testset "Triangular TB — real-space vs Bloch closed form" begin
+    for (Lx, Ly) in [(3, 3), (3, 4), (4, 4), (5, 5), (6, 6)]
+        lat = build_lattice(Triangular, Lx, Ly)
+
+        @testset "$(Lx)×$(Ly) triangular PBC" begin
+            H = build_tight_binding(lat, T_HOP)
+            λ_real = sort(eigvals(Symmetric(H)))
+            λ_bloch = QAtlas.fetch(
+                QAtlas.Triangular(), TightBindingSpectrum(); Lx=Lx, Ly=Ly, t=T_HOP
+            )
+
+            @test length(λ_real) == Lx * Ly
+            @test length(λ_bloch) == Lx * Ly
+            @test λ_real ≈ λ_bloch atol = 1e-10
+
+            # Structural: tr H = 0
+            @test tr(H) ≈ 0 atol = 1e-10
+
+            # Γ-point gives -6t unique minimum
+            @test λ_real[1] ≈ -6.0 atol = 1e-10
+            @test count(x -> abs(x - (-6.0)) < 1e-10, λ_real) == 1
+        end
+    end
+
+    @testset "3×3 hand-computable spectrum" begin
+        # Allowed (m, n) ∈ {0, 1, 2}²:
+        #   Γ = (0,0)                              → -6
+        #   (1,1), (2,2)                           →  0 (θ₂−θ₁ = 0)
+        #   (1,0), (0,1), (2,0), (0,2)             →  0 (one θ = 0)
+        #   (1,2)                                  → +3 (K)
+        #   (2,1)                                  → +3 (K′)
+        # Sorted: [-6, 0×6, 3, 3]
+        λ = QAtlas.fetch(
+            QAtlas.Triangular(), TightBindingSpectrum(); Lx=3, Ly=3, t=1.0
+        )
+        @test λ ≈ [-6.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3.0, 3.0] atol = 1e-12
+    end
+
+    @testset "K / K' degeneracy at multiples of 3" begin
+        # When both Lx and Ly are divisible by 3 the K-points
+        # (m/Lx, n/Ly) = (1/3, 2/3) and (2/3, 1/3) are allowed momenta
+        # and contribute +3t eigenvalues.
+        for (Lx, Ly) in [(3, 3), (3, 6), (6, 6)]
+            λ = QAtlas.fetch(
+                QAtlas.Triangular(), TightBindingSpectrum(); Lx=Lx, Ly=Ly, t=1.0
+            )
+            @test count(x -> abs(x - 3.0) < 1e-10, λ) >= 2
+            @test maximum(λ) ≈ 3.0 atol = 1e-10
+        end
+    end
+
+    @testset "Frustration: spectrum NOT symmetric about zero" begin
+        # Unlike honeycomb / Lieb (bipartite), the triangular band is
+        # asymmetric: min = -6, max = +3 (not ±6).
+        λ = QAtlas.fetch(
+            QAtlas.Triangular(), TightBindingSpectrum(); Lx=6, Ly=6, t=1.0
+        )
+        @test minimum(λ) ≈ -6.0 atol = 1e-10
+        @test maximum(λ) ≈ +3.0 atol = 1e-10
+        @test !(sort(λ) ≈ sort(-λ))  # not chiral-symmetric
+    end
+
+    @testset "t scaling: λ(t) = t · λ(1)" begin
+        λ1 = QAtlas.fetch(
+            QAtlas.Triangular(), TightBindingSpectrum(); Lx=4, Ly=4, t=1.0
+        )
+        for t in (0.5, 2.0, 3.7)
+            λt = QAtlas.fetch(
+                QAtlas.Triangular(), TightBindingSpectrum(); Lx=4, Ly=4, t=t
+            )
+            @test λt ≈ t .* λ1 rtol = 1e-12
+        end
+    end
+end


### PR DESCRIPTION
## Summary

Stage B の続きで triangular lattice の NN tight-binding verification を追加します。三角格子は **frustration** により bipartite 対称性を持たず、band edge が \`-6t / +3t\` と非対称なのが特徴です。

- \`src/models/quantum/tightbinding/Triangular.jl\`: \`Triangular\` dispatch tag + \`fetch(::Triangular, ::TightBindingSpectrum; Lx, Ly, t)\`
  - 1 sublattice per cell → Bloch は**スカラー**:
    \`\`\`
    E_{mn} = -2t · [cos(2π m/Lx) + cos(2π n/Ly) + cos(2π(n/Ly − m/Lx))]
    \`\`\`
  - Γ 点で最小 \`-6t\` (一意)、K/K' 点 \`(1/3, 2/3)\`, \`(2/3, 1/3)\` で最大 \`+3t\` (frustration により \`+6t\` に届かない)
  - \`Triangular\` は export せず、\`QAtlas.Triangular()\` で qualify (Lattice2D 側と名前衝突)

- \`test/verification/test_triangular_tight_binding.jl\`:
  - 3×3 〜 6×6 PBC で実空間対角化 vs Bloch 閉形式 (\`atol=1e-10\`)
  - **3×3 hand-computable spectrum \`[-6, 0×6, +3, +3]\`** を pin
  - Γ 点での \`-6t\` 一意 basis state
  - \`Lx, Ly\` 両方 3 の倍数のとき K/K' に \`+3t\` が出ることを確認 (3×3, 3×6, 6×6)
  - **Chiral 対称性の破れ**: spectrum が 0 について非対称 (honeycomb/Lieb とは対照的)
  - \`tr H = 0\`, \`t\` スケーリング

- \`Project.toml\`: version 0.10.0 → 0.11.0

## Test plan

- [x] \`Pkg.test()\` で全 **532 tests 通過** (追加 43 tests)
- [x] 3×3 の spectrum が \`[-6, 0, 0, 0, 0, 0, 0, 3, 3]\` で完全一致
- [x] Γ 点の \`-6t\` が一意、K/K' で \`+3t\` が確認

## Stage B 進捗

- [x] Honeycomb (graphene) — #16
- [x] Kagome — #18
- [x] Lieb — #19
- [x] Triangular — **this PR**
- [ ] Square π-flux Hofstadter (gap at E=0、magnetic unit cell が 2×1)
- [ ] Dice / UnionJack (flat band、さらにエキゾチック)