### PR TITLE
Fix docs links + version bump 0.12.7 + roadmap update

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.12.6"
+version = "0.12.7"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/docs/src/calc/ising-scaling-relations.md
+++ b/docs/src/calc/ising-scaling-relations.md
@@ -117,4 +117,4 @@ $\{\alpha = 0,\, \beta = 1/8,\, \gamma = 7/4,\, \delta = 15,\,
 ## Used by
 
 - [Ising Universality Class](../universalities/ising.md)
-- [test/standalone/test\_universality\_exponents.jl](../../test/standalone/test_universality_exponents.jl)
+- `test/standalone/test_universality_exponents.jl`

--- a/docs/src/methods/jordan-wigner/index.md
+++ b/docs/src/methods/jordan-wigner/index.md
@@ -29,14 +29,14 @@ fermionic anti-commutation: $\{c_i, c^\dagger_j\} = \delta_{ij}$.
 - **Convention dependence**: $\sigma^z\sigma^z$ and $\sigma^x\sigma^x$
   conventions produce different fermion Hamiltonians — one may be
   free while the other is interacting. See
-  [TFIM calculation](../calc/jw-tfim-bdg.md) for how the
+  [TFIM calculation](../../calc/jw-tfim-bdg.md) for how the
   Kramers-Wannier duality resolves this.
 
 ## Applications in QAtlas
 
 | Model | Calculation note | Result |
 | ----- | ---------------- | ------ |
-| [TFIM](../models/quantum/tfim.md) | [JW-TFIM-BdG](../calc/jw-tfim-bdg.md) | BdG quasiparticle spectrum |
+| [TFIM](../../models/quantum/tfim.md) | [JW-TFIM-BdG](../../calc/jw-tfim-bdg.md) | BdG quasiparticle spectrum |
 | Heisenberg | (interacting after JW — not directly solvable) | Bethe ansatz instead |
 | Kitaev chain | (planned) | Topological phase boundary |
 

--- a/docs/src/models/quantum/tightbinding/graphene.md
+++ b/docs/src/models/quantum/tightbinding/graphene.md
@@ -46,7 +46,7 @@ $n \in \{0, \ldots, L_y - 1\}$.
 
 ### Derivation
 
-See **[Bloch Honeycomb Dispersion](../../calc/bloch-honeycomb-dispersion.md)**
+See **[Bloch Honeycomb Dispersion](../../../calc/bloch-honeycomb-dispersion.md)**
 for the full derivation of $|f(\mathbf{k})|^2$ from the unit-cell
 geometry.
 
@@ -96,5 +96,5 @@ exactly 4 zero eigenvalues.
   lattices, the honeycomb has no flat band -- both bands are fully
   dispersive.
 - **Methods**: Computed via the
-  [Bloch Hamiltonian](../../methods/bloch-hamiltonian/index.md)
+  [Bloch Hamiltonian](../../../methods/bloch-hamiltonian/index.md)
   method; the generic builder provides an independent cross-check.

--- a/docs/src/models/quantum/tightbinding/kagome.md
+++ b/docs/src/models/quantum/tightbinding/kagome.md
@@ -66,7 +66,7 @@ total degeneracy of $L_x L_y + 1$.
 
 ### Derivation
 
-See **[Bloch Kagome Flat Band](../../calc/bloch-kagome-flat-band.md)**
+See **[Bloch Kagome Flat Band](../../../calc/bloch-kagome-flat-band.md)**
 for the derivation of $H(\mathbf{k})$ and the proof that one
 eigenvalue is identically $+2t$.
 
@@ -110,4 +110,4 @@ eigenvalue is identically $+2t$.
   frustration, while the Lieb flat band arises from bipartite sublattice
   imbalance.
 - **Methods**: Computed via the
-  [Bloch Hamiltonian](../../methods/bloch-hamiltonian/index.md) method.
+  [Bloch Hamiltonian](../../../methods/bloch-hamiltonian/index.md) method.

--- a/docs/src/models/quantum/tightbinding/lieb.md
+++ b/docs/src/models/quantum/tightbinding/lieb.md
@@ -65,7 +65,7 @@ $$N_{E=0} = L_x L_y + \begin{cases} 2 & \text{if both } L_x, L_y \text{ even} \\
 
 ### Derivation
 
-See **[Bloch Lieb Flat Band](../../calc/bloch-lieb-flat-band.md)** for
+See **[Bloch Lieb Flat Band](../../../calc/bloch-lieb-flat-band.md)** for
 the derivation of $H(\mathbf{k})$, the closed-form eigenvalues, and
 the proof that $E = 0$ is an exact eigenvalue at every momentum.
 
@@ -113,4 +113,4 @@ the proof that $E = 0$ is an exact eigenvalue at every momentum.
   flat-band mechanism with the Lieb lattice (flat band at $E = 0$,
   hub vs rim sublattice imbalance).
 - **Methods**: Computed via the
-  [Bloch Hamiltonian](../../methods/bloch-hamiltonian/index.md) method.
+  [Bloch Hamiltonian](../../../methods/bloch-hamiltonian/index.md) method.

--- a/docs/src/models/quantum/tightbinding/triangular.md
+++ b/docs/src/models/quantum/tightbinding/triangular.md
@@ -109,4 +109,4 @@ exactly 2 eigenvalues sit at $+3t$.
   classical Ising antiferromagnet frustration problem on the triangular
   lattice (Wannier 1950).
 - **Methods**: Computed via the
-  [Bloch Hamiltonian](../../methods/bloch-hamiltonian/index.md) method.
+  [Bloch Hamiltonian](../../../methods/bloch-hamiltonian/index.md) method.

--- a/md/README.md
+++ b/md/README.md
@@ -1,54 +1,49 @@
-# QAtlas.jl — 設計ドキュメント
+# QAtlas.jl — Internal Design Notes
 
-量子多体モデルの厳密解・解析的結果を一元管理するカタログパッケージの設計ノート。
+Internal notes for QAtlas development. NOT user-facing documentation
+(that lives in `docs/src/`).
 
-## 掲載方針
+## Current State (v0.12.6)
 
-| カテゴリ | 掲載条件 |
-|---------|---------|
-| 厳密解・解析的結果 | 積極的に掲載。導出の概要または参考文献を付記する |
-| 数値計算結果 | 査読済み論文または well-known preprint の reference とセットでのみ掲載 |
-| 未検証の推測 | 掲載しない |
+### What's implemented
 
-## クイックスタート
+**Models** (src/):
+- IsingSquare: partition function (transfer matrix), T_c (Onsager), M(T) (Yang)
+- TFIM: BdG spectrum (OBC, Infinite), thermal observables, dynamics, correlators
+- Heisenberg1D: dimer spectrum, 4-site PBC, Bethe ansatz e₀
+- Tight-binding: Graphene, Kagome, Lieb, Triangular (hardcoded Bloch)
 
-```julia
-using QAtlas
+**Universality classes** (src/universalities/):
+- Universality{C} parametric type with dimension d keyword
+- Ising (d=2 exact, d=3 bootstrap, MF), Percolation, Potts 3/4, KPZ, XY, Heisenberg, MF
+- E8 mass ratios
 
-# TFIM の熱力学極限エネルギー（β=2.0）
-fetch(:TFIM, :energy; J=1.0, h=0.5, beta=2.0)
+**Test infrastructure** (test/util/):
+- classical_partition.jl: brute-force 2^N enumeration
+- tight_binding.jl: real-space TB Hamiltonian from bonds
+- spinhalf_ed.jl: Kronecker embed, build_heisenberg, build_tfim, entanglement entropy
+- bloch.jl: generic Bloch builder from unit cell
 
-# 有限サイズ OBC
-fetch(:TFIM, :energy, OBC(); J=1.0, h=1.0, N=16, beta=3.0)
+**Test suites** (850+ tests):
+- standalone/: special values, scaling relations, Bethe ansatz
+- verification/: Lattice2D cross-check (8 topologies), AD thermodynamics, gap closure, entanglement, disordered, universality cross-checks
 
-# E8 質量比
-fetch(:E8, :mass_ratios)
-```
+**Documentation** (docs/src/, 46 pages):
+- Zettelkasten calc/ notes (15 atomic derivation notes)
+- Model pages, universality pages, verification philosophy, methods (Physical/Computational)
 
-エイリアスが使えます：
+### Two API styles coexist
 
-```julia
-fetch(:TFIM, :E; ...)        # :energy の別名
-fetch(:TFIM, :ee; ...)       # :entanglement_entropy の別名
-```
+1. **Old style**: `Model{:TFIM}` + `Quantity{:energy}` + `OBC()` — used by TFIM, E8
+2. **New style**: simple struct tags (`IsingSquare()`, `Universality(:Ising)`) — used by new models
 
-## ページ一覧
+No immediate plan to unify; both work. New additions should use the simple struct style.
 
-### API・設計
+## Pages in this directory
 
-- [api.md](api.md) — 型階層・fetch インターフェース・関数群・拡張方法
-
-### モデル別結果カタログ
-
-- [models/TFIM.md](models/TFIM.md) — 横磁場イジングモデル（実装済み）
-- [models/XXZ.md](models/XXZ.md) — XXZ モデル（将来）
-
-### 普遍クラス
-
-- [universalities/E8.md](universalities/E8.md) — E8 例外代数の質量スペクトル（実装済み）
-- [universalities/IsingCFT.md](universalities/IsingCFT.md) — Ising CFT (c=1/2)
-
-### 開発ガイド
-
-- [testing.md](testing.md) — テスト哲学・example-based testing の方針
-- [roadmap.md](roadmap.md) — 将来モデル・数値データ方針・API 再設計案
+- [roadmap.md](roadmap.md) — future models, open issues, development priorities
+- [documentation-design.md](documentation-design.md) — docs architecture blueprint
+- [api.md](api.md) — API type hierarchy (mostly stable, see note about two styles)
+- [testing.md](testing.md) — test philosophy (superseded by docs/src/verification/)
+- [models/](models/) — model-specific notes (partially superseded by docs/src/models/)
+- [universalities/](universalities/) — universality notes (superseded by docs/src/universalities/)

--- a/md/roadmap.md
+++ b/md/roadmap.md
@@ -1,97 +1,161 @@
-# ロードマップ
+# Roadmap and Open Issues
 
-## 数値データ掲載方針
+## Remaining Issues
 
-数値結果を QAtlas に掲載する場合は以下を必須とする:
+### Physics accuracy of documentation
 
-1. 査読済み論文 or well-known preprint（arXiv）の明示的な reference
-2. 測定量・値・不確かさ・測定条件のセット記述
-3. 実験値か数値計算かの区別を明記
+The `docs/src/calc/` derivation notes provide overview-level arguments
+for each result. Several notes — especially around E8 and integrable
+field theory — describe **what** is true and **why** it matters, but
+do not contain the full calculation. Specific gaps:
 
-掲載例（将来）:
-```
-CoNb₂O₆ での E8 質量比 m₂/m₁
-  値: 1.619 ± 0.015（実験）
-  条件: 横磁場 Bc = 5.5T 近傍
-  出典: Coldea et al., Science 327, 177 (2010)
-```
+- `calc/e8-mass-spectrum-derivation.md`: the S-matrix bootstrap
+  equations are stated but not solved. The actual derivation requires
+  the CDD factor construction and minimal form factor program
+  (Zamolodchikov 1989, Fateev 1994).
+- `calc/ising-cft-magnetic-perturbation.md`: Zamolodchikov's proof
+  that 8 conserved charges survive the σ perturbation is cited but not
+  reproduced. This requires counting integrals of motion order by order
+  in perturbation theory.
+- `calc/yang-magnetization-toeplitz.md`: the Toeplitz determinant
+  evaluation via Szegő's theorem is described at a high level but the
+  asymptotic analysis is not shown.
 
-## 将来追加するモデル
+These are candidates for deeper `calc/` sub-notes when expertise is
+available.
 
-現在の主な関心モデルとその既知の厳密解:
+### Peschel method for σ^z σ^z TFIM
 
-| モデル | 解法 | 実装可能な物理量 | 優先度 |
-|--------|------|----------------|--------|
-| **KitaevChain** | JW + BdG（TFIM と同構造） | エネルギー、ギャップ、位相相境界、エッジモード | 高 |
-| **Heisenberg (XXX)** | Bethe ansatz | 基底状態エネルギー密度、スピン波速度 | 高 |
-| **XXZ** | Bethe ansatz | エネルギー、Luttinger 液体パラメータ | 中 |
-| **KitaevHoneycomb** | Kitaev (2006) の解析的解法 | 基底状態相図、ギャップ | 中 |
-| **TFIML (TFIM+L)** | QFT 摂動論（E8 との接続） | 質量ギャップの λ 依存性 | 中 |
-| **自由フェルミオン鎖** | 解析的 | 単粒子スペクトル、エンタングルメント | 低 |
+The BdG eigenvectors for the TFIM in the σ^z σ^z convention give
+**dual-fermion** correlators (Kramers-Wannier dual), not spin-basis
+correlators. Computing the spin-basis entanglement entropy via the
+Peschel correlation-matrix method requires proper handling of the
+duality boundary conditions.
 
-### KitaevChain の詳細
+Current workaround: full ED (O(2^N), N ≤ 16 with 128GB RAM).
 
-```
-H = -μ Σᵢ (cᵢ†cᵢ - 1/2) - t Σᵢ (cᵢ†cᵢ₊₁ + h.c.) - Δ Σᵢ (cᵢcᵢ₊₁ + h.c.)
-```
+Resolution path: implement the duality-aware Peschel method, or switch
+to the σ^x σ^x convention for the entanglement-specific code path.
 
-- TFIM と同じ JW + BdG 解法 → TFIM の実装を流用可能
-- トポロジカル相（\|μ\| < 2t, Δ≠0）でマヨラナエッジモードが出現
-- 位相相境界: \|μ\| = 2t（Δ≠0 のとき）
-- 参考: Kitaev, *Phys. Usp.* 44, 131 (2001)
+### Central charge extraction precision
 
-### KitaevHoneycomb の詳細
+Current: c = 1/2 within ~10% at N=14 (TFIM), c = 1 within ~20% at
+N=12 (Heisenberg, even-l filtering).
 
-```
-H = -Jₓ Σ_{x-links} σˣᵢσˣⱼ - Jᵧ Σ_{y-links} σʸᵢσʸⱼ - Jᵤ Σ_{z-links} σᶻᵢσᶻⱼ
-```
+The OBC Calabrese-Cardy formula already includes the log-sin finite-size
+correction. Remaining errors come from:
 
-- Majorana フェルミオン表示で厳密に解ける（2D）
-- 相図: A 相（トポロジカル）/ B 相（ギャップレス）
-- 参考: Kitaev, *Ann. Phys.* 321, 2 (2006)
+1. Lattice discretization (irrelevant operators, O(1/N))
+2. Boundary effects not captured by the strip conformal mapping
+3. For Heisenberg: SU(2) alternating corrections (-1)^l f(l)
 
-## 将来のサブモジュール案
+Potential improvements:
+- Use PBC chains (eliminate boundary corrections) — requires PBC ED or
+  fixing the Peschel method
+- Include subleading corrections in the fit model
+- Larger N via sparse Lanczos (ground state only)
 
-| モジュール | 内容 | 優先度 | 備考 |
-|-----------|------|--------|------|
-| **ExactDiag.jl** | 小 N の厳密対角化（参照値として） | 中 | QAtlas のテストに使える |
-| **QMC.jl** | 量子モンテカルロの数値結果 | 低 | reference 要件が高い |
+### Bond counting convention for small PBC lattices
 
-## API 設計の再検討
+Lattice2D's `bonds(lat)` double-counts bonds when Lx = 2 or Ly = 2
+with PBC (each edge is traversed in both directions). The transfer
+matrix and brute-force enumeration use the same convention, so results
+agree — but the effective coupling is doubled compared to larger
+lattices. This is documented but can surprise new contributors.
 
-現行設計: `Model{S}(params::Dict{Symbol,Any})`
+### Two API styles
 
-```julia
-fetch(:TFIM, :energy; J=1.0, h=0.5, beta=2.0)
-```
+The old `Model{:TFIM}` + `Quantity{:energy}` style and the new simple
+struct style (`IsingSquare()`, `Universality(:Ising)`) coexist. No
+immediate plan to unify, but new models should use the simple struct
+style. A future refactor could migrate TFIM/E8 to the new style.
 
-**検討中の代替案: 具体的構造体ベース**
+## Future Directions
 
-```julia
-# 各モデルが固有の struct を持つ
-struct TFIM <: AbstractModel
-    J::Float64
-    h::Float64
-end
+### Near-term (infrastructure exists)
 
-fetch(TFIM(J=1.0, h=0.5), :energy; beta=2.0)
-```
+**Sparse ED for larger N** (N = 18–22):
+- `build_tfim` and `build_spinhalf_heisenberg` currently produce dense
+  matrices. Sparse construction + iterative Lanczos (Arpack.jl or
+  KrylovKit.jl) would enable ground state computation at N ~ 20.
+- This would improve central charge extraction significantly
+  (c precision scales as 1/N).
+- Estimated effort: small (sparse matrix fill + `eigsolve` call).
 
-**メリット:**
-- パラメータの型チェックがコンパイル時に行われる
-- FiniteTemperature.jl の `TFIM`, `TFIML` との統一が容易
-- IDE の補完が効く
+**More universality classes from Wikipedia table**:
+- Directed percolation (d=1,2,3: numerical, d≥4: MF)
+- Self-avoiding walk (d=2: exact, d=3: numerical)
+- Conserved directed percolation (Manna class)
+- Tricritical Ising (c = 7/10)
+- These are all data-entry tasks with the `Universality{C}` framework.
 
-**デメリット:**
-- モデルごとに struct 定義が必要
-- 現行コードとの互換性が失われる
+**Finite-size scaling util** (`test/util/fss.jl`):
+- Systematic extraction of critical exponents from ED data at multiple
+  N values. Binder cumulant crossing, data collapse, etc.
+- Would make the universality cross-checks more rigorous.
 
-**TOML パラメータファイル連携（長期課題）:**
-configs/*.toml から直接 Model オブジェクトを生成できるようにすると、
-FiniteTemperature.jl のパイプラインと QAtlas の参照値比較が自動化できる。
+### Medium-term (requires new packages or significant work)
 
-```julia
-# 将来のイメージ
-spec = load_p1_spec("configs/phase1.toml")
-e_ref = fetch(spec.model, :energy; beta=spec.beta_max)
-```
+**ITensors.jl DMRG benchmarks**:
+- Compare DMRG ground state energy against QAtlas exact values
+  (Heisenberg Bethe ansatz, TFIM BdG).
+- Requires ITensors.jl as a test dependency.
+- Goal: QAtlas as the "ground truth" for tensor network benchmarks.
+
+**Disordered systems — quantitative IRFP**:
+- Extract c_eff = ln 2 from the random TFIM at the Fisher IRFP
+  with proper disorder averaging (100+ realizations, N ~ 14).
+- Random singlet phase of the Heisenberg chain: verify the
+  log-averaged correlation function exponent.
+- Harris criterion test: compare clean α to disorder relevance.
+
+**Anderson localization** (1D TB + random on-site potential):
+- All states localized in 1D (exact result).
+- Localization length ξ ∝ 1/W² for weak disorder.
+- Can use existing `build_tight_binding` + random diagonal.
+
+**Entanglement entropy for free fermions** (Peschel done right):
+- Implement the correlation-matrix method for the σ^x σ^x convention
+  TFIM (direct JW, no KW duality needed).
+- O(N³) computation enables N ~ 1000 for precise c extraction.
+
+### Long-term (research-level)
+
+**TFIM + longitudinal field (TFIML)**:
+- Numerical verification of E8 mass ratios on finite chains.
+- Requires computing the excitation spectrum (not just ground state)
+  of the TFIML Hamiltonian and identifying the 8 stable particles.
+- Connection to `src/universalities/E8.jl`.
+
+**2D models on Lattice2D**:
+- Classical Monte Carlo verification of Onsager T_c, Yang M(T) via
+  Lattice2DMonteCarlo.
+- Finite-size scaling of the Binder cumulant crossing → extract ν.
+- Requires fixing the Lattice2DMonteCarlo LatticeCore compat issue.
+
+**Bethe ansatz beyond ground state**:
+- XXZ chain: Luttinger liquid parameter K, spin-wave velocity.
+- Heisenberg: des Cloizeaux-Pearson dispersion ε(k) = (π/2)|sin k|.
+- Finite-temperature Bethe ansatz (TBA) for thermodynamic quantities.
+
+**Kitaev models**:
+- Kitaev chain (1D): topological phase boundary, Majorana edge modes.
+  Same BdG framework as TFIM.
+- Kitaev honeycomb (2D): exact Majorana solution, A/B phase diagram.
+  Requires 2D lattice Majorana implementation.
+
+**Detailed E8 derivation**:
+- Fill in the missing calculation steps in `calc/e8-mass-spectrum-derivation.md`:
+  bootstrap equation solution, CDD factors, minimal form factors.
+- Requires expertise in integrable field theory.
+
+## Development Practices
+
+- **Version bump**: patch per PR, minor for significant features.
+- **Testing**: 3-tier (standalone, verification, cross-verification).
+  Every `src/` value must have independent test verification.
+- **Documentation**: Zettelkasten `calc/` notes for derivations, linked
+  from model/method/universality pages.
+- **Citations**: each stored value traces to a specific paper + equation.
+- **BLAS threading**: `runtests.jl` sets `BLAS.set_num_threads(Sys.CPU_THREADS)`.
+- **Adaptive sizing**: ED tests use larger N when RAM > 50GB.

--- a/test/models/test_TFIM_dynamics.jl
+++ b/test/models/test_TFIM_dynamics.jl
@@ -11,33 +11,10 @@
 #      with the analytically known correlation length.
 # =============================================================================
 
-using LinearAlgebra: eigen, Hermitian, Diagonal, kron
 
-# ---- ED helpers (used inside the test scope only) --------------------------
 
-const _SX = ComplexF64[0 1; 1 0]
-const _SZ = ComplexF64[1 0; 0 -1]
-const _ID = ComplexF64[1 0; 0 1]
 
-function _op_site(o::AbstractMatrix, k::Int, N::Int)
-    m = (k == 1) ? o : _ID
-    for j in 2:N
-        m = kron(m, j == k ? o : _ID)
-    end
-    return m
-end
 
-function _build_tfim_dense(N::Int, J::Float64, h::Float64)
-    d = 2^N
-    H = zeros(ComplexF64, d, d)
-    for i in 1:(N - 1)
-        H -= J * _op_site(_SZ, i, N) * _op_site(_SZ, i + 1, N)
-    end
-    for i in 1:N
-        H -= h * _op_site(_SX, i, N)
-    end
-    return Hermitian(H)
-end
 
 # Average of ⟨σᶻ_i σᶻ_{i+r}⟩ over a band of bulk r values, used as a
 # numerical estimate of the long-range plateau (in the ordered phase).

--- a/test/models/test_TFIM_thermal.jl
+++ b/test/models/test_TFIM_thermal.jl
@@ -22,32 +22,11 @@
 #      converge to the Infinite values, and the deviation shrinks with N.
 # =============================================================================
 
-using LinearAlgebra: eigen, eigvals, Hermitian, Diagonal, kron, tr, diag
 
 # ---- ED helpers (small N only) ---------------------------------------------
 
-const _SX = ComplexF64[0 1; 1 0]
-const _SZ = ComplexF64[1 0; 0 -1]
-const _ID = ComplexF64[1 0; 0 1]
 
-function _op_site(o::AbstractMatrix, k::Int, N::Int)
-    m = (k == 1) ? o : _ID
-    for j in 2:N
-        m = kron(m, j == k ? o : _ID)
-    end
-    return m
-end
 
-function _build_tfim_dense(N::Int, J::Float64, h::Float64)
-    H = zeros(ComplexF64, 2^N, 2^N)
-    for i in 1:(N - 1)
-        H -= J * _op_site(_SZ, i, N) * _op_site(_SZ, i + 1, N)
-    end
-    for i in 1:N
-        H -= h * _op_site(_SX, i, N)
-    end
-    return Hermitian(H)
-end
 
 # Per-site thermodynamic averages from the dense spectrum at temperature β.
 function _ed_thermo(N, J, h, β)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,7 @@ include(joinpath(@__DIR__, "util", "classical_partition.jl"))
 include(joinpath(@__DIR__, "util", "tight_binding.jl"))
 include(joinpath(@__DIR__, "util", "spinhalf_ed.jl"))
 include(joinpath(@__DIR__, "util", "bloch.jl"))
+include(joinpath(@__DIR__, "util", "tfim_dense_ed.jl"))
 
 @testset "tests" begin
     test_args = copy(ARGS)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 ENV["GKSwstype"] = "100"
 
-using QAtlas, Test, LinearAlgebra
+using QAtlas, Test, LinearAlgebra, Lattice2D, ForwardDiff, Random
 
 # Use all available BLAS threads for dense eigensolves (ED).
 # On multi-core machines this dramatically speeds up eigvals/eigen.
@@ -12,6 +12,12 @@ const dirs = ["core/", "universalities/", "models/", "standalone/", "verificatio
 const FIG_BASE = joinpath(pkgdir(QAtlas), "docs", "src", "assets")
 const PATHS = Dict()
 mkpath.(values(PATHS))
+
+# Load all test utilities ONCE to avoid method-overwrite warnings.
+include(joinpath(@__DIR__, "util", "classical_partition.jl"))
+include(joinpath(@__DIR__, "util", "tight_binding.jl"))
+include(joinpath(@__DIR__, "util", "spinhalf_ed.jl"))
+include(joinpath(@__DIR__, "util", "bloch.jl"))
 
 @testset "tests" begin
     test_args = copy(ARGS)

--- a/test/util/tfim_dense_ed.jl
+++ b/test/util/tfim_dense_ed.jl
@@ -1,0 +1,31 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# test/util/tfim_dense_ed.jl
+#
+# Shared dense ED helpers for TFIM tests (test_TFIM_dynamics.jl and
+# test_TFIM_thermal.jl). Loaded once from runtests.jl to avoid
+# method-overwrite warnings.
+# ─────────────────────────────────────────────────────────────────────────────
+
+const _SX = ComplexF64[0 1; 1 0]
+const _SZ = ComplexF64[1 0; 0 -1]
+const _ID = ComplexF64[1 0; 0 1]
+
+function _op_site(o::AbstractMatrix, k::Int, N::Int)
+    m = (k == 1) ? o : _ID
+    for j in 2:N
+        m = kron(m, j == k ? o : _ID)
+    end
+    return m
+end
+
+function _build_tfim_dense(N::Int, J::Float64, h::Float64)
+    d = 2^N
+    H = zeros(ComplexF64, d, d)
+    for i in 1:(N - 1)
+        H -= J * _op_site(_SZ, i, N) * _op_site(_SZ, i + 1, N)
+    end
+    for i in 1:N
+        H -= h * _op_site(_SX, i, N)
+    end
+    return Hermitian(H)
+end

--- a/test/verification/test_bloch_generic.jl
+++ b/test/verification/test_bloch_generic.jl
@@ -13,7 +13,6 @@
 
 using QAtlas, Lattice2D, LinearAlgebra, Test
 
-include("../util/bloch.jl")
 
 @testset "Generic Bloch TB vs hardcoded formulas" begin
     test_sizes = [(3, 3), (3, 4), (4, 4)]
@@ -58,7 +57,6 @@ include("../util/bloch.jl")
 
     @testset "Generic builder = real-space ED (honeycomb sanity)" begin
         # Triple cross-check: generic Bloch = hardcoded Bloch = real-space ED
-        include("../util/tight_binding.jl")
         lat = build_lattice(Honeycomb, 3, 3)
         H = build_tight_binding(lat, 1.0)
         λ_real = sort(eigvals(Symmetric(H)))

--- a/test/verification/test_bloch_generic.jl
+++ b/test/verification/test_bloch_generic.jl
@@ -13,7 +13,6 @@
 
 using QAtlas, Lattice2D, LinearAlgebra, Test
 
-
 @testset "Generic Bloch TB vs hardcoded formulas" begin
     test_sizes = [(3, 3), (3, 4), (4, 4)]
 

--- a/test/verification/test_dice_tight_binding.jl
+++ b/test/verification/test_dice_tight_binding.jl
@@ -17,8 +17,6 @@
 
 using QAtlas, Lattice2D, LinearAlgebra, Test
 
-include("../util/bloch.jl")
-include("../util/tight_binding.jl")
 
 const T_HOP = 1.0
 

--- a/test/verification/test_dice_tight_binding.jl
+++ b/test/verification/test_dice_tight_binding.jl
@@ -17,7 +17,6 @@
 
 using QAtlas, Lattice2D, LinearAlgebra, Test
 
-
 const T_HOP = 1.0
 
 @testset "Dice (T₃) TB — generic Bloch vs real-space ED" begin

--- a/test/verification/test_disordered_heisenberg.jl
+++ b/test/verification/test_disordered_heisenberg.jl
@@ -17,7 +17,6 @@
 
 using QAtlas, Lattice2D, LinearAlgebra, Random, Test
 
-include("../util/spinhalf_ed.jl")
 
 """
     build_random_heisenberg(lat, J_bonds) -> Matrix{Float64}

--- a/test/verification/test_disordered_heisenberg.jl
+++ b/test/verification/test_disordered_heisenberg.jl
@@ -17,7 +17,6 @@
 
 using QAtlas, Lattice2D, LinearAlgebra, Random, Test
 
-
 """
     build_random_heisenberg(lat, J_bonds) -> Matrix{Float64}
 

--- a/test/verification/test_entanglement_central_charge.jl
+++ b/test/verification/test_entanglement_central_charge.jl
@@ -20,7 +20,6 @@
 
 using QAtlas, Lattice2D, LinearAlgebra, Test
 
-
 # Extract c from S(l) profile using OBC Calabrese-Cardy (c/6)
 function extract_central_charge_obc(Ss::Vector{Float64}, ls, N::Int)
     ξs = [log((2N / π) * sin(π * l / N)) for l in ls]

--- a/test/verification/test_entanglement_central_charge.jl
+++ b/test/verification/test_entanglement_central_charge.jl
@@ -20,7 +20,6 @@
 
 using QAtlas, Lattice2D, LinearAlgebra, Test
 
-include("../util/spinhalf_ed.jl")
 
 # Extract c from S(l) profile using OBC Calabrese-Cardy (c/6)
 function extract_central_charge_obc(Ss::Vector{Float64}, ls, N::Int)

--- a/test/verification/test_graphene_tight_binding.jl
+++ b/test/verification/test_graphene_tight_binding.jl
@@ -15,7 +15,6 @@
 
 using QAtlas, Lattice2D, LinearAlgebra, Test
 
-
 const T_HOP = 1.0
 
 @testset "Graphene TB — real-space vs Bloch closed form" begin

--- a/test/verification/test_graphene_tight_binding.jl
+++ b/test/verification/test_graphene_tight_binding.jl
@@ -15,7 +15,6 @@
 
 using QAtlas, Lattice2D, LinearAlgebra, Test
 
-include("../util/tight_binding.jl")
 
 const T_HOP = 1.0
 

--- a/test/verification/test_heisenberg_4site_pbc.jl
+++ b/test/verification/test_heisenberg_4site_pbc.jl
@@ -13,7 +13,6 @@
 
 using QAtlas, Lattice2D, LinearAlgebra, Test
 
-include("../util/spinhalf_ed.jl")
 
 @testset "Heisenberg 4-site PBC — ED vs exact spectrum" begin
     # 4-site PBC ring via Lattice2D: PBC in x, OBC in y (drops the

--- a/test/verification/test_heisenberg_4site_pbc.jl
+++ b/test/verification/test_heisenberg_4site_pbc.jl
@@ -13,7 +13,6 @@
 
 using QAtlas, Lattice2D, LinearAlgebra, Test
 
-
 @testset "Heisenberg 4-site PBC — ED vs exact spectrum" begin
     # 4-site PBC ring via Lattice2D: PBC in x, OBC in y (drops the
     # (0,1) connection since Ly = 1).

--- a/test/verification/test_heisenberg_dimer.jl
+++ b/test/verification/test_heisenberg_dimer.jl
@@ -13,7 +13,6 @@
 
 using QAtlas, Lattice2D, LinearAlgebra, Test
 
-include("../util/spinhalf_ed.jl")
 
 @testset "Heisenberg dimer (N=2) — ED vs exact spectrum" begin
     # A 2-site OBC chain: build_lattice(Square, 2, 1) with OBC in y drops

--- a/test/verification/test_heisenberg_dimer.jl
+++ b/test/verification/test_heisenberg_dimer.jl
@@ -13,7 +13,6 @@
 
 using QAtlas, Lattice2D, LinearAlgebra, Test
 
-
 @testset "Heisenberg dimer (N=2) — ED vs exact spectrum" begin
     # A 2-site OBC chain: build_lattice(Square, 2, 1) with OBC in y drops
     # the (0, 1) connection; only the single (1, 0) bond survives.

--- a/test/verification/test_ising_2x2_classical.jl
+++ b/test/verification/test_ising_2x2_classical.jl
@@ -11,7 +11,6 @@
 
 using QAtlas, Lattice2D, Test
 
-
 const J_ISING = 1.0
 
 @testset "IsingSquare — transfer-matrix vs brute-force" begin

--- a/test/verification/test_ising_2x2_classical.jl
+++ b/test/verification/test_ising_2x2_classical.jl
@@ -11,7 +11,6 @@
 
 using QAtlas, Lattice2D, Test
 
-include("../util/classical_partition.jl")
 
 const J_ISING = 1.0
 

--- a/test/verification/test_ising_ad_thermodynamics.jl
+++ b/test/verification/test_ising_ad_thermodynamics.jl
@@ -19,7 +19,6 @@
 
 using QAtlas, Lattice2D, ForwardDiff, Test
 
-
 # log Z as a generic function of (β, J) so ForwardDiff.Dual propagates.
 function _log_Z_tm(Lx::Int, Ly::Int, β, J)
     return log(QAtlas.fetch(IsingSquare(), PartitionFunction(); Lx=Lx, Ly=Ly, β=β, J=J))

--- a/test/verification/test_ising_ad_thermodynamics.jl
+++ b/test/verification/test_ising_ad_thermodynamics.jl
@@ -19,7 +19,6 @@
 
 using QAtlas, Lattice2D, ForwardDiff, Test
 
-include("../util/classical_partition.jl")
 
 # log Z as a generic function of (β, J) so ForwardDiff.Dual propagates.
 function _log_Z_tm(Lx::Int, Ly::Int, β, J)

--- a/test/verification/test_kagome_tight_binding.jl
+++ b/test/verification/test_kagome_tight_binding.jl
@@ -16,7 +16,6 @@
 
 using QAtlas, Lattice2D, LinearAlgebra, Test
 
-include("../util/tight_binding.jl")
 
 const T_HOP = 1.0
 

--- a/test/verification/test_kagome_tight_binding.jl
+++ b/test/verification/test_kagome_tight_binding.jl
@@ -16,7 +16,6 @@
 
 using QAtlas, Lattice2D, LinearAlgebra, Test
 
-
 const T_HOP = 1.0
 
 @testset "Kagome TB — real-space vs Bloch closed form" begin

--- a/test/verification/test_lieb_tight_binding.jl
+++ b/test/verification/test_lieb_tight_binding.jl
@@ -17,7 +17,6 @@
 
 using QAtlas, Lattice2D, LinearAlgebra, Test
 
-include("../util/tight_binding.jl")
 
 const T_HOP = 1.0
 

--- a/test/verification/test_lieb_tight_binding.jl
+++ b/test/verification/test_lieb_tight_binding.jl
@@ -17,7 +17,6 @@
 
 using QAtlas, Lattice2D, LinearAlgebra, Test
 
-
 const T_HOP = 1.0
 
 expected_zero_count(Lx, Ly) = Lx * Ly + (iseven(Lx) && iseven(Ly) ? 2 : 0)

--- a/test/verification/test_shastry_sutherland_tight_binding.jl
+++ b/test/verification/test_shastry_sutherland_tight_binding.jl
@@ -14,7 +14,6 @@
 
 using QAtlas, Lattice2D, LinearAlgebra, Test
 
-
 const T_HOP = 1.0
 
 @testset "ShastrySutherland TB — generic Bloch vs real-space ED" begin

--- a/test/verification/test_shastry_sutherland_tight_binding.jl
+++ b/test/verification/test_shastry_sutherland_tight_binding.jl
@@ -14,8 +14,6 @@
 
 using QAtlas, Lattice2D, LinearAlgebra, Test
 
-include("../util/bloch.jl")
-include("../util/tight_binding.jl")
 
 const T_HOP = 1.0
 

--- a/test/verification/test_tfim_gap_closure.jl
+++ b/test/verification/test_tfim_gap_closure.jl
@@ -13,7 +13,6 @@
 
 using QAtlas, Lattice2D, LinearAlgebra, Test
 
-include("../util/spinhalf_ed.jl")
 
 @testset "TFIM — ED ground state vs BdG analytical" begin
     for N in [4, 6, 8]

--- a/test/verification/test_tfim_gap_closure.jl
+++ b/test/verification/test_tfim_gap_closure.jl
@@ -13,7 +13,6 @@
 
 using QAtlas, Lattice2D, LinearAlgebra, Test
 
-
 @testset "TFIM — ED ground state vs BdG analytical" begin
     for N in [4, 6, 8]
         lat = build_lattice(Square, N, 1; boundary=OpenAxis())

--- a/test/verification/test_triangular_tight_binding.jl
+++ b/test/verification/test_triangular_tight_binding.jl
@@ -18,7 +18,6 @@
 
 using QAtlas, Lattice2D, LinearAlgebra, Test
 
-include("../util/tight_binding.jl")
 
 const T_HOP = 1.0
 

--- a/test/verification/test_triangular_tight_binding.jl
+++ b/test/verification/test_triangular_tight_binding.jl
@@ -18,7 +18,6 @@
 
 using QAtlas, Lattice2D, LinearAlgebra, Test
 
-
 const T_HOP = 1.0
 
 @testset "Triangular TB — real-space vs Bloch closed form" begin

--- a/test/verification/test_unionjack_tight_binding.jl
+++ b/test/verification/test_unionjack_tight_binding.jl
@@ -10,7 +10,6 @@
 
 using QAtlas, Lattice2D, LinearAlgebra, Test
 
-
 const T_HOP = 1.0
 
 @testset "UnionJack TB — generic Bloch vs real-space ED" begin

--- a/test/verification/test_unionjack_tight_binding.jl
+++ b/test/verification/test_unionjack_tight_binding.jl
@@ -10,8 +10,6 @@
 
 using QAtlas, Lattice2D, LinearAlgebra, Test
 
-include("../util/bloch.jl")
-include("../util/tight_binding.jl")
 
 const T_HOP = 1.0
 

--- a/test/verification/test_universality_cross_check.jl
+++ b/test/verification/test_universality_cross_check.jl
@@ -18,7 +18,6 @@
 
 using QAtlas, Lattice2D, LinearAlgebra, ForwardDiff, Test
 
-include("../util/spinhalf_ed.jl")
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # 1. Yang magnetization → β = 1/8

--- a/test/verification/test_universality_cross_check.jl
+++ b/test/verification/test_universality_cross_check.jl
@@ -18,7 +18,6 @@
 
 using QAtlas, Lattice2D, LinearAlgebra, ForwardDiff, Test
 
-
 # ═══════════════════════════════════════════════════════════════════════════════
 # 1. Yang magnetization → β = 1/8
 #


### PR DESCRIPTION
## Summary

- Fix broken relative links in Documenter.jl build (depth miscalculation for tightbinding/ and jordan-wigner/ pages)
- Remove external link to test file (Documenter forbids links outside docs/)
- Update md/ internal notes: roadmap with remaining issues + future directions
- Version bump 0.12.6 → 0.12.7

Docs build now succeeds locally (46 HTML files generated, warnings only for $ escaping).