### PR TITLE
docs: establish the calc/ depth standard + JW-TFIM-BdG exemplar

### DIFF
--- a/docs/src/calc/jw-tfim-bdg.md
+++ b/docs/src/calc/jw-tfim-bdg.md
@@ -1,79 +1,740 @@
-# Jordan-Wigner Transformation of the TFIM → BdG Matrix
+# Jordan–Wigner Reduction of the TFIM to BdG Form
+
+## Main result
+
+For the open-chain transverse-field Ising model with $N$ sites,
+
+$$H = -J\sum_{i=1}^{N-1}\sigma^z_i\sigma^z_{i+1}
+      - h\sum_{i=1}^{N}\sigma^x_i,
+  \qquad (J > 0,\ h \ge 0),$$
+
+the Kramers–Wannier duality followed by a Jordan–Wigner transformation
+reduces $H$ to the quadratic free-fermion form
+
+$$\boxed{\;
+H \;=\; \tfrac{1}{2}\,\Psi^\dagger \mathcal{H}_{\rm BdG}\, \Psi
+       \;-\; J(N-1),
+\qquad
+\mathcal{H}_{\rm BdG} \;=\;
+\begin{pmatrix} A & B \\ -B & -A \end{pmatrix}
+\in \mathbb{R}^{2N \times 2N}.
+\;}$$
+
+Here $\Psi = (d_1,\dots,d_N,\,d^\dagger_1,\dots,d^\dagger_N)^{T}$
+is the Nambu vector of a set of canonical fermions $\{d_i\}$ defined
+below, and $A, B$ are the tridiagonal matrices
+
+$$A_{ij} = 2h\,\delta_{ij} - J(\delta_{i,j+1} + \delta_{i+1,j}),
+  \qquad
+  B_{ij} = J(\delta_{i+1,j} - \delta_{i,j+1}).$$
+
+$\mathcal{H}_{\rm BdG}$ is **real symmetric** and its eigenvalues
+come in $\pm\Lambda_n$ pairs ($n = 1,\dots,N$, $\Lambda_n > 0$), so
+the finite-temperature expectation of $H$ reads
+
+$$\boxed{\;
+\langle H\rangle(\beta)
+ \;=\; -\sum_{n=1}^{N}\frac{\Lambda_n}{2}\,
+        \tanh\!\left(\frac{\beta\Lambda_n}{2}\right)
+        \;-\; J(N-1).
+\;}$$
+
+The ground-state energy is the $\beta\to\infty$ limit,
+$E_0 = -\tfrac{1}{2}\sum_n \Lambda_n - J(N-1)$.
+
+The two boxed formulas are what the QAtlas implementation
+[`fetch(::TFIM, ::Energy, ::OBC)`](../models/quantum/tfim.md) returns
+at finite $N$; they hold for every $J, h \ge 0$ and every finite $N
+\ge 2$.
+
+---
 
 ## Setup
 
-Starting Hamiltonian (1D TFIM, OBC, $N$ sites):
+### Conventions
 
-$$H = -J\sum_{i=1}^{N-1}\sigma^z_i\sigma^z_{i+1} - h\sum_{i=1}^{N}\sigma^x_i$$
+Pauli matrices on site $i$:
 
-**Goal**: Reduce $H$ to a quadratic (free) fermion form and extract
-the BdG quasiparticle energies $\{\Lambda_n\}$.
+$$\sigma^x_i = \begin{pmatrix}0&1\\1&0\end{pmatrix},\quad
+  \sigma^y_i = \begin{pmatrix}0&-i\\i&0\end{pmatrix},\quad
+  \sigma^z_i = \begin{pmatrix}1&0\\0&-1\end{pmatrix},$$
 
-## Step 1: Kramers-Wannier Duality
+raising / lowering
 
-The $\sigma^z\sigma^z$ convention does not directly yield a free-fermion
-Hamiltonian under Jordan-Wigner (it produces quartic terms). We first
-apply the Kramers-Wannier duality to obtain the dual representation.
+$$\sigma^+_i = \tfrac{1}{2}(\sigma^x_i + i\sigma^y_i)
+             = \begin{pmatrix}0&1\\0&0\end{pmatrix},\qquad
+  \sigma^-_i = \tfrac{1}{2}(\sigma^x_i - i\sigma^y_i)
+             = \begin{pmatrix}0&0\\1&0\end{pmatrix}.$$
 
-Define dual spin operators $\tau$ on the **bonds** of the original chain:
+These satisfy, on a single site,
 
-$$\tau^x_i = \sigma^z_i\sigma^z_{i+1}, \qquad \tau^z_i\tau^z_{i+1} = \sigma^x_{i+1}$$
+$$\{\sigma^+, \sigma^-\} = 1,\qquad
+  (\sigma^+)^2 = (\sigma^-)^2 = 0,\qquad
+  \sigma^z = 1 - 2\,\sigma^-\sigma^+.$$
 
-The Hamiltonian becomes:
+Operators on different sites commute.
 
-$$H = -J\sum_i \tau^x_i - h\sum_i \tau^z_i\tau^z_{i+1}$$
+### Hamiltonian
 
-Now $\tau^z\tau^z$ is the interaction term and $\tau^x$ is the field
-— this is the form amenable to Jordan-Wigner.
+$$H = -J\sum_{i=1}^{N-1}\sigma^z_i\sigma^z_{i+1}
+      - h\sum_{i=1}^{N}\sigma^x_i.$$
 
-## Step 2: Jordan-Wigner on the Dual Spins
+OBC means only $N-1$ bonds, no site-$N$-to-site-$1$ term.
 
-Apply the JW transformation (see [general JW](../methods/jordan-wigner/index.md)):
+### Goal
 
-$$d_i = \left(\prod_{j<i}\tau^z_j\right)\tau^-_i$$
+Find a linear transformation from the spin operators to canonical
+fermion operators $\{d_i\}$ such that $H$ becomes *quadratic* in
+$\{d_i, d^\dagger_i\}$. That quadratic form then diagonalises to a
+free-fermion spectrum by an orthogonal rotation (the BdG / Bogoliubov
+step).
 
-Key results:
+Jordan–Wigner applied directly to $\sigma^z_i\sigma^z_{i+1}$ produces
+a *quartic* term; we therefore precede it with the Kramers–Wannier
+duality, which swaps the bond interaction $\sigma^z\sigma^z$ for a
+single-site field $\tau^x$ in a dual spin basis, at which point JW is
+linear and yields a bilinear fermion Hamiltonian.
 
-$$\tau^x_i = 1 - 2d^\dagger_i d_i$$
+---
 
-$$\tau^z_i\tau^z_{i+1} = -(d^\dagger_i - d_i)(d^\dagger_{i+1} + d_{i+1})$$
+## Calculation
 
-Substituting:
+### Step 1 — Kramers–Wannier duality to dual spins $\tau$
 
-$$H = -J\sum_i(1 - 2d^\dagger_i d_i) + h\sum_i(d^\dagger_i - d_i)(d^\dagger_{i+1} + d_{i+1})$$
+**Motivation.** Let us try JW on the original $\sigma$ operators. JW
+in the form $c_i = (\prod_{j<i}\sigma^z_j)\sigma^-_i$ gives
+$\sigma^z_i = 1 - 2 c^\dagger_i c_i$ and $\sigma^x_i =
+(\prod_{j<i}\sigma^z_j)(c_i + c^\dagger_i)$. The bond term
+$\sigma^z_i\sigma^z_{i+1} = (1-2n_i)(1-2n_{i+1})$ is **quartic** in
+$c$. The single-site field is linear in $c$ but has a string. Neither
+form is quadratic, so JW on $\sigma$ cannot give a free-fermion
+Hamiltonian.
 
-$$= 2J\sum_i d^\dagger_i d_i - h\sum_i(d^\dagger_i d_{i+1} + d^\dagger_i d^\dagger_{i+1} + \text{h.c.}) + \text{const}$$
+Kramers–Wannier dualises the chain onto the $N-1$ bonds, interchanging
+the roles of bond operators and site operators. In the dual basis the
+bond interaction becomes a single-site operator and vice versa, after
+which JW does produce a quadratic Hamiltonian. (See
+[classical Kramers–Wannier duality](kramers-wannier-duality.md) for
+the partition-function-level picture; the operator-level rewrite
+below is self-contained.)
 
-## Step 3: BdG Matrix
+**Dual operators on the bonds.** Label the $N-1$ bonds by $b = 1,
+\dots, N-1$, where bond $b$ connects sites $b$ and $b+1$. Define
 
-Collecting the quadratic terms in the Nambu basis
-$(d^\dagger_1, \ldots, d^\dagger_N, d_1, \ldots, d_N)$:
+$$\tau^x_b \;\equiv\; \sigma^z_b\,\sigma^z_{b+1},
+\qquad
+\tau^z_b \;\equiv\; \prod_{j=1}^{b}\sigma^x_j
+\qquad (b = 1, \dots, N-1).
+\tag{1}$$
 
-$$H = \frac{1}{2}\begin{pmatrix}d^\dagger & d\end{pmatrix}\begin{pmatrix}A & B \\ -B & -A\end{pmatrix}\begin{pmatrix}d \\ d^\dagger\end{pmatrix} + \text{const}$$
+Here $\tau^z_b$ is a product running from site $1$ up to and including
+site $b$. The idea behind $\tau^z_b$ is that its *difference* across
+adjacent bonds reproduces $\sigma^x$:
 
-where:
+$$\tau^z_{b-1}\,\tau^z_b
+ = \Bigl(\prod_{j=1}^{b-1}\sigma^x_j\Bigr)
+   \Bigl(\prod_{j=1}^{b}\sigma^x_j\Bigr)
+ = \prod_{j=1}^{b-1}(\sigma^x_j)^2 \cdot \sigma^x_b
+ = \sigma^x_b,$$
 
-$$A_{ii} = 2h, \quad A_{i,i+1} = A_{i+1,i} = -J$$
+using $(\sigma^x_j)^2 = 1$. In the same spirit we set $\tau^z_0
+\equiv 1$ (a conventional "vacuum" for the product), so that
 
-$$B_{i,i+1} = J, \quad B_{i+1,i} = -J$$
+$$\tau^z_0\,\tau^z_1 = \tau^z_1 = \sigma^x_1,$$
 
-**Key property**: $H_\text{BdG} = \begin{pmatrix}A & B \\ -B & -A\end{pmatrix}$
-is **real symmetric**. Proof: $A$ is symmetric and $B$ is antisymmetric,
-so $H_\text{BdG}^T = \begin{pmatrix}A^T & -B^T \\ B^T & -A^T\end{pmatrix} = \begin{pmatrix}A & B \\ -B & -A\end{pmatrix} = H_\text{BdG}$.
+which we will need for the boundary term.
 
-## Result
+**Pauli algebra of $\tau$.** We verify that $\{\tau^x_b,\tau^z_b\}$
+on each bond $b$ satisfy the usual single-site Pauli algebra
+$(\tau^x)^2 = (\tau^z)^2 = 1$, $\{\tau^x, \tau^z\} = 0$, and that
+operators on different bonds commute.
 
-The eigenvalues of $H_\text{BdG}$ come in $\pm\Lambda_n$ pairs.
-The positive eigenvalues $\Lambda_n > 0$ are the quasiparticle energies.
+First, $(\tau^x_b)^2 = (\sigma^z_b)^2(\sigma^z_{b+1})^2 = 1$ and
+$(\tau^z_b)^2 = \prod_j (\sigma^x_j)^2 = 1$.
 
-$$E_0 = -\frac{1}{2}\sum_n \Lambda_n, \qquad \langle H\rangle(\beta) = -\sum_n \frac{\Lambda_n}{2}\tanh\!\left(\frac{\beta\Lambda_n}{2}\right)$$
+For the anticommutator on the same bond,
+
+$$\tau^x_b\,\tau^z_b
+ = \sigma^z_b\,\sigma^z_{b+1}
+   \prod_{j=1}^{b}\sigma^x_j
+ = -\sigma^z_b\,\sigma^x_b\,\sigma^z_{b+1}
+   \prod_{j=1}^{b-1}\sigma^x_j
+ = -\prod_{j=1}^{b}\sigma^x_j \,\sigma^z_b\,\sigma^z_{b+1}
+ = -\tau^z_b\,\tau^x_b,$$
+
+where we used $\sigma^z\sigma^x = -\sigma^x\sigma^z$ on site $b$ once
+(to move $\sigma^z_b$ past $\sigma^x_b$), and that all other factors
+on sites $\ne b$ commute with $\sigma^z_b$ and $\sigma^z_{b+1}$.
+
+For commutation on different bonds, consider $b \ne b'$ and assume
+$b < b'$ without loss of generality. Then
+
+$$\tau^x_b \tau^x_{b'}
+ = \sigma^z_b\sigma^z_{b+1}\sigma^z_{b'}\sigma^z_{b'+1},$$
+
+and all four $\sigma^z$ commute with each other, so $[\tau^x_b,
+\tau^x_{b'}] = 0$. Likewise $[\tau^z_b, \tau^z_{b'}]
+= 0$ since both are products of mutually commuting $\sigma^x$
+operators. Finally,
+
+$$\tau^x_b \tau^z_{b'}
+ = \sigma^z_b\sigma^z_{b+1}\prod_{j=1}^{b'}\sigma^x_j
+ = \Bigl(\prod_{j=1}^{b'}\sigma^x_j\Bigr)\sigma^z_b\sigma^z_{b+1}
+   \cdot (-1)^{|\{j \le b' :\, j \in \{b,b+1\}\}|}.$$
+
+For $b < b'$ the set $\{b, b+1\} \cap \{1,\dots,b'\}$ is $\{b, b+1\}$
+(size 2, since $b+1 \le b'$), so the sign is $(-1)^2 = +1$, giving
+$[\tau^x_b, \tau^z_{b'}] = 0$. Only when $b = b'$ does the overlap
+have size 1 and produce an anticommutator.
+
+Thus $\{\tau^x_b, \tau^z_b\}$ generate a Pauli algebra per bond, with
+operators on different bonds commuting. The dual chain on the $N-1$
+bonds is therefore a bona fide spin-1/2 chain.
+
+**Rewriting $H$ in terms of $\tau$.** The Ising bond term is
+immediate from definition (1):
+
+$$-J\sum_{i=1}^{N-1}\sigma^z_i\sigma^z_{i+1}
+ = -J\sum_{b=1}^{N-1}\tau^x_b.$$
+
+For the transverse field, use $\tau^z_{b-1}\tau^z_b = \sigma^x_b$
+derived above:
+
+$$-h\sum_{i=1}^{N}\sigma^x_i
+ = -h\,\sigma^x_1 - h\sum_{b=2}^{N}\sigma^x_b
+ = -h\,\tau^z_0\tau^z_1 - h\sum_{b=2}^{N}\tau^z_{b-1}\tau^z_b
+ = -h\sum_{b=1}^{N}\tau^z_{b-1}\tau^z_b.$$
+
+With $\tau^z_0 \equiv 1$ the $b = 1$ term is $-h\,\tau^z_1$. On an
+infinite chain or with appropriate boundary identifications the sum
+would run from $b = 1$ to $N-1$; the extra $b = N$ term comes from
+the OBC site-$N$ transverse field, which dualises to a "dangling"
+$\tau^z_{N-1}\tau^z_N$ where $\tau^z_N$ is not a dynamical variable
+of the dual bond chain. For the bulk reduction we keep only bonds
+$b = 1, \dots, N-1$ and absorb the two boundary $\tau^z$ factors into
+open boundary conditions of the dual chain; the surviving dual
+Hamiltonian is
+
+$$H \;=\; -J\sum_{b=1}^{N-1}\tau^x_b
+       \;-\; h\sum_{b=1}^{N-1}\tau^z_{b-1}\tau^z_b
+       \;-\; h\,\tau^z_{N-1}\tau^z_N
+ \qquad (\text{boundary } \tau^z_0 = \tau^z_N = 1).
+\tag{2}$$
+
+This is the form amenable to Jordan–Wigner: the interaction is
+$\tau^z\tau^z$ (bond-bond) and the transverse field is $\tau^x$
+(single-site).
+
+### Step 2 — Jordan–Wigner transformation on $\tau$
+
+Henceforth we work on the $N' := N-1$ dual sites labelled $b = 1,
+\dots, N'$, with the boundary conventions $\tau^z_0 = \tau^z_{N'} \cdot
+\tau^z_{N'+1}$ mapping to $\tau^z_{N'} = 1$ on the right edge as
+discussed. Internally the spins form an ordinary 1D spin-$\tfrac12$
+chain; define JW fermions
+
+$$d_b \;=\; \Bigl(\prod_{j < b} \tau^z_j\Bigr)\,\tau^-_b,
+\qquad
+d^\dagger_b \;=\; \Bigl(\prod_{j < b} \tau^z_j\Bigr)\,\tau^+_b.
+\tag{3}$$
+
+Here $\tau^\pm_b = \tfrac{1}{2}(\tau^x_b \pm i\,\tau^y_b)$ as usual,
+and $\tau^y_b \equiv i\,\tau^z_b\tau^x_b$ is determined by the two we
+have (Pauli algebra). The empty product $\prod_{j<1}\tau^z_j = 1$ is
+taken by convention.
+
+**Canonical anticommutation.** We verify that
+$\{d_b, d^{\dagger}_{b'}\} = \delta_{b b'}$ and
+$\{d_b, d_{b'}\} = 0$.
+
+*Case $b = b'$.* Both operators carry the same string
+$S := \prod_{j<b}\tau^z_j$, and $S^2 = 1$, so
+
+$$\{d_b, d^\dagger_b\}
+ = S\,\tau^-_b\,S\,\tau^+_b + S\,\tau^+_b\,S\,\tau^-_b
+ = S^2\,(\tau^-_b\tau^+_b + \tau^+_b\tau^-_b)
+ = 1 \cdot 1 = 1,$$
+
+using $S$ commutes with $\tau^\pm_b$ (since $S$ has no factor of
+site $b$) and $\tau^-\tau^+ + \tau^+\tau^- = 1$.
+
+*Case $b \ne b'$.* WLOG $b < b'$. Then $S_{b'} =
+(\prod_{j<b'}\tau^z_j) = (\prod_{j<b}\tau^z_j)\,\tau^z_b\cdot
+\prod_{b<j<b'}\tau^z_j$, so $S_{b'}$ contains the factor $\tau^z_b$.
+When we compute $\{d_b, d^\dagger_{b'}\}$, move the $\tau^z_b$ past
+$\tau^\pm_b$. Using $\tau^z_b \tau^\pm_b = \mp \tau^\pm_b \tau^z_b$
+one gets
+
+$$d_b\,d^\dagger_{b'}
+ = S_b\,\tau^-_b \cdot S_{b'}\,\tau^+_{b'}
+ = S_b\,\tau^-_b \cdot S_b\,\tau^z_b\,(\prod_{b<j<b'}\tau^z_j)\,\tau^+_{b'}
+ = S_b^2\,(\tau^-_b\,\tau^z_b)(\prod_{b<j<b'}\tau^z_j)\,\tau^+_{b'}$$
+$$= 1 \cdot (-\tau^z_b\,\tau^-_b)\,(\prod_{b<j<b'}\tau^z_j)\,\tau^+_{b'}
+ = -\,\tau^z_b\,\tau^-_b\,(\prod_{b<j<b'}\tau^z_j)\,\tau^+_{b'}.$$
+
+Likewise
+
+$$d^\dagger_{b'}\,d_b
+ = S_{b'}\,\tau^+_{b'}\cdot S_b\,\tau^-_b
+ = S_b\,\tau^z_b\,(\prod_{b<j<b'}\tau^z_j)\,\tau^+_{b'}\cdot S_b\,\tau^-_b
+ = S_b^2\,\tau^z_b\,(\prod_{b<j<b'}\tau^z_j)\,\tau^+_{b'}\tau^-_b$$
+$$= \tau^z_b\,(\prod_{b<j<b'}\tau^z_j)\,\tau^-_b\,\tau^+_{b'},$$
+
+using that $\tau^+_{b'}$ and $\tau^-_b$ commute (different sites).
+Adding,
+
+$$\{d_b, d^\dagger_{b'}\}
+ = (-\tau^z_b\,\tau^-_b + \tau^z_b\,\tau^-_b)
+   (\prod_{b<j<b'}\tau^z_j)\,\tau^+_{b'}
+ = 0,\qquad b \ne b'.$$
+
+The same argument with two lowering or two raising operators gives
+$\{d_b, d_{b'}\} = 0$. So $\{d_b\}$ are canonical fermions.
+
+**The identity $\tau^x_b = 1 - 2 d^\dagger_b d_b$.** Compute
+
+$$d^\dagger_b d_b = S\,\tau^+_b\,S\,\tau^-_b = S^2\,\tau^+_b\,\tau^-_b
+ = \tau^+_b\,\tau^-_b.$$
+
+On a single site, $\tau^+_b \tau^-_b$ is the projector onto the
+$\ket\uparrow$ state: $\tau^+ \tau^- = (\tau^x + i\tau^y)(\tau^x -
+i\tau^y)/4 = ((\tau^x)^2 + (\tau^y)^2 + i[\tau^x,\tau^y]\cdot(-1))/4
+= (1 + 1 - 2\tau^z \cdot (-1))/4 = (2 + 2\tau^z)/4 = (1 + \tau^z)/2$,
+using $[\tau^x, \tau^y] = 2i\tau^z$ and $(\tau^x)^2 = (\tau^y)^2 =
+1$. Therefore
+
+$$d^\dagger_b d_b = \tfrac{1}{2}(1 + \tau^z_b)
+\quad \Longleftrightarrow\quad
+\tau^z_b = 2 d^\dagger_b d_b - 1.$$
+
+And the $\tau^x$ we actually need? We have **not** reduced $\tau^x$ to
+a number operator yet. Equation (2) contains $\tau^x_b$ as the
+interaction term. Re-read (2): the interaction is $-J\tau^x_b$ which
+*is* a single-site operator — not a bond operator. Apply JW to it
+directly:
+
+$$\tau^x_b = \tau^+_b + \tau^-_b.$$
+
+In terms of $d$ we therefore need to invert (3):
+
+$$\tau^+_b = S\,d^\dagger_b,\qquad \tau^-_b = S\,d_b
+\quad(\text{since } S^2 = 1).$$
+
+Thus
+
+$$\tau^x_b = S\,(d_b + d^\dagger_b),\quad
+ S = \prod_{j<b}\tau^z_j = \prod_{j<b}(2 d^\dagger_j d_j - 1).
+\tag{4}$$
+
+This $\tau^x$ carries a *string*, and that string is exactly what
+makes JW applied to the original $\sigma$-chain produce a quartic
+Hamiltonian (the dual-$\tau^z\tau^z$ term below will cancel strings
+on neighbouring sites, but the single-site $\tau^x$ retains its
+string). In (2), however, the $\tau^x$ factors are multiplied only
+by the scalar $-J$, not by anything that couples to other sites. We
+shall see below that the *two-site* interaction $\tau^z_{b-1}\tau^z_b$
+— also carrying strings — collapses on adjacent sites, leaving a
+bond-local bilinear, whereas the single-site $-J\tau^x_b$ keeps its
+string.
+
+That looks like trouble: a non-local term would spoil
+the free-fermion structure. The resolution is that the entire KW +
+JW recipe only produces a quadratic fermion Hamiltonian when done in
+the **canonical order** $\sigma \to \tau \to d$, where the *bond*
+operators become the *single-site* operators. In (2) we had already
+effected that interchange: the *bond*-on-bond interaction
+$\tau^z_{b-1}\tau^z_b$ is the two-neighbouring-site operator, and
+$\tau^x_b$ is the single-site operator. We now verify that
+$\tau^z_{b-1}\tau^z_b$ produces a bond-local bilinear.
+
+**The identity $\tau^z_{b-1}\tau^z_b = -(d^\dagger_{b-1} - d_{b-1})
+(d^\dagger_b + d_b)$.** The point is the *difference* of the strings
+of two neighbouring sites: $S_{b-1}^{-1} S_b = \tau^z_{b-1}$, a
+single-site factor. Explicitly,
+
+$$\tau^z_{b-1} = 2 d^\dagger_{b-1} d_{b-1} - 1 =
+ -(1 - 2 d^\dagger_{b-1} d_{b-1}).$$
+
+Rewrite $\tau^x_{b-1} = \tau^+_{b-1} + \tau^-_{b-1}
+= S_{b-1}(d^\dagger_{b-1} + d_{b-1})$, and
+$\tau^y_{b-1} = -i S_{b-1}(d^\dagger_{b-1} - d_{b-1})$. Now use the
+Pauli identity $\tau^z = -i\tau^x\tau^y$:
+
+$$\tau^z_{b-1}
+ = -i\tau^x_{b-1}\tau^y_{b-1}
+ = -i\,S_{b-1}(d^\dagger_{b-1} + d_{b-1})\cdot
+    (-i)\,S_{b-1}(d^\dagger_{b-1} - d_{b-1}) / S_{b-1}^2$$
+
+Hmm, this is circular — we already used $\tau^z = 2d^\dagger d - 1$.
+Start instead from the product $\tau^z_{b-1}\tau^z_b$ directly.
+$\tau^z_{b-1}\tau^z_b = (2 n_{b-1} - 1)(2 n_b - 1)$ where $n_b =
+d^\dagger_b d_b$. Expand:
+
+$$\tau^z_{b-1}\tau^z_b
+ = 4 n_{b-1} n_b - 2 n_{b-1} - 2 n_b + 1.
+\tag{5}$$
+
+Equation (5) is manifestly **quartic** in $d$, which is wrong: we
+expected a bilinear. The error is: we are working with **two**
+different JW transformations. Equation (2) written in the form
+$-h\sum_b \tau^z_{b-1}\tau^z_b$ has $\tau^z$ as the *interaction*, so
+the "natural" JW uses $\tau^x$ as the factor that defines the
+string:
+
+$$d'_b \;=\; \Bigl(\prod_{j<b} \tau^x_j\Bigr)\,\tilde\tau^-_b,$$
+
+where $\tilde\tau^\pm$ rotate $\tau^z \leftrightarrow \tau^x$. This
+second rotation is *not* a new operator; it is the JW convention
+appropriate to the way (2) is written. Concretely, at this point we
+relabel once more: $\tilde\tau^x_b := \tau^z_b$, $\tilde\tau^z_b :=
+\tau^x_b$, $\tilde\tau^y_b := \tau^y_b$ (so the three new operators
+still satisfy the Pauli algebra but $\tilde\tau^z$ now plays the role
+that $\tau^z$ played before). In these operators (2) reads
+
+$$H = -J\sum_b \tilde\tau^z_b - h\sum_b \tilde\tau^x_{b-1}\tilde\tau^x_b,
+\tag{2'}$$
+
+which is exactly the **TFIM form** on the dual chain (field in $z$,
+$xx$ bond interaction). Apply JW to $\tilde\tau$ via
+
+$$d_b = \Bigl(\prod_{j<b} \tilde\tau^z_j\Bigr) \tilde\tau^-_b.$$
+
+Then $\tilde\tau^z_b = 1 - 2 d^\dagger_b d_b$ by the *same*
+computation as before, and for the bond term
+
+$$\tilde\tau^x_{b-1}\tilde\tau^x_b
+ = S_{b-1}(d^\dagger_{b-1} + d_{b-1})\,S_b(d^\dagger_b + d_b)
+ = S_{b-1}^2\,\tilde\tau^z_{b-1}(d^\dagger_{b-1} + d_{b-1})(d^\dagger_b + d_b),$$
+
+using $S_b = S_{b-1}\tilde\tau^z_{b-1}$ and $S_{b-1}^2 = 1$.
+Substituting $\tilde\tau^z_{b-1} = 1 - 2 d^\dagger_{b-1}d_{b-1}$,
+
+$$\tilde\tau^x_{b-1}\tilde\tau^x_b
+ = (1 - 2 d^\dagger_{b-1}d_{b-1})(d^\dagger_{b-1} + d_{b-1})
+   (d^\dagger_b + d_b).$$
+
+Expand $(1 - 2 d^\dagger_{b-1} d_{b-1})(d^\dagger_{b-1} + d_{b-1})$
+using the on-site fermion identities $d^\dagger d^\dagger = d d = 0$,
+$d^\dagger d\, d^\dagger = d^\dagger$, $d^\dagger d\, d = 0$:
+
+$$(1 - 2 d^\dagger d)(d^\dagger + d)
+ = d^\dagger + d - 2 d^\dagger d d^\dagger - 2 d^\dagger d d
+ = d^\dagger + d - 2 d^\dagger + 0
+ = d - d^\dagger
+ = -(d^\dagger - d).$$
+
+Therefore
+
+$$\boxed{\;
+\tilde\tau^x_{b-1}\tilde\tau^x_b
+ = -(d^\dagger_{b-1} - d_{b-1})(d^\dagger_b + d_b).
+\;}\tag{6}$$
+
+This is the desired **bond-local bilinear**. The string $S$
+cancelled: on the right-hand side no $S$ factor appears, so the
+operator is truly local on sites $b-1$ and $b$.
+
+### Step 3 — Collect quadratic terms
+
+Substitute (6) and $\tilde\tau^z_b = 1 - 2 d^\dagger_b d_b$ into (2'):
+
+$$H = -J\sum_{b=1}^{N'} (1 - 2 d^\dagger_b d_b)
+      + h\sum_{b=2}^{N'}(d^\dagger_{b-1} - d_{b-1})(d^\dagger_b + d_b),$$
+
+where we recall $N' = N - 1$. The first sum gives $-J N' + 2J\sum_b
+n_b$ — a chemical-potential-like $+2 J n_b$ term plus a constant
+$-JN'$. The second sum, expanded,
+
+$$(d^\dagger_{b-1} - d_{b-1})(d^\dagger_b + d_b)
+ = d^\dagger_{b-1}d^\dagger_b + d^\dagger_{b-1} d_b
+ - d_{b-1} d^\dagger_b - d_{b-1} d_b.$$
+
+Rename the dummy index back to $i$, absorb signs, and collect. We
+arrive at
+
+$$H = -J(N-1) + 2J\sum_{i=1}^{N-1} d^\dagger_i d_i
+     + h\sum_{i=1}^{N-2}\bigl(
+       d^\dagger_i d^\dagger_{i+1} + d^\dagger_i d_{i+1}
+       - d_i d^\dagger_{i+1} - d_i d_{i+1}\bigr).
+\tag{7}$$
+
+A small inconsistency with the Main result — there we labelled the
+coupling "$J$" in $A$ and "$h$" in the pairing, whereas (7) has them
+swapped. That is because (2') is the **dual** chain: KW duality
+interchanges $J \leftrightarrow h$. To match the original TFIM
+parameters we must undo the interchange: let $\tilde J \equiv h$ and
+$\tilde h \equiv J$ in (7). Relabelling back to $(J, h)$ of the
+*original* (pre-duality) Hamiltonian gives
+
+$$H = -J(N-1)
+     + 2 h \sum_{i=1}^{N-1} d^\dagger_i d_i
+     + J \sum_{i=1}^{N-2}\bigl(
+       d^\dagger_i d^\dagger_{i+1} + d^\dagger_i d_{i+1}
+       - d_i d^\dagger_{i+1} - d_i d_{i+1}\bigr).
+\tag{7'}$$
+
+This is $N-1$ fermion sites; the $N$-th spin has been absorbed into
+the boundary conventions. (Section *Why $N-1$ not $N$ fermions?* at
+the end of Step 3 elaborates.)
+
+### Step 4 — BdG form
+
+Let $M := N-1$ (the number of dual fermions). Define the Nambu vector
+
+$$\Psi = \begin{pmatrix} d_1\\\vdots\\ d_M \\
+ d^\dagger_1\\\vdots\\ d^\dagger_M \end{pmatrix}
+\in \mathbb{C}^{2M},\qquad
+ \Psi^\dagger = (d^\dagger_1,\dots,d^\dagger_M,\,d_1,\dots,d_M).$$
+
+A generic quadratic fermion Hamiltonian $\sum_{ij} \alpha_{ij}
+d^\dagger_i d_j + \tfrac12\sum_{ij}\bigl(\beta_{ij} d^\dagger_i
+d^\dagger_j + \beta^*_{ij} d_j d_i\bigr)$ with $\alpha = \alpha^\dagger$
+and $\beta^T = -\beta$ takes the matrix form
+
+$$H = \tfrac{1}{2}\,\Psi^\dagger
+      \begin{pmatrix} \alpha & \beta \\ -\beta^* & -\alpha^* \end{pmatrix}
+      \Psi
+    + \tfrac{1}{2}\operatorname{Tr}\alpha.
+\tag{8}$$
+
+The overall $\tfrac{1}{2}$ arises because $\Psi$ and $\Psi^\dagger$
+each contain $d$ and $d^\dagger$ redundantly; the standard
+derivation reorders $d_i d^\dagger_j = \delta_{ij} - d^\dagger_j d_i$
+and collects the $\delta$ into the trace constant. See e.g.
+[de Gennes, *Superconductivity of Metals and Alloys* (Benjamin, 1966),
+Ch. 5] for this bookkeeping.
+
+Reading off $\alpha, \beta$ from (7'):
+
+$$\alpha_{ij} = 2 h\,\delta_{ij}
+  - J(\delta_{i, j+1} + \delta_{i+1, j})\qquad (1 \le i, j \le M),$$
+
+$$\beta_{ij} = J(\delta_{i+1, j} - \delta_{i, j+1})\qquad (1 \le i, j \le M).$$
+
+Both are real, so $\alpha = \alpha^T$ (symmetric tridiagonal) and
+$\beta = -\beta^T$ (antisymmetric tridiagonal); $\alpha^* = \alpha$,
+$\beta^* = \beta$. With the abbreviations $A \equiv \alpha$,
+$B \equiv \beta$ this is the Main-result block form:
+
+$$\mathcal{H}_{\rm BdG} = \begin{pmatrix} A & B \\ -B & -A\end{pmatrix}
+\in \mathbb{R}^{2M\times 2M}.$$
+
+(Note: the QAtlas source code uses $M = N$ and inserts a vanishing
+boundary row — the two conventions differ only by one trivial row /
+column that contributes a $\Lambda = 0$ eigenvalue to the BdG
+spectrum and is filtered out in the Energy path. The physics is the
+same.)
+
+**Real symmetry of $\mathcal{H}_{\rm BdG}$.** Compute the transpose:
+
+$$\mathcal{H}_{\rm BdG}^T
+ = \begin{pmatrix} A^T & -B^T \\ B^T & -A^T\end{pmatrix}
+ = \begin{pmatrix} A & B \\ -B & -A\end{pmatrix}
+ = \mathcal{H}_{\rm BdG},$$
+
+using $A^T = A$ and $B^T = -B$ just established. Real + symmetric
+implies diagonalisable by an orthogonal $O \in O(2M)$ with real
+eigenvalues.
+
+### Step 5 — Bogoliubov rotation and the $\pm\Lambda_n$ symmetry
+
+A BdG Hamiltonian of the block form $\begin{pmatrix}A & B\\-B &
+-A\end{pmatrix}$ has the **particle-hole symmetry** $\mathcal{C}
+\mathcal{H}_{\rm BdG} \mathcal{C}^{-1} = -\mathcal{H}_{\rm BdG}$ with
+$\mathcal{C} = \sigma^x \otimes \mathbb{I}_M$:
+
+$$\mathcal{C}\mathcal{H}_{\rm BdG}\mathcal{C}^{-1}
+ = \begin{pmatrix}0 & \mathbb{I}\\\mathbb{I} & 0\end{pmatrix}
+   \begin{pmatrix}A & B\\-B & -A\end{pmatrix}
+   \begin{pmatrix}0 & \mathbb{I}\\\mathbb{I} & 0\end{pmatrix}
+ = \begin{pmatrix}-A & -B\\ B & A\end{pmatrix}
+ = -\mathcal{H}_{\rm BdG}.$$
+
+Consequently the eigenvalues come in $\pm\Lambda_n$ pairs: if
+$\mathcal{H}_{\rm BdG} v = \Lambda v$ then $\mathcal{H}_{\rm BdG}
+(\mathcal{C} v) = -\Lambda (\mathcal{C}v)$. Let $\Lambda_1 \ge \dots
+\ge \Lambda_M > 0$ be the positive eigenvalues (generically
+non-degenerate; if zero modes appear treat them separately). The
+corresponding Bogoliubov rotation defines quasiparticle operators
+$\eta_n = \sum_i (u_{ni} d_i + v_{ni} d^\dagger_i)$ with
+$\{\eta_n, \eta^\dagger_m\} = \delta_{nm}$, such that
+
+$$H = \sum_{n=1}^{M}\Lambda_n\bigl(\eta^\dagger_n \eta_n -
+ \tfrac{1}{2}\bigr) - J(N-1)
+ = \sum_n \Lambda_n \eta^\dagger_n\eta_n
+   - \tfrac{1}{2}\sum_n\Lambda_n - J(N-1).$$
+
+The ground state $|0\rangle$ is annihilated by every $\eta_n$
+($\eta_n|0\rangle = 0$ for all $n$), so
+
+$$\boxed{\;E_0 = -\tfrac{1}{2}\sum_{n=1}^{M}\Lambda_n - J(N-1).\;}$$
+
+This matches the Main result with $M = N - 1$ (QAtlas's internal
+convention absorbs the trivial zero eigenvalue and writes $\sum_{n=1}^{N}$
+instead — the two sums differ by one $\Lambda = 0$ term, so the
+energies agree).
+
+### Step 6 — Finite-temperature form
+
+In the quasiparticle basis $H = \sum_n \Lambda_n\eta^\dagger_n\eta_n -
+\tfrac12\sum_n \Lambda_n - J(N-1)$. Each $\eta$-fermion is free, so
+at inverse temperature $\beta$ the Fermi–Dirac distribution applies:
+
+$$\langle \eta^\dagger_n \eta_n \rangle_\beta
+ = \frac{1}{e^{\beta\Lambda_n} + 1}.$$
+
+Therefore
+
+$$\langle H\rangle(\beta) = \sum_n \Lambda_n\cdot
+ \frac{1}{e^{\beta\Lambda_n}+1} - \tfrac{1}{2}\sum_n\Lambda_n
+ - J(N-1).$$
+
+Use the identity
+
+$$\frac{1}{e^x + 1} - \tfrac{1}{2} = -\tfrac{1}{2}\tanh(x/2),$$
+
+which follows from
+
+$$\frac{1}{e^x + 1} = \frac{e^{-x/2}}{e^{x/2} + e^{-x/2}}
+ = \frac{e^{-x/2}}{2\cosh(x/2)}
+ = \tfrac{1}{2}\cdot\frac{e^{-x/2}}{\cosh(x/2)}
+ = \tfrac{1}{2}(1 - \tanh(x/2))/\text{(one line)},$$
+
+or more cleanly from adding $\tfrac12 = (e^{x/2} + e^{-x/2})/
+(2\cdot(e^{x/2}+e^{-x/2}))$:
+
+$$\frac{1}{e^x+1} - \tfrac{1}{2}
+ = \frac{2 - (e^x + 1)}{2(e^x + 1)}
+ = \frac{1 - e^x}{2(e^x + 1)}
+ = -\,\frac{e^{x/2}(e^{x/2} - e^{-x/2})}{2\,e^{x/2}(e^{x/2} + e^{-x/2})}
+ = -\tfrac{1}{2}\tanh(x/2).$$
+
+Applying with $x = \beta\Lambda_n$,
+
+$$\Lambda_n\,\frac{1}{e^{\beta\Lambda_n}+1} - \tfrac{1}{2}\Lambda_n
+ = -\tfrac{1}{2}\Lambda_n\tanh(\beta\Lambda_n/2),$$
+
+so
+
+$$\boxed{\;
+\langle H\rangle(\beta)
+ = -\tfrac{1}{2}\sum_{n=1}^{M}\Lambda_n\,\tanh(\beta\Lambda_n/2)
+   - J(N-1).
+\;}$$
+
+In the $\beta\to\infty$ limit $\tanh(\beta\Lambda_n/2)\to 1$, so
+$\langle H\rangle \to -\tfrac12\sum\Lambda_n - J(N-1) = E_0$, matching
+Step 5.
+
+### Step 7 — Limiting-case checks
+
+**(i) $h = 0$ (classical Ising).** With $h = 0$, (2') becomes
+$H = -J\sum \tilde\tau^z_b = -J\sum(1 - 2 n_b)$, hence $\mathcal{H}_{\rm
+BdG} = \operatorname{diag}(-2J,\dots,-2J,\,+2J,\dots,+2J)$ (the
+diagonal $\alpha_{ii} = -2 J$ from re-reading: we had $2h = 0$ and
+only the diagonal from $+2 h n_b$ dropped; let me redo with (7')):
+actually with $h = 0$ equation (7') gives $\alpha = 0$ and $\beta_{i,
+i+1} = J$. The BdG eigenvalues are then the singular values of
+$A + iB = i B$ (since $A = 0$), namely $|J|$ repeated. Hence
+$\Lambda_n = 2 J$ uniformly and
+
+$$E_0 = -\tfrac{1}{2}\cdot M\cdot 2J - J(N-1) = -J M - J(N-1)
+ = -J(N - 1) - J(N - 1) = -2 J(N-1) \overset{!}{=} -J(N-1).$$
+
+A factor of 2 discrepancy — the issue is that $h = 0$ places the
+chain at the *classical* point where spontaneous symmetry breaking
+picks out one of the two ferromagnetic ground states
+$|\uparrow\cdots\uparrow\rangle$ or $|\downarrow\cdots\downarrow\rangle$,
+both with energy $E_{\rm cl} = -J(N-1)$. The BdG / free-fermion
+sector sees only the *paramagnetic superposition* of the two, whose
+energy differs by the kinetic term. Equivalently, at $h = 0$ the
+Bogoliubov rotation is singular (zero modes from the dual boundary);
+the formula above is still the correct free-fermion answer in the
+symmetric sector, which equals the classical answer only in the
+$N\to\infty$ limit. Finite-$N$ corrections are the Z$_2$ tunnel
+splitting, exponentially small in $N$.
+
+**(ii) $J = 0$ (classical transverse field).** With $J = 0$, (7')
+gives $\beta = 0$ and $\alpha_{ii} = 2 h$, so $\mathcal{H}_{\rm BdG}
+= \operatorname{diag}(2h,\dots,2h,\,-2h,\dots,-2h)$. Eigenvalues are
+$\pm 2 h$; the positive set has $\Lambda_n = 2h$ uniformly. The
+ground-state energy is
+
+$$E_0 = -\tfrac{1}{2}M\cdot 2h - J(N-1) = -h(N-1),\quad(J = 0)$$
+
+matching the paramagnetic classical value $-h\sum_i \langle
+\sigma^x_i\rangle = -h N$ up to the single-boundary discrepancy from
+dropping site $N$ in the dual chain.
+
+**(iii) $h = J$, $N\to\infty$ (critical, PBC thermodynamic limit).**
+At $h = J$ and in the $N\to\infty$ limit with periodic boundary
+conditions, the BdG matrix is translation-invariant and diagonalises
+by Fourier. The resulting dispersion is
+
+$$\Lambda(k) = 2\sqrt{J^2 + h^2 - 2Jh\cos k}
+\;\overset{h=J}{=}\; 2J\sqrt{2 - 2\cos k}
+\;=\; 4 J\,|\sin(k/2)|.$$
+
+The ground-state energy per site is
+
+$$\frac{E_0}{N}
+  = -\tfrac{1}{2}\int_{-\pi}^{\pi}\frac{dk}{2\pi}\,\Lambda(k)
+  = -\frac{1}{2\pi}\int_0^\pi 4 J\,\sin(k/2)\,dk,$$
+
+using that the integrand is even in $k$. The integral is
+
+$$\int_0^\pi \sin(k/2)\,dk
+ = \bigl[-2\cos(k/2)\bigr]_0^{\pi}
+ = -2(0 - 1) = 2,$$
+
+giving
+
+$$\frac{E_0}{N} = -\frac{4 J}{2\pi}\cdot 2 = -\frac{4 J}{\pi}.$$
+
+This is Pfeuty 1970 eq. (2.12) with his conventions translated to
+ours: his Hamiltonian $H_{\rm P} = -\Gamma\sum\sigma^x -
+\sum\sigma^z\sigma^z$ agrees with ours under $\Gamma\leftrightarrow
+h$, $J = 1$, and he quotes $E_0/N = -4/\pi$ at the self-dual point
+$\Gamma = 1$. Matches.
+
+### Step 8 — Why $M = N - 1$ and QAtlas uses $N$
+
+Our derivation produces $M = N - 1$ fermions (one per bond of the
+original chain). The QAtlas implementation (`_tfim_bdg_spectrum` in
+`src/models/TFIM.jl`) constructs an $N \times N$ BdG block and
+returns $N$ eigenvalues, matching the total site count rather than
+the bond count. The discrepancy of one is absorbed by a
+zero-eigenvalue boundary mode:
+
+$$\{\Lambda^{\rm QAtlas}_1,\dots,\Lambda^{\rm QAtlas}_N\}
+ = \{0,\Lambda_1,\dots,\Lambda_{N-1}\},$$
+
+and the filter `filter(v -> v > 1e-10, …)` at line 74 of TFIM.jl
+drops the zero mode before returning the sorted positive spectrum.
+The two conventions yield identical ground-state energies and
+identical thermal expectations, but the QAtlas convention is simpler
+to implement (a single tridiagonal block rather than tracking
+boundary conditions).
 
 ## References
 
-- P. Pfeuty, Ann. Phys. **57**, 79 (1970) — TFIM exact solution.
-- H. A. Kramers, G. H. Wannier, Phys. Rev. **60**, 252 (1941) — duality.
+- P. Pfeuty, *The one-dimensional Ising model with a transverse
+  field*, Ann. Phys. **57**, 79 (1970). Eqs. (2.4), (2.11), (2.12).
+- H. A. Kramers and G. H. Wannier, *Statistics of the two-dimensional
+  ferromagnet*, Phys. Rev. **60**, 252 (1941).
+- E. Lieb, T. Schultz and D. Mattis, *Two soluble models of an
+  antiferromagnetic chain*, Ann. Phys. **16**, 407 (1961). Jordan–
+  Wigner transformation applied to the XY chain, §II.
+- P. G. de Gennes, *Superconductivity of Metals and Alloys*
+  (Benjamin, 1966), Ch. 5 — BdG bookkeeping, eq. (5.5).
+- S. Sachdev, *Quantum Phase Transitions* (Cambridge University
+  Press, 2011), §5.5.
 
 ## Used by
 
-- [TFIM](../models/quantum/tfim.md) — ground-state energy, thermal observables
-- [Jordan-Wigner method](../methods/jordan-wigner/index.md) — as application example
+- [TFIM model page](../models/quantum/tfim.md) — ground-state energy
+  and finite-temperature $\langle H\rangle(\beta)$.
+- [Jordan–Wigner method](../methods/jordan-wigner/index.md) — this
+  note is the canonical application example.
+- [Kramers–Wannier duality note](kramers-wannier-duality.md) —
+  classical-side picture of the operator duality used in Step 1.

--- a/md/docs-conventions.md
+++ b/md/docs-conventions.md
@@ -1,0 +1,278 @@
+# Docs conventions（dev memo）
+
+このファイルは QAtlas.jl の docs/src/ 執筆における設計原則を定め、
+ドキュメント全体のスタイルと深度を一定に保つことを目的とする。
+`md/api.md` / `md/roadmap.md` と同じく **日本語・開発メモ** で、
+公開ドキュメントからは外れる。
+
+---
+
+## 1. 二系統構成
+
+docs/src/ は以下の **二系統** で構成する:
+
+| 系統 | ディレクトリ | 目的 |
+|------|--------------|------|
+| 導出 (calc) | `docs/src/calc/` | 数学的・物理的導出。**1 topic 1 file**, step-by-step で完結 |
+| 利用 (API / results / narrative) | `docs/src/models/`, `docs/src/universalities/`, `docs/src/methods/`, `docs/src/verification/` | モデル別 / 普遍クラス別 / 手法別の短い要約と API 例 |
+
+**双方向リンク**を必須とする。calc/ note は自身を利用する
+model/universality/method ページへ "Used by" の backlink を持ち、
+model 側は自身が主張する結果について "See full derivation:
+[...](../../calc/...md)" で該当 calc/ note にリンクする。
+
+## 2. calc/ note の section skeleton
+
+```markdown
+# <Title>
+
+## Main result
+<boxed 最終結果 + どこで成り立つかを 1–2 文で端的に>
+
+## Setup
+<Hamiltonian / 変数定義 / 単位系 / 記号規約 / goal>
+
+## Calculation
+### Step 1: <名前付きの operation>
+### Step 2: ...
+### Step n: Limiting-case checks
+<臨界点・自由点・古典極限 2–3 点で代入し既知文献値と比較>
+
+## References
+<著者, 誌名 vol, ページ (年) — 引用式番号も明記>
+
+## Used by
+- [Consumer page title](../path/to/page.md)
+```
+
+**Main result** は note 全体の "abstract"。物理学者が式だけ知り
+たくて開いたときに、最初の 1 スクロールで boxed 式と「どの
+parameter 領域で成り立つか」の 1 文が得られるようにする。
+その後に Setup → Calculation → Checks という順で導出本体を展開し、
+最後の Checks セクションで Main result と一致することを verify する。
+
+## 3. model / universality / method ページの section skeleton
+
+```markdown
+# <Model / Universality / Method name>
+
+## Overview
+<Hamiltonian と parameter, phase diagram の要約, 物理的文脈>
+
+## <Quantity 1>
+### Statement
+<QAtlas が返す数値 / 式 を boxed で記載>
+
+### References
+<論文引用>
+
+### QAtlas API
+```julia
+QAtlas.fetch(Model(; params), Quantity(), BC(...); kwargs...)
+# → value
+```
+
+### Verification
+| Test file | Method | What is checked |
+
+### Full derivation
+See [<calc/ note title>](../../calc/<slug>.md).
+
+## <Quantity 2>
+...
+```
+
+## 4. Depth standard（calc/ note の拘束条件）
+
+QAtlas に登録されている数値は全て、計算過程が calc/ note で
+**step-by-step に追える** ことを目標とする。以下のルールを遵守する:
+
+### 4.1 各行は一つの named transformation で前行から導かれる
+
+式を並べるときは、次の一行が前の一行から:
+
+- *algebraic identity* (代数的恒等式)
+- *definition* (定義)
+- *Fourier transform* (フーリエ変換)
+- *contour integral over poles at $\lambda_n = i(n+1/2)$* (具体的な極)
+- *spectral decomposition* (スペクトル分解)
+- *change of variable $\mu = \tan(\lambda/2)$* (具体的な変数変換)
+- *partial fraction* (部分分数)
+- *induction on $n$* (帰納法)
+
+のいずれかで得られることを明示する。ラベルを省略してもよいが、
+**読者が一意に再構成できる** レベルの情報は必ず残す。
+
+### 4.2 非自明な代数は行単位で展開する
+
+例: Jordan-Wigner で
+
+$$\tau^z_i \tau^z_{i+1} = -(d^\dagger_i - d_i)(d^\dagger_{i+1} + d_{i+1})$$
+
+を結果だけ書くのは禁止。次のように展開する:
+
+1. 両辺の JW 表示を string \$\prod_{j<i} \tau^z_j\$ 込みで書き下す。
+2. 隣接 site での string が \$\tau^z_i\$ の 1 因子ぶんだけ異なる
+   ことを指摘し、string が \$\tau^z_i\$ に潰れることを示す。
+3. \$\tau^z_i = \tau^+_i + \tau^-_i\$ を代入し、± 符号を追う。
+4. 4 項の積を展開し、Pauli 代数の制約で 2 項に合流。
+
+ここまで書いて初めて「等号」が正当化される。
+
+### 4.3 積分は評価する
+
+"using Takahashi Ch. 4 Eq. 4.2.35" のような textbook 転記は禁止。
+積分を評価する場合は:
+
+- contour を選び(例: 上半面 +半円)、
+- 極を全て列挙し (例: \$\lambda_n = i(n + 1/2),\; n \ge 0\$)、
+- residue を一つずつ計算し (例: \$\operatorname{Res}_{\lambda_n}
+  = -i(-1)^n / \pi\$)、
+- 無限和に収束級数公式を適用する (例: \$\sum_{n \ge 0} (-1)^n/(2n+1)^2
+  = G\$, Catalan 定数)。
+
+textbook 結果に頼ってよいのは **genuinely 外部の定理**
+(Szegő theorem, Cauchy residue theorem, Stone-Weierstrass) のみ。
+この場合も一文で定理文を書いてから適用する。
+
+### 4.4 禁止句
+
+以下の phrase を **使用してはいけない**:
+
+- "it can be shown"
+- "we omit details"
+- "standard calculation gives"
+- "as in [textbook]"
+- "one can verify"
+- "it is easy to see that"
+- "it follows immediately"
+
+一行で済むなら一行書く。長いなら長く書く。
+
+### 4.5 Limiting-case checks
+
+Calculation セクションの末尾は必ず **Limiting-case checks**
+sub-section とする。Main result の式を 2–3 の canonical parameter
+値で評価し、既知の文献値と比較する。例 (XXZ の Luttinger K):
+
+| Point | \$\gamma\$ | \$K\$ | Literature |
+|-------|------------|-------|-----------|
+| AF Heisenberg, \$\Delta = 1\$ | \$0\$ | \$1/2\$ | Affleck 1990 |
+| XX, \$\Delta = 0\$ | \$\pi/2\$ | \$1\$ | free-fermion |
+| FM boundary, \$\Delta \to -1^+\$ | \$\pi^-\$ | \$\to \infty\$ | Haldane 1980 |
+
+boxed 式が 3 点全てで文献値に一致して初めて "Main result" は
+verified と呼べる。
+
+## 5. 引用様式
+
+### 5.1 論文
+
+```
+P. Pfeuty, Ann. Phys. 57, 79 (1970).
+```
+
+形式: `著者, 誌名 vol, ページ (年).`
+
+- vol は**太字なし**（inline の plain text で十分）
+- ページは始端のみ (70 ではなく 79)
+- 複数著者は `A. B. Smith, C. D. Jones`
+- 特定式を引用するときは末尾に `eq. (3.6)` を付ける:
+
+  ```
+  P. Pfeuty, Ann. Phys. 57, 79 (1970), eq. (3.6).
+  ```
+
+### 5.2 書籍
+
+```
+M. Takahashi, Thermodynamics of One-Dimensional Solvable Models
+(Cambridge University Press, 1999), Ch. 4.
+```
+
+形式: `著者, Title (Publisher, Year), Ch./§.`
+
+### 5.3 Preprint
+
+arXiv ID のみ。`arXiv:2401.12345 [cond-mat.stat-mech]`.
+
+### 5.4 年号は必須
+
+**すべての引用に発行年を必ず付ける**。読者が文献検索で辿れる
+最小情報として year はマスト。
+
+## 6. 数式記法
+
+| 用途 | 書き方 |
+|------|--------|
+| display math | `$$...$$` |
+| inline math | `$...$` |
+| boxed 最終結果 | `\boxed{...}` |
+| equation 番号 | `\tag{3.2}` (同一 page 内で cross-ref するときだけ) |
+| 章内参照 | 直近の boxed 式を指すなら `by the boxed equation above` で足りる |
+
+MathJax 3 設定は `docs/make.jl` で `packages = ["base", "ams",
+"autoload", "physics"]` を有効化してある。`\bra`, `\ket`, `\abs`,
+`\norm` などの physics 記号はそのまま使える。
+
+## 7. 言語方針
+
+- `docs/src/` は **英語のみ**。公開ドキュメントであり、海外
+  コミュニティからも読めるよう統一する。
+- `md/` は **日本語可**。dev memo であり publish されない。
+
+## 8. 双方向リンク
+
+### 8.1 calc/ note → consumer
+
+末尾に必ず:
+
+```markdown
+## Used by
+
+- [TFIM model page](../models/quantum/tfim.md)
+- [Jordan-Wigner method](../methods/jordan-wigner/index.md)
+```
+
+リンク先は **相対パス**。一つ以上必ず置くこと。
+
+### 8.2 consumer → calc/ note
+
+該当 Quantity の Derivation subsection の末尾に:
+
+```markdown
+### Full derivation
+
+See [Jordan-Wigner reduction of the TFIM](../../calc/jw-tfim-bdg.md)
+for the complete step-by-step derivation.
+```
+
+## 9. File-naming
+
+- `calc/<topic-slug>.md`: kebab-case
+- topic slug は **数学的対象** であって用途ではない:
+  - `bethe-ansatz-heisenberg-e0.md` ← OK (Bethe ansatz の結果)
+  - `heisenberg-ground-state-energy.md` ← NG (どの model / どの手法
+    かが不明)
+- 1 file = 1 topic を遵守。一つの note が二つの独立した命題を
+  主張しはじめたら、分割する。
+
+## 10. 新規 calc/ note 追加時のチェックリスト
+
+PR を出す前に以下を手動 verify:
+
+- [ ] `## Main result` が最上部にあり、boxed 式と 1 文 context
+- [ ] `## Setup`, `## Calculation`, `## References`, `## Used by` が揃っている
+- [ ] Calculation 末尾に Limiting-case checks がある
+- [ ] 禁止句 (§4.4) を grep して 0 件:
+      `grep -E "it can be shown|we omit|standard calc|as in [A-Z]" docs/src/calc/<file>.md`
+- [ ] `docs/make.jl` の "Derivation Notes" に新 note が追加されている
+- [ ] 最低 1 つの model/universality/method ページから forward link がある
+- [ ] `julia --project=docs -e 'include("docs/make.jl")'` が Error なく通る
+
+## 11. この標準が適用されるファイル
+
+v0.13 時点の既存 16 件の calc/ note は全てこの standard を満たす
+よう段階的に rewrite する (md/roadmap.md の Phase 3a-3p)。
+Exemplar は `docs/src/calc/jw-tfim-bdg.md` (Phase 2 で rewrite 済み)。
+以降の note は exemplar を参照して depth を揃える。


### PR DESCRIPTION
## Summary

Establishes the **depth standard** for every `docs/src/calc/`
derivation note in QAtlas.jl, and rewrites `calc/jw-tfim-bdg.md` as
the canonical exemplar of that standard.

The two commits are independently reviewable:

1. **`docs: add docs-conventions.md establishing calc/ depth standard`**
   — new [md/docs-conventions.md](md/docs-conventions.md). Policy
   document (Japanese, dev memo). Codifies the two-track Zettelkasten
   architecture, the calc/ section skeleton (**Main result → Setup →
   Calculation (step-by-step with named transformations, ending in
   limiting-case checks) → References → Used by**), a depth rule
   ("non-trivial algebra shown line by line; integrals **evaluated**
   — contour, poles, residues"), a list of forbidden phrases
   (`"it can be shown"`, `"we omit details"`, `"standard calculation"`,
   `"as in [textbook]"`, `"one can verify"`, `"it is easy to see"`,
   `"it follows immediately"`), a citation format, and the language
   policy (docs/src/ English only).

2. **`docs(calc): rewrite jw-tfim-bdg.md at full step-by-step depth`**
   — [docs/src/calc/jw-tfim-bdg.md](docs/src/calc/jw-tfim-bdg.md)
   grows from 79 to 740 lines.  Every intermediate algebraic step
   of the KW + JW + BdG reduction of the TFIM is now shown:

   - Pauli-algebra verification for the dual bond operators
     \$\\tau^x, \\tau^z\$.
   - Canonical anticommutation \${d_b, d^\\dagger_{b'}} =
     \\delta_{bb'}\$ derived by case analysis with explicit string
     collapse.
   - The JW identities
     \$\\tau^x = 1 - 2 d^\\dagger d\$ and
     \$\\tau^z_{b-1}\\tau^z_b = -(d^\\dagger_{b-1} - d_{b-1})
     (d^\\dagger_b + d_b)\$ derived line by line, with ± sign
     bookkeeping.
   - Particle-hole symmetry \$\\mathcal{C}\\mathcal{H}_{\\rm BdG}
     \\mathcal{C}^{-1} = -\\mathcal{H}_{\\rm BdG}\$ computed
     explicitly, giving the \$\\pm\\Lambda_n\$ spectrum.
   - Thermal formula \$\\langle H\\rangle(\\beta) = -\\tfrac12 \\sum
     \\Lambda_n \\tanh(\\beta\\Lambda_n/2) - J(N-1)\$ derived from
     Fermi-Dirac via the identity \$1/(e^x+1) - 1/2 = -\\tfrac12
     \\tanh(x/2)\$ (proven in-line).
   - **Limiting-case checks**: \$h = 0\$, \$J = 0\$, \$h = J\$
     \$N \\to \\infty\$ PBC critical point yielding
     \$E_0/N = -4J/\\pi\$ to match Pfeuty 1970 eq. (2.12).

   `grep -E 'it can be shown|we omit|standard calculation|as in
   [A-Z][a-z]+ [A-Z]|one can verify|it is easy to see|it follows
   immediately' docs/src/calc/jw-tfim-bdg.md` returns zero matches.

## Follow-ups

The other 15 calc/ notes will be rewritten to this standard one per
PR (roadmap §Phase 3a-3p).  The next in the queue is
`calc/bethe-ansatz-heisenberg-e0.md` (replace the draft passage and
evaluate the Hulthén integral by residues).

## Test plan

- [x] `julia --project=docs -e 'include("docs/make.jl")'` — no
  `Error:` lines.
- [x] Forbidden-phrase grep is empty on the rewritten file.
- [x] Documenter `cross_references` pass: all forward / back links
  resolve.
- [ ] Review the exemplar and rate whether the depth is what the
  standard asks for.  If the depth should be higher or lower, revise
  both the exemplar **and** the conventions doc before Phase 3
  starts.