### PR TITLE
docs(calc): replace \operatorname{...} with \mathrm{...} throughout

### DIFF
--- a/docs/src/calc/ad-thermodynamics-from-z.md
+++ b/docs/src/calc/ad-thermodynamics-from-z.md
@@ -5,7 +5,7 @@
 A classical statistical-mechanical system with partition function
 $Z(\beta)$ depending on inverse temperature $\beta = 1/T$ and possibly
 coupling constants (e.g. $J$, $h$). The partition function may be
-computed as $Z = \operatorname{tr}(T^{L_x})$ where $T$ is the
+computed as $Z = \mathrm{tr}(T^{L_x})$ where $T$ is the
 transfer matrix, or from an explicit sum over configurations.
 
 ## Calculation
@@ -62,7 +62,7 @@ Cv(beta) = beta^2 * ForwardDiff.derivative(
     b -> ForwardDiff.derivative(b2 -> log(Z(b2)), b), beta)
 ```
 
-### Why $\operatorname{tr}(T^{L_x})$, not eigenvalue decomposition
+### Why $\mathrm{tr}(T^{L_x})$, not eigenvalue decomposition
 
 LAPACK's eigenvalue routines (`DGEEV`, `DSYEV`, etc.) do **not**
 accept dual-number inputs. The internal Fortran code performs
@@ -71,7 +71,7 @@ arithmetic. In contrast, matrix multiplication and the trace
 operation are purely algebraic and propagate dual numbers correctly.
 
 Therefore, the partition function must be computed as
-$Z = \operatorname{tr}(T^{L_x})$ via repeated matrix multiplication,
+$Z = \mathrm{tr}(T^{L_x})$ via repeated matrix multiplication,
 not as $Z = \sum_i \lambda_i^{L_x}$ from eigenvalues.
 
 For large $L_x$, the matrix power can be computed in $O(\log L_x)$
@@ -97,7 +97,7 @@ $$\boxed{\langle E \rangle = -\frac{\partial \ln Z}{\partial \beta}, \qquad
   \langle \sigma\sigma \rangle_{\mathrm{nn}} = \frac{1}{\beta}\frac{\partial \ln Z}{\partial J}}$$
 
 All thermodynamic observables are obtained from $\ln Z$ by automatic
-differentiation. The implementation uses $\operatorname{tr}(T^{L_x})$
+differentiation. The implementation uses $\mathrm{tr}(T^{L_x})$
 rather than eigenvalue decomposition to maintain compatibility with
 dual-number arithmetic.
 

--- a/docs/src/calc/bloch-honeycomb-dispersion.md
+++ b/docs/src/calc/bloch-honeycomb-dispersion.md
@@ -193,7 +193,7 @@ $$E_{\pm}(\mathbf{k}) \;=\; \pm\,|f(\mathbf{k})|.
 The eigenvalues are symmetric about $E = 0$ for every
 $\mathbf{k}$ — this is the chiral / sublattice symmetry
 $\sigma^z H(\mathbf{k})\sigma^z = -H(\mathbf{k})$ with $\sigma^z =
-\operatorname{diag}(1, -1)$ acting in the $A/B$ basis.
+\mathrm{diag}(1, -1)$ acting in the $A/B$ basis.
 
 ### Step 3 — Expand $|f(\mathbf{k})|^2$
 
@@ -356,10 +356,10 @@ $$\alpha^{*}\,\beta = \bigl(\tfrac{3\sqrt{3}}{4} + i\tfrac{3}{4}\bigr)
  + i\tfrac{9}{16} + i^2\,\tfrac{9\sqrt{3}}{16}
  = 0 + i\,\tfrac{36}{16} = i\,\tfrac{9}{4},$$
 
-so $2\operatorname{Re}(\alpha^{*}\beta) = 0$. Therefore
+so $2\mathrm{Re}(\alpha^{*}\beta) = 0$. Therefore
 
 $$|\alpha\,q_x + \beta\,q_y|^2
- = |\alpha|^2\,q_x^2 + 2\operatorname{Re}(\alpha^{*}\beta)\,q_x q_y
+ = |\alpha|^2\,q_x^2 + 2\mathrm{Re}(\alpha^{*}\beta)\,q_x q_y
    + |\beta|^2\,q_y^2
  = \tfrac{9}{4}\,(q_x^2 + q_y^2) = \tfrac{9}{4}\,|\mathbf{q}|^2,$$
 

--- a/docs/src/calc/bloch-lieb-flat-band.md
+++ b/docs/src/calc/bloch-lieb-flat-band.md
@@ -269,7 +269,7 @@ $$M\,\mathbf{v} = 0
 \quad\Longleftrightarrow\quad
 Q\,\mathbf{v}_{2} = 0\quad\text{and}\quad Q^{T}\,\mathbf{v}_{1} = 0.$$
 
-By rank-nullity, $\dim\ker Q = N_{2} - \operatorname{rank}(Q) \ge
+By rank-nullity, $\dim\ker Q = N_{2} - \mathrm{rank}(Q) \ge
 N_{2} - \min(N_{1}, N_{2}) = \max(0, N_{2} - N_{1})$, so there are
 at least $\max(0, N_{2} - N_{1})$ zero-energy eigenvectors
 supported on sublattice 2. Similarly at least
@@ -346,7 +346,7 @@ flat-band ferromagnetism (Lieb 1989).
 **(iii) Bipartite chiral symmetry.** The block form (3) makes the
 spectrum symmetric about $E = 0$: for every dispersive eigenvalue
 $+E(\mathbf{k})$ there is $-E(\mathbf{k})$. The sublattice operator
-$\Sigma = \operatorname{diag}(+1, -1, -1)$ (positive on $A$,
+$\Sigma = \mathrm{diag}(+1, -1, -1)$ (positive on $A$,
 negative on $B\cup C$) satisfies $\Sigma \widetilde{H}(\mathbf{k})
 \Sigma = -\widetilde{H}(\mathbf{k})$, the algebraic expression of
 bipartiteness.

--- a/docs/src/calc/jw-tfim-bdg.md
+++ b/docs/src/calc/jw-tfim-bdg.md
@@ -494,7 +494,7 @@ and $\beta^T = -\beta$ takes the matrix form
 $$H = \tfrac{1}{2}\,\Psi^\dagger
       \begin{pmatrix} \alpha & \beta \\ -\beta^* & -\alpha^* \end{pmatrix}
       \Psi
-    + \tfrac{1}{2}\operatorname{Tr}\alpha.
+    + \tfrac{1}{2}\mathrm{Tr}\alpha.
 \tag{8}$$
 
 The overall $\tfrac{1}{2}$ arises because $\Psi$ and $\Psi^\dagger$
@@ -630,7 +630,7 @@ Step 5.
 
 **(i) $h = 0$ (classical Ising).** With $h = 0$, (2') becomes
 $H = -J\sum \tilde\tau^z_b = -J\sum(1 - 2 n_b)$, hence $\mathcal{H}_{\rm
-BdG} = \operatorname{diag}(-2J,\dots,-2J,\,+2J,\dots,+2J)$ (the
+BdG} = \mathrm{diag}(-2J,\dots,-2J,\,+2J,\dots,+2J)$ (the
 diagonal $\alpha_{ii} = -2 J$ from re-reading: we had $2h = 0$ and
 only the diagonal from $+2 h n_b$ dropped; let me redo with (7')):
 actually with $h = 0$ equation (7') gives $\alpha = 0$ and $\beta_{i,
@@ -656,7 +656,7 @@ splitting, exponentially small in $N$.
 
 **(ii) $J = 0$ (classical transverse field).** With $J = 0$, (7')
 gives $\beta = 0$ and $\alpha_{ii} = 2 h$, so $\mathcal{H}_{\rm BdG}
-= \operatorname{diag}(2h,\dots,2h,\,-2h,\dots,-2h)$. Eigenvalues are
+= \mathrm{diag}(2h,\dots,2h,\,-2h,\dots,-2h)$. Eigenvalues are
 $\pm 2 h$; the positive set has $\Lambda_n = 2h$ uniformly. The
 ground-state energy is
 

--- a/docs/src/calc/kramers-wannier-duality.md
+++ b/docs/src/calc/kramers-wannier-duality.md
@@ -67,7 +67,7 @@ $$H = -J\sum_{i=1}^{N}\sigma^z_i\sigma^z_{i+1}
 
 (PBC) is obtained from the 2D Ising model by taking the **continuous-
 time limit** of the row-to-row transfer matrix: the 2D partition
-function becomes $Z = \operatorname{Tr}\,e^{-\beta_{\rm eff} H}$
+function becomes $Z = \mathrm{Tr}\,e^{-\beta_{\rm eff} H}$
 with $\beta_{\rm eff} \propto L_y$ and an anisotropic identification
 between $J, h$ and the two 2D couplings (Mattis §§3.4–3.5; Sachdev
 §5.2).  The self-dual structure of 2D Ising therefore descends to an

--- a/docs/src/calc/transfer-matrix-symmetric-split.md
+++ b/docs/src/calc/transfer-matrix-symmetric-split.md
@@ -12,7 +12,7 @@ the partition function $Z = \sum_{\{s\}} e^{-\beta H}$ admits the
 row-by-row **transfer-matrix representation**
 
 $$\boxed{\;
-Z \;=\; \operatorname{Tr}\bigl(T^{L_x}\bigr),
+Z \;=\; \mathrm{Tr}\bigl(T^{L_x}\bigr),
 \qquad
 T \in \mathbb{R}^{2^{L_y}\times 2^{L_y}},
 \;}$$
@@ -47,7 +47,7 @@ $$\boxed{\;T_{\sigma,\sigma'} = T_{\sigma', \sigma}\;}$$
 — **real symmetric**. This is the form QAtlas uses at
 [`src/models/classical/IsingSquare`](../models/classical/ising-square.md);
 the symmetry enables automatic-differentiation-compatible evaluation
-of thermodynamic quantities via $Z = \operatorname{Tr}(T^{L_x})$
+of thermodynamic quantities via $Z = \mathrm{Tr}(T^{L_x})$
 without an LAPACK eigendecomposition (see Step 6 below).
 
 ---
@@ -94,7 +94,7 @@ double counting).
 
 ### Goal
 
-Package (1) into the form $Z = \operatorname{Tr}(T^{L_x})$ with a
+Package (1) into the form $Z = \mathrm{Tr}(T^{L_x})$ with a
 real symmetric matrix $T$, so that the partition function can be
 computed by $L_x$ successive matrix multiplications.
 
@@ -158,7 +158,7 @@ $T_{\sigma, \sigma'}$ is the Boltzmann weight of placing row
 $\sigma$ adjacent to row $\sigma'$ in the "half-half" bond
 assignment.
 
-### Step 3 — $Z = \operatorname{Tr}(T^{L_x})$
+### Step 3 — $Z = \mathrm{Tr}(T^{L_x})$
 
 Substitute (3) back into (2):
 
@@ -178,7 +178,7 @@ Summing over $\sigma^{(0)}$ gives the diagonal trace:
 
 $$\boxed{\;
 Z \;=\; \sum_{\sigma^{(0)}} (T^{L_x})_{\sigma^{(0)}, \sigma^{(0)}}
- \;=\; \operatorname{Tr}\bigl(T^{L_x}\bigr).
+ \;=\; \mathrm{Tr}\bigl(T^{L_x}\bigr).
 \;}
 \tag{4}$$
 
@@ -217,7 +217,7 @@ $$\widetilde{T}_{\sigma,\sigma'}
  = \exp\!\Bigl[\,K\,E_h(\sigma')\;+\;K\,E_v(\sigma, \sigma')\,\Bigr].
 \tag{6}$$
 
-This matrix has the same trace $\operatorname{Tr}(\widetilde{T}^{L_x}) = Z$
+This matrix has the same trace $\mathrm{Tr}(\widetilde{T}^{L_x}) = Z$
 (provable by the same cyclic-trace argument, since
 $\prod_i \exp[K E_h(\sigma^{(i+1)})] = \exp[K \sum_i E_h(\sigma^{(i+1)})]
 = \exp[K \sum_i E_h(\sigma^{(i)})]$ by PBC reindexing). But (6) is
@@ -234,10 +234,10 @@ unless $E_h(\sigma) = E_h(\sigma')$, which is not generic.
 
 Symmetric (3) and asymmetric (6) are **similar matrices**: one can
 check $T = D^{1/2}\widetilde{T}\,D^{-1/2}$ with $D =
-\operatorname{diag}_\sigma \exp[K E_h(\sigma)]$, so they share the
+\mathrm{diag}_\sigma \exp[K E_h(\sigma)]$, so they share the
 same eigenvalues. The traces of all their powers agree
-($\operatorname{Tr}\widetilde{T}^{L_x} = \operatorname{Tr}(D^{1/2}
-\widetilde{T} D^{-1/2})^{L_x} = \operatorname{Tr} T^{L_x}$). Both
+($\mathrm{Tr}\widetilde{T}^{L_x} = \mathrm{Tr}(D^{1/2}
+\widetilde{T} D^{-1/2})^{L_x} = \mathrm{Tr} T^{L_x}$). Both
 give the same partition function, but the symmetric form has three
 distinct advantages (Step 6).
 
@@ -268,7 +268,7 @@ $$F(\beta) = -\tfrac{1}{\beta}\ln Z(\beta),\qquad
 S(\beta) = -\partial_T F,\qquad C_v(\beta) = -T\partial_T^{2} F$$
 
 as first- and second-order forward-mode derivatives of
-$\operatorname{Tr}(T^{L_x})$ with respect to $\beta$ — see
+$\mathrm{Tr}(T^{L_x})$ with respect to $\beta$ — see
 [`ad-thermodynamics-from-z`](ad-thermodynamics-from-z.md) for the
 derivation of the chain-rule formulas.
 
@@ -287,11 +287,11 @@ number matters for $L_y \gtrsim 20$ at low temperatures.
 **(i) $\beta = 0$ (infinite temperature).** All bonds contribute
 $\exp(0) = 1$, so $T_{\sigma, \sigma'} = 1$ for every pair. The
 matrix is the $2^{L_y}\times 2^{L_y}$ all-ones matrix;
-$\operatorname{rank}(T) = 1$ with single non-zero eigenvalue
+$\mathrm{rank}(T) = 1$ with single non-zero eigenvalue
 $\lambda_{\max} = 2^{L_y}$ and eigenvector the uniform vector
 $(1, 1, \dots, 1)^T$. Then
 
-$$Z = \operatorname{Tr}(T^{L_x}) = \lambda_{\max}^{L_x} = 2^{L_y L_x},$$
+$$Z = \mathrm{Tr}(T^{L_x}) = \lambda_{\max}^{L_x} = 2^{L_y L_x},$$
 
 the correct infinite-temperature result $Z = 2^{\#\text{spins}}$.
 
@@ -315,9 +315,9 @@ s_1 s_2 + s_2 s_1 = 2 s_1 s_2$ (PBC gives two identical bonds on
 a 2-site ring; this is the standard double-counting artefact of
 small-$L_y$ PBC lattices noted in the repository
 `CONTRIBUTING.md`).  For $L_x = 2$ the $4\times 4$ matrix $T$ has
-$\operatorname{Tr}(T^2) = Z$. The explicit brute-force sum over
+$\mathrm{Tr}(T^2) = Z$. The explicit brute-force sum over
 the $2^{4} = 16$ spin configurations on the $2\times 2$ torus
-matches $\operatorname{Tr}(T^2)$ to machine precision in every
+matches $\mathrm{Tr}(T^2)$ to machine precision in every
 QAtlas test (`test/verification/test_ising_2x2_classical.jl`).
 
 ---

--- a/docs/src/calc/xxz-luttinger-parameters.md
+++ b/docs/src/calc/xxz-luttinger-parameters.md
@@ -190,7 +190,7 @@ $$\cosh(2\gamma\lambda) - \cos(n\gamma)
 
 The residue of $g$ at $\lambda_0^{-}$ is therefore
 
-$$\operatorname{Res}_{\lambda_0^{-}}\!g
+$$\mathrm{Res}_{\lambda_0^{-}}\!g
  = \frac{e^{-i\omega\lambda_0^{-}}}{-2 i\gamma\sin(n\gamma)}
  = \frac{e^{-\omega n/2}}{-2 i\gamma\sin(n\gamma)}.$$
 


### PR DESCRIPTION
## Summary

Cross-cutting replacement of \`\operatorname{X}\` with \`\mathrm{X}\` across all seven calc/ notes that used it. Renders identically in MathJax (both produce upright Roman text), but is compatible with GitHub's markdown renderer which uses MathJax SafeMode and disallows \`\operatorname\`.

This fix was originally commit 2 of PR #59 but only the Phase 3h rewrite (commit 1) made it into the merge. Filing standalone so the fix lands on main.

## Files touched

- \`ad-thermodynamics-from-z.md\` (\`\operatorname{tr}\`)
- \`bloch-honeycomb-dispersion.md\` (\`\operatorname{diag}\`, \`\operatorname{Re}\`)
- \`bloch-lieb-flat-band.md\` (\`\operatorname{rank}\`, \`\operatorname{diag}\`)
- \`jw-tfim-bdg.md\` (\`\operatorname{Tr}\`, \`\operatorname{diag}\`)
- \`kramers-wannier-duality.md\` (\`\operatorname{Tr}\`)
- \`transfer-matrix-symmetric-split.md\` (\`\operatorname{Tr}\`, \`\operatorname{diag}\`, \`\operatorname{rank}\`)
- \`xxz-luttinger-parameters.md\` (\`\operatorname{Res}\`)

28 insertions, 28 deletions across 7 files.

## Test plan

- [x] Documenter build clean (no Error lines).
- [x] \`grep -c operatorname docs/src/calc/*.md\` returns 0 for every file.
- [x] No semantic changes — \`\operatorname\` and \`\mathrm\` render identically in Documenter / MathJax 3.