### PR TITLE
Universality{C} framework: 7 classes × multiple dimensions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.12.3"
+version = "0.12.4"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -22,11 +22,16 @@ include("core/type.jl")
 include("core/pfaffian.jl")
 
 # --- Universality Classes ---
-export Ising2D, KPZ1D, MeanField, CriticalExponents
+export Universality, CriticalExponents, GrowthExponents
+export Ising2D, KPZ1D, MeanField  # backward-compatible aliases
+include("universalities/Universality.jl")
 include("universalities/E8.jl")
+include("universalities/MeanField.jl")
 include("universalities/Ising2D.jl")
 include("universalities/KPZ.jl")
-include("universalities/MeanField.jl")
+include("universalities/Percolation.jl")
+include("universalities/Potts.jl")
+include("universalities/ONModel.jl")
 
 # --- Models ---
 include("models/TFIM.jl")

--- a/src/universalities/Ising2D.jl
+++ b/src/universalities/Ising2D.jl
@@ -32,15 +32,7 @@ Critical exponents of the Ising universality class (Z₂ symmetry).
 """
 function fetch(::Universality{:Ising}, ::CriticalExponents; d::Int, kwargs...)
     if d == 2
-        return (
-            α=0 // 1,
-            β=1 // 8,
-            γ=7 // 4,
-            δ=15 // 1,
-            ν=1 // 1,
-            η=1 // 4,
-            c=1 // 2,
-        )
+        return (α=0 // 1, β=1 // 8, γ=7 // 4, δ=15 // 1, ν=1 // 1, η=1 // 4, c=1 // 2)
     elseif d == 3
         # Conformal bootstrap: Kos, Poland, Simmons-Duffin, Vichi (2016)
         return (

--- a/src/universalities/Ising2D.jl
+++ b/src/universalities/Ising2D.jl
@@ -1,67 +1,64 @@
 # ─────────────────────────────────────────────────────────────────────────────
-# 2D Ising universality class — exact critical exponents
-#
-# The 2D Ising model is the archetype of a second-order phase transition
-# in two dimensions. Its universality class is characterized by the
-# Virasoro minimal model M(3,4) with central charge c = 1/2.
-#
-# All critical exponents are known exactly (rational numbers).
+# Ising universality class — exact (d=2) and numerical (d=3) exponents
 #
 # References:
-#   L. Onsager, Phys. Rev. 65, 117 (1944).
-#   C. N. Yang, Phys. Rev. 85, 808 (1952).
-#   A. A. Belavin, A. M. Polyakov, A. B. Zamolodchikov,
-#     Nucl. Phys. B 241, 333 (1984) — conformal field theory.
+#   d=2: Belavin, Polyakov, Zamolodchikov, Nucl. Phys. B 241, 333 (1984).
+#   d=3: Kos, Poland, Simmons-Duffin, Vichi, JHEP 08, 036 (2016)
+#         — conformal bootstrap bounds.
 # ─────────────────────────────────────────────────────────────────────────────
 
-"""
-    Ising2D
-
-Dispatch tag for the 2D Ising universality class.
-
-Central charge c = 1/2 (Virasoro minimal model M(3,4)).
-Applies to: 2D classical Ising model, 1+1D TFIM at criticality,
-and any system in the same universality class.
-"""
+# Backward-compatible alias — delegates to Universality{:Ising} with d=2
 struct Ising2D end
-
-"""
-    CriticalExponents
-
-Dispatch tag for the set of critical exponents of a universality class.
-Returns a `NamedTuple` of exact values (typically `Rational{Int}`).
-"""
-struct CriticalExponents end
 
 """
     fetch(::Ising2D, ::CriticalExponents) -> NamedTuple
 
-Exact critical exponents of the 2D Ising universality class:
-
-| Symbol | Value | Physical meaning                              |
-|--------|-------|-----------------------------------------------|
-| β      | 1/8   | Order parameter: M ∼ (T_c − T)^β             |
-| ν      | 1     | Correlation length: ξ ∼ |T − T_c|^{−ν}       |
-| γ      | 7/4   | Susceptibility: χ ∼ |T − T_c|^{−γ}           |
-| η      | 1/4   | Anomalous dimension: G(r) ∼ r^{−(d−2+η)}     |
-| δ      | 15    | Critical isotherm: M ∼ h^{1/δ} at T = T_c    |
-| α      | 0     | Specific heat: C ∼ ln|T − T_c| (logarithmic) |
-| c      | 1/2   | Central charge (CFT)                          |
-
-All values are `Rational{Int}` for exact representation.
-
-# References
-    A. A. Belavin, A. M. Polyakov, A. B. Zamolodchikov,
-      Nucl. Phys. B 241, 333 (1984).
+Backward-compatible alias for `fetch(Universality(:Ising), CriticalExponents(); d=2)`.
 """
 function fetch(::Ising2D, ::CriticalExponents; kwargs...)
-    return (
-        β=1 // 8,    # order parameter exponent
-        ν=1 // 1,    # correlation length exponent
-        γ=7 // 4,    # susceptibility exponent
-        η=1 // 4,    # anomalous dimension
-        δ=15 // 1,   # critical isotherm exponent
-        α=0 // 1,    # specific heat (logarithmic divergence)
-        c=1 // 2,    # central charge
-    )
+    return fetch(Universality(:Ising), CriticalExponents(); d=2, kwargs...)
+end
+
+"""
+    fetch(::Universality{:Ising}, ::CriticalExponents; d) -> NamedTuple
+
+Critical exponents of the Ising universality class (Z₂ symmetry).
+
+- **d = 2**: Exact rational values (CFT minimal model M(3,4), c = 1/2).
+- **d = 3**: High-precision numerical estimates from the conformal
+  bootstrap (Kos et al. 2016). Fields `α_err`, `β_err`, … give the
+  uncertainty in the last digits.
+- **d ≥ 4**: Mean-field (Landau) exponents (upper critical dimension).
+"""
+function fetch(::Universality{:Ising}, ::CriticalExponents; d::Int, kwargs...)
+    if d == 2
+        return (
+            α=0 // 1,
+            β=1 // 8,
+            γ=7 // 4,
+            δ=15 // 1,
+            ν=1 // 1,
+            η=1 // 4,
+            c=1 // 2,
+        )
+    elseif d == 3
+        # Conformal bootstrap: Kos, Poland, Simmons-Duffin, Vichi (2016)
+        return (
+            α=0.11009,
+            α_err=0.00001,
+            β=0.32642,
+            β_err=0.00001,
+            γ=1.23708,
+            γ_err=0.00001,
+            δ=4.78984,
+            δ_err=0.00001,
+            ν=0.62997,
+            ν_err=0.00001,
+            η=0.03630,
+            η_err=0.00005,
+        )
+    elseif d >= 4
+        return fetch(MeanField(), CriticalExponents())
+    end
+    return error("Ising universality: d=$d not supported (d ∈ {2, 3, ≥4}).")
 end

--- a/src/universalities/KPZ.jl
+++ b/src/universalities/KPZ.jl
@@ -1,58 +1,35 @@
 # ─────────────────────────────────────────────────────────────────────────────
-# KPZ (Kardar–Parisi–Zhang) universality class — exact scaling exponents
+# KPZ (Kardar–Parisi–Zhang) universality class
 #
-# The KPZ equation describes the nonequilibrium growth of interfaces:
-#
-#   ∂h/∂t = ν ∇²h + (λ/2)(∇h)² + η(x,t)
-#
-# In 1+1 dimensions all three scaling exponents are known exactly
-# (rigorous, not conjectured) from the connection to directed polymers
-# and the replica method.
+# The KPZ equation is a non-equilibrium growth model. Its scaling
+# exponents differ from equilibrium critical exponents and are accessed
+# via the `GrowthExponents` tag rather than `CriticalExponents`.
 #
 # References:
-#   M. Kardar, G. Parisi, Y.-C. Zhang, "Dynamic Scaling of Growing
-#     Interfaces", Phys. Rev. Lett. 56, 889 (1986).
-#   M. Prähofer, H. Spohn, "Exact Scaling Functions for One-Dimensional
-#     Stationary KPZ Growth", J. Stat. Phys. 115, 255 (2004) — exact
-#     scaling function via Tracy–Widom distribution.
-#   T. Sasamoto, H. Spohn, "Exact height distributions for the KPZ
-#     equation with narrow wedge initial condition",
-#     Nucl. Phys. B 834, 523 (2010).
+#   M. Kardar, G. Parisi, Y.-C. Zhang, Phys. Rev. Lett. 56, 889 (1986).
+#   T. Sasamoto, H. Spohn, Nucl. Phys. B 834, 523 (2010).
 # ─────────────────────────────────────────────────────────────────────────────
 
-"""
-    KPZ1D
-
-Dispatch tag for the KPZ universality class in 1+1 dimensions.
-
-The 1+1D KPZ equation has exact scaling exponents connected via
-the Galilean invariance relation α + z = 2 and the scaling relation
-β = α / z.
-"""
+# Backward-compatible alias
 struct KPZ1D end
-
-"""
-    fetch(::KPZ1D, ::CriticalExponents) -> NamedTuple
-
-Exact scaling exponents of the 1+1D KPZ universality class:
-
-| Symbol    | Value | Physical meaning                           |
-|-----------|-------|--------------------------------------------|
-| β_growth  | 1/3   | Growth: width ∼ t^{β}                      |
-| α_rough   | 1/2   | Roughness: width ∼ L^{α} (saturated)       |
-| z         | 3/2   | Dynamic: t_sat ∼ L^{z}                     |
-
-Scaling relations: α + z = 2 (Galilean invariance), β = α / z.
-
-All values are `Rational{Int}` for exact representation.
-
-# References
-    M. Kardar, G. Parisi, Y.-C. Zhang, Phys. Rev. Lett. 56, 889 (1986).
-"""
 function fetch(::KPZ1D, ::CriticalExponents; kwargs...)
-    return (
-        β_growth=1 // 3,   # growth exponent (width ~ t^β)
-        α_rough=1 // 2,    # roughness exponent (width ~ L^α)
-        z=3 // 2,          # dynamic exponent (t_sat ~ L^z)
-    )
+    return fetch(Universality(:KPZ), GrowthExponents(); d=1, kwargs...)
+end
+
+"""
+    fetch(::Universality{:KPZ}, ::GrowthExponents; d) -> NamedTuple
+
+Scaling exponents of the KPZ universality class.
+
+- **d = 1** (1+1D): All three exponents are exact (Rational{Int}).
+  Scaling relations: α + z = 2 (Galilean invariance), β = α / z.
+
+Higher dimensions (d ≥ 2) are not exactly known and are not yet
+included.
+"""
+function fetch(::Universality{:KPZ}, ::GrowthExponents; d::Int, kwargs...)
+    if d == 1
+        return (β_growth=1 // 3, α_rough=1 // 2, z=3 // 2)
+    end
+    return error("KPZ growth exponents: only d=1 (1+1D) implemented; got d=$d.")
 end

--- a/src/universalities/MeanField.jl
+++ b/src/universalities/MeanField.jl
@@ -1,57 +1,29 @@
 # ─────────────────────────────────────────────────────────────────────────────
-# Mean-field (Landau) universality class — exact critical exponents
+# Mean-field (Landau) universality class
 #
-# Mean-field exponents are the baseline reference for all universality
-# classes. They are exact above the upper critical dimension d_c (= 4
-# for standard Ising-like transitions) and serve as the starting point
-# for ε-expansion (d = d_c − ε) corrections.
+# Exact for d ≥ d_c (upper critical dimension; d_c = 4 for Ising-like).
+# Serves as the baseline reference for all universality classes.
 #
 # References:
-#   L. D. Landau, "On the theory of phase transitions",
-#     Zh. Eksp. Teor. Fiz. 7, 19 (1937).
-#   J. Zinn-Justin, "Quantum Field Theory and Critical Phenomena",
-#     Oxford University Press (2002), Ch. 23.
+#   L. D. Landau, Zh. Eksp. Teor. Fiz. 7, 19 (1937).
 # ─────────────────────────────────────────────────────────────────────────────
 
 """
     MeanField
 
 Dispatch tag for the mean-field (Landau) universality class.
-
-These exponents are exact for spatial dimension d ≥ 4 (the upper
-critical dimension for Ising-like transitions). Below d = 4, critical
-fluctuations renormalize the exponents (see `Ising2D` for d = 2).
+Exact for d ≥ d_c (upper critical dimension).
 """
 struct MeanField end
 
 """
     fetch(::MeanField, ::CriticalExponents) -> NamedTuple
 
-Exact critical exponents of the mean-field universality class:
+Mean-field critical exponents (exact, Rational{Int}):
+α=0, β=1/2, γ=1, δ=3, ν=1/2, η=0.
 
-| Symbol | Value | Physical meaning                              |
-|--------|-------|-----------------------------------------------|
-| β      | 1/2   | Order parameter: M ∼ (T_c − T)^β             |
-| ν      | 1/2   | Correlation length: ξ ∼ |T − T_c|^{−ν}       |
-| γ      | 1     | Susceptibility: χ ∼ |T − T_c|^{−γ}           |
-| η      | 0     | Anomalous dimension: G(r) ∼ r^{−(d−2+η)}     |
-| δ      | 3     | Critical isotherm: M ∼ h^{1/δ} at T = T_c    |
-| α      | 0     | Specific heat: discontinuity (step function)  |
-
-All values are `Rational{Int}` for exact representation.
-Satisfies the standard scaling relations:
-  α + 2β + γ = 2,   γ = β(δ−1),   γ = ν(2−η).
-
-# References
-    L. D. Landau, Zh. Eksp. Teor. Fiz. 7, 19 (1937).
+Satisfies Rushbrooke, Widom, and Fisher scaling relations exactly.
 """
 function fetch(::MeanField, ::CriticalExponents; kwargs...)
-    return (
-        β=1 // 2,    # order parameter exponent
-        ν=1 // 2,    # correlation length exponent
-        γ=1 // 1,    # susceptibility exponent
-        η=0 // 1,    # anomalous dimension
-        δ=3 // 1,    # critical isotherm exponent
-        α=0 // 1,    # specific heat (discontinuity)
-    )
+    return (α=0 // 1, β=1 // 2, γ=1 // 1, δ=3 // 1, ν=1 // 2, η=0 // 1)
 end

--- a/src/universalities/ONModel.jl
+++ b/src/universalities/ONModel.jl
@@ -1,0 +1,84 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# O(n) model universality classes: XY (n=2), Heisenberg (n=3)
+#
+# In d=2, Mermin-Wagner forbids spontaneous symmetry breaking for
+# continuous symmetry → no standard power-law exponents.
+# In d=3, high-precision numerical estimates are available.
+#
+# References:
+#   XY d=3: Chester, Landry, Liu, Poland, Simmons-Duffin, Su, Vichi,
+#     JHEP 02, 098 (2020) — conformal bootstrap.
+#   Heisenberg d=3: Chester, Landry, Liu, Poland, Simmons-Duffin, Su,
+#     Vichi, Phys. Rev. D 104, 105013 (2021).
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    fetch(::Universality{:XY}, ::CriticalExponents; d) -> NamedTuple
+
+Critical exponents of the XY (O(2)) universality class.
+
+- **d = 2**: BKT transition — no standard power-law exponents.
+  Returns η(T_c) = 1/4 only.
+- **d = 3**: Conformal bootstrap (Chester et al. 2020).
+- **d ≥ 4**: Mean-field.
+"""
+function fetch(::Universality{:XY}, ::CriticalExponents; d::Int, kwargs...)
+    if d == 2
+        # BKT: no standard critical exponents; only η at T_c is universal.
+        return (η=1 // 4, note="BKT transition — no standard power-law exponents")
+    elseif d == 3
+        return (
+            α=-0.01526,
+            α_err=0.00030,
+            β=0.34869,
+            β_err=0.00007,
+            γ=1.3179,
+            γ_err=0.0002,
+            δ=4.77937,
+            δ_err=0.00025,
+            ν=0.67175,
+            ν_err=0.00010,
+            η=0.038176,
+            η_err=0.000044,
+        )
+    elseif d >= 4
+        return fetch(MeanField(), CriticalExponents())
+    end
+    return error("XY universality: d=$d not supported (d ∈ {2, 3, ≥4}).")
+end
+
+"""
+    fetch(::Universality{:Heisenberg}, ::CriticalExponents; d) -> NamedTuple
+
+Critical exponents of the Heisenberg (O(3)) universality class.
+
+- **d ≤ 2**: Mermin-Wagner theorem — no spontaneous order at T > 0.
+- **d = 3**: Conformal bootstrap / Monte Carlo.
+- **d ≥ 4**: Mean-field.
+"""
+function fetch(::Universality{:Heisenberg}, ::CriticalExponents; d::Int, kwargs...)
+    if d <= 2
+        return error(
+            "Heisenberg universality in d=$d: Mermin-Wagner theorem " *
+            "prohibits spontaneous breaking of continuous symmetry.",
+        )
+    elseif d == 3
+        return (
+            α=-0.1336,
+            α_err=0.0015,
+            β=0.3689,
+            β_err=0.0003,
+            γ=1.3960,
+            γ_err=0.0009,
+            δ=4.783,
+            δ_err=0.003,
+            ν=0.7112,
+            ν_err=0.0005,
+            η=0.0375,
+            η_err=0.0005,
+        )
+    elseif d >= 4
+        return fetch(MeanField(), CriticalExponents())
+    end
+    return error("Heisenberg universality: d=$d not supported.")
+end

--- a/src/universalities/Percolation.jl
+++ b/src/universalities/Percolation.jl
@@ -17,14 +17,7 @@ Critical exponents of the ordinary (site/bond) percolation universality class.
 """
 function fetch(::Universality{:Percolation}, ::CriticalExponents; d::Int, kwargs...)
     if d == 2
-        return (
-            α=-2 // 3,
-            β=5 // 36,
-            γ=43 // 18,
-            δ=91 // 5,
-            ν=4 // 3,
-            η=5 // 24,
-        )
+        return (α=-2 // 3, β=5 // 36, γ=43 // 18, δ=91 // 5, ν=4 // 3, η=5 // 24)
     elseif d == 3
         return (
             α=-0.625,

--- a/src/universalities/Percolation.jl
+++ b/src/universalities/Percolation.jl
@@ -1,0 +1,48 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Percolation universality class
+#
+# References:
+#   d=2: Nienhuis, Phys. Rev. Lett. 49, 1062 (1982) — exact via Coulomb gas.
+#   d=3: Wang, Zhou, Zhang, Garoni, Deng, Phys. Rev. E 87, 052107 (2013).
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    fetch(::Universality{:Percolation}, ::CriticalExponents; d) -> NamedTuple
+
+Critical exponents of the ordinary (site/bond) percolation universality class.
+
+- **d = 2**: Exact rational values (Coulomb gas mapping).
+- **d = 3**: Numerical (Monte Carlo).
+- **d ≥ 6**: Mean-field.
+"""
+function fetch(::Universality{:Percolation}, ::CriticalExponents; d::Int, kwargs...)
+    if d == 2
+        return (
+            α=-2 // 3,
+            β=5 // 36,
+            γ=43 // 18,
+            δ=91 // 5,
+            ν=4 // 3,
+            η=5 // 24,
+        )
+    elseif d == 3
+        return (
+            α=-0.625,
+            α_err=0.003,
+            β=0.4181,
+            β_err=0.0008,
+            γ=1.793,
+            γ_err=0.003,
+            δ=5.29,
+            δ_err=0.06,
+            ν=0.87619,
+            ν_err=0.00012,
+            η=0.46,
+            η_err=0.08,
+        )
+    elseif d >= 6
+        # Percolation upper critical dimension is 6
+        return (α=-1 // 1, β=1 // 1, γ=1 // 1, δ=2 // 1, ν=1 // 2, η=0 // 1)
+    end
+    return error("Percolation universality: d=$d not supported (d ∈ {2, 3, ≥6}).")
+end

--- a/src/universalities/Potts.jl
+++ b/src/universalities/Potts.jl
@@ -1,0 +1,50 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Potts universality classes (q-state, d=2 exact)
+#
+# The q-state Potts model generalizes the Ising model (q=2).
+# For d=2, exact exponents are known for q ≤ 4 via Coulomb gas / CFT.
+#
+# References:
+#   R. J. Baxter, "Exactly Solved Models in Statistical Mechanics" (1982).
+#   B. Nienhuis, J. Stat. Phys. 34, 731 (1984).
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    fetch(::Universality{:Potts3}, ::CriticalExponents; d=2) -> NamedTuple
+
+Exact critical exponents of the 3-state Potts model in d=2 (S₃ symmetry).
+"""
+function fetch(::Universality{:Potts3}, ::CriticalExponents; d::Int=2, kwargs...)
+    if d == 2
+        return (
+            α=1 // 3,
+            β=1 // 9,
+            γ=13 // 9,
+            δ=14 // 1,
+            ν=5 // 6,
+            η=4 // 15,
+        )
+    end
+    return error("Potts3 universality: only d=2 implemented; got d=$d.")
+end
+
+"""
+    fetch(::Universality{:Potts4}, ::CriticalExponents; d=2) -> NamedTuple
+
+Exact critical exponents of the 4-state Potts model (Ashkin–Teller point)
+in d=2 (S₄ symmetry). This is the marginal case: the transition is
+second-order with logarithmic corrections.
+"""
+function fetch(::Universality{:Potts4}, ::CriticalExponents; d::Int=2, kwargs...)
+    if d == 2
+        return (
+            α=2 // 3,
+            β=1 // 12,
+            γ=7 // 6,
+            δ=15 // 1,
+            ν=2 // 3,
+            η=1 // 4,
+        )
+    end
+    return error("Potts4 universality: only d=2 implemented; got d=$d.")
+end

--- a/src/universalities/Potts.jl
+++ b/src/universalities/Potts.jl
@@ -16,14 +16,7 @@ Exact critical exponents of the 3-state Potts model in d=2 (S₃ symmetry).
 """
 function fetch(::Universality{:Potts3}, ::CriticalExponents; d::Int=2, kwargs...)
     if d == 2
-        return (
-            α=1 // 3,
-            β=1 // 9,
-            γ=13 // 9,
-            δ=14 // 1,
-            ν=5 // 6,
-            η=4 // 15,
-        )
+        return (α=1 // 3, β=1 // 9, γ=13 // 9, δ=14 // 1, ν=5 // 6, η=4 // 15)
     end
     return error("Potts3 universality: only d=2 implemented; got d=$d.")
 end
@@ -37,14 +30,7 @@ second-order with logarithmic corrections.
 """
 function fetch(::Universality{:Potts4}, ::CriticalExponents; d::Int=2, kwargs...)
     if d == 2
-        return (
-            α=2 // 3,
-            β=1 // 12,
-            γ=7 // 6,
-            δ=15 // 1,
-            ν=2 // 3,
-            η=1 // 4,
-        )
+        return (α=2 // 3, β=1 // 12, γ=7 // 6, δ=15 // 1, ν=2 // 3, η=1 // 4)
     end
     return error("Potts4 universality: only d=2 implemented; got d=$d.")
 end

--- a/src/universalities/Universality.jl
+++ b/src/universalities/Universality.jl
@@ -1,0 +1,56 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Universality{C} — parametric type for universality classes
+#
+# Each universality class is identified by a Symbol parameter C
+# (e.g., :Ising, :XY, :Heisenberg, :Potts3, :Percolation, :KPZ).
+# The spatial dimension d is passed as a keyword argument to `fetch`.
+#
+# Standard critical exponents {α, β, γ, δ, ν, η} are returned as a
+# NamedTuple. For exact (analytically known) values, the fields are
+# Rational{Int}. For numerical estimates, the fields are Float64 with
+# corresponding `_err` fields indicating the uncertainty.
+#
+# Non-equilibrium classes (e.g., KPZ) have different exponent sets
+# and use separate dispatch tags (GrowthExponents instead of
+# CriticalExponents).
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    Universality{C}
+
+Parametric dispatch tag for universality classes. `C` is a `Symbol`
+identifying the class (`:Ising`, `:XY`, `:Heisenberg`, `:Potts3`,
+`:Potts4`, `:Percolation`, `:KPZ`, etc.).
+
+Use with [`CriticalExponents`](@ref) (equilibrium) or
+[`GrowthExponents`](@ref) (KPZ-type) and a `d` keyword to select
+the spatial dimension:
+
+```julia
+QAtlas.fetch(Universality(:Ising), CriticalExponents(); d=2)   # exact Rational
+QAtlas.fetch(Universality(:Ising), CriticalExponents(); d=3)   # numerical + _err
+QAtlas.fetch(Universality(:Ising), CriticalExponents(); d=4)   # mean-field
+```
+"""
+struct Universality{C} end
+Universality(name::Symbol) = Universality{name}()
+
+"""
+    CriticalExponents
+
+Dispatch tag for the standard set of equilibrium critical exponents
+{α, β, γ, δ, ν, η} of a universality class. Returns a `NamedTuple`.
+
+For exact values: fields are `Rational{Int}`.
+For numerical estimates: fields are `Float64` with corresponding
+`_err` fields (e.g., `β_err`) giving the uncertainty.
+"""
+struct CriticalExponents end
+
+"""
+    GrowthExponents
+
+Dispatch tag for KPZ-type growth/roughness/dynamic exponents.
+Returns `(β_growth, α_rough, z)` instead of the equilibrium set.
+"""
+struct GrowthExponents end

--- a/test/standalone/test_universality_exponents.jl
+++ b/test/standalone/test_universality_exponents.jl
@@ -1,16 +1,36 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # Standalone test: universality class critical exponents
 #
-# Verify exact (rational) exponents for each universality class and
-# check standard scaling relations between them.
+# Verify exact (rational) and numerical exponents, and check standard
+# scaling relations.
 # ─────────────────────────────────────────────────────────────────────────────
 
 using QAtlas, Test
 
-@testset "Universality: 2D Ising critical exponents" begin
-    e = QAtlas.fetch(Ising2D(), CriticalExponents())
+# ─────────────── Helper: check scaling relations on exact exponents ───────────
 
-    # Exact rational values
+function check_scaling_relations(e; d::Int=0)
+    @test e.α + 2 * e.β + e.γ == 2                 # Rushbrooke
+    @test e.γ == e.β * (e.δ - 1)                    # Widom
+    @test e.γ == e.ν * (2 - e.η)                    # Fisher
+    if d > 0
+        @test 2 - e.α ≈ d * e.ν atol = 1e-10       # Josephson (hyperscaling)
+    end
+end
+
+function check_scaling_relations_approx(e; d::Int=0)
+    @test e.α + 2 * e.β + e.γ ≈ 2 atol = 0.01      # Rushbrooke
+    @test e.γ ≈ e.β * (e.δ - 1) atol = 0.01         # Widom
+    @test e.γ ≈ e.ν * (2 - e.η) atol = 0.01         # Fisher
+    if d > 0
+        @test 2 - e.α ≈ d * e.ν atol = 0.01         # Josephson
+    end
+end
+
+# ═══════════════════ Exact universality classes (Rational) ═══════════════════
+
+@testset "Universality: 2D Ising (exact)" begin
+    e = QAtlas.fetch(Universality(:Ising), CriticalExponents(); d=2)
     @test e.β == 1 // 8
     @test e.ν == 1 // 1
     @test e.γ == 7 // 4
@@ -18,38 +38,119 @@ using QAtlas, Test
     @test e.δ == 15 // 1
     @test e.α == 0 // 1
     @test e.c == 1 // 2
-
-    # Standard scaling relations (must hold exactly for rational exponents)
-    @test e.α + 2 * e.β + e.γ == 2               # Rushbrooke
-    @test e.γ == e.β * (e.δ - 1)                  # Widom
-    @test e.γ == e.ν * (2 - e.η)                  # Fisher
-    @test 2 - e.α == 2 * e.ν                      # Josephson (d=2: dν = 2-α)
+    check_scaling_relations(e; d=2)
 end
 
-@testset "Universality: KPZ 1+1D scaling exponents" begin
-    e = QAtlas.fetch(KPZ1D(), CriticalExponents())
-
-    @test e.β_growth == 1 // 3
-    @test e.α_rough == 1 // 2
-    @test e.z == 3 // 2
-
-    # KPZ scaling relations
-    @test e.α_rough + e.z == 2                    # Galilean invariance
-    @test e.β_growth == e.α_rough / e.z           # β = α / z
+@testset "Universality: backward compat Ising2D()" begin
+    e_old = QAtlas.fetch(Ising2D(), CriticalExponents())
+    e_new = QAtlas.fetch(Universality(:Ising), CriticalExponents(); d=2)
+    @test e_old == e_new
 end
 
-@testset "Universality: Mean-field critical exponents" begin
+@testset "Universality: Mean-field (exact)" begin
     e = QAtlas.fetch(MeanField(), CriticalExponents())
-
     @test e.β == 1 // 2
     @test e.ν == 1 // 2
     @test e.γ == 1 // 1
     @test e.η == 0 // 1
     @test e.δ == 3 // 1
     @test e.α == 0 // 1
+    check_scaling_relations(e)
+end
 
-    # Scaling relations (hold at mean-field level)
-    @test e.α + 2 * e.β + e.γ == 2               # Rushbrooke
-    @test e.γ == e.β * (e.δ - 1)                  # Widom
-    @test e.γ == e.ν * (2 - e.η)                  # Fisher
+@testset "Universality: Ising d≥4 = Mean-field" begin
+    e_mf = QAtlas.fetch(MeanField(), CriticalExponents())
+    for d in [4, 5, 100]
+        e = QAtlas.fetch(Universality(:Ising), CriticalExponents(); d=d)
+        @test e == e_mf
+    end
+end
+
+@testset "Universality: 2D Percolation (exact)" begin
+    e = QAtlas.fetch(Universality(:Percolation), CriticalExponents(); d=2)
+    @test e.α == -2 // 3
+    @test e.β == 5 // 36
+    @test e.γ == 43 // 18
+    @test e.δ == 91 // 5
+    @test e.ν == 4 // 3
+    @test e.η == 5 // 24
+    check_scaling_relations(e; d=2)
+end
+
+@testset "Universality: 3-state Potts d=2 (exact)" begin
+    e = QAtlas.fetch(Universality(:Potts3), CriticalExponents(); d=2)
+    @test e.β == 1 // 9
+    @test e.ν == 5 // 6
+    @test e.η == 4 // 15
+    @test e.δ == 14 // 1
+    check_scaling_relations(e; d=2)
+end
+
+@testset "Universality: 4-state Potts d=2 (exact)" begin
+    e = QAtlas.fetch(Universality(:Potts4), CriticalExponents(); d=2)
+    @test e.β == 1 // 12
+    @test e.ν == 2 // 3
+    @test e.η == 1 // 4
+    @test e.δ == 15 // 1
+    check_scaling_relations(e; d=2)
+end
+
+@testset "Universality: KPZ 1+1D (exact growth exponents)" begin
+    e = QAtlas.fetch(Universality(:KPZ), GrowthExponents(); d=1)
+    @test e.β_growth == 1 // 3
+    @test e.α_rough == 1 // 2
+    @test e.z == 3 // 2
+    @test e.α_rough + e.z == 2              # Galilean invariance
+    @test e.β_growth == e.α_rough / e.z     # β = α / z
+end
+
+@testset "Universality: KPZ1D() backward compat" begin
+    e_old = QAtlas.fetch(KPZ1D(), CriticalExponents())
+    e_new = QAtlas.fetch(Universality(:KPZ), GrowthExponents(); d=1)
+    @test e_old == e_new
+end
+
+# ═══════════════ Numerical universality classes (Float64 + _err) ═════════════
+
+@testset "Universality: 3D Ising (conformal bootstrap)" begin
+    e = QAtlas.fetch(Universality(:Ising), CriticalExponents(); d=3)
+    @test 0.10 < e.β < 0.35
+    @test 0.60 < e.ν < 0.65
+    @test e.β_err > 0
+    @test e.ν_err > 0
+    check_scaling_relations_approx(e; d=3)
+end
+
+@testset "Universality: 3D XY (conformal bootstrap)" begin
+    e = QAtlas.fetch(Universality(:XY), CriticalExponents(); d=3)
+    @test 0.34 < e.β < 0.36
+    @test 0.66 < e.ν < 0.68
+    @test e.β_err > 0
+    check_scaling_relations_approx(e; d=3)
+end
+
+@testset "Universality: 3D Heisenberg" begin
+    e = QAtlas.fetch(Universality(:Heisenberg), CriticalExponents(); d=3)
+    @test 0.36 < e.β < 0.38
+    @test 0.70 < e.ν < 0.72
+    @test e.β_err > 0
+    check_scaling_relations_approx(e; d=3)
+end
+
+@testset "Universality: XY d=2 is BKT" begin
+    e = QAtlas.fetch(Universality(:XY), CriticalExponents(); d=2)
+    @test e.η == 1 // 4
+end
+
+@testset "Universality: Heisenberg d=2 → Mermin-Wagner error" begin
+    @test_throws ErrorException QAtlas.fetch(
+        Universality(:Heisenberg), CriticalExponents(); d=2
+    )
+end
+
+@testset "Universality: 3D Percolation (numerical)" begin
+    e = QAtlas.fetch(Universality(:Percolation), CriticalExponents(); d=3)
+    @test 0.40 < e.β < 0.45
+    @test 0.85 < e.ν < 0.90
+    @test e.β_err > 0
 end


### PR DESCRIPTION
## Summary

Wikipedia の universality class 表を参考に、QAtlas に体系的な universality class framework を導入します。

### 設計: \`Universality{C}\` parametric type

\`\`\`julia
# 統一 API: class × dimension
fetch(Universality(:Ising), CriticalExponents(); d=2)   # exact Rational
fetch(Universality(:Ising), CriticalExponents(); d=3)   # numerical + _err (Option A)
fetch(Universality(:Ising), CriticalExponents(); d=4)   # → MeanField
\`\`\`

### 収録 universality classes

| class | d | 種別 | 特徴 |
|-------|---|------|------|
| **Ising** | 2 | exact | β=1/8, c=1/2 (CFT M(3,4)) |
| | 3 | numerical | conformal bootstrap (Kos+ 2016) |
| | ≥4 | MF | Landau |
| **Percolation** | 2 | exact | β=5/36, ν=4/3 (Coulomb gas) |
| | 3 | numerical | Monte Carlo |
| | ≥6 | MF | |
| **3-state Potts** | 2 | exact | β=1/9, S₃ symmetry |
| **4-state Potts** | 2 | exact | β=1/12, marginal |
| **XY** | 2 | BKT | η=1/4 only (no power-law) |
| | 3 | numerical | bootstrap (Chester+ 2020) |
| **Heisenberg** | ≤2 | error | Mermin-Wagner |
| | 3 | numerical | bootstrap |
| **KPZ** | 1+1D | exact | β=1/3, z=3/2 (GrowthExponents) |
| **MeanField** | any | exact | baseline (d ≥ d_c) |

### 不確かさの表現 (Option A)

numerical の場合、\`_err\` フィールドで uncertainty を返す:

\`\`\`julia
e = fetch(Universality(:Ising), CriticalExponents(); d=3)
# (α=0.11009, α_err=1.0e-5, β=0.32642, β_err=1.0e-5, ...)
\`\`\`

### Scaling relations の algebraic verification

exact class では **Rational arithmetic** で scaling relations を exact に検証:
- Rushbrooke: α + 2β + γ = 2 ✓
- Widom: γ = β(δ−1) ✓
- Fisher: γ = ν(2−η) ✓
- Josephson (d=2): 2−α = dν ✓
- KPZ: α+z = 2, β = α/z ✓

numerical class では \`atol=0.01\` で近似的に検証。

### 後方互換

\`Ising2D()\`, \`KPZ1D()\`, \`MeanField()\` は引き続き動作 (delegate)。

## Test plan

- [x] \`Pkg.test()\` で全 **771 tests 通過** (追加 58 tests)
- [x] 6 exact classes × scaling relations = algebraic exact
- [x] 3 numerical classes × bounds check
- [x] XY d=2 → BKT, Heisenberg d=2 → Mermin-Wagner error