### PR TITLE
feat: XXZ1D model (critical-regime Luttinger parameters + exact Δ points)

### DIFF
--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -11,6 +11,7 @@ export IsingSquare, PartitionFunction, CriticalTemperature, SpontaneousMagnetiza
 # --- Quantum Models ---
 export TFIM                                             # v0.13 concrete struct
 export E8                                               # v0.13 concrete struct
+export XXZ1D                                            # v0.13 new model
 export Honeycomb, TightBindingSpectrum                  # v0.13 rename: was Graphene
 # NOTE: `Kagome`, `Lieb`, `Triangular` are NOT exported — they conflict
 # with Lattice2D's topology types of the same name. Access them as
@@ -60,6 +61,7 @@ include("models/quantum/tightbinding/Kagome.jl")
 include("models/quantum/tightbinding/Lieb.jl")
 include("models/quantum/tightbinding/Triangular.jl")
 include("models/quantum/Heisenberg.jl")
+include("models/quantum/XXZ.jl")
 
 # --- Deprecation shims (legacy API) ---
 # Loaded last so they can route into any already-registered concrete
@@ -69,5 +71,6 @@ include("deprecate/legacy_tfim.jl")
 include("deprecate/legacy_e8.jl")
 include("deprecate/legacy_honeycomb.jl")
 export Graphene                                         # backward-compat alias
+include("deprecate/legacy_xxz.jl")
 
 end # module QAtlas

--- a/src/core/alias.jl
+++ b/src/core/alias.jl
@@ -61,6 +61,26 @@ end
 @register_aliases canonicalize_quantity :longitudinal_susceptibility [
     :chi_zz, :χ_zz, :LongitudinalSusceptibility, :susceptibility_z, :uniform_susceptibility
 ]
+
+# v0.13 velocity family — all resolve to the same canonical Symbol
+# (`:luttinger_velocity`) at the alias layer.  The legacy shim in
+# `src/deprecate/legacy_xxz.jl` then maps the Symbol to
+# `LuttingerVelocity()`; `SpinWaveVelocity` is a type-level alias for
+# `LuttingerVelocity`.
+@register_aliases canonicalize_quantity :luttinger_velocity [
+    :v_LL, :vLL, :u_LL, :uLL, :sound_velocity,
+    :spin_wave_velocity, :v_s, :vs, :SpinWaveVelocity,
+    :fermi_velocity, :v_F, :vF, :FermiVelocity,
+    :LuttingerVelocity,
+]
+
+@register_aliases canonicalize_quantity :luttinger_parameter [
+    :K, :K_LL, :LuttingerParameter
+]
+
+@register_aliases canonicalize_quantity :ground_state_energy [
+    :e0, :E0, :GroundStateEnergyDensity, :ground_state_energy_density
+]
 @register_aliases canonicalize_quantity :zz_static_thermal [
     :zz_static, :sz_sz_static, :static_zz_thermal
 ]
@@ -83,3 +103,5 @@ end
 @register_aliases canonicalize_model :TFIM [
     :TransverseFieldIsingModel, :transverseFieldIsingModel
 ]
+
+@register_aliases canonicalize_model :XXZ1D [:XXZ, :xxz, :xxz1d]

--- a/src/core/alias.jl
+++ b/src/core/alias.jl
@@ -68,9 +68,19 @@ end
 # `LuttingerVelocity()`; `SpinWaveVelocity` is a type-level alias for
 # `LuttingerVelocity`.
 @register_aliases canonicalize_quantity :luttinger_velocity [
-    :v_LL, :vLL, :u_LL, :uLL, :sound_velocity,
-    :spin_wave_velocity, :v_s, :vs, :SpinWaveVelocity,
-    :fermi_velocity, :v_F, :vF, :FermiVelocity,
+    :v_LL,
+    :vLL,
+    :u_LL,
+    :uLL,
+    :sound_velocity,
+    :spin_wave_velocity,
+    :v_s,
+    :vs,
+    :SpinWaveVelocity,
+    :fermi_velocity,
+    :v_F,
+    :vF,
+    :FermiVelocity,
     :LuttingerVelocity,
 ]
 

--- a/src/deprecate/legacy_xxz.jl
+++ b/src/deprecate/legacy_xxz.jl
@@ -1,0 +1,39 @@
+# deprecate/legacy_xxz.jl — Symbol-dispatch shim for `XXZ1D`.
+#
+# The canonical API is the concrete struct form:
+#
+#   fetch(XXZ1D(; J, Δ), Energy(), Infinite())
+#
+# Legacy Symbol callers route through Model{:XXZ1D}(params::Dict) which
+# is constructed by `Model(:XXZ; kwargs...)` via canonicalize_model
+# (alias `:XXZ → :XXZ1D`).  The shims below translate that into the new
+# concrete-struct dispatch.
+
+"""
+    _xxz1d_from_legacy_model(m::Model{:XXZ1D}) -> XXZ1D
+"""
+function _xxz1d_from_legacy_model(m::Model{:XXZ1D})::XXZ1D
+    J = Float64(get(m.params, :J, 1.0))
+    Δ = Float64(get(m.params, :Δ, 0.0))
+    return XXZ1D(; J=J, Δ=Δ)
+end
+
+# One shim per supported (Symbol quantity, BC) pair.
+const _LEGACY_XXZ1D_QUANTITY_MAP = (
+    (:energy, Energy),
+    (:ground_state_energy, GroundStateEnergyDensity),
+    (:central_charge, CentralCharge),
+    (:luttinger_parameter, LuttingerParameter),
+    (:luttinger_velocity, LuttingerVelocity),
+    (:sound_velocity, LuttingerVelocity),     # alias: same physical quantity
+    (:spin_wave_velocity, LuttingerVelocity), # alias
+    (:fermi_velocity, LuttingerVelocity),     # alias (free-fermion XX limit)
+)
+
+for (qsym, QTy) in _LEGACY_XXZ1D_QUANTITY_MAP
+    @eval function fetch(
+        m::Model{:XXZ1D}, ::Quantity{$(QuoteNode(qsym))}, bc::Infinite; kwargs...
+    )
+        return fetch(_xxz1d_from_legacy_model(m), $QTy(), bc; kwargs...)
+    end
+end

--- a/src/models/quantum/XXZ.jl
+++ b/src/models/quantum/XXZ.jl
@@ -98,7 +98,7 @@ function fetch(model::XXZ1D, ::Energy, ::Infinite; kwargs...)
         return _xxz1d_energy_heisenberg_fm(J)
     else
         @warn "XXZ1D Energy: general-Δ Bethe ansatz not yet implemented; " *
-              "only Δ ∈ {-1, 0, 1} are exposed in this release." Δ = Δ
+            "only Δ ∈ {-1, 0, 1} are exposed in this release." Δ = Δ
         return NaN
     end
 end

--- a/src/models/quantum/XXZ.jl
+++ b/src/models/quantum/XXZ.jl
@@ -1,0 +1,184 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# XXZ chain (1D, spin-1/2) — Bethe-ansatz ground-state energy and
+# Luttinger-liquid parameters in the critical regime.
+#
+# Hamiltonian (Takahashi / standard convention):
+#
+#   H = J Σ_i [ S^x_i S^x_{i+1} + S^y_i S^y_{i+1} + Δ S^z_i S^z_{i+1} ]
+#
+#   (spin-1/2, `J > 0` is the antiferromagnetic sign convention).
+#
+# In Pauli notation this is equivalently
+#
+#   H = (J/4) Σ_i [ σ^x σ^x + σ^y σ^y + Δ σ^z σ^z ]
+#
+# Known limiting values (all per site, units of J):
+#
+#   Δ =  1  (isotropic AF / Heisenberg):  e₀/J = 1/4 − ln 2 ≈ −0.4431
+#                                         (Hulthén 1938)
+#   Δ =  0  (XX / free fermion):          e₀/J = −1/π       ≈ −0.3183
+#   Δ = −1  (isotropic FM):               e₀/J = −1/4
+#
+# The generic Yang-Yang integral representation for general -1 < Δ < 1
+# is deferred to a follow-up commit (it has several equivalent forms in
+# the literature that differ by nontrivial substitutions; verifying any
+# one of them against both boundary limits (Hulthén at Δ=1 and the
+# free-fermion result at Δ=0) requires careful derivation).  For the
+# current scope we expose exact values only at the three canonical
+# points:
+#
+#   Δ = -1:  -1/4      (FM saturated)
+#   Δ =  0:  -1/π      (XX / free fermion)
+#   Δ =  1:  1/4 - ln 2 (AF Heisenberg, Hulthén 1938)
+#
+# Other observables (central charge, Luttinger parameter, Luttinger
+# velocity) are implemented analytically across the full critical
+# regime -1 < Δ ≤ 1.
+#
+# References:
+#
+#   - L. Hulthén (1938) Arkiv Mat. Astron. Fysik 26A, 1.
+#   - C. N. Yang and C. P. Yang (1966) Phys. Rev. 150, 321.
+#   - M. Takahashi, "Thermodynamics of One-Dimensional Solvable Models",
+#     Cambridge University Press (1999).
+#   - T. Giamarchi, "Quantum Physics in One Dimension",
+#     Oxford University Press (2004), §6 for Luttinger parameter & velocity.
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    XXZ1D(; J::Real = 1.0, Δ::Real = 0.0) <: AbstractQAtlasModel
+
+Spin-1/2 XXZ chain
+
+    H = J Σ_i [ S^x_i S^x_{i+1} + S^y_i S^y_{i+1} + Δ S^z_i S^z_{i+1} ]
+
+Convention: `J > 0` is antiferromagnetic.  `Δ = 1` is the isotropic
+Heisenberg AF point, `Δ = 0` is the XX (free-fermion) point, `Δ = -1`
+is the isotropic ferromagnet.  For `|Δ| < 1` the chain is critical
+(Luttinger liquid, central charge `c = 1`).
+"""
+struct XXZ1D <: AbstractQAtlasModel
+    J::Float64
+    Δ::Float64
+end
+XXZ1D(; J::Real=1.0, Δ::Real=0.0) = XXZ1D(Float64(J), Float64(Δ))
+
+# ── Ground-state energy per site (infinite chain) ──────────────────────
+#
+# Exact values at three canonical points only — see module docstring
+# for the rationale (the general-Δ Yang-Yang integral is deferred to a
+# follow-up commit; several equivalent forms in the literature differ
+# by nontrivial substitutions and require careful verification against
+# both boundary limits).
+
+_xxz1d_energy_free_fermion(J::Float64)::Float64 = -J / π
+_xxz1d_energy_heisenberg_af(J::Float64)::Float64 = J * (0.25 - log(2.0))
+_xxz1d_energy_heisenberg_fm(J::Float64)::Float64 = -J / 4
+
+"""
+    fetch(model::XXZ1D, ::Energy, ::Infinite) -> Float64
+
+Ground-state energy **per site** of the infinite XXZ chain in units of
+the Hamiltonian `J`.  Currently exposes the three canonical values:
+
+- `Δ = -1`  →  `-J/4`             (isotropic FM, saturated)
+- `Δ =  0`  →  `-J/π`             (XX, free fermion)
+- `Δ =  1`  →  `J (1/4 - ln 2)`   (AF Heisenberg, Hulthén 1938)
+
+For every other `Δ` a warning is emitted and `NaN` is returned — the
+general-`Δ` Bethe-ansatz integral is tracked as a v0.13 follow-up.
+"""
+function fetch(model::XXZ1D, ::Energy, ::Infinite; kwargs...)
+    J, Δ = model.J, model.Δ
+    if isapprox(Δ, 0.0; atol=1e-12)
+        return _xxz1d_energy_free_fermion(J)
+    elseif isapprox(Δ, 1.0; atol=1e-12)
+        return _xxz1d_energy_heisenberg_af(J)
+    elseif isapprox(Δ, -1.0; atol=1e-12)
+        return _xxz1d_energy_heisenberg_fm(J)
+    else
+        @warn "XXZ1D Energy: general-Δ Bethe ansatz not yet implemented; " *
+              "only Δ ∈ {-1, 0, 1} are exposed in this release." Δ = Δ
+        return NaN
+    end
+end
+
+"""
+    fetch(model::XXZ1D, ::GroundStateEnergyDensity, ::Infinite) -> Float64
+
+Alias for [`fetch(::XXZ1D, ::Energy, ::Infinite)`](@ref) kept so that
+the `GroundStateEnergyDensity` quantity — already exported by
+`Heisenberg.jl` — works uniformly across 1D Bethe-ansatz chains.
+"""
+function fetch(model::XXZ1D, ::GroundStateEnergyDensity, ::Infinite; kwargs...)
+    return fetch(model, Energy(), Infinite(); kwargs...)
+end
+
+# ── Central charge & Luttinger-liquid parameters (critical regime) ─────
+
+"""
+    fetch(model::XXZ1D, ::CentralCharge, ::Infinite) -> Float64
+
+Central charge of the XXZ chain:
+
+- `-1 < Δ < 1`  → `c = 1` (Luttinger liquid)
+- otherwise     → `NaN` (non-critical)
+"""
+function fetch(model::XXZ1D, ::CentralCharge, ::Infinite; kwargs...)
+    if -1.0 < model.Δ < 1.0
+        return 1.0
+    end
+    @warn "XXZ1D CentralCharge is only defined in the critical regime -1 < Δ < 1." Δ =
+        model.Δ
+    return NaN
+end
+
+"""
+    fetch(model::XXZ1D, ::LuttingerParameter, ::Infinite) -> Float64
+
+Luttinger-liquid parameter `K = π / (2(π − γ))`, with `γ = arccos(Δ)`,
+valid for `-1 < Δ ≤ 1`.
+
+Canonical values:
+- `Δ = 0` (XX free fermion) → `K = 1`
+- `Δ = 1` (AF Heisenberg)   → `K = 1/2`
+- `Δ → -1` (FM boundary)    → `K → ∞`
+"""
+function fetch(model::XXZ1D, ::LuttingerParameter, ::Infinite; kwargs...)
+    Δ = model.Δ
+    if -1.0 < Δ ≤ 1.0
+        γ = acos(Δ)
+        return π / (2 * (π - γ))
+    end
+    @warn "XXZ1D LuttingerParameter is only defined for -1 < Δ ≤ 1." Δ = Δ
+    return NaN
+end
+
+"""
+    fetch(model::XXZ1D, ::LuttingerVelocity, ::Infinite) -> Float64
+    fetch(model::XXZ1D, ::SpinWaveVelocity,   ::Infinite) -> Float64
+
+Sound velocity of the low-energy Luttinger-liquid mode,
+
+    u(Δ) = J · (π/2) · sin(γ)/γ,   γ = arccos(Δ).
+
+Canonical values:
+- `Δ = 0` (XX)       → `u = J`         (= free-fermion v_F)
+- `Δ = 1` (AF)       → `u = (π/2) J`  (des Cloizeaux-Pearson)
+
+`SpinWaveVelocity` dispatches here via the `const SpinWaveVelocity =
+LuttingerVelocity` type alias (both are the same physical quantity for
+1D critical spin chains).
+"""
+function fetch(model::XXZ1D, ::LuttingerVelocity, ::Infinite; kwargs...)
+    J, Δ = model.J, model.Δ
+    if -1.0 < Δ ≤ 1.0
+        γ = acos(Δ)
+        # sin(γ)/γ has a removable singularity at γ = 0 (Heisenberg AF);
+        # the naive ratio is fine in Float64 for any γ > 0 that
+        # corresponds to Δ < 1, and at Δ = 1 we take the limit.
+        return J * (π / 2) * (isapprox(γ, 0.0; atol=1e-12) ? 1.0 : sin(γ) / γ)
+    end
+    @warn "XXZ1D LuttingerVelocity is only defined for -1 < Δ ≤ 1." Δ = Δ
+    return NaN
+end

--- a/test/models/test_XXZ1D.jl
+++ b/test/models/test_XXZ1D.jl
@@ -1,0 +1,109 @@
+using QAtlas, Test
+
+@testset "XXZ1D — dispatch & construction" begin
+    m = XXZ1D()
+    @test m isa QAtlas.AbstractQAtlasModel
+    @test m.J == 1.0
+    @test m.Δ == 0.0
+
+    m2 = XXZ1D(; J=2.5, Δ=0.7)
+    @test m2.J == 2.5
+    @test m2.Δ == 0.7
+
+    # Symbol alias resolves to :XXZ1D canonical
+    @test QAtlas.canonicalize_model(Val(:XXZ)) === :XXZ1D
+    @test QAtlas.canonicalize_model(Val(:xxz)) === :XXZ1D
+    @test QAtlas.canonicalize_model(Val(:xxz1d)) === :XXZ1D
+end
+
+@testset "XXZ1D — known closed-form points (J=1, Infinite)" begin
+    # Δ = 0 (XX, free fermion): e₀/J = -1/π
+    e_xx = QAtlas.fetch(XXZ1D(; J=1.0, Δ=0.0), Energy(), Infinite())
+    @test e_xx ≈ -1 / π atol = 1e-10
+
+    # Δ = 1 (AF Heisenberg, Hulthén 1938): e₀/J = 1/4 - ln 2
+    e_af = QAtlas.fetch(XXZ1D(; J=1.0, Δ=1.0), Energy(), Infinite())
+    @test e_af ≈ 0.25 - log(2.0) atol = 1e-10
+
+    # Δ = -1 (FM): e₀/J = -1/4
+    e_fm = QAtlas.fetch(XXZ1D(; J=1.0, Δ=-1.0), Energy(), Infinite())
+    @test e_fm ≈ -0.25 atol = 1e-14
+
+    # GroundStateEnergyDensity alias returns the same value.
+    e_gs = QAtlas.fetch(XXZ1D(; J=1.0, Δ=1.0), GroundStateEnergyDensity(), Infinite())
+    @test e_gs ≈ e_af
+end
+
+@testset "XXZ1D — Energy outside the three canonical Δ is NaN + warning" begin
+    # The general-Δ Bethe-ansatz integral is deferred; for now XXZ1D
+    # advertises only Δ ∈ {-1, 0, 1} and returns NaN + a warning elsewhere.
+    for Δ in (-0.5, 0.3, 0.7, 1.5, 2.0)
+        e = @test_logs (:warn, r"general-Δ") QAtlas.fetch(
+            XXZ1D(; J=1.0, Δ=Δ), Energy(), Infinite()
+        )
+        @test isnan(e)
+    end
+end
+
+@testset "XXZ1D — Luttinger parameter K" begin
+    @test QAtlas.fetch(XXZ1D(; J=1.0, Δ=0.0), LuttingerParameter(), Infinite()) ≈ 1.0 atol = 1e-12
+    @test QAtlas.fetch(XXZ1D(; J=1.0, Δ=1.0), LuttingerParameter(), Infinite()) ≈ 0.5 atol = 1e-12
+
+    # Monotone decreasing from Δ = -1 (K → ∞) to Δ = 1 (K = 1/2)
+    ks = [QAtlas.fetch(XXZ1D(; J=1, Δ=Δ), LuttingerParameter(), Infinite()) for Δ in -0.9:0.2:0.9]
+    @test all(diff(ks) .< 0)
+end
+
+@testset "XXZ1D — LuttingerVelocity (+ SpinWaveVelocity alias)" begin
+    # Canonical values at Δ=0 (XX) and Δ=1 (AF Heisenberg)
+    @test QAtlas.fetch(XXZ1D(; J=1.0, Δ=0.0), LuttingerVelocity(), Infinite()) ≈ 1.0 atol = 1e-12
+    @test QAtlas.fetch(XXZ1D(; J=1.0, Δ=1.0), LuttingerVelocity(), Infinite()) ≈ π / 2 atol = 1e-12
+
+    # J scaling linear
+    @test QAtlas.fetch(XXZ1D(; J=3.0, Δ=0.0), LuttingerVelocity(), Infinite()) ≈ 3.0
+
+    # SpinWaveVelocity() === LuttingerVelocity at the type level
+    @test SpinWaveVelocity === LuttingerVelocity
+    @test SpinWaveVelocity() isa LuttingerVelocity
+
+    u1 = QAtlas.fetch(XXZ1D(; J=1.0, Δ=0.5), LuttingerVelocity(), Infinite())
+    u2 = QAtlas.fetch(XXZ1D(; J=1.0, Δ=0.5), SpinWaveVelocity(), Infinite())
+    @test u1 === u2
+end
+
+@testset "XXZ1D — central charge (critical regime only)" begin
+    for Δ in (-0.9, -0.5, 0.0, 0.5, 0.99)
+        @test QAtlas.fetch(XXZ1D(; J=1.0, Δ=Δ), CentralCharge(), Infinite()) == 1.0
+    end
+    # Outside the critical regime we return NaN + a warning.
+    @test isnan(
+        @test_logs (:warn, r"critical regime") QAtlas.fetch(
+            XXZ1D(; J=1.0, Δ=1.5), CentralCharge(), Infinite()
+        )
+    )
+end
+
+@testset "XXZ1D — gapped regime is NaN (general-Δ deferred)" begin
+    # |Δ| > 1: gapped; NaN + warning.  This is the same branch as the
+    # generic-Δ path above (single deferred-implementation warning);
+    # the test spells it out for documentation value.
+    e = @test_logs (:warn, r"general-Δ") QAtlas.fetch(
+        XXZ1D(; J=1.0, Δ=2.0), Energy(), Infinite()
+    )
+    @test isnan(e)
+end
+
+@testset "XXZ1D — legacy Symbol dispatch routes to new API" begin
+    # Deprecation log on every new (model, quantity) pair
+    e_sym = QAtlas.fetch(:XXZ, :energy, Infinite(); J=1.0, Δ=0.0)
+    @test e_sym ≈ -1 / π atol = 1e-10
+
+    u_sym = QAtlas.fetch(:XXZ, :spin_wave_velocity, Infinite(); J=1.0, Δ=1.0)
+    @test u_sym ≈ π / 2 atol = 1e-12
+
+    u_fv = QAtlas.fetch(:XXZ, :fermi_velocity, Infinite(); J=1.0, Δ=0.0)
+    @test u_fv ≈ 1.0 atol = 1e-12
+
+    K_sym = QAtlas.fetch(:XXZ, :luttinger_parameter, Infinite(); J=1.0, Δ=0.0)
+    @test K_sym ≈ 1.0 atol = 1e-12
+end

--- a/test/models/test_XXZ1D.jl
+++ b/test/models/test_XXZ1D.jl
@@ -46,18 +46,25 @@ end
 end
 
 @testset "XXZ1D — Luttinger parameter K" begin
-    @test QAtlas.fetch(XXZ1D(; J=1.0, Δ=0.0), LuttingerParameter(), Infinite()) ≈ 1.0 atol = 1e-12
-    @test QAtlas.fetch(XXZ1D(; J=1.0, Δ=1.0), LuttingerParameter(), Infinite()) ≈ 0.5 atol = 1e-12
+    @test QAtlas.fetch(XXZ1D(; J=1.0, Δ=0.0), LuttingerParameter(), Infinite()) ≈ 1.0 atol =
+        1e-12
+    @test QAtlas.fetch(XXZ1D(; J=1.0, Δ=1.0), LuttingerParameter(), Infinite()) ≈ 0.5 atol =
+        1e-12
 
     # Monotone decreasing from Δ = -1 (K → ∞) to Δ = 1 (K = 1/2)
-    ks = [QAtlas.fetch(XXZ1D(; J=1, Δ=Δ), LuttingerParameter(), Infinite()) for Δ in -0.9:0.2:0.9]
+    ks = [
+        QAtlas.fetch(XXZ1D(; J=1, Δ=Δ), LuttingerParameter(), Infinite()) for
+        Δ in -0.9:0.2:0.9
+    ]
     @test all(diff(ks) .< 0)
 end
 
 @testset "XXZ1D — LuttingerVelocity (+ SpinWaveVelocity alias)" begin
     # Canonical values at Δ=0 (XX) and Δ=1 (AF Heisenberg)
-    @test QAtlas.fetch(XXZ1D(; J=1.0, Δ=0.0), LuttingerVelocity(), Infinite()) ≈ 1.0 atol = 1e-12
-    @test QAtlas.fetch(XXZ1D(; J=1.0, Δ=1.0), LuttingerVelocity(), Infinite()) ≈ π / 2 atol = 1e-12
+    @test QAtlas.fetch(XXZ1D(; J=1.0, Δ=0.0), LuttingerVelocity(), Infinite()) ≈ 1.0 atol =
+        1e-12
+    @test QAtlas.fetch(XXZ1D(; J=1.0, Δ=1.0), LuttingerVelocity(), Infinite()) ≈ π / 2 atol =
+        1e-12
 
     # J scaling linear
     @test QAtlas.fetch(XXZ1D(; J=3.0, Δ=0.0), LuttingerVelocity(), Infinite()) ≈ 3.0


### PR DESCRIPTION
## Summary

Adds the spin-1/2 XXZ chain as a new concrete model in the v0.13 API:

    H = J Σ_i [S^x_i S^x_{i+1} + S^y_i S^y_{i+1} + Δ S^z_i S^z_{i+1}],  J > 0

`XXZ1D(; J=1.0, Δ=0.0) <: AbstractQAtlasModel`.

### Implemented quantities

| quantity | dispatch | scope |
|---|---|---|
| `Energy` | `::XXZ1D, ::Infinite` | exact closed-form values at Δ ∈ {-1, 0, 1}; NaN + warning elsewhere |
| `GroundStateEnergyDensity` | `::XXZ1D, ::Infinite` | alias for `Energy` |
| `CentralCharge` | `::XXZ1D, ::Infinite` | `c = 1` in `-1 < Δ < 1`; NaN + warning outside |
| `LuttingerParameter` | `::XXZ1D, ::Infinite` | `K = π/(2(π - γ))`, `γ = arccos(Δ)`.  `K(0) = 1`, `K(1) = 1/2`. |
| `LuttingerVelocity` | `::XXZ1D, ::Infinite` | `u = J (π/2) sin(γ)/γ`.  `u(0) = J` (free-fermion v_F), `u(1) = πJ/2` (des Cloizeaux-Pearson). |
| `SpinWaveVelocity` | `::XXZ1D, ::Infinite` | transparent alias for `LuttingerVelocity` (type identity). |

### Exact `Energy` points

| Δ | e₀ / J | reference |
|---|---|---|
| −1 | −1/4 | isotropic FM (saturated) |
|  0 | −1/π | XX (free fermion) |
|  1 | 1/4 − ln 2 | AF Heisenberg (Hulthén 1938) |

The general-Δ Yang-Yang integral is **deferred to a follow-up commit**: the literature has several equivalent forms that differ by nontrivial substitutions, and none of them reproduced both boundary limits (`−1/π` at Δ=0 and `1/4 − ln 2` at Δ=1) in my first implementation.  Keeping the scope to the exact points lets the Luttinger / velocity / central-charge coverage land cleanly while I verify the correct integrand form offline.

### Symbol aliases
- Model: `:XXZ → :XXZ1D` (and `:xxz`, `:xxz1d`).
- Quantity: `:luttinger_velocity` canonicalises all of `v_F`, `v_LL`, `v_s`, `sound_velocity`, `spin_wave_velocity`, `fermi_velocity`, `SpinWaveVelocity` to the same name.
- `src/deprecate/legacy_xxz.jl` routes `fetch(:XXZ, q, Infinite(); J, Δ)` into the new concrete-struct API.

## Test plan

- [x] 44 assertions in `test/models/test_XXZ1D.jl`:
  - Construction + field access + Symbol alias resolution.
  - Energy at Δ ∈ {-1, 0, 1} matches the known closed-form values to rtol 1e-10.
  - `GroundStateEnergyDensity == Energy` at the isotropic AF point.
  - Deferred branch returns NaN with the expected warning for generic / gapped Δ.
  - `K(0) = 1`, `K(1) = 1/2`; monotonically decreasing across `Δ ∈ [-0.9, 0.9]`.
  - `u(0) = J`, `u(1) = πJ/2`; linear `J` scaling.
  - `SpinWaveVelocity === LuttingerVelocity` type identity; `u1 === u2` via both names.
  - `CentralCharge = 1.0` for 5 representative Δ in the critical regime; NaN + warning at `|Δ| > 1`.
  - Legacy Symbol dispatch path returns the same values as the struct path.

## Follow-ups

- General-Δ Yang-Yang integral (separate PR — requires sign-convention reconciliation).
- docs/src/calc + docs/src/models/quantum/xxz.md dual-track pages (M1.10).
- md/ roadmap refresh + md/models/XXZ.md fill-in (M1.11).
- Version bump 0.12.9 → 0.13.0 (M1.12, final PR closing M1).