### PR TITLE
Complete all 8 Lattice2D topologies: UnionJack + ShastrySutherland

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/test/verification/test_shastry_sutherland_tight_binding.jl
+++ b/test/verification/test_shastry_sutherland_tight_binding.jl
@@ -1,0 +1,47 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Verification: NN tight-binding on the Shastry–Sutherland lattice
+#
+# Four sublattices per unit cell (square + dimer bonds). The unit cell
+# has two bond types (type 1 = NN square, type 2 = dimer diagonal), but
+# the generic builder treats all bonds with uniform hopping -t.
+#
+# The Shastry–Sutherland lattice is famous for its orthogonal-dimer
+# structure; its tight-binding spectrum reflects the interplay between
+# square-lattice connectivity and extra dimer hoppings.
+#
+# Zero src code — generic bloch_tb_spectrum only.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Lattice2D, LinearAlgebra, Test
+
+include("../util/bloch.jl")
+include("../util/tight_binding.jl")
+
+const T_HOP = 1.0
+
+@testset "ShastrySutherland TB — generic Bloch vs real-space ED" begin
+    for (Lx, Ly) in [(2, 2), (3, 3), (3, 4), (4, 4)]
+        lat = build_lattice(ShastrySutherland, Lx, Ly)
+
+        @testset "$(Lx)×$(Ly) SS PBC" begin
+            H = build_tight_binding(lat, T_HOP)
+            λ_real = sort(eigvals(Symmetric(H)))
+            λ_bloch = bloch_tb_spectrum(ShastrySutherland, Lx, Ly, T_HOP)
+
+            @test length(λ_real) == 4 * Lx * Ly
+            @test length(λ_bloch) == 4 * Lx * Ly
+            @test λ_real ≈ λ_bloch atol = 1e-10
+
+            # Structural: tr H = 0 (NN TB, no on-site)
+            @test tr(H) ≈ 0 atol = 1e-10
+        end
+    end
+
+    @testset "t scaling" begin
+        λ1 = bloch_tb_spectrum(ShastrySutherland, 3, 3, 1.0)
+        for t in (0.5, 2.0)
+            λt = bloch_tb_spectrum(ShastrySutherland, 3, 3, t)
+            @test λt ≈ t .* λ1 rtol = 1e-12
+        end
+    end
+end

--- a/test/verification/test_unionjack_tight_binding.jl
+++ b/test/verification/test_unionjack_tight_binding.jl
@@ -1,0 +1,46 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Verification: NN tight-binding on the Union Jack (centred square) lattice
+#
+# Two sublattices: A (corner, 8-coordinated) and B (body-centre,
+# 4-coordinated). A–A square-lattice bonds exist → NOT bipartite → no
+# chiral symmetry and no flat-band guarantee.
+#
+# Zero src code — generic bloch_tb_spectrum only.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Lattice2D, LinearAlgebra, Test
+
+include("../util/bloch.jl")
+include("../util/tight_binding.jl")
+
+const T_HOP = 1.0
+
+@testset "UnionJack TB — generic Bloch vs real-space ED" begin
+    for (Lx, Ly) in [(3, 3), (3, 4), (4, 4)]
+        lat = build_lattice(UnionJack, Lx, Ly)
+
+        @testset "$(Lx)×$(Ly) UnionJack PBC" begin
+            H = build_tight_binding(lat, T_HOP)
+            λ_real = sort(eigvals(Symmetric(H)))
+            λ_bloch = bloch_tb_spectrum(UnionJack, Lx, Ly, T_HOP)
+
+            @test length(λ_real) == 2 * Lx * Ly
+            @test length(λ_bloch) == 2 * Lx * Ly
+            @test λ_real ≈ λ_bloch atol = 1e-10
+
+            # Structural: tr H = 0 (NN TB)
+            @test tr(H) ≈ 0 atol = 1e-10
+
+            # NOT bipartite: spectrum is NOT symmetric about zero
+            @test !(sort(λ_real) ≈ sort(-λ_real))
+        end
+    end
+
+    @testset "t scaling" begin
+        λ1 = bloch_tb_spectrum(UnionJack, 3, 3, 1.0)
+        for t in (0.5, 2.0)
+            λt = bloch_tb_spectrum(UnionJack, 3, 3, t)
+            @test λt ≈ t .* λ1 rtol = 1e-12
+        end
+    end
+end


### PR DESCRIPTION
## Summary

Lattice2D がサポートする **全 8 格子の TB verification が完了**しました。本 PR で UnionJack と ShastrySutherland を追加 (generic builder、src コードゼロ)。

### 全格子の verification status

| # | Topology | sublattices | bipartite | flat band | method | PR |
|---|----------|-------------|-----------|-----------|--------|-----|
| 1 | Square | 1 | ✓ | — | IsingSquare (classical) | #14 |
| 2 | Honeycomb | 2 | ✓ | — | Graphene (hardcoded Bloch) | #16 |
| 3 | Kagome | 3 | — | +2t | hardcoded Bloch | #18 |
| 4 | Lieb | 3 | ✓ | E=0 | hardcoded Bloch | #19 |
| 5 | Triangular | 1 | — | — | hardcoded Bloch | #20 |
| 6 | Dice | 3 | ✓ | E=0 | generic builder | #24 |
| 7 | **UnionJack** | 2 | **✗** | — | generic builder | **#25** |
| 8 | **ShastrySutherland** | 4 | — | — | generic builder | **#25** |

全格子で **generic Bloch = real-space ED** が \`atol=1e-10\` で一致。

### 物理的特徴

- **UnionJack**: A-A 結合 (square lattice bonds on corners) が存在するため **non-bipartite** → chiral 対称性なし (テストで明示的に確認)
- **ShastrySutherland**: NN (type 1) + dimer (type 2) の 2 種結合。uniform-t TB として検証。物理的な frustration (J ≠ J') は将来の拡張

## Test plan

- [x] \`Pkg.test()\` で全 **672 tests 通過** (追加 35 tests)
- [x] 全 8 格子で generic Bloch = real-space ED