### PR TITLE
ci: nightly full-tests workflow (QATLAS_TEST_FULL=1, 18:00 UTC daily)

### DIFF
--- a/.github/workflows/NightlyFullTests.yml
+++ b/.github/workflows/NightlyFullTests.yml
@@ -1,0 +1,43 @@
+name: Nightly full tests (QATLAS_TEST_FULL=1)
+
+# The default PR CI profile runs the entanglement-entropy central-charge
+# test up to N=14 via sparse + KrylovKit Lanczos (about 2 minutes on a
+# 4-core GitHub runner).  This workflow additionally exercises the
+# N=16 branch — ~32 GB sparse matrix, minutes of extra runtime — so
+# the expensive branch is run daily but not on every PR push.
+#
+# Trigger: every day at 18:00 UTC (~03:00 JST).  Also `workflow_dispatch`
+# so it can be invoked manually from the GitHub UI.  No `push` or
+# `pull_request` triggers — the default CI.yml workflow covers those.
+
+on:
+  schedule:
+    - cron: '0 18 * * *'
+  workflow_dispatch:
+
+jobs:
+  full-tests:
+    name: QATLAS_TEST_FULL=1 — Julia ${{ matrix.version }} / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+    env:
+      QATLAS_TEST_FULL: '1'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v3
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          julia-args: "--threads=auto"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,7 +200,7 @@ Public docs (`docs/src/`) are **English only**. Dev memos under `md/` may be in 
 - **Bond counting in small PBC systems**: Lattice2D's `bonds(lat)` double-counts bonds when `Lx = 2` or `Ly = 2` with periodic boundaries. Both the transfer-matrix and brute-force paths use the same convention, so they agree — but be aware of this when writing new models.
 - **OBC vs PBC for gap analysis**: in the ordered phase of the TFIM (h ≪ J), the lowest ED "gap" is actually the Z₂ tunneling splitting (exponentially small in N), not the physical excitation gap. This is correct physics but can be surprising in tests.
 - **ForwardDiff compatibility**: if you want a `fetch` function to support automatic differentiation, relax type constraints from `Float64` to `Real` and avoid LAPACK-only operations like `eigvals(Symmetric(T))` — use `tr(T^n)` instead, which works with dual numbers.
-- **Entanglement tests and RAM**: the ED-based entanglement-entropy tests (`test_entanglement_central_charge.jl`) scale as $O(2^N)$ memory at $N \ge 14$. The default PR-CI profile runs $N \le 14$ via sparse + KrylovKit Lanczos. `QATLAS_TEST_FULL=1` enables $N = 16$ (~24 GB peak).
+- **Entanglement tests and RAM**: the ED-based entanglement-entropy tests (`test_entanglement_central_charge.jl`) scale as $O(2^N)$ memory at $N \ge 14$. The default PR-CI profile runs $N \le 14$ via sparse + KrylovKit Lanczos. `QATLAS_TEST_FULL=1` enables $N = 16$ (~24 GB peak) and is run automatically every night by [`NightlyFullTests.yml`](.github/workflows/NightlyFullTests.yml) (also invokable via `workflow_dispatch` from the Actions tab).
 
 ## Before Submitting a PR
 


### PR DESCRIPTION
## Summary

Adds [`.github/workflows/NightlyFullTests.yml`](.github/workflows/NightlyFullTests.yml) that runs the expensive `QATLAS_TEST_FULL=1` branch of the test suite (N=16 entanglement ED, ~24 GB sparse matrix) once per day at 18:00 UTC, and on manual `workflow_dispatch` from the Actions tab.

## Why

Landed together with PR #45 (sparse ED + fast/full switch):

> **Default PR profile** (QATLAS_TEST_FULL unset): N ∈ {10, 12, 14}, sparse Lanczos at N=14, ~2 min on a 4-core GitHub runner.
> **Full profile** (QATLAS_TEST_FULL=1): also N=16, ~24 GB peak RAM, ~5+ extra minutes.

We want coverage of the N=16 branch but not on every PR push. A nightly cron runs it once per day so regressions surface within 24 hours of merging, without paying the cost on every PR iteration.

## Touches

- `.github/workflows/NightlyFullTests.yml` — new; `schedule: cron '0 18 * * *'` + `workflow_dispatch`, no push / pull_request triggers (so it doesn't double up with the default CI.yml workflow).
- `CONTRIBUTING.md` — note pointing contributors at the nightly workflow and explaining that the N=16 branch is auto-run every night.

## Test plan

- [x] YAML syntax is valid (GitHub Actions workflow parser will verify on push).
- [ ] After merge, verify the first scheduled run succeeds at 18:00 UTC tomorrow; otherwise trigger manually via workflow_dispatch and check the runtime.

## Follow-ups

Not in this PR but queued:
- Peschel σˣ entanglement implementation in `src/` (M2 in md/roadmap.md) — will let the nightly's N=16 branch be replaced by O(N³) Peschel correlation-matrix method for N ≳ 1000.