### PR TITLE
refactor: IsingSquare + Universality + tight-binding struct migration (Graphene -> Honeycomb)

### DIFF
--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -11,11 +11,12 @@ export IsingSquare, PartitionFunction, CriticalTemperature, SpontaneousMagnetiza
 # --- Quantum Models ---
 export TFIM                                             # v0.13 concrete struct
 export E8                                               # v0.13 concrete struct
-export Graphene, TightBindingSpectrum
+export Honeycomb, TightBindingSpectrum                  # v0.13 rename: was Graphene
 # NOTE: `Kagome`, `Lieb`, `Triangular` are NOT exported — they conflict
 # with Lattice2D's topology types of the same name. Access them as
 # `QAtlas.Kagome()` / `QAtlas.Lieb()` / `QAtlas.Triangular()` in code
-# that also uses `Lattice2D`.
+# that also uses `Lattice2D`.  `Graphene` is kept as a top-level
+# backward-compat alias for `Honeycomb` (see src/deprecate/).
 export Heisenberg1D, ExactSpectrum, GroundStateEnergyDensity
 
 # --- Core Implementation ---
@@ -54,7 +55,7 @@ include("models/TFIM_dynamics.jl")
 include("models/TFIM_thermal.jl")
 include("models/TFIM_local.jl")
 include("models/classical/IsingSquare.jl")
-include("models/quantum/tightbinding/Graphene.jl")
+include("models/quantum/tightbinding/Honeycomb.jl")
 include("models/quantum/tightbinding/Kagome.jl")
 include("models/quantum/tightbinding/Lieb.jl")
 include("models/quantum/tightbinding/Triangular.jl")
@@ -66,5 +67,7 @@ include("models/quantum/Heisenberg.jl")
 include("deprecate/legacy_fetch.jl")
 include("deprecate/legacy_tfim.jl")
 include("deprecate/legacy_e8.jl")
+include("deprecate/legacy_honeycomb.jl")
+export Graphene                                         # backward-compat alias
 
 end # module QAtlas

--- a/src/deprecate/legacy_honeycomb.jl
+++ b/src/deprecate/legacy_honeycomb.jl
@@ -1,0 +1,16 @@
+# deprecate/legacy_honeycomb.jl — keep the `Graphene` name alive after
+# the v0.13 rename to `Honeycomb` (QAtlas's graphene tight-binding lived
+# under the material name, which collides with Lattice2D's topology
+# type of the same name; the lattice is named `Honeycomb` going forward).
+#
+# A plain `const` alias suffices: `typeof(Graphene()) === Honeycomb`, so
+# every existing `fetch(Graphene(), ...)` call dispatches through the new
+# `Honeycomb` methods without a warning.
+
+"""
+    const Graphene = Honeycomb
+
+Backward-compatible alias for [`Honeycomb`](@ref).  New code should
+prefer the lattice-named model.
+"""
+const Graphene = Honeycomb

--- a/src/models/classical/IsingSquare.jl
+++ b/src/models/classical/IsingSquare.jl
@@ -22,25 +22,41 @@ using LinearAlgebra: tr
 # ═══════════════════════════════════════════════════════════════════════════════
 
 """
-    IsingSquare
+    IsingSquare(; J::Real = 1.0, Lx::Int = 0, Ly::Int = 0) <: AbstractQAtlasModel
 
-Dispatch tag for the classical 2D Ising model on a square lattice with
-periodic boundary conditions (PBC) in both directions.
+Classical 2D Ising model on a square lattice with periodic boundary
+conditions (PBC) in both directions.
 
 Hamiltonian: H = -J Σ_{⟨i,j⟩} σᵢ σⱼ, σᵢ ∈ {-1, +1}.
 
-See also: [`PartitionFunction`](@ref), [`fetch(::IsingSquare, ::PartitionFunction)`](@ref).
+Physics parameters are carried as typed struct fields:
+
+- `J`   — Ising coupling (default `1.0`, `J > 0` ferromagnetic).
+- `Lx`, `Ly` — lattice extents.  `0` is a legacy sentinel meaning
+  "thermodynamic limit / unspecified"; finite-size quantities like
+  [`PartitionFunction`](@ref) require both to be positive.
+
+For backward compatibility the `fetch` methods accept `Lx`, `Ly`, `J`,
+`β` as kwargs too — kwargs override the struct fields when both are
+supplied.
+
+See also: [`PartitionFunction`](@ref), [`CriticalTemperature`](@ref),
+[`SpontaneousMagnetization`](@ref).
 """
-struct IsingSquare end
+struct IsingSquare <: AbstractQAtlasModel
+    J::Float64
+    Lx::Int
+    Ly::Int
+end
+IsingSquare(; J::Real=1.0, Lx::Integer=0, Ly::Integer=0) =
+    IsingSquare(Float64(J), Int(Lx), Int(Ly))
 
 """
-    PartitionFunction
+    PartitionFunction() <: AbstractQuantity
 
-Dispatch tag for the canonical partition function Z = Σ_σ exp(-β H(σ)).
-
-See also: [`IsingSquare`](@ref).
+Canonical partition function `Z = Σ_σ exp(-β H(σ))`.
 """
-struct PartitionFunction end
+struct PartitionFunction <: AbstractQuantity end
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Internal: transfer matrix for a row of Ly spins (PBC in y)
@@ -152,7 +168,18 @@ against direct ensemble averages.
     L. Onsager, Phys. Rev. 65, 117 (1944).
     B. M. McCoy and T. T. Wu, "The Two-Dimensional Ising Model" (1973).
 """
-function fetch(::IsingSquare, ::PartitionFunction; Lx::Int, Ly::Int, β::Real, J::Real=1.0)
+function fetch(
+    m::IsingSquare,
+    ::PartitionFunction;
+    β::Real,
+    Lx::Integer=m.Lx,
+    Ly::Integer=m.Ly,
+    J::Real=m.J,
+)
+    Lx > 0 && Ly > 0 || error(
+        "IsingSquare PartitionFunction: Lx and Ly must be positive. " *
+        "Pass them in the struct (IsingSquare(; Lx, Ly, J)) or as kwargs.",
+    )
     T = _ising_sq_transfer_matrix(Ly, β, J)
     return tr(T^Lx)
 end
@@ -162,19 +189,22 @@ end
 # ═══════════════════════════════════════════════════════════════════════════════
 
 """
-    CriticalTemperature
+    CriticalTemperature() <: AbstractQuantity
 
-Dispatch tag for the exact critical temperature of a classical model.
+Exact critical temperature of a classical model.
 """
-struct CriticalTemperature end
+struct CriticalTemperature <: AbstractQuantity end
 
 """
-    SpontaneousMagnetization
+    SpontaneousMagnetization() <: AbstractQuantity
 
-Dispatch tag for the spontaneous magnetization of a classical model
-as a function of temperature.
+Spontaneous magnetization of a classical model as a function of
+temperature.  Retained under this name for backward compatibility
+with the classical-Ising literature; new code may prefer the
+axis-explicit [`MagnetizationZ`](@ref) together with a `T < T_c`
+context.
 """
-struct SpontaneousMagnetization end
+struct SpontaneousMagnetization <: AbstractQuantity end
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # fetch: Onsager critical temperature
@@ -193,7 +223,7 @@ or sinh(2K_c) = 1.
 # References
     L. Onsager, "Crystal Statistics. I.", Phys. Rev. 65, 117 (1944).
 """
-function fetch(::IsingSquare, ::CriticalTemperature; J::Real=1.0)
+function fetch(m::IsingSquare, ::CriticalTemperature; J::Real=m.J)
     return 2J / log(1 + sqrt(2))
 end
 
@@ -225,7 +255,7 @@ Special values:
     C. N. Yang, "The spontaneous magnetization of a two-dimensional Ising
     model", Phys. Rev. 85, 808 (1952).
 """
-function fetch(::IsingSquare, ::SpontaneousMagnetization; β::Real, J::Real=1.0)
+function fetch(m::IsingSquare, ::SpontaneousMagnetization; β::Real, J::Real=m.J)
     s = sinh(2 * β * J)
     if s <= 1.0  # T ≥ T_c
         return 0.0

--- a/src/models/classical/IsingSquare.jl
+++ b/src/models/classical/IsingSquare.jl
@@ -48,8 +48,9 @@ struct IsingSquare <: AbstractQAtlasModel
     Lx::Int
     Ly::Int
 end
-IsingSquare(; J::Real=1.0, Lx::Integer=0, Ly::Integer=0) =
+function IsingSquare(; J::Real=1.0, Lx::Integer=0, Ly::Integer=0)
     IsingSquare(Float64(J), Int(Lx), Int(Ly))
+end
 
 """
     PartitionFunction() <: AbstractQuantity

--- a/src/models/quantum/tightbinding/Honeycomb.jl
+++ b/src/models/quantum/tightbinding/Honeycomb.jl
@@ -1,5 +1,11 @@
 # ─────────────────────────────────────────────────────────────────────────────
-# Graphene — nearest-neighbor tight-binding on the honeycomb lattice
+# Honeycomb — nearest-neighbor tight-binding on the honeycomb lattice
+#
+# Also known as the graphene band structure (Wallace 1947).  The model
+# is named after the lattice rather than the material so it composes
+# cleanly with Lattice2D (which already uses the `Graphene` name for
+# its topology type).  `const Graphene = Honeycomb` in
+# `src/deprecate/legacy_honeycomb.jl` keeps pre-v0.13 callers working.
 #
 # Hamiltonian (single-particle, spinless):
 #   H = -t Σ_{⟨i,j⟩ ∈ A-B} (c†_i c_j + c†_j c_i)
@@ -29,21 +35,39 @@
 # ═══════════════════════════════════════════════════════════════════════════════
 
 """
-    Graphene
+    Honeycomb(; t::Real = 1.0, Lx::Int = 0, Ly::Int = 0) <: AbstractQAtlasModel
 
-Dispatch tag for the nearest-neighbor tight-binding model on the
-honeycomb lattice (spinless, single-orbital).
+Nearest-neighbor tight-binding model on the honeycomb lattice
+(spinless, single-orbital) — historically known as graphene.
 
-Hamiltonian: H = -t Σ_{⟨i,j⟩} (c†_i c_j + h.c.)
+Hamiltonian: `H = -t Σ_{⟨i,j⟩} (c†_i c_j + h.c.)`.
+
+Fields:
+- `t`  — nearest-neighbor hopping amplitude (default `1.0`).
+- `Lx`, `Ly` — unit-cell counts in the two lattice directions.  `0` is
+  a sentinel meaning "caller passes via kwargs at fetch time".
+
+For backward compatibility with the pre-v0.13 call form
+`fetch(Graphene(), TightBindingSpectrum(); Lx, Ly, t=…)`, the fetch
+method still accepts `Lx`, `Ly`, `t` as kwargs (they override the
+struct fields when supplied).  The legacy name `Graphene` is retained
+as a type alias in `src/deprecate/legacy_honeycomb.jl`.
 """
-struct Graphene end
+struct Honeycomb <: AbstractQAtlasModel
+    t::Float64
+    Lx::Int
+    Ly::Int
+end
+Honeycomb(; t::Real=1.0, Lx::Integer=0, Ly::Integer=0) =
+    Honeycomb(Float64(t), Int(Lx), Int(Ly))
 
 """
-    TightBindingSpectrum
+    TightBindingSpectrum() <: AbstractQuantity
 
-Dispatch tag for the single-particle spectrum of a tight-binding model.
+Single-particle Bloch spectrum of a tight-binding model.  Returned as
+a sorted `Vector{Float64}` of length `n_orbitals · Lx · Ly`.
 """
-struct TightBindingSpectrum end
+struct TightBindingSpectrum <: AbstractQuantity end
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # fetch: closed-form Bloch spectrum for Lx × Ly honeycomb PBC
@@ -85,12 +109,22 @@ A sorted `Vector{Float64}` of length `2·Lx·Ly`.
     P. R. Wallace, Phys. Rev. 71, 622 (1947).
     A. H. Castro Neto et al., Rev. Mod. Phys. 81, 109 (2009).
 """
-function fetch(::Graphene, ::TightBindingSpectrum; Lx::Int, Ly::Int, t::Real=1.0)
+function fetch(
+    m::Honeycomb,
+    ::TightBindingSpectrum;
+    Lx::Integer=m.Lx,
+    Ly::Integer=m.Ly,
+    t::Real=m.t,
+)
+    Lx > 0 && Ly > 0 || error(
+        "Honeycomb TightBindingSpectrum: Lx and Ly must be positive. " *
+        "Pass them in the struct (Honeycomb(; Lx, Ly)) or as kwargs.",
+    )
     eigs = Float64[]
     sizehint!(eigs, 2 * Lx * Ly)
-    for m in 0:(Lx - 1), n in 0:(Ly - 1)
-        θ1 = 2π * m / Lx
-        θ2 = 2π * n / Ly
+    for mi in 0:(Lx - 1), ni in 0:(Ly - 1)
+        θ1 = 2π * mi / Lx
+        θ2 = 2π * ni / Ly
         # |f(k)|² / t² = 3 + 2cos(θ1) + 2cos(θ2) + 2cos(θ2 - θ1)
         val = 3 + 2cos(θ1) + 2cos(θ2) + 2cos(θ2 - θ1)
         energy = abs(t) * sqrt(max(val, 0.0))

--- a/src/models/quantum/tightbinding/Honeycomb.jl
+++ b/src/models/quantum/tightbinding/Honeycomb.jl
@@ -58,8 +58,9 @@ struct Honeycomb <: AbstractQAtlasModel
     Lx::Int
     Ly::Int
 end
-Honeycomb(; t::Real=1.0, Lx::Integer=0, Ly::Integer=0) =
+function Honeycomb(; t::Real=1.0, Lx::Integer=0, Ly::Integer=0)
     Honeycomb(Float64(t), Int(Lx), Int(Ly))
+end
 
 """
     TightBindingSpectrum() <: AbstractQuantity
@@ -110,11 +111,7 @@ A sorted `Vector{Float64}` of length `2·Lx·Ly`.
     A. H. Castro Neto et al., Rev. Mod. Phys. 81, 109 (2009).
 """
 function fetch(
-    m::Honeycomb,
-    ::TightBindingSpectrum;
-    Lx::Integer=m.Lx,
-    Ly::Integer=m.Ly,
-    t::Real=m.t,
+    m::Honeycomb, ::TightBindingSpectrum; Lx::Integer=m.Lx, Ly::Integer=m.Ly, t::Real=m.t
 )
     Lx > 0 && Ly > 0 || error(
         "Honeycomb TightBindingSpectrum: Lx and Ly must be positive. " *

--- a/src/models/quantum/tightbinding/Kagome.jl
+++ b/src/models/quantum/tightbinding/Kagome.jl
@@ -43,7 +43,8 @@ Hamiltonian: H = -t Σ_{⟨i,j⟩} (c†_i c_j + h.c.)
 The spectrum exhibits a dispersionless flat band at E = +2t touching the
 lower dispersive bands at the Γ-point.
 """
-struct Kagome end
+struct Kagome <: AbstractQAtlasModel; t::Float64; Lx::Int; Ly::Int; end
+Kagome(; t::Real=1.0, Lx::Integer=0, Ly::Integer=0) = Kagome(Float64(t), Int(Lx), Int(Ly))
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # fetch: closed-form Bloch spectrum for Lx × Ly kagome PBC
@@ -88,7 +89,8 @@ A sorted `Vector{Float64}` of length `3·Lx·Ly`.
     I. Syôzi, Prog. Theor. Phys. 6, 306 (1951).
     D. L. Bergman et al., Phys. Rev. B 78, 125104 (2008).
 """
-function fetch(::Kagome, ::TightBindingSpectrum; Lx::Int, Ly::Int, t::Real=1.0)
+function fetch(m::Kagome, ::TightBindingSpectrum; Lx::Integer=m.Lx, Ly::Integer=m.Ly, t::Real=m.t)
+    Lx > 0 && Ly > 0 || error("Kagome TightBindingSpectrum: Lx, Ly must be positive")
     eigs = Float64[]
     sizehint!(eigs, 3 * Lx * Ly)
     for m in 0:(Lx - 1), n in 0:(Ly - 1)

--- a/src/models/quantum/tightbinding/Kagome.jl
+++ b/src/models/quantum/tightbinding/Kagome.jl
@@ -43,7 +43,12 @@ Hamiltonian: H = -t Σ_{⟨i,j⟩} (c†_i c_j + h.c.)
 The spectrum exhibits a dispersionless flat band at E = +2t touching the
 lower dispersive bands at the Γ-point.
 """
-struct Kagome <: AbstractQAtlasModel; t::Float64; Lx::Int; Ly::Int; end
+struct Kagome <: AbstractQAtlasModel
+    ;
+    t::Float64;
+    Lx::Int;
+    Ly::Int;
+end
 Kagome(; t::Real=1.0, Lx::Integer=0, Ly::Integer=0) = Kagome(Float64(t), Int(Lx), Int(Ly))
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -89,7 +94,9 @@ A sorted `Vector{Float64}` of length `3·Lx·Ly`.
     I. Syôzi, Prog. Theor. Phys. 6, 306 (1951).
     D. L. Bergman et al., Phys. Rev. B 78, 125104 (2008).
 """
-function fetch(m::Kagome, ::TightBindingSpectrum; Lx::Integer=m.Lx, Ly::Integer=m.Ly, t::Real=m.t)
+function fetch(
+    m::Kagome, ::TightBindingSpectrum; Lx::Integer=m.Lx, Ly::Integer=m.Ly, t::Real=m.t
+)
     Lx > 0 && Ly > 0 || error("Kagome TightBindingSpectrum: Lx, Ly must be positive")
     eigs = Float64[]
     sizehint!(eigs, 3 * Lx * Ly)

--- a/src/models/quantum/tightbinding/Lieb.jl
+++ b/src/models/quantum/tightbinding/Lieb.jl
@@ -53,7 +53,8 @@ sublattices). Hamiltonian:
 The spectrum contains a dispersionless flat band at `E = 0` for every
 momentum, with an additional three-fold band touching at the M-point.
 """
-struct Lieb end
+struct Lieb <: AbstractQAtlasModel; t::Float64; Lx::Int; Ly::Int; end
+Lieb(; t::Real=1.0, Lx::Integer=0, Ly::Integer=0) = Lieb(Float64(t), Int(Lx), Int(Ly))
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # fetch: closed-form Bloch spectrum for Lx × Ly Lieb PBC
@@ -96,7 +97,8 @@ A sorted `Vector{Float64}` of length `3·Lx·Ly`.
 # References
     E. H. Lieb, Phys. Rev. Lett. 62, 1201 (1989).
 """
-function fetch(::Lieb, ::TightBindingSpectrum; Lx::Int, Ly::Int, t::Real=1.0)
+function fetch(m::Lieb, ::TightBindingSpectrum; Lx::Integer=m.Lx, Ly::Integer=m.Ly, t::Real=m.t)
+    Lx > 0 && Ly > 0 || error("Lieb TightBindingSpectrum: Lx, Ly must be positive")
     eigs = Float64[]
     sizehint!(eigs, 3 * Lx * Ly)
     for m in 0:(Lx - 1), n in 0:(Ly - 1)

--- a/src/models/quantum/tightbinding/Lieb.jl
+++ b/src/models/quantum/tightbinding/Lieb.jl
@@ -53,7 +53,12 @@ sublattices). Hamiltonian:
 The spectrum contains a dispersionless flat band at `E = 0` for every
 momentum, with an additional three-fold band touching at the M-point.
 """
-struct Lieb <: AbstractQAtlasModel; t::Float64; Lx::Int; Ly::Int; end
+struct Lieb <: AbstractQAtlasModel
+    ;
+    t::Float64;
+    Lx::Int;
+    Ly::Int;
+end
 Lieb(; t::Real=1.0, Lx::Integer=0, Ly::Integer=0) = Lieb(Float64(t), Int(Lx), Int(Ly))
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -97,7 +102,9 @@ A sorted `Vector{Float64}` of length `3·Lx·Ly`.
 # References
     E. H. Lieb, Phys. Rev. Lett. 62, 1201 (1989).
 """
-function fetch(m::Lieb, ::TightBindingSpectrum; Lx::Integer=m.Lx, Ly::Integer=m.Ly, t::Real=m.t)
+function fetch(
+    m::Lieb, ::TightBindingSpectrum; Lx::Integer=m.Lx, Ly::Integer=m.Ly, t::Real=m.t
+)
     Lx > 0 && Ly > 0 || error("Lieb TightBindingSpectrum: Lx, Ly must be positive")
     eigs = Float64[]
     sizehint!(eigs, 3 * Lx * Ly)

--- a/src/models/quantum/tightbinding/Triangular.jl
+++ b/src/models/quantum/tightbinding/Triangular.jl
@@ -47,8 +47,15 @@ The single band ranges from `-6t` (at the Γ-point) to `+3t` (at the
 K-points), reflecting geometric frustration: the absence of
 particle-hole (chiral) symmetry on a non-bipartite lattice.
 """
-struct Triangular <: AbstractQAtlasModel; t::Float64; Lx::Int; Ly::Int; end
-Triangular(; t::Real=1.0, Lx::Integer=0, Ly::Integer=0) = Triangular(Float64(t), Int(Lx), Int(Ly))
+struct Triangular <: AbstractQAtlasModel
+    ;
+    t::Float64;
+    Lx::Int;
+    Ly::Int;
+end
+function Triangular(; t::Real=1.0, Lx::Integer=0, Ly::Integer=0)
+    Triangular(Float64(t), Int(Lx), Int(Ly))
+end
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # fetch: closed-form Bloch spectrum for Lx × Ly triangular PBC
@@ -83,7 +90,9 @@ A sorted `Vector{Float64}` of length `Lx·Ly`.
 # References
     G. H. Wannier, Phys. Rev. 79, 357 (1950).
 """
-function fetch(m::Triangular, ::TightBindingSpectrum; Lx::Integer=m.Lx, Ly::Integer=m.Ly, t::Real=m.t)
+function fetch(
+    m::Triangular, ::TightBindingSpectrum; Lx::Integer=m.Lx, Ly::Integer=m.Ly, t::Real=m.t
+)
     Lx > 0 && Ly > 0 || error("Triangular TightBindingSpectrum: Lx, Ly must be positive")
     eigs = Vector{Float64}(undef, Lx * Ly)
     idx = 1

--- a/src/models/quantum/tightbinding/Triangular.jl
+++ b/src/models/quantum/tightbinding/Triangular.jl
@@ -47,7 +47,8 @@ The single band ranges from `-6t` (at the Γ-point) to `+3t` (at the
 K-points), reflecting geometric frustration: the absence of
 particle-hole (chiral) symmetry on a non-bipartite lattice.
 """
-struct Triangular end
+struct Triangular <: AbstractQAtlasModel; t::Float64; Lx::Int; Ly::Int; end
+Triangular(; t::Real=1.0, Lx::Integer=0, Ly::Integer=0) = Triangular(Float64(t), Int(Lx), Int(Ly))
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # fetch: closed-form Bloch spectrum for Lx × Ly triangular PBC
@@ -82,7 +83,8 @@ A sorted `Vector{Float64}` of length `Lx·Ly`.
 # References
     G. H. Wannier, Phys. Rev. 79, 357 (1950).
 """
-function fetch(::Triangular, ::TightBindingSpectrum; Lx::Int, Ly::Int, t::Real=1.0)
+function fetch(m::Triangular, ::TightBindingSpectrum; Lx::Integer=m.Lx, Ly::Integer=m.Ly, t::Real=m.t)
+    Lx > 0 && Ly > 0 || error("Triangular TightBindingSpectrum: Lx, Ly must be positive")
     eigs = Vector{Float64}(undef, Lx * Ly)
     idx = 1
     for m in 0:(Lx - 1), n in 0:(Ly - 1)

--- a/src/universalities/Ising2D.jl
+++ b/src/universalities/Ising2D.jl
@@ -24,8 +24,10 @@
 #   These are currently the most precise known estimates.
 # ─────────────────────────────────────────────────────────────────────────────
 
-# Backward-compatible alias — delegates to Universality{:Ising} with d=2
-struct Ising2D end
+# Backward-compatible alias — delegates to Universality{:Ising} with d=2.
+# Subtyped to `AbstractQAtlasModel` so it composes with the new top-level
+# fetch(::AbstractQAtlasModel, ::AbstractQuantity, ::BC) signature.
+struct Ising2D <: AbstractQAtlasModel end
 
 """
     fetch(::Ising2D, ::CriticalExponents) -> NamedTuple

--- a/src/universalities/KPZ.jl
+++ b/src/universalities/KPZ.jl
@@ -10,8 +10,11 @@
 #   T. Sasamoto, H. Spohn, Nucl. Phys. B 834, 523 (2010).
 # ─────────────────────────────────────────────────────────────────────────────
 
-# Backward-compatible alias
-struct KPZ1D end
+# Backward-compatible alias — previously a bare struct tag; now
+# subtyped to `AbstractQAtlasModel` so dispatch composes with the new
+# top-level `fetch(::AbstractQAtlasModel, ::AbstractQuantity, ::BC)`
+# canonical signature.
+struct KPZ1D <: AbstractQAtlasModel end
 function fetch(::KPZ1D, ::CriticalExponents; kwargs...)
     return fetch(Universality(:KPZ), GrowthExponents(); d=1, kwargs...)
 end

--- a/src/universalities/MeanField.jl
+++ b/src/universalities/MeanField.jl
@@ -9,12 +9,14 @@
 # ─────────────────────────────────────────────────────────────────────────────
 
 """
-    MeanField
+    MeanField() <: AbstractQAtlasModel
 
-Dispatch tag for the mean-field (Landau) universality class.
-Exact for d ≥ d_c (upper critical dimension).
+Mean-field (Landau) universality class.  Exact for `d ≥ d_c` (upper
+critical dimension).  Kept as a top-level alias so that existing
+`fetch(MeanField(), ...)` callers keep working after the v0.13 API
+redesign; the canonical form is `Universality(:MeanField)`.
 """
-struct MeanField end
+struct MeanField <: AbstractQAtlasModel end
 
 """
     fetch(::MeanField, ::CriticalExponents) -> NamedTuple

--- a/src/universalities/Universality.jl
+++ b/src/universalities/Universality.jl
@@ -32,25 +32,25 @@ QAtlas.fetch(Universality(:Ising), CriticalExponents(); d=3)   # numerical + _er
 QAtlas.fetch(Universality(:Ising), CriticalExponents(); d=4)   # mean-field
 ```
 """
-struct Universality{C} end
+struct Universality{C} <: AbstractQAtlasModel end
 Universality(name::Symbol) = Universality{name}()
 
 """
-    CriticalExponents
+    CriticalExponents() <: AbstractQuantity
 
-Dispatch tag for the standard set of equilibrium critical exponents
+Standard set of equilibrium critical exponents
 {α, β, γ, δ, ν, η} of a universality class. Returns a `NamedTuple`.
 
 For exact values: fields are `Rational{Int}`.
 For numerical estimates: fields are `Float64` with corresponding
 `_err` fields (e.g., `β_err`) giving the uncertainty.
 """
-struct CriticalExponents end
+struct CriticalExponents <: AbstractQuantity end
 
 """
-    GrowthExponents
+    GrowthExponents() <: AbstractQuantity
 
-Dispatch tag for KPZ-type growth/roughness/dynamic exponents.
-Returns `(β_growth, α_rough, z)` instead of the equilibrium set.
+KPZ-type growth / roughness / dynamic exponents.  Returns
+`(β_growth, α_rough, z)` instead of the equilibrium set.
 """
-struct GrowthExponents end
+struct GrowthExponents <: AbstractQuantity end


### PR DESCRIPTION
## Summary

Third step of the v0.13 API redesign: migrate the classical + universality + tight-binding models from zero-field dispatch tags to concrete parameter-carrying structs, and rename `Graphene` → `Honeycomb`.

Builds on #40 (foundation) and #41 (TFIM + E8).

## Changes

### IsingSquare (classical)
- `struct IsingSquare(; J::Real=1.0, Lx::Int=0, Ly::Int=0) <: AbstractQAtlasModel`.  Previously a zero-field tag with `J`/`Lx`/`Ly` passed as fetch kwargs.
- `Lx = Ly = 0` is a legacy sentinel meaning "not yet specified"; `PartitionFunction` errors out if either is still `0`.
- `fetch` methods prefer struct fields but still accept the legacy `J`/`Lx`/`Ly`/`β` kwargs; old call sites keep working.
- `PartitionFunction`, `CriticalTemperature`, `SpontaneousMagnetization` now subtype `AbstractQuantity`.

### Universality class tags
- `Universality{C}` now subtypes `AbstractQAtlasModel`.
- `CriticalExponents`, `GrowthExponents` subtype `AbstractQuantity`.
- Backward-compat aliases `Ising2D`, `KPZ1D`, `MeanField` subtype `AbstractQAtlasModel`.

### Tight-binding lattices
- `Honeycomb(; t=1.0, Lx=0, Ly=0) <: AbstractQAtlasModel` — replaces the `Graphene` dispatch tag.  `TightBindingSpectrum <: AbstractQuantity`.
- `Kagome` / `Lieb` / `Triangular` get the same `(t, Lx, Ly)` typed fields.  Still unexported to avoid `Lattice2D` namespace collision.
- Each `fetch` method reads parameters from the struct by default and still accepts the legacy kwargs for back-compat.  `Lx = Ly = 0` raises an informative error instead of silently iterating an empty Brillouin zone.

### `Graphene` → `Honeycomb` rename
- `src/models/quantum/tightbinding/Graphene.jl` → `Honeycomb.jl` via `git mv` so history is preserved.
- `src/deprecate/legacy_honeycomb.jl` exports
  ```julia
  const Graphene = Honeycomb
  ```
  so `Graphene()` is literally `Honeycomb()` at the type level — existing `fetch(Graphene(), ...)` callers dispatch through the new Honeycomb methods without a deprecation hint (identical types mean identical methods).

## Test plan

- [x] `fetch(IsingSquare(; J=1, Lx=3, Ly=3), PartitionFunction(); β=0.4)` matches the legacy `fetch(IsingSquare(), PartitionFunction(); Lx=3, Ly=3, β=0.4, J=1.0)` at rtol 1e-12.
- [x] `fetch(Honeycomb(; t=1, Lx=3, Ly=3), TightBindingSpectrum())` matches `fetch(Graphene(), TightBindingSpectrum(); Lx=3, Ly=3, t=1.0)` element-wise at rtol 1e-14.  `Graphene === Honeycomb` is type-identical.
- [x] `QAtlas.Kagome / Lieb / Triangular` produce 27 / 27 / 9 eigenvalues respectively for `Lx = Ly = 3`.
- [x] `Universality(:Ising)` + `CriticalExponents()` still returns `β = 1//8`.
- [ ] Full `Pkg.test()` — CI.

## Follow-ups

- XXZ1D Bethe-ansatz implementation (M1.9)
- docs/src/ dual-track build (M1.10)
- md refresh + version bump 0.12.9 → 0.13.0 (M1.11-12)