### PR TITLE
4-site Heisenberg PBC ring (E₀ = -2J)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/models/quantum/Heisenberg.jl
+++ b/src/models/quantum/Heisenberg.jl
@@ -81,9 +81,21 @@ function fetch(::Heisenberg1D, ::ExactSpectrum; N::Int, J::Real=1.0, bc::Symbol=
         #   E = -2J ×1 (singlet), -J ×3 (triplet), 0 ×7, +J ×5 (quintet)
         return sort([
             -2J,
-            -J, -J, -J,
-            zero(J), zero(J), zero(J), zero(J), zero(J), zero(J), zero(J),
-            J, J, J, J, J,
+            -J,
+            -J,
+            -J,
+            zero(J),
+            zero(J),
+            zero(J),
+            zero(J),
+            zero(J),
+            zero(J),
+            zero(J),
+            J,
+            J,
+            J,
+            J,
+            J,
         ])
     end
     return error(

--- a/src/models/quantum/Heisenberg.jl
+++ b/src/models/quantum/Heisenberg.jl
@@ -53,33 +53,41 @@ struct ExactSpectrum end
     fetch(::Heisenberg1D, ::ExactSpectrum; N, J=1.0) -> Vector{Float64}
 
 Return the sorted exact spectrum of the spin-1/2 Heisenberg Hamiltonian
-on an N-site cluster with a single nearest-neighbor bond per pair.
+on an N-site chain or ring with boundary condition `bc`.
 
-Currently only `N = 2` (the dimer) is implemented, with the
-closed-form spectrum
+# Supported cases
 
-    [-3J/4, J/4, J/4, J/4]
-
-corresponding to one singlet (S_tot = 0) and a three-fold degenerate
-triplet (S_tot = 1).
-
-Longer chains (4-site PBC with E₀ = −2J, etc.) are tracked as future
-additions in `dev/1_physical-verification/todo.md`.
+- **N=2, bc=:OBC** (dimer): `[-3J/4, J/4, J/4, J/4]`
+  (singlet E_s = -3J/4, triplet E_t = J/4, three-fold degenerate).
+- **N=4, bc=:PBC** (4-site ring): `[-2J, -J×3, 0×7, +J×5]`
+  Ground state E₀ = -2J (unique singlet). The ferromagnetic quintet
+  sits at E = +J. The full degeneracy structure is:
+  1 singlet + 1 triplet + (1 singlet + 2 triplets at E=0) + 1 quintet.
 
 # Arguments
-- `N::Int`: number of spin-1/2 sites (only `N = 2` supported for now)
+- `N::Int`: number of spin-1/2 sites
 - `J::Real`: Heisenberg coupling constant (default 1.0; J > 0 AFM)
+- `bc::Symbol`: boundary condition, `:OBC` (default) or `:PBC`
 
 # References
-    For the dimer derivation see any standard textbook, e.g.
     A. Auerbach, "Interacting Electrons and Quantum Magnetism" (1994), §2.
+    H. Bethe, Z. Physik 71, 205 (1931).
 """
-function fetch(::Heisenberg1D, ::ExactSpectrum; N::Int, J::Real=1.0)
-    if N == 2
+function fetch(::Heisenberg1D, ::ExactSpectrum; N::Int, J::Real=1.0, bc::Symbol=:OBC)
+    if N == 2 && bc == :OBC
         return sort([-3J / 4, J / 4, J / 4, J / 4])
+    elseif N == 4 && bc == :PBC
+        # Exact spectrum of the 4-site PBC Heisenberg ring H = J Σ S_i·S_{i+1}:
+        #   E = -2J ×1 (singlet), -J ×3 (triplet), 0 ×7, +J ×5 (quintet)
+        return sort([
+            -2J,
+            -J, -J, -J,
+            zero(J), zero(J), zero(J), zero(J), zero(J), zero(J), zero(J),
+            J, J, J, J, J,
+        ])
     end
     return error(
-        "Heisenberg1D exact spectrum: only N=2 (dimer) implemented; got N=$N. " *
-        "Longer chains are tracked in dev/1_physical-verification/todo.md.",
+        "Heisenberg1D exact spectrum: only (N=2, OBC) and (N=4, PBC) " *
+        "are implemented; got (N=$N, bc=$bc).",
     )
 end

--- a/test/verification/test_heisenberg_4site_pbc.jl
+++ b/test/verification/test_heisenberg_4site_pbc.jl
@@ -28,9 +28,7 @@ include("../util/spinhalf_ed.jl")
         for J in (1.0, 0.5, 2.0, -1.0)
             H = build_spinhalf_heisenberg(lat, J)
             λ_ed = sort(eigvals(Symmetric(H)))
-            λ_exact = QAtlas.fetch(
-                Heisenberg1D(), ExactSpectrum(); N=4, J=J, bc=:PBC
-            )
+            λ_exact = QAtlas.fetch(Heisenberg1D(), ExactSpectrum(); N=4, J=J, bc=:PBC)
             @test length(λ_ed) == 16
             @test length(λ_exact) == 16
             @test λ_ed ≈ λ_exact atol = 1e-12

--- a/test/verification/test_heisenberg_4site_pbc.jl
+++ b/test/verification/test_heisenberg_4site_pbc.jl
@@ -1,0 +1,80 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Verification: 4-site spin-1/2 Heisenberg ring (PBC)
+#
+# Build H = J Σ_{i mod 4} S_i · S_{i+1} via Lattice2D's 4-site PBC
+# square chain (build_lattice(Square, 4, 1; PeriodicAxis in x, OpenAxis
+# in y)) and compare the full 2^4 = 16-state spectrum against the
+# hardcoded exact result in src/models/quantum/Heisenberg.jl.
+#
+# Two independent construction paths cross-check each other:
+#   src:  hardcoded {-2J, -J×3, 0×7, +J×5} (from textbook / Bethe ansatz)
+#   test: Lattice2D bonds(lat) → build_spinhalf_heisenberg → eigvals
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Lattice2D, LinearAlgebra, Test
+
+include("../util/spinhalf_ed.jl")
+
+@testset "Heisenberg 4-site PBC — ED vs exact spectrum" begin
+    # 4-site PBC ring via Lattice2D: PBC in x, OBC in y (drops the
+    # (0,1) connection since Ly = 1).
+    lat = build_lattice(
+        Square, 4, 1; boundary=LatticeBoundary((PeriodicAxis(), OpenAxis()))
+    )
+    @test num_sites(lat) == 4
+    @test length(collect(bonds(lat))) == 4
+
+    @testset "Full spectrum for various J" begin
+        for J in (1.0, 0.5, 2.0, -1.0)
+            H = build_spinhalf_heisenberg(lat, J)
+            λ_ed = sort(eigvals(Symmetric(H)))
+            λ_exact = QAtlas.fetch(
+                Heisenberg1D(), ExactSpectrum(); N=4, J=J, bc=:PBC
+            )
+            @test length(λ_ed) == 16
+            @test length(λ_exact) == 16
+            @test λ_ed ≈ λ_exact atol = 1e-12
+        end
+    end
+
+    @testset "Ground state E_0 = -2J (unique singlet)" begin
+        for J in (1.0, 0.5, 3.7)
+            λ = QAtlas.fetch(Heisenberg1D(), ExactSpectrum(); N=4, J=J, bc=:PBC)
+            @test λ[1] ≈ -2J atol = 1e-12
+            @test λ[2] > λ[1] + 1e-10
+        end
+    end
+
+    @testset "Degeneracy structure" begin
+        λ = QAtlas.fetch(Heisenberg1D(), ExactSpectrum(); N=4, J=1.0, bc=:PBC)
+        @test count(x -> abs(x + 2.0) < 1e-10, λ) == 1   # singlet
+        @test count(x -> abs(x + 1.0) < 1e-10, λ) == 3   # triplet
+        @test count(x -> abs(x) < 1e-10, λ) == 7          # singlet + 2 triplets
+        @test count(x -> abs(x - 1.0) < 1e-10, λ) == 5   # quintet
+    end
+
+    @testset "Structural: tr H = 0 and Hermitian" begin
+        H = build_spinhalf_heisenberg(lat, 1.0)
+        @test tr(H) ≈ 0 atol = 1e-14
+        @test H ≈ H' atol = 1e-14
+    end
+
+    @testset "Quintet at E = J (ferromagnetic sector)" begin
+        # All spins up: ⟨↑↑↑↑|H|↑↑↑↑⟩ = J·4·(1/4) = J
+        # (4 bonds, each Sz·Sz = 1/4, ladder terms vanish)
+        H = build_spinhalf_heisenberg(lat, 1.0)
+        all_up = zeros(16)
+        all_up[1] = 1.0   # |↑↑↑↑⟩ in kron convention
+        @test (H * all_up) ≈ (1.0 * all_up) atol = 1e-14
+    end
+
+    @testset "E_0 per site approaches Bethe-ansatz limit" begin
+        # For 4-site PBC: E₀ / N = -2J / 4 = -0.5J
+        # Bethe ansatz (N → ∞): e₀ = (1/4 - ln 2)J ≈ -0.4431J
+        # 4-site overshoot is expected (finite-size effect).
+        λ = QAtlas.fetch(Heisenberg1D(), ExactSpectrum(); N=4, J=1.0, bc=:PBC)
+        e0_per_site = λ[1] / 4
+        @test e0_per_site < (0.25 - log(2))  # below Bethe ansatz
+        @test e0_per_site > -0.6              # not too far off
+    end
+end


### PR DESCRIPTION
## Summary

Stage C の続きで、4-site 1D Heisenberg PBC ring の exact spectrum verification を追加します。

- **\`src/models/quantum/Heisenberg.jl\` 拡張**: \`fetch\` に \`bc::Symbol = :OBC\` kwarg を追加。N=4, bc=:PBC で hardcoded spectrum \`[-2J, -J×3, 0×7, +J×5]\` を返す。独立な Kronecker-product ED で値を確認済。
- **\`test/verification/test_heisenberg_4site_pbc.jl\`**: \`build_lattice(Square, 4, 1; PBC in x, OBC in y)\` 上で \`build_spinhalf_heisenberg(lat, J)\` → \`eigvals\` の 16 固有値を hardcoded 値と \`atol=1e-12\` で照合
  - degeneracy 構造 \`1-3-7-5\` (singlet / triplet / {singlet+2triplets} / quintet)
  - 基底状態 \`E₀ = -2J\` の一意性  
  - quintet sector \`⟨↑↑↑↑|H|↑↑↑↑⟩ = J\` の直接 verify  
  - finite-size overshoot: \`E₀/N = -0.5J\` vs Bethe ansatz \`e_∞ ≈ -0.443J\`
  - \`tr H = 0\`, Hermitian check
- **\`Project.toml\`**: version 0.11.0 → 0.12.0

## Test plan

- [x] \`Pkg.test()\` で全 **561 tests 通過** (追加 29 tests)
- [x] J=1 で ground state \`E₀ = -2.0\` 確認
- [x] 既存 dimer test (N=2, OBC) は \`bc\` 省略可 (default :OBC) で不変