### PR TITLE
feat: migrate TFIM + E8 to concrete struct API (legacy Symbol shims retained)

### DIFF
--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -10,6 +10,7 @@ export IsingSquare, PartitionFunction, CriticalTemperature, SpontaneousMagnetiza
 
 # --- Quantum Models ---
 export TFIM                                             # v0.13 concrete struct
+export E8                                               # v0.13 concrete struct
 export Graphene, TightBindingSpectrum
 # NOTE: `Kagome`, `Lieb`, `Triangular` are NOT exported — they conflict
 # with Lattice2D's topology types of the same name. Access them as
@@ -64,5 +65,6 @@ include("models/quantum/Heisenberg.jl")
 # `fetch` method.  See src/deprecate/README.md.
 include("deprecate/legacy_fetch.jl")
 include("deprecate/legacy_tfim.jl")
+include("deprecate/legacy_e8.jl")
 
 end # module QAtlas

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -9,6 +9,7 @@ export fetch
 export IsingSquare, PartitionFunction, CriticalTemperature, SpontaneousMagnetization
 
 # --- Quantum Models ---
+export TFIM                                             # v0.13 concrete struct
 export Graphene, TightBindingSpectrum
 # NOTE: `Kagome`, `Lieb`, `Triangular` are NOT exported — they conflict
 # with Lattice2D's topology types of the same name. Access them as
@@ -62,5 +63,6 @@ include("models/quantum/Heisenberg.jl")
 # Loaded last so they can route into any already-registered concrete
 # `fetch` method.  See src/deprecate/README.md.
 include("deprecate/legacy_fetch.jl")
+include("deprecate/legacy_tfim.jl")
 
 end # module QAtlas

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -190,10 +190,11 @@ struct SusceptibilityZZ <: AbstractQuantity end
 # methods should error explicitly for unsupported modes.
 
 """
-    ZZCorrelation(; mode::Symbol = :static) <: AbstractQuantity
+    ZZCorrelation{M}() <: AbstractQuantity
+    ZZCorrelation(; mode::Symbol = :static)
 
-Real-space 2-point correlator `⟨σᶻ_i σᶻ_j⟩` (or its connected /
-dynamic / light-cone variant selected by `mode`).
+Real-space 2-point correlator `⟨σᶻ_i σᶻ_j⟩`.  The mode `M::Symbol` is
+a phantom type parameter so dispatch can specialise on it.
 
 Supported `mode` values (by convention; individual models need only
 implement the ones they support):
@@ -201,37 +202,34 @@ implement the ones they support):
 - `:static` — equal-time, thermal or zero-temperature value
 - `:connected` — `⟨σᶻ_i σᶻ_j⟩ − ⟨σᶻ_i⟩⟨σᶻ_j⟩`
 - `:dynamic` — retarded real-time correlator `⟨σᶻ_i(t) σᶻ_j(0)⟩`
-- `:lightcone` — space-time spreading `|⟨σᶻ_i(t) σᶻ_j(0)⟩ − ...|`
+- `:lightcone` — space-time spreading `⟨σᶻ_i(t) σᶻ_j(0)⟩` as a
+  matrix over (site, time)
 
 The companion type for Fourier-space structure factors is
 [`ZZStructureFactor`](@ref), kept separate because it carries (q, ω)
 arguments instead of (i, j, t).
 """
-struct ZZCorrelation <: AbstractQuantity
-    mode::Symbol
-end
-ZZCorrelation(; mode::Symbol=:static) = ZZCorrelation(mode)
+struct ZZCorrelation{M} <: AbstractQuantity end
+ZZCorrelation(; mode::Symbol=:static) = ZZCorrelation{mode}()
 
 """
-    XXCorrelation(; mode::Symbol = :static) <: AbstractQuantity
+    XXCorrelation{M}() <: AbstractQuantity
+    XXCorrelation(; mode::Symbol = :static)
 
 Real-space 2-point `⟨σˣ_i σˣ_j⟩` correlator.  See
 [`ZZCorrelation`](@ref) for the `mode` semantics.
 """
-struct XXCorrelation <: AbstractQuantity
-    mode::Symbol
-end
-XXCorrelation(; mode::Symbol=:static) = XXCorrelation(mode)
+struct XXCorrelation{M} <: AbstractQuantity end
+XXCorrelation(; mode::Symbol=:static) = XXCorrelation{mode}()
 
 """
-    YYCorrelation(; mode::Symbol = :static) <: AbstractQuantity
+    YYCorrelation{M}() <: AbstractQuantity
+    YYCorrelation(; mode::Symbol = :static)
 
 Real-space 2-point `⟨σʸ_i σʸ_j⟩` correlator.
 """
-struct YYCorrelation <: AbstractQuantity
-    mode::Symbol
-end
-YYCorrelation(; mode::Symbol=:static) = YYCorrelation(mode)
+struct YYCorrelation{M} <: AbstractQuantity end
+YYCorrelation(; mode::Symbol=:static) = YYCorrelation{mode}()
 
 # ─── Fourier-space structure factors (q, ω) ────────────────────────────
 

--- a/src/deprecate/legacy_e8.jl
+++ b/src/deprecate/legacy_e8.jl
@@ -1,0 +1,11 @@
+# deprecate/legacy_e8.jl — backward-compat shim for the E8 Symbol API.
+#
+# Routes the pre-v0.13 call:
+#   fetch(Model(:E8), Quantity(:E8_spectrum), Infinite())
+#   fetch(:E8, :E8_spectrum, Infinite())
+# into the concrete-struct method in src/universalities/E8.jl.
+
+# Legacy Model{:E8} is stateless; just forward.
+function fetch(::Model{:E8}, ::Quantity{:E8_spectrum}, bc::Infinite; kwargs...)
+    return fetch(E8(), E8Spectrum(), bc; kwargs...)
+end

--- a/src/deprecate/legacy_tfim.jl
+++ b/src/deprecate/legacy_tfim.jl
@@ -45,3 +45,26 @@ end
 function fetch(m::Model{:TFIM}, ::Quantity{:central_charge}, bc::Infinite; kwargs...)
     return fetch(_tfim_from_legacy_model(m), CentralCharge(), bc; kwargs...)
 end
+
+# ── Thermal quantities (TFIM_thermal.jl) ────────────────────────────────
+# Mapping: legacy Symbol Quantity → concrete struct used by the new API.
+const _LEGACY_TFIM_THERMAL_MAP = (
+    (:free_energy, FreeEnergy),
+    (:entropy, ThermalEntropy),
+    (:specific_heat, SpecificHeat),
+    (:transverse_magnetization, MagnetizationX),
+    (:transverse_susceptibility, SusceptibilityXX),
+)
+
+for (qsym, QTy) in _LEGACY_TFIM_THERMAL_MAP
+    @eval begin
+        function fetch(m::Model{:TFIM}, ::Quantity{$(QuoteNode(qsym))}, bc::Infinite; kwargs...)
+            return fetch(_tfim_from_legacy_model(m), $QTy(), bc; kwargs...)
+        end
+        function fetch(m::Model{:TFIM}, ::Quantity{$(QuoteNode(qsym))}, bc::OBC; kwargs...)
+            return fetch(
+                _tfim_from_legacy_model(m), $QTy(), _bc_with_legacy_N(bc, m); kwargs...
+            )
+        end
+    end
+end

--- a/src/deprecate/legacy_tfim.jl
+++ b/src/deprecate/legacy_tfim.jl
@@ -1,0 +1,47 @@
+# deprecate/legacy_tfim.jl — backward-compat shims for the TFIM Symbol API.
+#
+# Routes the pre-v0.13 call patterns:
+#   fetch(Model(:TFIM; J, h, N), Quantity(:energy), OBC(); …)
+#   fetch(:TFIM, :energy, OBC(); N, J, h, beta)
+# into the canonical concrete-struct API defined in src/models/TFIM*.jl.
+#
+# Scheduled for removal in v1.0.
+
+"""
+    _tfim_from_legacy_model(m::Model{:TFIM}) -> TFIM
+
+Extract `J`, `h` from the legacy `Model{:TFIM}(params)` Dict and build
+the concrete struct.
+"""
+function _tfim_from_legacy_model(m::Model{:TFIM})::TFIM
+    J = Float64(get(m.params, :J, 1.0))
+    h = Float64(get(m.params, :h, 1.0))
+    return TFIM(; J=J, h=h)
+end
+
+"""
+    _bc_with_legacy_N(bc::OBC, m::Model{:TFIM}) -> OBC
+
+If `bc.N == 0` (zero-arg `OBC()` call) but the legacy `Model` Dict has
+an `:N` entry, promote it to a sized `OBC(N)` so the concrete fetch can
+read `bc.N` uniformly.
+"""
+function _bc_with_legacy_N(bc::OBC, m::Model{:TFIM})::OBC
+    bc.N > 0 && return bc
+    haskey(m.params, :N) && return OBC(Int(m.params[:N]))
+    return bc
+end
+_bc_with_legacy_N(bc::BoundaryCondition, ::Model{:TFIM}) = bc
+
+# ── Energy ──────────────────────────────────────────────────────────────
+function fetch(m::Model{:TFIM}, ::Quantity{:energy}, bc::OBC; kwargs...)
+    return fetch(_tfim_from_legacy_model(m), Energy(), _bc_with_legacy_N(bc, m); kwargs...)
+end
+function fetch(m::Model{:TFIM}, ::Quantity{:energy}, bc::Infinite; kwargs...)
+    return fetch(_tfim_from_legacy_model(m), Energy(), bc; kwargs...)
+end
+
+# ── Central charge ──────────────────────────────────────────────────────
+function fetch(m::Model{:TFIM}, ::Quantity{:central_charge}, bc::Infinite; kwargs...)
+    return fetch(_tfim_from_legacy_model(m), CentralCharge(), bc; kwargs...)
+end

--- a/src/deprecate/legacy_tfim.jl
+++ b/src/deprecate/legacy_tfim.jl
@@ -58,7 +58,9 @@ const _LEGACY_TFIM_THERMAL_MAP = (
 
 for (qsym, QTy) in _LEGACY_TFIM_THERMAL_MAP
     @eval begin
-        function fetch(m::Model{:TFIM}, ::Quantity{$(QuoteNode(qsym))}, bc::Infinite; kwargs...)
+        function fetch(
+            m::Model{:TFIM}, ::Quantity{$(QuoteNode(qsym))}, bc::Infinite; kwargs...
+        )
             return fetch(_tfim_from_legacy_model(m), $QTy(), bc; kwargs...)
         end
         function fetch(m::Model{:TFIM}, ::Quantity{$(QuoteNode(qsym))}, bc::OBC; kwargs...)
@@ -76,8 +78,12 @@ const _LEGACY_TFIM_LOCAL_MAP = (
     (:energy_local, EnergyLocal),
 )
 for (qsym, QTy) in _LEGACY_TFIM_LOCAL_MAP
-    @eval function fetch(m::Model{:TFIM}, ::Quantity{$(QuoteNode(qsym))}, bc::OBC; kwargs...)
-        return fetch(_tfim_from_legacy_model(m), $QTy(), _bc_with_legacy_N(bc, m); kwargs...)
+    @eval function fetch(
+        m::Model{:TFIM}, ::Quantity{$(QuoteNode(qsym))}, bc::OBC; kwargs...
+    )
+        return fetch(
+            _tfim_from_legacy_model(m), $QTy(), _bc_with_legacy_N(bc, m); kwargs...
+        )
     end
 end
 
@@ -117,17 +123,13 @@ function fetch(m::Model{:TFIM}, ::Quantity{:zz_static_thermal}, bc::OBC; kwargs.
 end
 function fetch(m::Model{:TFIM}, ::Quantity{:zz_structure_factor}, bc::OBC; kwargs...)
     return fetch(
-        _tfim_from_legacy_model(m),
-        ZZStructureFactor(),
-        _bc_with_legacy_N(bc, m);
-        kwargs...,
+        _tfim_from_legacy_model(m), ZZStructureFactor(), _bc_with_legacy_N(bc, m); kwargs...
     )
 end
-function fetch(m::Model{:TFIM}, ::Quantity{:longitudinal_susceptibility}, bc::OBC; kwargs...)
+function fetch(
+    m::Model{:TFIM}, ::Quantity{:longitudinal_susceptibility}, bc::OBC; kwargs...
+)
     return fetch(
-        _tfim_from_legacy_model(m),
-        SusceptibilityZZ(),
-        _bc_with_legacy_N(bc, m);
-        kwargs...,
+        _tfim_from_legacy_model(m), SusceptibilityZZ(), _bc_with_legacy_N(bc, m); kwargs...
     )
 end

--- a/src/deprecate/legacy_tfim.jl
+++ b/src/deprecate/legacy_tfim.jl
@@ -80,3 +80,54 @@ for (qsym, QTy) in _LEGACY_TFIM_LOCAL_MAP
         return fetch(_tfim_from_legacy_model(m), $QTy(), _bc_with_legacy_N(bc, m); kwargs...)
     end
 end
+
+# ── Dynamics / correlators / structure factors (TFIM_dynamics.jl) ──────
+# These use parametric ZZCorrelation{:mode} dispatch in the new API.
+function fetch(m::Model{:TFIM}, ::Quantity{:sz_sz_correlation}, bc::OBC; kwargs...)
+    return fetch(
+        _tfim_from_legacy_model(m),
+        ZZCorrelation{:dynamic}(),
+        _bc_with_legacy_N(bc, m);
+        kwargs...,
+    )
+end
+function fetch(m::Model{:TFIM}, ::Quantity{:sx_sx_correlation}, bc::OBC; kwargs...)
+    return fetch(
+        _tfim_from_legacy_model(m),
+        XXCorrelation{:dynamic}(),
+        _bc_with_legacy_N(bc, m);
+        kwargs...,
+    )
+end
+function fetch(m::Model{:TFIM}, ::Quantity{:sz_sz_spreading}, bc::OBC; kwargs...)
+    return fetch(
+        _tfim_from_legacy_model(m),
+        ZZCorrelation{:lightcone}(),
+        _bc_with_legacy_N(bc, m);
+        kwargs...,
+    )
+end
+function fetch(m::Model{:TFIM}, ::Quantity{:zz_static_thermal}, bc::OBC; kwargs...)
+    return fetch(
+        _tfim_from_legacy_model(m),
+        ZZCorrelation{:static}(),
+        _bc_with_legacy_N(bc, m);
+        kwargs...,
+    )
+end
+function fetch(m::Model{:TFIM}, ::Quantity{:zz_structure_factor}, bc::OBC; kwargs...)
+    return fetch(
+        _tfim_from_legacy_model(m),
+        ZZStructureFactor(),
+        _bc_with_legacy_N(bc, m);
+        kwargs...,
+    )
+end
+function fetch(m::Model{:TFIM}, ::Quantity{:longitudinal_susceptibility}, bc::OBC; kwargs...)
+    return fetch(
+        _tfim_from_legacy_model(m),
+        SusceptibilityZZ(),
+        _bc_with_legacy_N(bc, m);
+        kwargs...,
+    )
+end

--- a/src/deprecate/legacy_tfim.jl
+++ b/src/deprecate/legacy_tfim.jl
@@ -68,3 +68,15 @@ for (qsym, QTy) in _LEGACY_TFIM_THERMAL_MAP
         end
     end
 end
+
+# ── Site-local quantities (TFIM_local.jl) ──────────────────────────────
+const _LEGACY_TFIM_LOCAL_MAP = (
+    (:magnetization_x_local, MagnetizationXLocal),
+    (:magnetization_z_local, MagnetizationZLocal),
+    (:energy_local, EnergyLocal),
+)
+for (qsym, QTy) in _LEGACY_TFIM_LOCAL_MAP
+    @eval function fetch(m::Model{:TFIM}, ::Quantity{$(QuoteNode(qsym))}, bc::OBC; kwargs...)
+        return fetch(_tfim_from_legacy_model(m), $QTy(), _bc_with_legacy_N(bc, m); kwargs...)
+    end
+end

--- a/src/models/TFIM.jl
+++ b/src/models/TFIM.jl
@@ -9,11 +9,30 @@
 #
 #   ⟨H⟩(β) = -Σₙ (Λₙ/2) tanh(β Λₙ / 2)
 #
-# Aliases: :TFIM, :TransverseFieldIsingModel
+# The canonical API uses the concrete `TFIM` struct and concrete `Quantity`
+# types from `src/core/quantities.jl`.  Legacy symbol-dispatch
+# (`fetch(:TFIM, :energy, OBC(); …)`) routes through
+# `src/deprecate/legacy_tfim.jl`.
 # ─────────────────────────────────────────────────────────────────────────────
 
 using LinearAlgebra: eigvals, Symmetric
 using QuadGK: quadgk
+
+"""
+    TFIM(; J = 1.0, h = 1.0) <: AbstractQAtlasModel
+
+The 1D transverse field Ising model with Hamiltonian
+
+    H = -J Σ_i σᶻ_i σᶻ_{i+1} - h Σ_i σˣ_i
+
+`J > 0` is ferromagnetic, `h` is the transverse field.  The critical
+point sits at `h = J`.
+"""
+struct TFIM <: AbstractQAtlasModel
+    J::Float64
+    h::Float64
+end
+TFIM(; J::Real=1.0, h::Real=1.0) = TFIM(Float64(J), Float64(h))
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Internal: BdG quasiparticle spectrum (OBC, finite N)
@@ -60,12 +79,12 @@ end
 # ═══════════════════════════════════════════════════════════════════════════════
 
 """
-    fetch(model::Model{:TFIM}, ::Quantity{:energy}, ::OBC; beta, betas) -> Float64 or Vector{Float64}
+    fetch(model::TFIM, ::Energy, bc::OBC; beta, betas) -> Float64 or Vector{Float64}
 
 Total energy ⟨H⟩(β) for the OBC TFIM with N sites.
 
-Required model params: `N` (Int), `J` (Float64), `h` (Float64, transverse field)
-
+- `N` is read from `bc.N` (`OBC(N)` / `OBC(; N)`) or from `kwargs[:N]`
+  as a legacy fallback.
 - `beta::Float64`: return scalar ⟨H⟩(β)
 - `betas::AbstractVector{Float64}`: return vector, reusing spectrum (O(N³) once)
 - no keyword: return ground-state energy E₀ = -Σₙ Λₙ/2  (β → ∞)
@@ -73,17 +92,15 @@ Required model params: `N` (Int), `J` (Float64), `h` (Float64, transverse field)
 Uses the exact BdG formula:  ⟨H⟩ = -Σₙ (Λₙ/2) tanh(β Λₙ / 2)
 """
 function fetch(
-    model::Model{:TFIM},
-    ::Quantity{:energy},
-    ::OBC;
+    model::TFIM,
+    ::Energy,
+    bc::OBC;
     beta::Union{Float64,Nothing}=nothing,
     betas::Union{AbstractVector{Float64},Nothing}=nothing,
     kwargs...,
 )
-    N = Int(model.params[:N])
-    J = Float64(model.params[:J])
-    h = Float64(model.params[:h])
-    Λ = _tfim_bdg_spectrum(N, J, h)
+    N = _bc_size(bc, kwargs)
+    Λ = _tfim_bdg_spectrum(N, model.J, model.h)
     if betas !== nothing
         return Float64[-sum(λ -> (λ / 2) * tanh(β * λ / 2), Λ) for β in betas]
     elseif beta !== nothing
@@ -99,7 +116,7 @@ end
 # ═══════════════════════════════════════════════════════════════════════════════
 
 """
-    fetch(model::Model{:TFIM}, ::Quantity{:energy}, ::Infinite; beta, betas) -> Float64 or Vector{Float64}
+    fetch(model::TFIM, ::Energy, ::Infinite; beta, betas) -> Float64 or Vector{Float64}
 
 Energy *per site* ⟨H⟩/N in the thermodynamic limit (PBC, N → ∞).
 
@@ -114,15 +131,15 @@ where the PBC dispersion is  Λ(k) = 2√(J² + h² - 2Jh cos k).
 Uses adaptive Gauss-Kronrod quadrature (QuadGK).
 """
 function fetch(
-    model::Model{:TFIM},
-    ::Quantity{:energy},
+    model::TFIM,
+    ::Energy,
     ::Infinite;
     beta::Union{Float64,Nothing}=nothing,
     betas::Union{AbstractVector{Float64},Nothing}=nothing,
     kwargs...,
 )
-    J = Float64(model.params[:J])
-    h = Float64(model.params[:h])
+    J = model.J
+    h = model.h
     _energy_at_beta =
         β -> begin
             result, _ = quadgk(
@@ -148,16 +165,14 @@ end
 # ═══════════════════════════════════════════════════════════════════════════════
 
 """
-    fetch(model::Model{:TFIM}, ::Quantity{:central_charge}, ::Infinite) -> Float64
+    fetch(model::TFIM, ::CentralCharge, ::Infinite) -> Float64
 
 Central charge of the TFIM critical point (h = J): c = 1/2 (Ising CFT).
 Returns NaN if not at the critical point (|h/J - 1| > 1e-6).
 """
-function fetch(model::Model{:TFIM}, ::Quantity{:central_charge}, ::Infinite; kwargs...)
-    J = Float64(model.params[:J])
-    h = Float64(model.params[:h])
-    if abs(h / J - 1.0) > 1e-6
-        @warn "TFIM central charge c=1/2 only at the critical point h=J. Got h/J=$(h/J)."
+function fetch(model::TFIM, ::CentralCharge, ::Infinite; kwargs...)
+    if abs(model.h / model.J - 1.0) > 1e-6
+        @warn "TFIM central charge c=1/2 only at the critical point h=J. Got h/J=$(model.h/model.J)."
         return NaN
     end
     return 0.5

--- a/src/models/TFIM_dynamics.jl
+++ b/src/models/TFIM_dynamics.jl
@@ -467,9 +467,7 @@ end
 
 Static structure factor `S_zz(q, β)` for the OBC TFIM at wave vector `q`.
 """
-function fetch(
-    model::TFIM, ::ZZStructureFactor, bc::OBC; beta::Float64, q::Real, kwargs...
-)
+function fetch(model::TFIM, ::ZZStructureFactor, bc::OBC; beta::Float64, q::Real, kwargs...)
     N = _bc_size(bc, kwargs)
     return _zz_static_structure_factor(N, model.J, model.h, beta, q)
 end

--- a/src/models/TFIM_dynamics.jl
+++ b/src/models/TFIM_dynamics.jl
@@ -377,74 +377,68 @@ end
 # ═══════════════════════════════════════════════════════════════════════════════
 
 """
-    fetch(model::Model{:TFIM}, ::Quantity{:sz_sz_correlation}, ::OBC;
+    fetch(model::TFIM, ::ZZCorrelation{:dynamic}, bc::OBC;
           i::Int, j::Int, t::Float64, beta::Float64 = Inf) -> ComplexF64
 
 Exact `⟨σᶻ_i(t) σᶻ_j(0)⟩_β` for the OBC TFIM.  `beta = Inf` (the default)
-gives the ground-state result.
+gives the ground-state result.  `N` comes from `bc.N`.
 """
 function fetch(
-    model::Model{:TFIM},
-    ::Quantity{:sz_sz_correlation},
-    ::OBC;
+    model::TFIM,
+    ::ZZCorrelation{:dynamic},
+    bc::OBC;
     i::Int,
     j::Int,
     t::Float64,
     beta::Real=Inf,
     kwargs...,
 )
-    N = Int(model.params[:N])
-    J = Float64(model.params[:J])
-    h = Float64(model.params[:h])
-    return _sz_sz_corr(N, J, h, i, j, t; β=beta)
+    N = _bc_size(bc, kwargs)
+    return _sz_sz_corr(N, model.J, model.h, i, j, t; β=beta)
 end
 
 """
-    fetch(model::Model{:TFIM}, ::Quantity{:sx_sx_correlation}, ::OBC;
+    fetch(model::TFIM, ::XXCorrelation{:dynamic}, bc::OBC;
           i::Int, j::Int, t::Float64, beta::Float64 = Inf) -> ComplexF64
 
 Exact `⟨σˣ_i(t) σˣ_j(0)⟩_β` for the OBC TFIM.
 """
 function fetch(
-    model::Model{:TFIM},
-    ::Quantity{:sx_sx_correlation},
-    ::OBC;
+    model::TFIM,
+    ::XXCorrelation{:dynamic},
+    bc::OBC;
     i::Int,
     j::Int,
     t::Float64,
     beta::Real=Inf,
     kwargs...,
 )
-    N = Int(model.params[:N])
-    J = Float64(model.params[:J])
-    h = Float64(model.params[:h])
-    return _sx_sx_corr(N, J, h, i, j, t; β=beta)
+    N = _bc_size(bc, kwargs)
+    return _sx_sx_corr(N, model.J, model.h, i, j, t; β=beta)
 end
 
 """
-    fetch(model::Model{:TFIM}, ::Quantity{:sz_sz_spreading}, ::OBC;
+    fetch(model::TFIM, ::ZZCorrelation{:lightcone}, bc::OBC;
           center::Int, times::AbstractVector{<:Real}, beta::Float64 = Inf) -> Matrix{ComplexF64}
 
 Exact spreading correlation `C[it, ix] = ⟨σᶻ_ix(t_it) σᶻ_center(0)⟩_β` for all
 sites `ix ∈ 1:N` and `t_it ∈ times`.
 """
 function fetch(
-    model::Model{:TFIM},
-    ::Quantity{:sz_sz_spreading},
-    ::OBC;
+    model::TFIM,
+    ::ZZCorrelation{:lightcone},
+    bc::OBC;
     center::Int,
     times::AbstractVector{<:Real},
     beta::Real=Inf,
     kwargs...,
 )
-    N = Int(model.params[:N])
-    J = Float64(model.params[:J])
-    h = Float64(model.params[:h])
-    return _sz_sz_spreading(N, J, h, center, times; β=beta)
+    N = _bc_size(bc, kwargs)
+    return _sz_sz_spreading(N, model.J, model.h, center, times; β=beta)
 end
 
 """
-    fetch(model::Model{:TFIM}, ::Quantity{:zz_static_thermal}, ::OBC;
+    fetch(model::TFIM, ::ZZCorrelation{:static}, bc::OBC;
           beta::Float64, [i::Int, j::Int]) -> Matrix{Float64} or Float64
 
 Static (equal-time) thermal correlator `⟨σᶻ_i σᶻ_j⟩_β` for the OBC TFIM.
@@ -452,60 +446,45 @@ With both `i` and `j` given returns a scalar; otherwise returns the full
 N×N matrix.
 """
 function fetch(
-    model::Model{:TFIM},
-    ::Quantity{:zz_static_thermal},
-    ::OBC;
+    model::TFIM,
+    ::ZZCorrelation{:static},
+    bc::OBC;
     beta::Float64,
     i::Union{Int,Nothing}=nothing,
     j::Union{Int,Nothing}=nothing,
     kwargs...,
 )
-    N = Int(model.params[:N])
-    J = Float64(model.params[:J])
-    h = Float64(model.params[:h])
+    N = _bc_size(bc, kwargs)
     if i !== nothing && j !== nothing
-        return _sz_sz_static_thermal(N, J, h, beta; i=i, j=j)[1, 1]
+        return _sz_sz_static_thermal(N, model.J, model.h, beta; i=i, j=j)[1, 1]
     end
-    return _sz_sz_static_thermal(N, J, h, beta)
+    return _sz_sz_static_thermal(N, model.J, model.h, beta)
 end
 
 """
-    fetch(model::Model{:TFIM}, ::Quantity{:zz_structure_factor}, ::OBC;
+    fetch(model::TFIM, ::ZZStructureFactor, bc::OBC;
           beta::Float64, q::Real) -> Float64
 
 Static structure factor `S_zz(q, β)` for the OBC TFIM at wave vector `q`.
 """
 function fetch(
-    model::Model{:TFIM},
-    ::Quantity{:zz_structure_factor},
-    ::OBC;
-    beta::Float64,
-    q::Real,
-    kwargs...,
+    model::TFIM, ::ZZStructureFactor, bc::OBC; beta::Float64, q::Real, kwargs...
 )
-    N = Int(model.params[:N])
-    J = Float64(model.params[:J])
-    h = Float64(model.params[:h])
-    return _zz_static_structure_factor(N, J, h, beta, q)
+    N = _bc_size(bc, kwargs)
+    return _zz_static_structure_factor(N, model.J, model.h, beta, q)
 end
 
 """
-    fetch(model::Model{:TFIM}, ::Quantity{:longitudinal_susceptibility}, ::OBC;
+    fetch(model::TFIM, ::SusceptibilityZZ, bc::OBC;
           beta::Float64) -> Float64
 
 Static uniform longitudinal (`q = 0`) susceptibility per site,
 
     χ_zz(β) = (β/N) Σ_{i,j} ⟨σᶻ_i σᶻ_j⟩_β.
 """
-function fetch(
-    model::Model{:TFIM},
-    ::Quantity{:longitudinal_susceptibility},
-    ::OBC;
-    beta::Float64,
-    kwargs...,
-)
-    N = Int(model.params[:N])
-    J = Float64(model.params[:J])
-    h = Float64(model.params[:h])
+function fetch(model::TFIM, ::SusceptibilityZZ, bc::OBC; beta::Float64, kwargs...)
+    N = _bc_size(bc, kwargs)
+    J = model.J
+    h = model.h
     return _zz_uniform_susceptibility(N, J, h, beta)
 end

--- a/src/models/TFIM_local.jl
+++ b/src/models/TFIM_local.jl
@@ -23,29 +23,25 @@
 _zz_bond(Σ::AbstractMatrix, i::Int) = Σ[2i, 2i + 1]
 
 """
-    fetch(model::Model{:TFIM}, ::Quantity{:magnetization_x_local}, ::OBC;
-          beta::Float64, kwargs...) -> Vector{Float64}
+    fetch(model::TFIM, ::MagnetizationXLocal, bc::OBC; beta::Float64, kwargs...)
+        -> Vector{Float64}
 
 Site-resolved transverse magnetisation `[⟨σˣ_i⟩_β for i = 1:N]` of the OBC
 TFIM at inverse temperature `beta`, read off from the Majorana thermal
-covariance as `Σ[2i-1, 2i]`.
+covariance as `Σ[2i-1, 2i]`.  `N` is taken from `bc.N`.
 
 `beta = Inf` falls back to the ground state.
 """
-function fetch(
-    model::Model{:TFIM}, ::Quantity{:magnetization_x_local}, ::OBC; beta::Float64, kwargs...
-)
-    N = Int(model.params[:N])
-    J = Float64(model.params[:J])
-    h = Float64(model.params[:h])
-    hmat = _majorana_ham(N, J, h)
+function fetch(model::TFIM, ::MagnetizationXLocal, bc::OBC; beta::Float64, kwargs...)
+    N = _bc_size(bc, kwargs)
+    hmat = _majorana_ham(N, model.J, model.h)
     Σ = _majorana_thermal_covariance(hmat, beta)
     return Float64[_sx_expect(Σ, i) for i in 1:N]
 end
 
 """
-    fetch(model::Model{:TFIM}, ::Quantity{:magnetization_z_local}, ::OBC;
-          beta::Float64, kwargs...) -> Vector{Float64}
+    fetch(model::TFIM, ::MagnetizationZLocal, bc::OBC; beta::Float64, kwargs...)
+        -> Vector{Float64}
 
 Site-resolved longitudinal magnetisation `[⟨σᶻ_i⟩_β for i = 1:N]`.
 Identically zero in the OBC TFIM by the Z₂ symmetry σᶻ → −σᶻ of the
@@ -53,16 +49,14 @@ Hamiltonian (Gaussian state, odd product of Majoranas).  Returned as an
 explicit zero vector so consumers can use it as an exact baseline against
 finite random-sample estimates that fluctuate around zero.
 """
-function fetch(
-    model::Model{:TFIM}, ::Quantity{:magnetization_z_local}, ::OBC; beta::Float64, kwargs...
-)
-    N = Int(model.params[:N])
+function fetch(::TFIM, ::MagnetizationZLocal, bc::OBC; beta::Float64, kwargs...)
+    N = _bc_size(bc, kwargs)
     return zeros(Float64, N)
 end
 
 """
-    fetch(model::Model{:TFIM}, ::Quantity{:energy_local}, ::OBC;
-          beta::Float64, kwargs...) -> Vector{Float64}
+    fetch(model::TFIM, ::EnergyLocal, bc::OBC; beta::Float64, kwargs...)
+        -> Vector{Float64}
 
 Site-local energy density `ε_i` of the OBC TFIM at inverse temperature
 `beta`, defined so that `Σᵢ ε_i = ⟨H⟩_β`.  Each bond is split symmetrically
@@ -74,13 +68,9 @@ with the missing bonds at the i = 1 and i = N boundaries taken to be zero.
 Bond expectations are read off as `Σ(β)[2i, 2i+1]` from the Majorana thermal
 covariance (exact, O(N) after the single 2N×2N diagonalisation).
 """
-function fetch(
-    model::Model{:TFIM}, ::Quantity{:energy_local}, ::OBC; beta::Float64, kwargs...
-)
-    N = Int(model.params[:N])
-    J = Float64(model.params[:J])
-    h = Float64(model.params[:h])
-    hmat = _majorana_ham(N, J, h)
+function fetch(model::TFIM, ::EnergyLocal, bc::OBC; beta::Float64, kwargs...)
+    N = _bc_size(bc, kwargs)
+    hmat = _majorana_ham(N, model.J, model.h)
     Σ = _majorana_thermal_covariance(hmat, beta)
 
     bonds = Float64[_zz_bond(Σ, i) for i in 1:(N - 1)]
@@ -89,7 +79,7 @@ function fetch(
     @inbounds for i in 1:N
         left = i > 1 ? bonds[i - 1] : 0.0
         right = i < N ? bonds[i] : 0.0
-        ε[i] = -(J / 2) * (left + right) - h * _sx_expect(Σ, i)
+        ε[i] = -(model.J / 2) * (left + right) - model.h * _sx_expect(Σ, i)
     end
     return ε
 end

--- a/src/models/TFIM_thermal.jl
+++ b/src/models/TFIM_thermal.jl
@@ -195,54 +195,42 @@ end
 # fetch dispatch
 # ═══════════════════════════════════════════════════════════════════════════════
 
-const _THERMAL_QUANTITIES = (
-    :free_energy,
-    :entropy,
-    :specific_heat,
-    :transverse_magnetization,
-    :transverse_susceptibility,
+# (quantity struct, internal symbol) pairs — the internal helpers
+# `_tfim_thermo_infinite` / `_tfim_thermo_obc` still key off the symbol.
+# The concrete-struct dispatch below is meta-programmed over this list
+# so adding a thermal quantity only requires adding one row + wiring
+# the inner Symbol branch.
+const _TFIM_THERMAL_METHODS = (
+    (FreeEnergy, :free_energy),
+    (ThermalEntropy, :entropy),
+    (SpecificHeat, :specific_heat),
+    (MagnetizationX, :transverse_magnetization),
+    (SusceptibilityXX, :transverse_susceptibility),
 )
 
-for q in _THERMAL_QUANTITIES
+for (QTy, qsym) in _TFIM_THERMAL_METHODS
     @eval begin
         """
-            fetch(model::Model{:TFIM}, ::Quantity{$($(QuoteNode(q)))}, ::Infinite;
-                  beta::Float64, kwargs...)
+            fetch(model::TFIM, ::$($QTy), ::Infinite; beta::Float64, kwargs...)
 
-        Per-site `$($(string(q)))` of the TFIM in the thermodynamic limit at
+        Per-site $($(string(qsym))) of the TFIM in the thermodynamic limit at
         inverse temperature `beta`.  Uses adaptive Gauss-Kronrod quadrature
         over the BdG dispersion `Λ(k) = 2√(J² + h² − 2Jh cos k)`.
         """
-        function fetch(
-            model::Model{:TFIM},
-            ::Quantity{$(QuoteNode(q))},
-            ::Infinite;
-            beta::Float64,
-            kwargs...,
-        )
-            J = Float64(model.params[:J])
-            h = Float64(model.params[:h])
-            return _tfim_thermo_infinite($(QuoteNode(q)), J, h, beta)
+        function fetch(model::TFIM, ::$QTy, ::Infinite; beta::Float64, kwargs...)
+            return _tfim_thermo_infinite($(QuoteNode(qsym)), model.J, model.h, beta)
         end
 
         """
-            fetch(model::Model{:TFIM}, ::Quantity{$($(QuoteNode(q)))}, ::OBC;
-                  beta::Float64, kwargs...)
+            fetch(model::TFIM, ::$($QTy), bc::OBC; beta::Float64, kwargs...)
 
-        Per-site `$($(string(q)))` of the OBC TFIM with `N` sites at inverse
-        temperature `beta`.  Computed exactly via the BdG diagonalisation.
+        Per-site $($(string(qsym))) of the OBC TFIM with `N = bc.N` sites at
+        inverse temperature `beta`.  Computed exactly via the BdG
+        diagonalisation.
         """
-        function fetch(
-            model::Model{:TFIM},
-            ::Quantity{$(QuoteNode(q))},
-            ::OBC;
-            beta::Float64,
-            kwargs...,
-        )
-            N = Int(model.params[:N])
-            J = Float64(model.params[:J])
-            h = Float64(model.params[:h])
-            return _tfim_thermo_obc($(QuoteNode(q)), N, J, h, beta)
+        function fetch(model::TFIM, ::$QTy, bc::OBC; beta::Float64, kwargs...)
+            N = _bc_size(bc, kwargs)
+            return _tfim_thermo_obc($(QuoteNode(qsym)), N, model.J, model.h, beta)
         end
     end
 end

--- a/src/universalities/E8.jl
+++ b/src/universalities/E8.jl
@@ -26,14 +26,29 @@ end
 
 # --- Registry & Fetch ---
 
+"""
+    E8() <: AbstractQAtlasModel
+
+The E8 integrable field theory — the low-energy continuum theory of the
+2D Ising model perturbed by a small longitudinal magnetic field at
+T = T_c (Zamolodchikov 1989).  The only physics parameter is the
+underlying magnetic field perturbation strength, but QAtlas currently
+only exposes the universal mass-ratio spectrum, so this struct carries
+no fields.
+"""
+struct E8 <: AbstractQAtlasModel end
+
 @register_aliases canonicalize_quantity :E8_spectrum [
     :E8_mass_ratios, :E8_masses, :mass_ratios, :E8_mass_ratio, :mass_ratio
 ]
 
 """
-    fetch(Model(:E8), Quantity(:E8_spectrum), Infinite())
-Returns the analytical E8 mass spectrum.
+    fetch(::E8, ::E8Spectrum, ::Infinite) -> Vector{Float64}
+
+Returns the analytical E8 mass spectrum `[m₁, m₂, …, m₈]` normalised
+by `m₁ = 1`.  `m₂/m₁ = 2 cos(π/5) = ϕ` (golden ratio) is the hallmark
+of the E8 symmetry.
 """
-function QAtlas.fetch(::Model{:E8}, ::Quantity{:E8_spectrum}, ::Infinite; kwargs...)
+function QAtlas.fetch(::E8, ::E8Spectrum, ::Infinite; kwargs...)
     return get_e8_mass_ratios()
 end


### PR DESCRIPTION
## Summary

Second step of the v0.13 API redesign: migrate `TFIM` (4 source files) and `E8` (1 file) from the legacy `Model{S}(params::Dict)` + `Quantity{:foo}` phantom-type dispatch to concrete struct types.

Builds on #40 (Aqua + core types + axis-explicit quantities + deprecate/ scaffold).

## What moves

| Legacy | New canonical |
|---|---|
| `Model{:TFIM}(Dict(:J, :h, :N))` | `TFIM(; J, h)` |
| `Model{:E8}()` | `E8()` (stateless) |
| `Quantity{:energy}` | `Energy()` |
| `Quantity{:free_energy}` | `FreeEnergy()` |
| `Quantity{:entropy}` | `ThermalEntropy()` |
| `Quantity{:specific_heat}` | `SpecificHeat()` |
| `Quantity{:transverse_magnetization}` | `MagnetizationX()` |
| `Quantity{:transverse_susceptibility}` | `SusceptibilityXX()` |
| `Quantity{:longitudinal_susceptibility}` | `SusceptibilityZZ()` |
| `Quantity{:magnetization_x_local}` | `MagnetizationXLocal()` |
| `Quantity{:magnetization_z_local}` | `MagnetizationZLocal()` |
| `Quantity{:energy_local}` | `EnergyLocal()` |
| `Quantity{:sz_sz_correlation}` | `ZZCorrelation{:dynamic}()` |
| `Quantity{:sx_sx_correlation}` | `XXCorrelation{:dynamic}()` |
| `Quantity{:sz_sz_spreading}` | `ZZCorrelation{:lightcone}()` |
| `Quantity{:zz_static_thermal}` | `ZZCorrelation{:static}()` |
| `Quantity{:zz_structure_factor}` | `ZZStructureFactor()` |
| `Quantity{:central_charge}` | `CentralCharge()` |
| `Quantity{:E8_spectrum}` | `E8Spectrum()` |

`N` for `OBC` is now read from `bc.N` (via the `_bc_size` helper); legacy callers passing `OBC()` + `kwargs[:N]` still work via the shim.

## Structural change

`ZZCorrelation` / `XXCorrelation` / `YYCorrelation` are upgraded from `struct X; mode::Symbol; end` to **parametric** `struct X{M}; end`, so dispatch specialises on mode at compile time.  `XXCorrelation(; mode=:static)` still returns an `XXCorrelation{:static}()` — the user-facing API is unchanged, but the dispatch `fetch(::TFIM, ::ZZCorrelation{:dynamic}, ::OBC; …)` beats the previous `if corr.mode === :dynamic` branch.

## Deprecation shims

Every legacy Symbol fetch signature for TFIM + E8 is kept alive in `src/deprecate/legacy_{tfim,e8}.jl` as a thin forwarder to the new API.  Existing downstream (ReducedEnvExperiments) keeps working unchanged — it just emits a one-shot `@info` deprecation hint per (model, quantity).

## Test plan

- [x] Parity: every new-API call vs. legacy-Symbol call returns the same value at rtol 1e-12 for the 15 migrated `(quantity, BC)` pairs.  Verified for
  - `Energy`, `CentralCharge`
  - `FreeEnergy`, `ThermalEntropy`, `SpecificHeat`, `MagnetizationX`, `SusceptibilityXX`
  - `MagnetizationXLocal`, `MagnetizationZLocal`, `EnergyLocal`
  - `ZZCorrelation{:dynamic/:static/:lightcone}`, `XXCorrelation{:dynamic}`, `ZZStructureFactor`, `SusceptibilityZZ`
  - `E8Spectrum` (golden-ratio `m₂/m₁ = 2 cos(π/5)` check)
- [ ] Full `Pkg.test()` — CI.

## Follow-ups (not in this PR)

- IsingSquare typed-field struct (M1.7)
- Tight-binding struct-ification + `Graphene` → `Honeycomb` rename (M1.8)
- XXZ1D new model with Bethe ansatz (M1.9)
- docs/src/ dual-track build (M1.10)
- Version bump 0.12.9 → 0.13.0 — held until the full M1 stack lands