### PR TITLE
Onsager T_c, Yang M(T), and universality class exponents

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.12.2"
+version = "0.12.3"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -6,7 +6,7 @@ export AbstractQuantity, Quantity
 export fetch
 
 # --- Classical Models ---
-export IsingSquare, PartitionFunction
+export IsingSquare, PartitionFunction, CriticalTemperature, SpontaneousMagnetization
 
 # --- Quantum Models ---
 export Graphene, TightBindingSpectrum
@@ -22,7 +22,11 @@ include("core/type.jl")
 include("core/pfaffian.jl")
 
 # --- Universality Classes ---
+export Ising2D, KPZ1D, MeanField, CriticalExponents
 include("universalities/E8.jl")
+include("universalities/Ising2D.jl")
+include("universalities/KPZ.jl")
+include("universalities/MeanField.jl")
 
 # --- Models ---
 include("models/TFIM.jl")

--- a/src/models/classical/IsingSquare.jl
+++ b/src/models/classical/IsingSquare.jl
@@ -156,3 +156,80 @@ function fetch(::IsingSquare, ::PartitionFunction; Lx::Int, Ly::Int, β::Real, J
     T = _ising_sq_transfer_matrix(Ly, β, J)
     return tr(T^Lx)
 end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Dispatch tags: Onsager + Yang exact results
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    CriticalTemperature
+
+Dispatch tag for the exact critical temperature of a classical model.
+"""
+struct CriticalTemperature end
+
+"""
+    SpontaneousMagnetization
+
+Dispatch tag for the spontaneous magnetization of a classical model
+as a function of temperature.
+"""
+struct SpontaneousMagnetization end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# fetch: Onsager critical temperature
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    fetch(::IsingSquare, ::CriticalTemperature; J=1.0) -> Float64
+
+Exact critical temperature of the 2D Ising model on the square lattice:
+
+    T_c = 2J / ln(1 + √2) ≈ 2.269 J
+
+Equivalently, the critical reduced coupling is K_c = J/T_c = ln(1+√2)/2,
+or sinh(2K_c) = 1.
+
+# References
+    L. Onsager, "Crystal Statistics. I.", Phys. Rev. 65, 117 (1944).
+"""
+function fetch(::IsingSquare, ::CriticalTemperature; J::Real=1.0)
+    return 2J / log(1 + sqrt(2))
+end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# fetch: Yang spontaneous magnetization
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    fetch(::IsingSquare, ::SpontaneousMagnetization; β, J=1.0) -> Float64
+
+Exact spontaneous magnetization of the 2D Ising model on the infinite
+square lattice:
+
+    M(T) = (1 − sinh⁻⁴(2βJ))^{1/8}    for T < T_c  (i.e. sinh(2βJ) > 1)
+    M(T) = 0                            for T ≥ T_c
+
+The critical exponent β = 1/8 is visible in the approach M → 0 as
+T → T_c⁻.
+
+Special values:
+- T = 0 (β → ∞): M = 1 (fully ordered)
+- T = T_c: M = 0 (onset of disorder)
+
+# Arguments
+- `β::Real`: inverse temperature (β = 1/(k_B T))
+- `J::Real`: Ising coupling constant (default 1.0; J > 0 ferromagnetic)
+
+# References
+    C. N. Yang, "The spontaneous magnetization of a two-dimensional Ising
+    model", Phys. Rev. 85, 808 (1952).
+"""
+function fetch(::IsingSquare, ::SpontaneousMagnetization; β::Real, J::Real=1.0)
+    s = sinh(2 * β * J)
+    if s <= 1.0  # T ≥ T_c
+        return 0.0
+    else
+        return (1 - s^(-4))^(1 / 8)
+    end
+end

--- a/src/universalities/Ising2D.jl
+++ b/src/universalities/Ising2D.jl
@@ -1,0 +1,67 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# 2D Ising universality class — exact critical exponents
+#
+# The 2D Ising model is the archetype of a second-order phase transition
+# in two dimensions. Its universality class is characterized by the
+# Virasoro minimal model M(3,4) with central charge c = 1/2.
+#
+# All critical exponents are known exactly (rational numbers).
+#
+# References:
+#   L. Onsager, Phys. Rev. 65, 117 (1944).
+#   C. N. Yang, Phys. Rev. 85, 808 (1952).
+#   A. A. Belavin, A. M. Polyakov, A. B. Zamolodchikov,
+#     Nucl. Phys. B 241, 333 (1984) — conformal field theory.
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    Ising2D
+
+Dispatch tag for the 2D Ising universality class.
+
+Central charge c = 1/2 (Virasoro minimal model M(3,4)).
+Applies to: 2D classical Ising model, 1+1D TFIM at criticality,
+and any system in the same universality class.
+"""
+struct Ising2D end
+
+"""
+    CriticalExponents
+
+Dispatch tag for the set of critical exponents of a universality class.
+Returns a `NamedTuple` of exact values (typically `Rational{Int}`).
+"""
+struct CriticalExponents end
+
+"""
+    fetch(::Ising2D, ::CriticalExponents) -> NamedTuple
+
+Exact critical exponents of the 2D Ising universality class:
+
+| Symbol | Value | Physical meaning                              |
+|--------|-------|-----------------------------------------------|
+| β      | 1/8   | Order parameter: M ∼ (T_c − T)^β             |
+| ν      | 1     | Correlation length: ξ ∼ |T − T_c|^{−ν}       |
+| γ      | 7/4   | Susceptibility: χ ∼ |T − T_c|^{−γ}           |
+| η      | 1/4   | Anomalous dimension: G(r) ∼ r^{−(d−2+η)}     |
+| δ      | 15    | Critical isotherm: M ∼ h^{1/δ} at T = T_c    |
+| α      | 0     | Specific heat: C ∼ ln|T − T_c| (logarithmic) |
+| c      | 1/2   | Central charge (CFT)                          |
+
+All values are `Rational{Int}` for exact representation.
+
+# References
+    A. A. Belavin, A. M. Polyakov, A. B. Zamolodchikov,
+      Nucl. Phys. B 241, 333 (1984).
+"""
+function fetch(::Ising2D, ::CriticalExponents; kwargs...)
+    return (
+        β=1 // 8,    # order parameter exponent
+        ν=1 // 1,    # correlation length exponent
+        γ=7 // 4,    # susceptibility exponent
+        η=1 // 4,    # anomalous dimension
+        δ=15 // 1,   # critical isotherm exponent
+        α=0 // 1,    # specific heat (logarithmic divergence)
+        c=1 // 2,    # central charge
+    )
+end

--- a/src/universalities/KPZ.jl
+++ b/src/universalities/KPZ.jl
@@ -1,0 +1,58 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# KPZ (Kardar–Parisi–Zhang) universality class — exact scaling exponents
+#
+# The KPZ equation describes the nonequilibrium growth of interfaces:
+#
+#   ∂h/∂t = ν ∇²h + (λ/2)(∇h)² + η(x,t)
+#
+# In 1+1 dimensions all three scaling exponents are known exactly
+# (rigorous, not conjectured) from the connection to directed polymers
+# and the replica method.
+#
+# References:
+#   M. Kardar, G. Parisi, Y.-C. Zhang, "Dynamic Scaling of Growing
+#     Interfaces", Phys. Rev. Lett. 56, 889 (1986).
+#   M. Prähofer, H. Spohn, "Exact Scaling Functions for One-Dimensional
+#     Stationary KPZ Growth", J. Stat. Phys. 115, 255 (2004) — exact
+#     scaling function via Tracy–Widom distribution.
+#   T. Sasamoto, H. Spohn, "Exact height distributions for the KPZ
+#     equation with narrow wedge initial condition",
+#     Nucl. Phys. B 834, 523 (2010).
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    KPZ1D
+
+Dispatch tag for the KPZ universality class in 1+1 dimensions.
+
+The 1+1D KPZ equation has exact scaling exponents connected via
+the Galilean invariance relation α + z = 2 and the scaling relation
+β = α / z.
+"""
+struct KPZ1D end
+
+"""
+    fetch(::KPZ1D, ::CriticalExponents) -> NamedTuple
+
+Exact scaling exponents of the 1+1D KPZ universality class:
+
+| Symbol    | Value | Physical meaning                           |
+|-----------|-------|--------------------------------------------|
+| β_growth  | 1/3   | Growth: width ∼ t^{β}                      |
+| α_rough   | 1/2   | Roughness: width ∼ L^{α} (saturated)       |
+| z         | 3/2   | Dynamic: t_sat ∼ L^{z}                     |
+
+Scaling relations: α + z = 2 (Galilean invariance), β = α / z.
+
+All values are `Rational{Int}` for exact representation.
+
+# References
+    M. Kardar, G. Parisi, Y.-C. Zhang, Phys. Rev. Lett. 56, 889 (1986).
+"""
+function fetch(::KPZ1D, ::CriticalExponents; kwargs...)
+    return (
+        β_growth=1 // 3,   # growth exponent (width ~ t^β)
+        α_rough=1 // 2,    # roughness exponent (width ~ L^α)
+        z=3 // 2,          # dynamic exponent (t_sat ~ L^z)
+    )
+end

--- a/src/universalities/MeanField.jl
+++ b/src/universalities/MeanField.jl
@@ -1,0 +1,57 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Mean-field (Landau) universality class — exact critical exponents
+#
+# Mean-field exponents are the baseline reference for all universality
+# classes. They are exact above the upper critical dimension d_c (= 4
+# for standard Ising-like transitions) and serve as the starting point
+# for ε-expansion (d = d_c − ε) corrections.
+#
+# References:
+#   L. D. Landau, "On the theory of phase transitions",
+#     Zh. Eksp. Teor. Fiz. 7, 19 (1937).
+#   J. Zinn-Justin, "Quantum Field Theory and Critical Phenomena",
+#     Oxford University Press (2002), Ch. 23.
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    MeanField
+
+Dispatch tag for the mean-field (Landau) universality class.
+
+These exponents are exact for spatial dimension d ≥ 4 (the upper
+critical dimension for Ising-like transitions). Below d = 4, critical
+fluctuations renormalize the exponents (see `Ising2D` for d = 2).
+"""
+struct MeanField end
+
+"""
+    fetch(::MeanField, ::CriticalExponents) -> NamedTuple
+
+Exact critical exponents of the mean-field universality class:
+
+| Symbol | Value | Physical meaning                              |
+|--------|-------|-----------------------------------------------|
+| β      | 1/2   | Order parameter: M ∼ (T_c − T)^β             |
+| ν      | 1/2   | Correlation length: ξ ∼ |T − T_c|^{−ν}       |
+| γ      | 1     | Susceptibility: χ ∼ |T − T_c|^{−γ}           |
+| η      | 0     | Anomalous dimension: G(r) ∼ r^{−(d−2+η)}     |
+| δ      | 3     | Critical isotherm: M ∼ h^{1/δ} at T = T_c    |
+| α      | 0     | Specific heat: discontinuity (step function)  |
+
+All values are `Rational{Int}` for exact representation.
+Satisfies the standard scaling relations:
+  α + 2β + γ = 2,   γ = β(δ−1),   γ = ν(2−η).
+
+# References
+    L. D. Landau, Zh. Eksp. Teor. Fiz. 7, 19 (1937).
+"""
+function fetch(::MeanField, ::CriticalExponents; kwargs...)
+    return (
+        β=1 // 2,    # order parameter exponent
+        ν=1 // 2,    # correlation length exponent
+        γ=1 // 1,    # susceptibility exponent
+        η=0 // 1,    # anomalous dimension
+        δ=3 // 1,    # critical isotherm exponent
+        α=0 // 1,    # specific heat (discontinuity)
+    )
+end

--- a/test/standalone/test_ising_onsager_yang.jl
+++ b/test/standalone/test_ising_onsager_yang.jl
@@ -1,0 +1,77 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Standalone test: Onsager critical temperature + Yang magnetization
+#
+# Lattice-independent checks of the closed-form IsingSquare results.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Test
+
+@testset "IsingSquare — Onsager T_c" begin
+    Tc = QAtlas.fetch(IsingSquare(), CriticalTemperature())
+    @test Tc ≈ 2 / log(1 + sqrt(2)) atol = 1e-14
+    @test Tc ≈ 2.269185314213022 atol = 1e-10  # known numerical value
+
+    # J scaling: T_c(J) = J · T_c(1)
+    for J in (0.5, 2.0, 3.7)
+        @test QAtlas.fetch(IsingSquare(), CriticalTemperature(); J=J) ≈ J * Tc rtol = 1e-14
+    end
+
+    # Relation to sinh: at T_c, sinh(2J/T_c) = 1
+    β_c = 1 / Tc
+    @test sinh(2 * β_c) ≈ 1.0 atol = 1e-14
+end
+
+@testset "IsingSquare — Yang spontaneous magnetization" begin
+    Tc = QAtlas.fetch(IsingSquare(), CriticalTemperature())
+    β_c = 1 / Tc
+
+    @testset "Special values" begin
+        # T = 0 (β → ∞): M = 1 (fully ordered)
+        @test QAtlas.fetch(IsingSquare(), SpontaneousMagnetization(); β=1000.0) ≈ 1.0 atol =
+            1e-10
+
+        # T = T_c: M = 0
+        @test QAtlas.fetch(IsingSquare(), SpontaneousMagnetization(); β=β_c) == 0.0
+
+        # T > T_c: M = 0
+        @test QAtlas.fetch(IsingSquare(), SpontaneousMagnetization(); β=β_c * 0.5) == 0.0
+
+        # T slightly below T_c: M is positive (but NOT small — the exponent
+        # β = 1/8 is so small that M ~ (1 - T/T_c)^{1/8} ≈ 0.01^{1/8} ≈ 0.7
+        # even at 1% below T_c). Just verify positivity and < 1.
+        M_near = QAtlas.fetch(IsingSquare(), SpontaneousMagnetization(); β=β_c * 1.01)
+        @test 0 < M_near < 1
+    end
+
+    @testset "M is monotonically increasing as T → 0 (β increasing)" begin
+        betas = [β_c * 1.1, β_c * 1.5, β_c * 2, β_c * 5, β_c * 20]
+        Ms = [QAtlas.fetch(IsingSquare(), SpontaneousMagnetization(); β=β) for β in betas]
+        for k in 1:(length(Ms) - 1)
+            @test Ms[k] < Ms[k + 1]
+        end
+    end
+
+    @testset "Critical exponent β = 1/8 near T_c" begin
+        # M ~ (T_c - T)^{1/8} as T → T_c⁻
+        # log M / log(T_c - T) → 1/8
+        # Test at two temperatures near T_c
+        δT1 = 0.001
+        δT2 = 0.01
+        T1 = Tc - δT1
+        T2 = Tc - δT2
+        M1 = QAtlas.fetch(IsingSquare(), SpontaneousMagnetization(); β=1 / T1)
+        M2 = QAtlas.fetch(IsingSquare(), SpontaneousMagnetization(); β=1 / T2)
+        # Effective exponent: log(M1/M2) / log(δT1/δT2) ≈ β = 1/8
+        β_eff = log(M1 / M2) / log(δT1 / δT2)
+        @test β_eff ≈ 1 / 8 rtol = 0.05  # within 5% of exact
+    end
+
+    @testset "J scaling" begin
+        β = 0.5
+        M1 = QAtlas.fetch(IsingSquare(), SpontaneousMagnetization(); β=β, J=1.0)
+        # M(β, J) = M(βJ=const), so M(β=0.5, J=2) = M(β=1, J=1)
+        M2 = QAtlas.fetch(IsingSquare(), SpontaneousMagnetization(); β=1.0, J=1.0)
+        M_scaled = QAtlas.fetch(IsingSquare(), SpontaneousMagnetization(); β=0.5, J=2.0)
+        @test M_scaled ≈ M2 atol = 1e-14
+    end
+end

--- a/test/standalone/test_universality_exponents.jl
+++ b/test/standalone/test_universality_exponents.jl
@@ -1,0 +1,55 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Standalone test: universality class critical exponents
+#
+# Verify exact (rational) exponents for each universality class and
+# check standard scaling relations between them.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Test
+
+@testset "Universality: 2D Ising critical exponents" begin
+    e = QAtlas.fetch(Ising2D(), CriticalExponents())
+
+    # Exact rational values
+    @test e.β == 1 // 8
+    @test e.ν == 1 // 1
+    @test e.γ == 7 // 4
+    @test e.η == 1 // 4
+    @test e.δ == 15 // 1
+    @test e.α == 0 // 1
+    @test e.c == 1 // 2
+
+    # Standard scaling relations (must hold exactly for rational exponents)
+    @test e.α + 2 * e.β + e.γ == 2               # Rushbrooke
+    @test e.γ == e.β * (e.δ - 1)                  # Widom
+    @test e.γ == e.ν * (2 - e.η)                  # Fisher
+    @test 2 - e.α == 2 * e.ν                      # Josephson (d=2: dν = 2-α)
+end
+
+@testset "Universality: KPZ 1+1D scaling exponents" begin
+    e = QAtlas.fetch(KPZ1D(), CriticalExponents())
+
+    @test e.β_growth == 1 // 3
+    @test e.α_rough == 1 // 2
+    @test e.z == 3 // 2
+
+    # KPZ scaling relations
+    @test e.α_rough + e.z == 2                    # Galilean invariance
+    @test e.β_growth == e.α_rough / e.z           # β = α / z
+end
+
+@testset "Universality: Mean-field critical exponents" begin
+    e = QAtlas.fetch(MeanField(), CriticalExponents())
+
+    @test e.β == 1 // 2
+    @test e.ν == 1 // 2
+    @test e.γ == 1 // 1
+    @test e.η == 0 // 1
+    @test e.δ == 3 // 1
+    @test e.α == 0 // 1
+
+    # Scaling relations (hold at mean-field level)
+    @test e.α + 2 * e.β + e.γ == 2               # Rushbrooke
+    @test e.γ == e.β * (e.δ - 1)                  # Widom
+    @test e.γ == e.ν * (2 - e.η)                  # Fisher
+end


### PR DESCRIPTION
## Summary

QAtlas の「rigorous results 辞書」をスペクトル計算だけでなく、統計物理の iconic な厳密解にまで拡張します。

### Model-specific: IsingSquare

- **\`CriticalTemperature\`**: \`T_c = 2J / ln(1 + √2)\` (Onsager 1944)
  - \`sinh(2β_c J) = 1\` の恒等式もテストで verify
- **\`SpontaneousMagnetization\`**: Yang (1952) の閉形式
  - \`M(T) = (1 − sinh⁻⁴(2βJ))^{1/8}\` for T < T_c
  - Critical exponent β = 1/8: log-log slope で抽出し 5% 以内で一致を確認

### Universality classes (新規 3 ファイル)

| class | file | exponents | key |
|-------|------|-----------|-----|
| **2D Ising** | \`Ising2D.jl\` | β=1/8, ν=1, γ=7/4, η=1/4, δ=15, c=1/2 | Belavin-Polyakov-Zamolodchikov CFT |
| **KPZ 1+1D** | \`KPZ.jl\` | β=1/3, α=1/2, z=3/2 | Tracy-Widom / directed polymer |
| **Mean-field** | \`MeanField.jl\` | β=1/2, ν=1/2, γ=1, η=0, δ=3 | Landau d≥4 baseline |

全て \`Rational{Int}\` で格納 → **scaling relations を exact arithmetic で verify** (Rushbrooke α+2β+γ=2、Widom γ=β(δ−1)、Fisher γ=ν(2−η)、KPZ の Galilean invariance α+z=2)。

## Test plan

- [x] \`Pkg.test()\` で全 **713 tests 通過** (追加 41 tests)
- [x] T_c numerical value \`≈ 2.2692\` pin
- [x] Yang M: special values + monotonicity + β=1/8 extraction
- [x] 3 universality classes × scaling relations = exact algebraic verification