### PR TITLE
Generic Bloch TB builder: meta-verify all hardcoded formulas

### DIFF
--- a/test/util/bloch.jl
+++ b/test/util/bloch.jl
@@ -42,9 +42,7 @@ periodic topology that `Lattice2D` supports.
 # Return
 A sorted `Vector{Float64}` of length `n_sub · Lx · Ly`.
 """
-function bloch_tb_spectrum(
-    Topology::Type{<:AbstractTopology{2}}, Lx::Int, Ly::Int, t::Real
-)
+function bloch_tb_spectrum(Topology::Type{<:AbstractTopology{2}}, Lx::Int, Ly::Int, t::Real)
     uc = get_unit_cell(Topology)
     nsub = length(uc.sublattice_positions)
     eigs = Float64[]

--- a/test/util/bloch.jl
+++ b/test/util/bloch.jl
@@ -1,0 +1,68 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# test/util/bloch.jl
+#
+# Generic Bloch Hamiltonian builder for nearest-neighbor tight-binding
+# on any Lattice2D periodic topology.  Given a topology type (Square,
+# Honeycomb, Kagome, Lieb, Triangular, Dice, …) and a system size
+# (Lx, Ly), this util constructs the n_sub × n_sub Bloch Hamiltonian
+#
+#   H_{αβ}(k) = -t Σ_{connections c: β→α at offset (dx,dy)}  exp(i(dx θ₁ + dy θ₂))
+#             + h.c.
+#
+# at each of the Lx·Ly allowed k-points (θ₁ = 2π m/Lx, θ₂ = 2π n/Ly),
+# diagonalizes it, and returns the full sorted spectrum.
+#
+# This provides an INDEPENDENT cross-check of the hand-derived Bloch
+# formulas in src/models/quantum/tightbinding/*.jl: if the generic
+# builder agrees with the hardcoded formula, both are correct.
+#
+# Dependencies (expected to be `using`'d by the including test file):
+#   Lattice2D  — `get_unit_cell`, `Connection`, topology types
+#   LinearAlgebra — `eigvals`, `Hermitian`
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    bloch_tb_spectrum(Topology, Lx, Ly, t) -> Vector{Float64}
+
+Compute the sorted single-particle spectrum of the nearest-neighbor
+tight-binding Hamiltonian on an `Lx × Ly` periodic lattice of topology
+`Topology` by diagonalizing the `n_sub × n_sub` Bloch Hamiltonian at
+each allowed momentum.
+
+This function reads the unit-cell definition (sublattice positions,
+connection list) directly from `Lattice2D.get_unit_cell(Topology)` and
+requires no hand-derived formulas — it is fully generic over any 2D
+periodic topology that `Lattice2D` supports.
+
+# Arguments
+- `Topology`: a Lattice2D topology type (e.g., `Honeycomb`, `Kagome`)
+- `Lx::Int`, `Ly::Int`: number of unit cells in each direction
+- `t::Real`: nearest-neighbor hopping amplitude
+
+# Return
+A sorted `Vector{Float64}` of length `n_sub · Lx · Ly`.
+"""
+function bloch_tb_spectrum(
+    Topology::Type{<:AbstractTopology{2}}, Lx::Int, Ly::Int, t::Real
+)
+    uc = get_unit_cell(Topology)
+    nsub = length(uc.sublattice_positions)
+    eigs = Float64[]
+    sizehint!(eigs, nsub * Lx * Ly)
+
+    for m in 0:(Lx - 1), n in 0:(Ly - 1)
+        θ1 = 2π * m / Lx
+        θ2 = 2π * n / Ly
+
+        H = zeros(ComplexF64, nsub, nsub)
+        for c in uc.connections
+            phase = exp(im * (c.dx * θ1 + c.dy * θ2))
+            H[c.dst_sub, c.src_sub] -= t * phase
+            H[c.src_sub, c.dst_sub] -= t * conj(phase)
+        end
+
+        append!(eigs, eigvals(Hermitian(H)))
+    end
+
+    return sort!(eigs)
+end

--- a/test/verification/test_bloch_generic.jl
+++ b/test/verification/test_bloch_generic.jl
@@ -1,0 +1,78 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Meta-verification: generic Bloch builder vs hardcoded TB formulas
+#
+# For every tight-binding model in QAtlas/src/models/quantum/tightbinding/,
+# verify that the hand-derived closed-form Bloch spectrum matches the
+# generic `bloch_tb_spectrum` builder (which reads the unit cell
+# definition from `Lattice2D.get_unit_cell` and constructs H(k) with
+# no model-specific knowledge).
+#
+# If both agree, the hardcoded formulas are correct AND the generic
+# builder is correct — mutual cross-validation.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Lattice2D, LinearAlgebra, Test
+
+include("../util/bloch.jl")
+
+@testset "Generic Bloch TB vs hardcoded formulas" begin
+    test_sizes = [(3, 3), (3, 4), (4, 4)]
+
+    @testset "Honeycomb (Graphene)" begin
+        for (Lx, Ly) in test_sizes
+            λ_generic = bloch_tb_spectrum(Honeycomb, Lx, Ly, 1.0)
+            λ_atlas = QAtlas.fetch(
+                Graphene(), TightBindingSpectrum(); Lx=Lx, Ly=Ly, t=1.0
+            )
+            @test λ_generic ≈ λ_atlas atol = 1e-10
+        end
+    end
+
+    @testset "Kagome" begin
+        for (Lx, Ly) in test_sizes
+            λ_generic = bloch_tb_spectrum(Kagome, Lx, Ly, 1.0)
+            λ_atlas = QAtlas.fetch(
+                QAtlas.Kagome(), TightBindingSpectrum(); Lx=Lx, Ly=Ly, t=1.0
+            )
+            @test λ_generic ≈ λ_atlas atol = 1e-10
+        end
+    end
+
+    @testset "Lieb" begin
+        for (Lx, Ly) in test_sizes
+            λ_generic = bloch_tb_spectrum(Lieb, Lx, Ly, 1.0)
+            λ_atlas = QAtlas.fetch(
+                QAtlas.Lieb(), TightBindingSpectrum(); Lx=Lx, Ly=Ly, t=1.0
+            )
+            @test λ_generic ≈ λ_atlas atol = 1e-10
+        end
+    end
+
+    @testset "Triangular" begin
+        for (Lx, Ly) in test_sizes
+            λ_generic = bloch_tb_spectrum(Triangular, Lx, Ly, 1.0)
+            λ_atlas = QAtlas.fetch(
+                QAtlas.Triangular(), TightBindingSpectrum(); Lx=Lx, Ly=Ly, t=1.0
+            )
+            @test λ_generic ≈ λ_atlas atol = 1e-10
+        end
+    end
+
+    @testset "Generic builder = real-space ED (honeycomb sanity)" begin
+        # Triple cross-check: generic Bloch = hardcoded Bloch = real-space ED
+        include("../util/tight_binding.jl")
+        lat = build_lattice(Honeycomb, 3, 3)
+        H = build_tight_binding(lat, 1.0)
+        λ_real = sort(eigvals(Symmetric(H)))
+        λ_generic = bloch_tb_spectrum(Honeycomb, 3, 3, 1.0)
+        @test λ_real ≈ λ_generic atol = 1e-10
+    end
+
+    @testset "t scaling (generic builder)" begin
+        for t in (0.5, 2.0, 3.7)
+            λ1 = bloch_tb_spectrum(Kagome, 3, 3, 1.0)
+            λt = bloch_tb_spectrum(Kagome, 3, 3, t)
+            @test λt ≈ t .* λ1 rtol = 1e-12
+        end
+    end
+end

--- a/test/verification/test_bloch_generic.jl
+++ b/test/verification/test_bloch_generic.jl
@@ -21,9 +21,7 @@ include("../util/bloch.jl")
     @testset "Honeycomb (Graphene)" begin
         for (Lx, Ly) in test_sizes
             λ_generic = bloch_tb_spectrum(Honeycomb, Lx, Ly, 1.0)
-            λ_atlas = QAtlas.fetch(
-                Graphene(), TightBindingSpectrum(); Lx=Lx, Ly=Ly, t=1.0
-            )
+            λ_atlas = QAtlas.fetch(Graphene(), TightBindingSpectrum(); Lx=Lx, Ly=Ly, t=1.0)
             @test λ_generic ≈ λ_atlas atol = 1e-10
         end
     end


### PR DESCRIPTION
## Summary

Stage D の入口: Lattice2D の unit cell 定義から自動的に Bloch Hamiltonian を構築する generic util を追加し、これまでの 4 つの hardcoded TB モデル全てを一括 meta-verify します。

### \`test/util/bloch.jl\` — generic builder

\`\`\`julia
bloch_tb_spectrum(Topology, Lx, Ly, t) -> Vector{Float64}
\`\`\`

\`get_unit_cell(Topology)\` から connection list を読み、各 allowed k-point で n_sub × n_sub の Bloch Hamiltonian

\`\`\`
H_{αβ}(k) = -t Σ_{connections β→α} exp(i(dx θ₁ + dy θ₂)) + h.c.
\`\`\`

を構築 → \`eigvals(Hermitian(H))\` → sorted spectrum。**model-specific 知識ゼロ**: Lattice2D が提供する任意の topology で動きます。

### \`test/verification/test_bloch_generic.jl\` — meta-verification

4 つの hardcoded formula (\`Graphene\`, \`Kagome\`, \`Lieb\`, \`Triangular\`) と generic builder の spectrum が完全一致 (\`atol=1e-10\`) することを 3×3 / 3×4 / 4×4 で検証。さらに:

- **Triple cross-check**: generic Bloch = hardcoded Bloch = real-space ED (3×3 honeycomb)
- \`t\` scaling

Generic builder が正しい ⟹ hardcoded formulas も正しい (mutual cross-validation)。

### 今後の活用

この util で Lattice2D がサポートする **全格子** (Dice, UnionJack, ShastrySutherland, …) の TB spectrum が hardcode なしで出せるようになったので、新しい格子の verification は「generic builder の呼び出し + structural check」だけで済みます。

## Test plan

- [x] \`Pkg.test()\` で全 **607 tests 通過** (追加 16 tests)
- [x] 4 models × 3 sizes = 12 組で generic = hardcoded 完全一致
- [x] Triple cross-check (generic = hardcoded = real-space ED) on 3×3 honeycomb