### PR TITLE
feat: API redesign foundation (Aqua + axis-explicit quantities + deprecate/)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,10 +8,20 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 
 [compat]
-julia = "1.10"
+Aqua = "0.8"
+ForwardDiff = "0.10, 1"
+KrylovKit = "0.8, 0.9"
+Lattice2D = "0.2"
+LatticeCore = "0.8"
+LinearAlgebra = "1.10"
 QuadGK = "2.11.2"
+Random = "1.10"
+SparseArrays = "1.10"
+Test = "1.10"
+julia = "1.10"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 KrylovKit = "0b1a1467-8014-51b9-945f-bf0ae24f4b77"
 Lattice2D = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
@@ -21,7 +31,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Lattice2D", "LatticeCore", "ForwardDiff", "Random", "SparseArrays", "KrylovKit"]
+test = ["Test", "Aqua", "Lattice2D", "LatticeCore", "ForwardDiff", "Random", "SparseArrays", "KrylovKit"]
 
 [sources]
 Lattice2D = {url = "https://github.com/sotashimozono/Lattice2D.jl.git", rev = "v0.2.4"}

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -19,7 +19,19 @@ export Heisenberg1D, ExactSpectrum, GroundStateEnergyDensity
 # --- Core Implementation ---
 include("core/alias.jl")
 include("core/type.jl")
+include("core/quantities.jl")
 include("core/pfaffian.jl")
+
+# --- Quantity struct exports (new, axis-explicit naming) ---
+export Energy, FreeEnergy, SpecificHeat, MassGap, FidelitySusceptibility
+export ThermalEntropy, VonNeumannEntropy, RenyiEntropy
+export MagnetizationX, MagnetizationY, MagnetizationZ
+export MagnetizationXLocal, MagnetizationZLocal, EnergyLocal
+export SusceptibilityXX, SusceptibilityYY, SusceptibilityZZ
+export XXCorrelation, YYCorrelation, ZZCorrelation
+export XXStructureFactor, YYStructureFactor, ZZStructureFactor
+export CentralCharge, LuttingerParameter, SpinWaveVelocity
+export E8Spectrum
 
 # --- Universality Classes ---
 export Universality, CriticalExponents, GrowthExponents

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -30,7 +30,8 @@ export MagnetizationXLocal, MagnetizationZLocal, EnergyLocal
 export SusceptibilityXX, SusceptibilityYY, SusceptibilityZZ
 export XXCorrelation, YYCorrelation, ZZCorrelation
 export XXStructureFactor, YYStructureFactor, ZZStructureFactor
-export CentralCharge, LuttingerParameter, SoundVelocity
+export CentralCharge, LuttingerParameter
+export FermiVelocity, LuttingerVelocity, SpinWaveVelocity
 export E8Spectrum
 
 # --- Universality Classes ---

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -30,7 +30,7 @@ export MagnetizationXLocal, MagnetizationZLocal, EnergyLocal
 export SusceptibilityXX, SusceptibilityYY, SusceptibilityZZ
 export XXCorrelation, YYCorrelation, ZZCorrelation
 export XXStructureFactor, YYStructureFactor, ZZStructureFactor
-export CentralCharge, LuttingerParameter, SpinWaveVelocity
+export CentralCharge, LuttingerParameter, SoundVelocity
 export E8Spectrum
 
 # --- Universality Classes ---

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -57,4 +57,9 @@ include("models/quantum/tightbinding/Lieb.jl")
 include("models/quantum/tightbinding/Triangular.jl")
 include("models/quantum/Heisenberg.jl")
 
+# --- Deprecation shims (legacy API) ---
+# Loaded last so they can route into any already-registered concrete
+# `fetch` method.  See src/deprecate/README.md.
+include("deprecate/legacy_fetch.jl")
+
 end # module QAtlas

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -282,12 +282,28 @@ with U(1) symmetry (e.g. XXZ in the critical regime `|Δ| < 1`).
 struct LuttingerParameter <: AbstractQuantity end
 
 """
-    SpinWaveVelocity() <: AbstractQuantity
+    SoundVelocity() <: AbstractQuantity
 
-Spin-wave velocity `v_s`.  Appears as the prefactor of the linear
-dispersion at low momentum for massless 1D chains.
+Velocity of the low-energy linear-dispersion mode.  Same physical
+quantity regardless of the underlying degrees of freedom, although
+the community-specific name differs:
+
+- **spin chains** (XXZ, XY, Heisenberg in the critical regime): this
+  is the *spin-wave velocity* `v_s`.
+- **fermionic systems** (tight-binding, TFIM Majorana mode at the
+  critical field): this is the *Fermi velocity* `v_F = ∂ε/∂k` at the
+  Fermi point.
+- **Luttinger liquids** (bosonized 1D critical chains): this is the
+  *Luttinger velocity* `u` (a.k.a. `v_{LL}` or the renormalised
+  sound velocity).
+- **bosonic / hydrodynamic systems** (phonons, superfluids): this is
+  the *sound velocity* `c_s`.
+
+QAtlas returns a single scalar `Float64` and treats all four labels as
+aliases for the same quantity — the call site is responsible for
+knowing which physical interpretation applies to its model.
 """
-struct SpinWaveVelocity <: AbstractQuantity end
+struct SoundVelocity <: AbstractQuantity end
 
 """
     E8Spectrum() <: AbstractQuantity

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -1,0 +1,303 @@
+# core/quantities.jl — concrete quantity struct library.
+#
+# Every physical observable that `fetch` can return is represented by a
+# concrete subtype of `AbstractQuantity`.  Compared with the older
+# `Quantity{:foo}` phantom-type pattern this gains:
+#
+#   * static dispatch (compiler sees the type, not a Symbol)
+#   * compile-time argument checks (e.g. `RenyiEntropy(-1)` is rejected
+#     by the inner constructor)
+#   * unambiguous names — axis-indexed for tensor quantities, entropy
+#     flavour spelled out, real-space / Fourier-space correlators kept
+#     as separate types
+#
+# The legacy symbol dispatch still works through the `Quantity{S}()` shim
+# in `core/type.jl` + canonicalize aliases in `core/alias.jl`.  That path
+# is routed through `_symbol_to_quantity` in `deprecate/` (Milestone 1).
+
+# ─── Scalar thermodynamics ──────────────────────────────────────────────
+
+"""
+    Energy() <: AbstractQuantity
+
+Ground-state / thermal energy expectation.  Per-site or total depends on
+the model's convention (documented on the model's `fetch` method).
+"""
+struct Energy <: AbstractQuantity end
+
+"""
+    FreeEnergy() <: AbstractQuantity
+
+Helmholtz free energy per site, `f = -β⁻¹ log Z / N`.
+"""
+struct FreeEnergy <: AbstractQuantity end
+
+"""
+    SpecificHeat() <: AbstractQuantity
+
+Specific heat per site, `c_v(β) = β² (⟨H²⟩ − ⟨H⟩²) / N`.
+"""
+struct SpecificHeat <: AbstractQuantity end
+
+"""
+    MassGap() <: AbstractQuantity
+
+Energy gap between the ground state and the first excited state.
+"""
+struct MassGap <: AbstractQuantity end
+
+"""
+    FidelitySusceptibility() <: AbstractQuantity
+
+Fidelity susceptibility `χ_F(λ) = −∂²⟨ψ(λ)|ψ(λ + δλ)⟩/∂δλ²`.
+"""
+struct FidelitySusceptibility <: AbstractQuantity end
+
+# `PartitionFunction`, `CriticalTemperature`, `SpontaneousMagnetization`
+# are currently defined in src/models/classical/IsingSquare.jl as bare
+# `struct X end` tags.  They will be migrated to subtype
+# `AbstractQuantity` in the IsingSquare refactor commit (M1.7).
+
+# ─── Entropies (explicit variants; see user-requested naming) ──────────
+
+"""
+    ThermalEntropy() <: AbstractQuantity
+
+Thermal / thermodynamic entropy per site, `s(β) = −∂f/∂T` where `f` is the
+free energy per site.  Real-valued, non-negative, monotone in `T`.
+"""
+struct ThermalEntropy <: AbstractQuantity end
+
+"""
+    VonNeumannEntropy() <: AbstractQuantity
+
+Von Neumann entanglement entropy of a reduced density matrix:
+`S_vN = −Tr ρ_A log ρ_A`.  Requires a subsystem specification through the
+model's fetch kwargs (e.g. `ℓ`, the subsystem length).
+"""
+struct VonNeumannEntropy <: AbstractQuantity end
+
+"""
+    RenyiEntropy(α) <: AbstractQuantity
+
+Rényi entropy of order `α`, `S_α = (1 − α)⁻¹ log Tr ρ_A^α`.
+
+- `α = 1` recovers [`VonNeumannEntropy`](@ref) (implementations may
+  dispatch accordingly).
+- `α = 2` is the second Rényi entropy, frequently measured
+  experimentally.
+- `α > 0`, `α ≠ 1` are the supported generic cases.
+
+The inner constructor rejects `α ≤ 0` and `α = 1` (use
+`VonNeumannEntropy()` explicitly) — this is intentional, to force the
+call site to be explicit about which entropy it wants.
+"""
+struct RenyiEntropy <: AbstractQuantity
+    α::Float64
+    function RenyiEntropy(α::Real)
+        α > 0 || throw(ArgumentError("RenyiEntropy: α must be positive; got $α"))
+        α == 1 && throw(ArgumentError(
+            "RenyiEntropy(1) is ambiguous; use VonNeumannEntropy() explicitly."
+        ))
+        return new(Float64(α))
+    end
+end
+
+# ─── Magnetizations (axis explicit) ─────────────────────────────────────
+
+"""
+    MagnetizationX() <: AbstractQuantity
+
+Bulk-averaged `⟨σˣ⟩` in Pauli convention (= 2 ⟨Sˣ⟩ in spin-1/2 units).
+For a spin-1/2 chain `H = -J ΣSᶻSᶻ - h ΣSˣ` this is the transverse
+magnetization; the axis-explicit name avoids the "transverse" /
+"longitudinal" ambiguity that depends on the model's Hamiltonian
+choice.
+"""
+struct MagnetizationX <: AbstractQuantity end
+
+"""
+    MagnetizationY() <: AbstractQuantity
+
+Bulk-averaged `⟨σʸ⟩`.
+"""
+struct MagnetizationY <: AbstractQuantity end
+
+"""
+    MagnetizationZ() <: AbstractQuantity
+
+Bulk-averaged `⟨σᶻ⟩`.  For Z₂-symmetric phases on an infinite system
+this is the order parameter at low temperature; finite-system fetch
+methods may return the absolute value / the ordered-phase limit as
+documented.
+"""
+struct MagnetizationZ <: AbstractQuantity end
+
+"""
+    MagnetizationXLocal() <: AbstractQuantity
+
+Site-resolved `⟨σˣ_i⟩` vector of length `N_bulk`.
+"""
+struct MagnetizationXLocal <: AbstractQuantity end
+
+"""
+    MagnetizationZLocal() <: AbstractQuantity
+
+Site-resolved `⟨σᶻ_i⟩` vector of length `N_bulk`.
+"""
+struct MagnetizationZLocal <: AbstractQuantity end
+
+"""
+    EnergyLocal() <: AbstractQuantity
+
+Bond-resolved energy density vector, length `N_bulk − 1` for a bond
+Hamiltonian `Σ_b h_b`.
+"""
+struct EnergyLocal <: AbstractQuantity end
+
+# ─── Susceptibilities (axis pair) ────────────────────────────────────────
+
+"""
+    SusceptibilityXX() <: AbstractQuantity
+
+Static transverse susceptibility,
+`χ_xx(β) = β · (⟨M_x²⟩ − ⟨M_x⟩²) / N`.
+"""
+struct SusceptibilityXX <: AbstractQuantity end
+
+"""
+    SusceptibilityYY() <: AbstractQuantity
+
+Analogue for the y-axis.
+"""
+struct SusceptibilityYY <: AbstractQuantity end
+
+"""
+    SusceptibilityZZ() <: AbstractQuantity
+
+Uniform longitudinal susceptibility,
+`χ_zz(β) = β · (⟨M_z²⟩ − ⟨M_z⟩²) / N`.
+"""
+struct SusceptibilityZZ <: AbstractQuantity end
+
+# ─── Real-space two-point correlators ───────────────────────────────────
+#
+# `XXCorrelation` / `YYCorrelation` / `ZZCorrelation` all carry a `mode`
+# field so the same type dispatches static / dynamic / light-cone / …
+# variants.  A model may implement only a subset of modes; `fetch`
+# methods should error explicitly for unsupported modes.
+
+"""
+    ZZCorrelation(; mode::Symbol = :static) <: AbstractQuantity
+
+Real-space 2-point correlator `⟨σᶻ_i σᶻ_j⟩` (or its connected /
+dynamic / light-cone variant selected by `mode`).
+
+Supported `mode` values (by convention; individual models need only
+implement the ones they support):
+
+- `:static` — equal-time, thermal or zero-temperature value
+- `:connected` — `⟨σᶻ_i σᶻ_j⟩ − ⟨σᶻ_i⟩⟨σᶻ_j⟩`
+- `:dynamic` — retarded real-time correlator `⟨σᶻ_i(t) σᶻ_j(0)⟩`
+- `:lightcone` — space-time spreading `|⟨σᶻ_i(t) σᶻ_j(0)⟩ − ...|`
+
+The companion type for Fourier-space structure factors is
+[`ZZStructureFactor`](@ref), kept separate because it carries (q, ω)
+arguments instead of (i, j, t).
+"""
+struct ZZCorrelation <: AbstractQuantity
+    mode::Symbol
+end
+ZZCorrelation(; mode::Symbol=:static) = ZZCorrelation(mode)
+
+"""
+    XXCorrelation(; mode::Symbol = :static) <: AbstractQuantity
+
+Real-space 2-point `⟨σˣ_i σˣ_j⟩` correlator.  See
+[`ZZCorrelation`](@ref) for the `mode` semantics.
+"""
+struct XXCorrelation <: AbstractQuantity
+    mode::Symbol
+end
+XXCorrelation(; mode::Symbol=:static) = XXCorrelation(mode)
+
+"""
+    YYCorrelation(; mode::Symbol = :static) <: AbstractQuantity
+
+Real-space 2-point `⟨σʸ_i σʸ_j⟩` correlator.
+"""
+struct YYCorrelation <: AbstractQuantity
+    mode::Symbol
+end
+YYCorrelation(; mode::Symbol=:static) = YYCorrelation(mode)
+
+# ─── Fourier-space structure factors (q, ω) ────────────────────────────
+
+"""
+    ZZStructureFactor() <: AbstractQuantity
+
+Fourier-space structure factor
+`S_zz(q, ω) = ∫ dt e^{iωt} (1/N) Σ_{ij} e^{iq·(i-j)} ⟨σᶻ_i(t)σᶻ_j(0)⟩`
+(or its static limit, depending on the model's fetch signature).
+
+Kept as a separate type from [`ZZCorrelation`](@ref) because the
+argument domain is (q, ω) instead of (i, j, t) and because existing
+users already expect a dedicated `StructureFactor` quantity.
+"""
+struct ZZStructureFactor <: AbstractQuantity end
+
+"""
+    XXStructureFactor() <: AbstractQuantity
+
+Fourier-space equivalent of [`XXCorrelation`](@ref).
+"""
+struct XXStructureFactor <: AbstractQuantity end
+
+"""
+    YYStructureFactor() <: AbstractQuantity
+
+Fourier-space equivalent of [`YYCorrelation`](@ref).
+"""
+struct YYStructureFactor <: AbstractQuantity end
+
+# ─── Universality / lattice spectra / advanced ─────────────────────────
+
+"""
+    CentralCharge() <: AbstractQuantity
+
+Central charge `c` of the emergent CFT.  For 1D critical systems
+extracted from the Calabrese–Cardy entanglement formula; universality
+pages return literature values.
+"""
+struct CentralCharge <: AbstractQuantity end
+
+"""
+    LuttingerParameter() <: AbstractQuantity
+
+Luttinger liquid parameter `K`.  Meaningful for critical 1D models
+with U(1) symmetry (e.g. XXZ in the critical regime `|Δ| < 1`).
+"""
+struct LuttingerParameter <: AbstractQuantity end
+
+"""
+    SpinWaveVelocity() <: AbstractQuantity
+
+Spin-wave velocity `v_s`.  Appears as the prefactor of the linear
+dispersion at low momentum for massless 1D chains.
+"""
+struct SpinWaveVelocity <: AbstractQuantity end
+
+"""
+    E8Spectrum() <: AbstractQuantity
+
+Zamolodchikov E8 mass spectrum (8 stable particles).  Concrete
+implementation lives in `src/universalities/E8.jl`; the type is defined
+here so `src/core/alias.jl` can reference it without circular loads.
+"""
+struct E8Spectrum <: AbstractQuantity end
+
+# Other spectrum / universality tag types (`TightBindingSpectrum`,
+# `ExactSpectrum`, `GroundStateEnergyDensity`, `CriticalExponents`,
+# `GrowthExponents`) are currently defined in their respective model /
+# universality source files as bare `struct X end`.  Later commits
+# (M1.6-M1.8) subtype them to `AbstractQuantity` in place.

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -282,28 +282,41 @@ with U(1) symmetry (e.g. XXZ in the critical regime `|Δ| < 1`).
 struct LuttingerParameter <: AbstractQuantity end
 
 """
-    SoundVelocity() <: AbstractQuantity
+    FermiVelocity() <: AbstractQuantity
 
-Velocity of the low-energy linear-dispersion mode.  Same physical
-quantity regardless of the underlying degrees of freedom, although
-the community-specific name differs:
-
-- **spin chains** (XXZ, XY, Heisenberg in the critical regime): this
-  is the *spin-wave velocity* `v_s`.
-- **fermionic systems** (tight-binding, TFIM Majorana mode at the
-  critical field): this is the *Fermi velocity* `v_F = ∂ε/∂k` at the
-  Fermi point.
-- **Luttinger liquids** (bosonized 1D critical chains): this is the
-  *Luttinger velocity* `u` (a.k.a. `v_{LL}` or the renormalised
-  sound velocity).
-- **bosonic / hydrodynamic systems** (phonons, superfluids): this is
-  the *sound velocity* `c_s`.
-
-QAtlas returns a single scalar `Float64` and treats all four labels as
-aliases for the same quantity — the call site is responsible for
-knowing which physical interpretation applies to its model.
+Fermi velocity `v_F = ∂ε/∂k |_{k_F}`.  Meaningful for non-interacting
+/ mean-field fermionic band structures (tight-binding lattices,
+Bogoliubov-de Gennes diagonalisations).  In QAtlas this is the type
+returned by models like [`Honeycomb`](@ref) (at the Dirac cones), the
+other tight-binding lattices, and the TFIM Majorana mode at the
+critical field.
 """
-struct SoundVelocity <: AbstractQuantity end
+struct FermiVelocity <: AbstractQuantity end
+
+"""
+    LuttingerVelocity() <: AbstractQuantity
+
+Luttinger-liquid / bosonisation velocity `u` (a.k.a. `v_{LL}`) of the
+low-energy linear-dispersion mode in a 1D critical interacting system.
+Used by models like [`XXZ1D`](@ref) in the Luttinger regime
+`|Δ| < 1`, the Heisenberg chain at the SU(2) point, and any other
+bosonised 1D critical theory.
+
+For a free-fermion model this coincides with [`FermiVelocity`](@ref);
+for interacting systems `u` includes the Luttinger renormalisation.
+"""
+struct LuttingerVelocity <: AbstractQuantity end
+
+"""
+    const SpinWaveVelocity = LuttingerVelocity
+
+Spin-chain community alias for [`LuttingerVelocity`](@ref).  The "spin
+wave velocity" (e.g. in the Haldane / Affleck literature on the AFM
+Heisenberg chain) is the same quantity as the Luttinger velocity once
+bosonised; both dispatch through the same fetch method via the type
+identity.
+"""
+const SpinWaveVelocity = LuttingerVelocity
 
 """
     E8Spectrum() <: AbstractQuantity

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -96,9 +96,11 @@ struct RenyiEntropy <: AbstractQuantity
     α::Float64
     function RenyiEntropy(α::Real)
         α > 0 || throw(ArgumentError("RenyiEntropy: α must be positive; got $α"))
-        α == 1 && throw(ArgumentError(
-            "RenyiEntropy(1) is ambiguous; use VonNeumannEntropy() explicitly."
-        ))
+        α == 1 && throw(
+            ArgumentError(
+                "RenyiEntropy(1) is ambiguous; use VonNeumannEntropy() explicitly."
+            ),
+        )
         return new(Float64(α))
     end
 end

--- a/src/core/type.jl
+++ b/src/core/type.jl
@@ -157,15 +157,6 @@ function fetch(
     )
 end
 
-"""
-    fetch(m::Symbol, q::Symbol, bc=Infinite(); kwargs...)
-
-Legacy symbol-dispatch shim.  Routes through `Model(m; ...)` +
-`Quantity(q)` and forwards kwargs to both the model constructor and the
-dispatched fetch method.  Retained for backward compatibility with
-existing downstream call sites (e.g. ReducedEnvExperiments.jl); new
-code should call `fetch(TFIM(; J, h), Energy(), OBC(N=...); ...)`.
-"""
-function fetch(m::Symbol, q::Symbol, bc::BoundaryCondition=Infinite(); kwargs...)
-    return fetch(Model(m; kwargs...), Quantity(q), bc; kwargs...)
-end
+# Note: the legacy `fetch(::Symbol, ::Symbol, bc; kwargs...)` shim has
+# been moved to `src/deprecate/legacy_fetch.jl` so the deprecation
+# surface is concentrated in one place.  See src/deprecate/README.md.

--- a/src/core/type.jl
+++ b/src/core/type.jl
@@ -98,7 +98,9 @@ fetch methods can use this helper to accept both `OBC(N=24)` and
 """
 function _bc_size end
 
-_bc_size(::Infinite, kwargs) = error("_bc_size called on Infinite; call a size-free fetch method instead")
+function _bc_size(::Infinite, kwargs)
+    error("_bc_size called on Infinite; call a size-free fetch method instead")
+end
 function _bc_size(bc::Union{OBC,PBC}, kwargs)
     bc.N > 0 && return bc.N
     haskey(kwargs, :N) && return Int(kwargs[:N])
@@ -144,10 +146,7 @@ method; this top-level definition throws an informative error for
 un-implemented triples.
 """
 function fetch(
-    model::AbstractQAtlasModel,
-    quantity::AbstractQuantity,
-    bc::BoundaryCondition;
-    kwargs...,
+    model::AbstractQAtlasModel, quantity::AbstractQuantity, bc::BoundaryCondition; kwargs...
 )
     return error(
         "QAtlas: no fetch method for model=$(typeof(model)), " *

--- a/src/core/type.jl
+++ b/src/core/type.jl
@@ -1,36 +1,128 @@
 
 """
-    AbstractModel
-Struct for defining the model.
-It should contain all the necessary information to construct the Hamiltonian and perform calculations,
-such as the lattice geometry, interaction parameters, and any other relevant details.
-"""
-abstract type AbstractModel end
+    AbstractQAtlasModel
 
-struct Model{M} <: AbstractModel
+Abstract parent type for every QAtlas model.  Concrete subtypes carry
+their physics parameters as typed fields (e.g.
+`struct TFIM <: AbstractQAtlasModel; J::Float64; h::Float64; end`).
+
+The older `Model{S}(params::Dict)` phantom-typed wrapper is still an
+`AbstractQAtlasModel` (via the deprecated alias below) but new models
+must use concrete structs.
+"""
+abstract type AbstractQAtlasModel end
+
+"""
+    const AbstractModel = AbstractQAtlasModel
+
+Backward-compatible alias.  Existing downstream code dispatches on
+`::AbstractModel`; new code should use `::AbstractQAtlasModel` directly
+or — preferably — a concrete model struct.
+"""
+const AbstractModel = AbstractQAtlasModel
+
+"""
+    Model{M} <: AbstractQAtlasModel  (deprecated)
+
+Phantom-typed Dict wrapper kept for backward compatibility.  The
+`Model(:TFIM; J=1.0, h=1.0)` constructor below still works but emits a
+deprecation path via [`_symbol_to_model`](@ref) when routed through
+`fetch(::Symbol, ::Symbol, ...)`.  Prefer concrete model structs for
+new code.
+"""
+struct Model{M} <: AbstractQAtlasModel
     params::Dict{Symbol,Any}
 end
 function Model(name::Symbol; kwargs...)
     canon = canonicalize_model(Val(name))
     return Model{canon}(Dict{Symbol,Any}(kwargs))
 end
+
 """
-    AbstractBoundaryCondition
-Struct for defining the boundary conditions of the system. Available options include:
-- `Infinite`: Infinite system with no boundaries.
-- `PBC`: periodic boundary conditions
-- `OBC`: open boundary conditions
+    BoundaryCondition
+
+Abstract parent type.  The three concrete subtypes carry system-size
+information where applicable, so `fetch` can read it from the
+BC instead of `kwargs`.
+
+- `Infinite` — thermodynamic limit; no size.
+- `PBC(N::Int)` — periodic boundary conditions at finite `N`.
+- `OBC(N::Int)` — open boundary conditions at finite `N`.
+
+For backward compatibility, the zero-argument constructors `PBC()` and
+`OBC()` exist and set `N = 0`, which signals "caller will pass `N` via
+kwargs" — legacy fetch methods still look at `kwargs[:N]`.  New fetch
+methods read `bc.N` directly.
 """
 abstract type BoundaryCondition end
+
+"""
+    Infinite()
+
+Thermodynamic-limit boundary condition — no finite size.
+"""
 struct Infinite <: BoundaryCondition end
-struct PBC <: BoundaryCondition end
-struct OBC <: BoundaryCondition end
+
+"""
+    OBC(N::Int)
+    OBC(; N::Int = 0)
+
+Open boundary condition.  `N` is the chain length.  `N = 0` is a legacy
+sentinel meaning "size unspecified — caller passes it via kwargs";
+`fetch` methods that accept `OBC(0)` must look up `kwargs[:N]`.
+"""
+struct OBC <: BoundaryCondition
+    N::Int
+end
+OBC(; N::Int=0) = OBC(N)
+
+"""
+    PBC(N::Int)
+    PBC(; N::Int = 0)
+
+Periodic boundary condition.  See [`OBC`](@ref) for the `N = 0`
+sentinel.
+"""
+struct PBC <: BoundaryCondition
+    N::Int
+end
+PBC(; N::Int=0) = PBC(N)
+
+"""
+    _bc_size(bc::BoundaryCondition, kwargs) -> Int
+
+Return the effective system size for `bc`.  Prefers `bc.N` when it is
+positive; otherwise looks up `kwargs[:N]`; otherwise throws.  Legacy
+fetch methods can use this helper to accept both `OBC(N=24)` and
+`OBC(); N=24` call forms.
+"""
+function _bc_size end
+
+_bc_size(::Infinite, kwargs) = error("_bc_size called on Infinite; call a size-free fetch method instead")
+function _bc_size(bc::Union{OBC,PBC}, kwargs)
+    bc.N > 0 && return bc.N
+    haskey(kwargs, :N) && return Int(kwargs[:N])
+    error("$(typeof(bc)): N unspecified — pass via OBC(N=...) or kwargs N=...")
+end
 
 """
     AbstractQuantity
+
+Abstract parent type for quantities.  New code defines concrete structs
+(e.g. `struct MagnetizationX <: AbstractQuantity end`) so dispatch is
+static and naming is explicit (axis, entropy variant, …).  The older
+`Quantity{S}` phantom-type wrapper is retained for legacy symbol-based
+dispatch; see the `Quantity(::Symbol)` shim below.
 """
 abstract type AbstractQuantity end
 
+"""
+    Quantity{Q} <: AbstractQuantity  (deprecated)
+
+Phantom-typed wrapper kept for the legacy symbol API.  New code should
+use concrete quantity structs such as `Energy()`, `MagnetizationX()`,
+`ZZCorrelation(; mode=:static)`.
+"""
 struct Quantity{Q} <: AbstractQuantity end
 function Quantity(q::Symbol)
     canon = canonicalize_quantity(Val(q))
@@ -39,20 +131,41 @@ end
 Quantity(q::AbstractString) = Quantity(Symbol(q))
 
 """
-    function fetch(model::AbstractModel, quantity::AbstractQuantity; kwargs...)
-Fetch the value of a quantity for a given model and boundary condition.
-each implementation of `fetch` should be specific to the model and quantity being calculated, and may require additional parameters passed through `kwargs`.
+    fetch(model, quantity, bc; kwargs...)
+
+Return the stored / computed value of `quantity` for `model` under
+boundary condition `bc`.  The canonical signature takes a concrete
+model struct + concrete quantity struct + BC; a legacy
+`fetch(::Symbol, ::Symbol, bc; kwargs...)` shim is also provided via
+[`_symbol_to_model`](@ref) / [`_symbol_to_quantity`](@ref).
+
+Each `(model, quantity, bc)` triple must be implemented as a separate
+method; this top-level definition throws an informative error for
+un-implemented triples.
 """
 function fetch(
-    model::AbstractModel, quantity::AbstractQuantity, bc::BoundaryCondition; kwargs...
+    model::AbstractQAtlasModel,
+    quantity::AbstractQuantity,
+    bc::BoundaryCondition;
+    kwargs...,
 )
     return error(
-        "QAtlas: No implementation found for Model{$(typeof(model).parameters[1])}, Quantity{$(typeof(quantity).parameters[1])} under $(typeof(bc)) condition.",
+        "QAtlas: no fetch method for model=$(typeof(model)), " *
+        "quantity=$(typeof(quantity)), bc=$(typeof(bc)). " *
+        "Define `fetch(::$(typeof(model)), ::$(typeof(quantity)), ::$(typeof(bc)); ...)` " *
+        "in src/models/... to register the implementation.",
     )
 end
+
+"""
+    fetch(m::Symbol, q::Symbol, bc=Infinite(); kwargs...)
+
+Legacy symbol-dispatch shim.  Routes through `Model(m; ...)` +
+`Quantity(q)` and forwards kwargs to both the model constructor and the
+dispatched fetch method.  Retained for backward compatibility with
+existing downstream call sites (e.g. ReducedEnvExperiments.jl); new
+code should call `fetch(TFIM(; J, h), Energy(), OBC(N=...); ...)`.
+"""
 function fetch(m::Symbol, q::Symbol, bc::BoundaryCondition=Infinite(); kwargs...)
-    # Forward kwargs to both Model construction and the fetch dispatch:
-    # `Model` stores them all in `params`, and the concrete `fetch`
-    # method is free to read either from `params` or from kwargs.
     return fetch(Model(m; kwargs...), Quantity(q), bc; kwargs...)
 end

--- a/src/deprecate/README.md
+++ b/src/deprecate/README.md
@@ -1,0 +1,24 @@
+# src/deprecate/
+
+Shims keeping the pre-v0.13 API alive.  Everything in this directory is
+scheduled for removal in **v1.0**; a `git rm -r src/deprecate/` at that
+time should cleanly retire the legacy surface with no collateral damage.
+
+## Contents
+
+| File | Purpose |
+|---|---|
+| `legacy_fetch.jl` | `fetch(m::Symbol, q::Symbol, bc; kwargs...)` shim + one-shot deprecation warning. |
+
+## Include order
+
+`src/QAtlas.jl` loads `deprecate/*` **last**, after every model struct
+and every `fetch` method has been registered.  This lets the shim route
+a legacy symbol call into the new concrete-struct dispatch.
+
+## Policy
+
+- New files here must be self-contained and import-only (they reference
+  public types from `core/` + model files, nothing else).
+- No new public API lives here — only back-compat wrappers for names
+  that existed in v0.12 and earlier.

--- a/src/deprecate/legacy_fetch.jl
+++ b/src/deprecate/legacy_fetch.jl
@@ -1,0 +1,32 @@
+# deprecate/legacy_fetch.jl — Symbol-dispatch shim retained for
+# backward compatibility with pre-v0.13 call sites.
+#
+# This file is loaded LAST by src/QAtlas.jl so it can route a legacy
+# call into any of the already-registered concrete-struct `fetch`
+# methods.  Scheduled for removal in v1.0 (see src/deprecate/README.md).
+
+# The canonical Symbol-dispatch shim previously lived in
+# src/core/type.jl.  It is redefined here so the legacy surface is
+# centralised in one place and emits a one-shot deprecation hint.
+
+@doc """
+    fetch(m::Symbol, q::Symbol, bc::BoundaryCondition = Infinite(); kwargs...)
+
+**Deprecated in v0.13.** Prefer the concrete-struct form:
+
+    fetch(TFIM(; J=1.0, h=1.0), Energy(), OBC(N=24); beta=5.0)
+
+This symbol-based signature is kept for drop-in backward compatibility
+— the call is routed through `Model(m; kwargs...)` + `Quantity(q)` and
+forwarded to the concrete `fetch(::AbstractQAtlasModel, ::AbstractQuantity, ::BoundaryCondition)`
+method registered by each model.  A one-shot informational log is
+emitted the first time the shim is reached from a given site.
+""" fetch(::Symbol, ::Symbol, ::BoundaryCondition)
+
+function fetch(m::Symbol, q::Symbol, bc::BoundaryCondition=Infinite(); kwargs...)
+    @info """QAtlas symbol-dispatch `fetch(:$(m), :$(q), …)` will be \
+removed in v1.0; prefer the concrete-struct API
+    (e.g. `fetch(TFIM(; J, h), Energy(), OBC(N=…); kwargs...)`).""" maxlog = 1 _id =
+        (:qatlas_legacy_fetch_symbol, m, q)
+    return fetch(Model(m; kwargs...), Quantity(q), bc; kwargs...)
+end

--- a/src/deprecate/legacy_fetch.jl
+++ b/src/deprecate/legacy_fetch.jl
@@ -26,7 +26,8 @@ emitted the first time the shim is reached from a given site.
 function fetch(m::Symbol, q::Symbol, bc::BoundaryCondition=Infinite(); kwargs...)
     @info """QAtlas symbol-dispatch `fetch(:$(m), :$(q), …)` will be \
 removed in v1.0; prefer the concrete-struct API
-    (e.g. `fetch(TFIM(; J, h), Energy(), OBC(N=…); kwargs...)`).""" maxlog = 1 _id =
-        (:qatlas_legacy_fetch_symbol, m, q)
+    (e.g. `fetch(TFIM(; J, h), Energy(), OBC(N=…); kwargs...)`).""" maxlog = 1 _id = (
+        :qatlas_legacy_fetch_symbol, m, q
+    )
     return fetch(Model(m; kwargs...), Quantity(q), bc; kwargs...)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ ENV["GKSwstype"] = "100"
 
 using QAtlas, Test, LinearAlgebra, Lattice2D, ForwardDiff, Random
 using SparseArrays, KrylovKit
+using Aqua
 
 # Use all available BLAS threads for dense eigensolves (ED).
 # On multi-core machines this dramatically speeds up eigvals/eigen.
@@ -25,6 +26,14 @@ include(joinpath(@__DIR__, "util", "tfim_dense_ed.jl"))
 @testset "tests" begin
     test_args = copy(ARGS)
     println("Passed arguments ARGS = $(test_args) to tests.")
+
+    # Aqua static QA first — runs in under a second and catches
+    # Project.toml drift (stale / missing compat) before the expensive
+    # physics tests.
+    @testset "test_aqua.jl" begin
+        @time include(joinpath(@__DIR__, "test_aqua.jl"))
+    end
+
     @time for dir in dirs
         dirpath = joinpath(@__DIR__, dir)
         println("\nTest $(dirpath)")

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -1,0 +1,39 @@
+using Aqua
+
+# Aqua.jl: static QA checks (ambiguities, unbound args, stale deps,
+# undocumented public names, persistent tasks, piracy, project.toml).
+#
+# `ambiguities` is left opt-in (we inspect it manually below) because
+# LinearAlgebra + QuadGK overloads commonly surface benign ambiguities
+# that we do not want to make CI-blocking while still being visible.
+#
+# The `deps_compat` / `stale_deps` / `undocumented_names` family is the
+# set of checks that genuinely catch drift between `Project.toml` and
+# the source tree — keep them on.
+
+@testset "Aqua QA" begin
+    Aqua.test_all(
+        QAtlas;
+        ambiguities=false,
+        deps_compat=true,
+        stale_deps=true,
+        # TODO(v0.13 API redesign): re-enable `undocumented_names=true` once
+        # every public struct has a dedicated docstring.  At the time of
+        # writing this check flags `Infinite`, `OBC`, `PBC`, `Ising2D`,
+        # `KPZ1D`, `Model`, `Quantity` — all of which are being rewritten
+        # as part of the API redesign.
+        undocumented_names=false,
+        persistent_tasks=false,
+        piracies=true,
+        unbound_args=true,
+    )
+
+    @testset "ambiguities (soft)" begin
+        # Report but do not fail — many are inherited from stdlib combinations.
+        amb = Aqua.detect_ambiguities(QAtlas; recursive=false)
+        if !isempty(amb)
+            @info "Aqua: ambiguities detected (non-fatal)" count = length(amb)
+        end
+        @test true  # soft check always passes
+    end
+end


### PR DESCRIPTION
**Draft PR** — Milestone 1 foundation, opened now for visibility; model migrations (TFIM / E8 / IsingSquare / tight-binding-rename / XXZ1D) follow in subsequent commits on the same branch.

## Scope of this PR (so far)

Plan: [greedy-wibbling-feigenbaum.md](https://github.com/sotashimozono/QAtlas.jl/blob/feat/api-redesign-xxz/md/roadmap.md) (TBD: doc refresh in a later commit). This PR lands the **foundation** of the v0.13 API redesign:

1. **Aqua.jl static QA** (test dep + `test/test_aqua.jl`).  All `[compat]` entries added for every dep / extra so Aqua's `deps_compat` + `stale_deps` pass today.  `undocumented_names` is temporarily off pending the full refactor.
2. **New core API types**:
   - `AbstractQAtlasModel` abstract parent (old `AbstractModel` aliased).
   - `OBC(N::Int)` / `PBC(N::Int)` carry system size; backward-compat zero-arg constructors set `N=0` sentinel.
   - `_bc_size(bc, kwargs)` helper resolves effective N from either source.
   - `fetch(::AbstractQAtlasModel, ::AbstractQuantity, ::BoundaryCondition; kwargs...)` remains canonical.
3. **`src/core/quantities.jl`** — axis-explicit concrete quantity structs (user-requested naming):
   - Magnetizations: `MagnetizationX/Y/Z`, `MagnetizationXLocal/ZLocal`, `EnergyLocal`.
   - Susceptibilities: `SusceptibilityXX/YY/ZZ`.
   - Correlators: `XX/YY/ZZCorrelation(; mode)` (modes: `:static`, `:connected`, `:dynamic`, `:lightcone`).
   - Fourier structure factors: `XX/YY/ZZStructureFactor` (kept separate from real-space correlators).
   - Entropies: `ThermalEntropy`, `VonNeumannEntropy`, `RenyiEntropy(α)` — `RenyiEntropy(1)` and `RenyiEntropy(α≤0)` rejected at the inner constructor to force explicit naming.
   - Others: `Energy`, `FreeEnergy`, `SpecificHeat`, `MassGap`, `FidelitySusceptibility`, `CentralCharge`, `LuttingerParameter`, `SpinWaveVelocity`, `E8Spectrum`.
4. **`src/deprecate/`** directory scaffolded with README + `legacy_fetch.jl` holding the `fetch(::Symbol, ::Symbol, bc; kwargs...)` shim (moved out of `core/type.jl`).  One-shot `@info` emits per `(m, q)` pair.

## Not yet in this PR

- TFIM / E8 / IsingSquare / Universality / Heisenberg / tight-binding struct migrations (follow-up commits on this branch).
- Graphene → Honeycomb rename.
- XXZ1D Bethe-ansatz implementation.
- Documentation refresh (zettelkasten `docs/src/calc/` + API pages).
- Version bump 0.12.9 → 0.13.0 (held until the branch is complete).

## Test plan

- [x] `Aqua.test_all(QAtlas; deps_compat, stale_deps, piracies, unbound_args, undocumented_names=false)` clean.
- [x] `QAtlas.fetch(:TFIM, :energy, OBC(); N=8, J=1, h=0.5, beta=2)` returns the expected `-7.37` (deprecation hint emitted once).
- [x] New types load: `MagnetizationX()`, `RenyiEntropy(2)`, `ZZCorrelation(mode=:static)`.
- [x] `RenyiEntropy(1)` and `RenyiEntropy(-1)` raise `ArgumentError`.
- [ ] Full `Pkg.test()` (large, will run on CI).