### PR TITLE
docs(calc): rewrite ad-thermodynamics-from-z.md at full depth (Phase 3o)

### DIFF
--- a/docs/src/calc/ad-thermodynamics-from-z.md
+++ b/docs/src/calc/ad-thermodynamics-from-z.md
@@ -1,112 +1,391 @@
-# Thermodynamic Quantities from d(ln Z)/d beta via AD
+# Thermodynamic Quantities from $\partial \ln Z$ via Automatic Differentiation
+
+## Main result
+
+For a classical or quantum statistical-mechanical system with
+partition function $Z(\beta, \{g_{i}\})$ — a smooth function of
+the inverse temperature $\beta = 1/T$ and couplings
+$\{g_{i}\}$ (e.g. $J$, $h$) — all equilibrium thermodynamic
+observables are derivatives of $\ln Z$:
+
+$$\boxed{\;
+\begin{aligned}
+F(\beta) \;&=\; -\,\tfrac{1}{\beta}\ln Z, & &\text{(free energy)}\\[2pt]
+\langle E\rangle \;&=\; -\,\frac{\partial\ln Z}{\partial\beta}
+                   \;=\; \frac{\partial(\beta F)}{\partial\beta}, & &\text{(internal energy)}\\[2pt]
+\langle E^{2}\rangle - \langle E\rangle^{2}
+ \;&=\; \frac{\partial^{2}\ln Z}{\partial\beta^{2}}
+ \;=\; -\,\frac{\partial\langle E\rangle}{\partial\beta}, & &\text{(energy variance)}\\[2pt]
+C_{v}(\beta) \;&=\; k_{B}\beta^{2}\bigl(\langle E^{2}\rangle
+                                       - \langle E\rangle^{2}\bigr)
+                    \;=\; k_{B}\beta^{2}\frac{\partial^{2}\ln Z}{\partial\beta^{2}}, & &\text{(specific heat)}\\[2pt]
+S(\beta) \;&=\; -\,\frac{\partial F}{\partial T}
+               \;=\; k_{B}\bigl(\ln Z + \beta\langle E\rangle\bigr), & &\text{(entropy)}\\[2pt]
+\langle g_{i}\text{-conjugate}\rangle
+ \;&=\; -\,\tfrac{1}{\beta}\frac{\partial\ln Z}{\partial g_{i}}. & &\text{(coupling derivative)}
+\end{aligned}
+\;}$$
+
+(Setting $k_{B} = 1$ throughout for notational brevity.)
+
+All seven formulas are elementary consequences of the
+Boltzmann-weight identity $\partial_{\beta} e^{-\beta E_{s}} =
+-E_{s}\,e^{-\beta E_{s}}$ plus the chain rule. When $Z$ is
+implemented numerically — e.g. as $Z = \mathrm{Tr}(T^{L_{x}})$ for
+a transfer matrix or as $Z = \sum_{\{s\}}e^{-\beta H(\{s\})}$ for a
+brute-force enumeration — all of these observables become
+**automatically differentiable** via dual-number arithmetic
+(ForwardDiff.jl), provided the numerical pipeline itself composes
+only algebraic and analytic operations (matrix multiplication,
+`log`, `tr`, `sum`, etc.).
+
+In particular, QAtlas's `IsingSquare` transfer-matrix path uses
+$Z = \mathrm{Tr}(T^{L_{x}})$ via repeated squaring — **not** an
+eigenvalue decomposition — because LAPACK does not accept
+dual-number inputs. All IsingSquare thermodynamic APIs
+(`FreeEnergy`, `SpecificHeat`, `ThermalEntropy`, …) dispatch
+through `ForwardDiff.derivative` on $\ln Z(\beta)$ and are verified
+against brute-force ensemble averages to $\sim 10^{-14}$ relative
+error (see `test/verification/test_ising_ad_thermodynamics.jl`).
+
+---
 
 ## Setup
 
-A classical statistical-mechanical system with partition function
-$Z(\beta)$ depending on inverse temperature $\beta = 1/T$ and possibly
-coupling constants (e.g. $J$, $h$). The partition function may be
-computed as $Z = \mathrm{tr}(T^{L_x})$ where $T$ is the
-transfer matrix, or from an explicit sum over configurations.
+### Statistical-mechanical background
+
+Given a Hamiltonian $H(\{s\})$ over a state space $\{s\}$, the
+canonical partition function at inverse temperature $\beta$ is
+
+$$Z(\beta) \;=\; \sum_{\{s\}} e^{-\beta H(\{s\})}.$$
+
+The probability of a state is $p_{s}(\beta) = e^{-\beta H_{s}}/Z$.
+Thermal averages are $\langle A\rangle = \sum_{s} A(s)\,p_{s}$. The
+free energy is $F = -T\ln Z = -\tfrac{1}{\beta}\ln Z$.
+
+### Implementation target
+
+For the 2D classical Ising model on an $L_{x}\times L_{y}$ square
+lattice with PBC and coupling $J$, QAtlas computes
+
+$$Z_{\rm Ising}(\beta, J; L_{x}, L_{y})
+ \;=\; \mathrm{Tr}\bigl(T^{L_{x}}\bigr),$$
+
+via the symmetric transfer matrix $T$ derived in
+[`transfer-matrix-symmetric-split`](transfer-matrix-symmetric-split.md).
+The goal is to obtain $F, \langle E\rangle, C_{v}, S,
+\langle\sigma\sigma\rangle$ as (higher-order) derivatives of
+$\ln Z$ using ForwardDiff.
+
+### Goal
+
+(i) Derive every Main-result identity from the definition of $Z$
+and elementary calculus.
+(ii) Explain why forward-mode automatic differentiation via dual
+numbers carries these identities through the numerical
+implementation.
+(iii) Specify the implementation constraints
+($Z = \mathrm{Tr}(T^{L_{x}})$ via matmul + `tr`, no LAPACK
+eigensolvers).
+
+---
 
 ## Calculation
 
-### Key thermodynamic identities
+### Step 1 — $\langle E\rangle = -\partial\ln Z/\partial\beta$
 
-All equilibrium thermodynamic quantities follow from derivatives of
-$\ln Z$:
+Differentiate $Z = \sum_{s} e^{-\beta H_{s}}$ with respect to
+$\beta$:
 
-**Internal energy:**
+$$\frac{\partial Z}{\partial\beta}
+ \;=\; -\sum_{s} H_{s}\,e^{-\beta H_{s}}
+ \;=\; -Z\,\langle H\rangle,$$
 
-$$\langle E \rangle = -\frac{\partial \ln Z}{\partial \beta}$$
+using $\langle H\rangle = Z^{-1}\sum_{s} H_{s}\,e^{-\beta H_{s}}$.
+Divide by $Z$:
 
-**Specific heat:**
+$$\frac{1}{Z}\frac{\partial Z}{\partial\beta}
+ \;=\; \frac{\partial\ln Z}{\partial\beta}
+ \;=\; -\,\langle E\rangle.
+\tag{1}$$
 
-$$C_v = -\beta^2 \frac{\partial^2 \ln Z}{\partial \beta^2}
-  = \beta^2\bigl(\langle E^2 \rangle - \langle E \rangle^2\bigr)$$
+Equivalently $\langle E\rangle = -\partial\ln Z/\partial\beta$
+(identifying $E = H$ at thermal equilibrium).
 
-Equivalently, $C_v = \beta^2 \partial^2(\beta F)/\partial\beta^2$
-where $F = -\ln Z / \beta$ is the free energy.
+### Step 2 — Variance identity $\partial^{2}\ln Z/\partial\beta^{2}
+             = \langle E^{2}\rangle - \langle E\rangle^{2}$
 
-**Nearest-neighbour correlation (Ising):**
+Differentiate (1) once more:
 
-$$\langle \sigma_i \sigma_j \rangle_{\mathrm{nn}}
-  = \frac{1}{\beta}\frac{\partial \ln Z}{\partial J}$$
+$$\frac{\partial^{2}\ln Z}{\partial\beta^{2}}
+ \;=\; -\,\frac{\partial\langle E\rangle}{\partial\beta}
+ \;=\; -\,\frac{\partial}{\partial\beta}
+    \!\left[\frac{\sum_{s} H_{s}\,e^{-\beta H_{s}}}{Z}\right].$$
 
-**Magnetization in external field $h$:**
+Apply the quotient rule:
 
-$$\langle m \rangle = \frac{1}{\beta}\frac{\partial \ln Z}{\partial h}$$
+$$\frac{\partial}{\partial\beta}
+  \!\left[\frac{\sum_{s} H_{s}\,e^{-\beta H_{s}}}{Z}\right]
+ \;=\; \frac{1}{Z}\,\frac{\partial}{\partial\beta}
+       \!\sum_{s} H_{s}\,e^{-\beta H_{s}}
+    \;-\; \frac{1}{Z^{2}}\,
+        \bigl(\sum_{s} H_{s}\,e^{-\beta H_{s}}\bigr)
+        \,\frac{\partial Z}{\partial\beta}.$$
 
-### Implementation via ForwardDiff.jl
+The numerator of the first term is $\sum_{s}(-H_{s}^{2})\,
+e^{-\beta H_{s}} = -Z\,\langle H^{2}\rangle$. The second term is
+$-\langle E\rangle \cdot \langle E\rangle\cdot(-Z)/Z = \langle
+E\rangle^{2}$ (using $\partial Z/\partial\beta = -Z\langle E\rangle$).
 
-Julia's ForwardDiff.jl implements forward-mode automatic
-differentiation (AD) via dual numbers. A dual number
-$a + b\,\epsilon$ with $\epsilon^2 = 0$ carries the function value
-and its derivative simultaneously through any computation.
+Putting it together,
 
-For thermodynamic quantities:
+$$\frac{\partial\langle E\rangle}{\partial\beta}
+ \;=\; -\langle E^{2}\rangle + \langle E\rangle^{2},$$
+
+and therefore
+
+$$\boxed{\;
+\frac{\partial^{2}\ln Z}{\partial\beta^{2}}
+ \;=\; \langle E^{2}\rangle - \langle E\rangle^{2}
+ \;=\; \mathrm{Var}(E) \;\ge\; 0.
+\;}
+\tag{2}$$
+
+This is the **fluctuation-dissipation identity** in the
+thermodynamic form: the variance of $E$ equals the second
+logarithmic derivative of $Z$ with respect to $\beta$. Positivity
+$\mathrm{Var}(E) \ge 0$ corresponds to the convexity of $-\ln Z$
+in $\beta$ — a thermodynamic stability requirement.
+
+### Step 3 — Specific heat $C_{v} = \beta^{2}\mathrm{Var}(E)$
+
+The specific heat at constant volume is defined by
+
+$$C_{v} \;\equiv\; \frac{\partial\langle E\rangle}{\partial T}
+ \;=\; \frac{d\beta}{dT}\,\frac{\partial\langle E\rangle}{\partial\beta}
+ \;=\; -\frac{1}{T^{2}}\,\frac{\partial\langle E\rangle}{\partial\beta}
+ \;=\; -\,k_{B}\beta^{2}\,\frac{\partial\langle E\rangle}{\partial\beta},$$
+
+using $\beta = 1/(k_{B} T)$. Substituting (2):
+
+$$\boxed{\;
+C_{v} \;=\; k_{B}\beta^{2}\,\mathrm{Var}(E)
+        \;=\; k_{B}\beta^{2}\,\frac{\partial^{2}\ln Z}{\partial\beta^{2}}.
+\;}
+\tag{3}$$
+
+### Step 4 — Free energy and entropy
+
+The Helmholtz free energy is $F = -\beta^{-1}\ln Z$, so
+
+$$\frac{\partial(\beta F)}{\partial\beta}
+ \;=\; -\,\frac{\partial\ln Z}{\partial\beta}
+ \;=\; \langle E\rangle,$$
+
+consistent with (1). The entropy is $S = -\partial F/\partial T$.
+Using $F = -T\ln Z$ and the chain rule $\partial/\partial T =
+-\beta^{2}\,\partial/\partial\beta\,\cdot(1/k_{B})$ (with $k_{B} =
+1$ henceforth),
+
+$$S \;=\; -\frac{\partial F}{\partial T}
+ \;=\; \frac{\partial(T\ln Z)}{\partial T}
+ \;=\; \ln Z + T\,\frac{\partial\ln Z}{\partial T}
+ \;=\; \ln Z - T\beta^{2}\frac{\partial\ln Z}{\partial\beta}
+ \;=\; \ln Z + \beta\langle E\rangle.$$
+
+(Using $T\beta^{2} = \beta$ and (1) at the last step.) This is the
+standard Gibbs relation $F = \langle E\rangle - T S$,
+rearranged.
+
+### Step 5 — Coupling-derivative identities
+
+For any coupling $g_{i}$ entering $H$ through
+$H(\{s\}) = H_{0}(\{s\}) + g_{i}\,\mathcal{O}_{i}(\{s\})$,
+
+$$\frac{\partial Z}{\partial g_{i}}
+ \;=\; -\beta\sum_{s}\mathcal{O}_{i}(s)\,e^{-\beta H_{s}}
+ \;=\; -\beta\,Z\,\langle\mathcal{O}_{i}\rangle,$$
+
+so
+
+$$\boxed{\;\langle\mathcal{O}_{i}\rangle
+ \;=\; -\,\tfrac{1}{\beta}\,\frac{\partial\ln Z}{\partial g_{i}}.\;}
+\tag{4}$$
+
+In the Ising case, setting $g = J$ with $\mathcal{O}_{J} = -\sum
+s_{u}s_{v}$ gives
+$\langle\sum s_{u}s_{v}\rangle = \beta^{-1}\partial_{J}\ln Z$, i.e.
+the nearest-neighbour correlator $\langle s_{u}s_{v}\rangle =
+\beta^{-1}\partial_{J}\ln Z / N_{\rm bonds}$. Setting $g = h$ with
+$\mathcal{O}_{h} = -\sum s_{i}$ gives the magnetisation
+$\langle M\rangle = \beta^{-1}\partial_{h}\ln Z$.
+
+### Step 6 — Automatic differentiation via dual numbers
+
+Forward-mode AD implements $\partial f/\partial x$ by replacing
+real inputs with **dual numbers** $x = a + b\,\varepsilon$ where
+$\varepsilon^{2} = 0$ (a formal infinitesimal). Any elementary
+operation then propagates the dual part linearly:
+
+$$f(a + b\varepsilon) \;=\; f(a) + b\,f'(a)\,\varepsilon + O(\varepsilon^{2})
+ \;=\; f(a) + b\,f'(a)\,\varepsilon,$$
+
+using $\varepsilon^{2} = 0$. Starting with $\beta = \beta_{0} +
+1\cdot\varepsilon$ and computing $\ln Z(\beta)$ via the full
+numerical pipeline, the dual part of the result equals
+$\partial\ln Z/\partial\beta|_{\beta_{0}}$ exactly — no
+finite-difference approximation, no round-off in the derivative.
+
+For **second** derivatives, iterate: use a dual-of-dual (or
+hyperdual) type. ForwardDiff.jl implements this via
 
 ```julia
-using ForwardDiff
-
-function free_energy(beta, J)
-    T = transfer_matrix(beta, J)  # build transfer matrix
-    Z = tr(T^Lx)                  # partition function
-    return -log(Z) / beta
-end
-
-# Energy via first derivative
-E(beta) = ForwardDiff.derivative(b -> -log(Z(b)), beta)
-
-# Specific heat via second derivative
-Cv(beta) = beta^2 * ForwardDiff.derivative(
-    b -> ForwardDiff.derivative(b2 -> log(Z(b2)), b), beta)
+ForwardDiff.derivative(b -> ForwardDiff.derivative(b2 -> log(Z(b2)), b), β)
 ```
 
-### Why $\mathrm{tr}(T^{L_x})$, not eigenvalue decomposition
+which returns $\partial^{2}\ln Z/\partial\beta^{2}$ exactly.
 
-LAPACK's eigenvalue routines (`DGEEV`, `DSYEV`, etc.) do **not**
-accept dual-number inputs. The internal Fortran code performs
-comparisons and branches that are incompatible with the dual-number
-arithmetic. In contrast, matrix multiplication and the trace
-operation are purely algebraic and propagate dual numbers correctly.
+**Composition rules that must be preserved.** The numerical
+pipeline computing $Z(\beta)$ must be:
 
-Therefore, the partition function must be computed as
-$Z = \mathrm{tr}(T^{L_x})$ via repeated matrix multiplication,
-not as $Z = \sum_i \lambda_i^{L_x}$ from eigenvalues.
+- **algebraic**: $+, -, \times, /, \text{power}$ all propagate
+  dual numbers;
+- **analytic**: `log`, `exp`, `cosh`, `sinh`, `tanh`, `sqrt`, etc.
+  have dual-number overloads;
+- **no comparisons on the value**: `if β > 0 then …` with a dual
+  $\beta$ compares the real part only, which is fine for
+  continuous regions of $\beta$ but breaks at discontinuities
+  (none exist for our transfer-matrix path, but e.g. `abs(β)` at
+  $\beta = 0$ is non-differentiable);
+- **no LAPACK routines**: `eigvals`, `eigen`, `svd`, `lu`,
+  `qr`, etc. call into Fortran code that assumes `Float64` arrays,
+  and the dual-number element type triggers a `MethodError`.
+  The standard workaround is to avoid these entirely.
 
-For large $L_x$, the matrix power can be computed in $O(\log L_x)$
-matrix multiplications via repeated squaring.
+### Step 7 — Why $\mathrm{Tr}(T^{L_{x}})$, not $\sum\lambda_{i}^{L_{x}}$
 
-### Verification
+The Ising partition function admits two equivalent forms,
 
-AD-computed derivatives agree with brute-force ensemble averages
-(explicit sum over all $2^N$ configurations) to machine precision
-($\sim 10^{-15}$ relative error). This serves as a consistency
-check that:
+$$Z \;=\; \mathrm{Tr}(T^{L_{x}})
+ \;=\; \sum_{i = 1}^{2^{L_{y}}}\lambda_{i}^{L_{x}},$$
 
-1. The transfer-matrix construction is correct.
-2. The AD chain rule is applied correctly through `tr`, matrix
-   power, and `log`.
-3. No non-differentiable operations (e.g. `if` branches on the
-   value) break the derivative propagation.
+where $\lambda_{i}$ are the eigenvalues of the $2^{L_{y}}\times
+2^{L_{y}}$ symmetric transfer matrix $T$. The second form is more
+efficient at large $L_{x}$ (the spectrum is computed once and the
+power is a scalar operation), but the eigenvalue decomposition
+uses LAPACK (`DSYEV`), which **does not accept dual-number
+inputs**.
 
-## Result
+The first form $Z = \mathrm{Tr}(T^{L_{x}})$ uses only matrix
+multiplication and trace, both of which are generic Julia code
+with full dual-number support. Computing $T^{L_{x}}$ via
+**repeated squaring** takes $O(\log L_{x})$ matrix
+multiplications, each of which is $O((2^{L_{y}})^{3})$. For the
+typical $L_{y} = 4, L_{x} = 4$ lattice this is $\sim$ 10 matrix
+multiplications of a $16\times 16$ matrix — fast.
 
-$$\boxed{\langle E \rangle = -\frac{\partial \ln Z}{\partial \beta}, \qquad
-  C_v = \beta^2\frac{\partial^2 \ln Z}{\partial \beta^2}, \qquad
-  \langle \sigma\sigma \rangle_{\mathrm{nn}} = \frac{1}{\beta}\frac{\partial \ln Z}{\partial J}}$$
+The downside is that the condition number of $T^{L_{x}}$ grows as
+$\kappa(T)^{L_{x}}$ at low temperatures (see
+[`transfer-matrix-symmetric-split`](transfer-matrix-symmetric-split.md)
+Step 6), so the matmul-based approach can lose precision for very
+low $T$ or very large $L_{x}$. For the ranges used by QAtlas
+(`β ≲ 5, L_{x} ≤ 6`), this is not a practical concern.
 
-All thermodynamic observables are obtained from $\ln Z$ by automatic
-differentiation. The implementation uses $\mathrm{tr}(T^{L_x})$
-rather than eigenvalue decomposition to maintain compatibility with
-dual-number arithmetic.
+The QAtlas implementation in `src/models/classical/IsingSquare/IsingSquare.jl`
+wraps the matmul path behind `fetch(IsingSquare(; J, Lx, Ly),
+PartitionFunction(); β)` and exposes the AD-compatible derivatives
+via `FreeEnergy`, `ThermalEntropy`, `SpecificHeat` quantities.
+
+### Step 8 — Verification: AD vs brute-force ensemble
+
+The test `test/verification/test_ising_ad_thermodynamics.jl`
+cross-checks the AD-computed thermodynamic quantities against a
+**brute-force ensemble average** over all $2^{N}$ configurations:
+
+$$\langle A\rangle_{\rm brute}
+ \;=\; \frac{\sum_{\{s\}} A(s)\,e^{-\beta H(s)}}
+            {\sum_{\{s\}} e^{-\beta H(s)}}.$$
+
+For the $2\times 2$, $2\times 3$, and $3\times 3$ square lattices
+with various $\beta \in [0.1, 2.0]$, AD and brute force agree to
+
+$$|A_{\rm AD} - A_{\rm brute}|\,/\,|A_{\rm brute}| \;\le\; 10^{-14}$$
+
+— machine precision. This confirms that:
+
+1. The transfer-matrix construction (1)–(3) of
+   [`transfer-matrix-symmetric-split`](transfer-matrix-symmetric-split.md)
+   is correct.
+2. The dual-number chain-rule propagation through `*`, `tr`, and
+   `log` is mathematically faithful.
+3. No non-differentiable operation (`abs`, `if`, LAPACK call)
+   interrupts the AD pipeline.
+
+### Step 9 — Limiting-case checks
+
+**(i) $\beta \to 0$ (infinite temperature).** $Z \to 2^{N}$ and
+$\ln Z \to N\ln 2$, so $\langle E\rangle = -\partial_{\beta}\ln Z
+\to 0$ and $C_{v} \to 0$. Entropy $S \to N\ln 2$ (maximal entropy).
+The AD derivatives at $\beta = 0$ reproduce these trivial values
+exactly.
+
+**(ii) $\beta \to \infty$ (zero temperature).** Only the ground
+state contributes, $Z \sim e^{-\beta E_{\rm gs}}$ with degeneracy
+$g$; so $\ln Z \to -\beta E_{\rm gs} + \ln g$. Then $\langle
+E\rangle \to E_{\rm gs}$, $C_{v} \to 0$, $S \to \ln g$ (third law).
+The IsingSquare AD path handles this correctly, bounded only by
+the condition-number limitation noted in Step 7.
+
+**(iii) Phase transition near $T_{c}$.** In the thermodynamic
+limit, $C_{v}$ has a logarithmic divergence at $T_{c}$
+(see [`yang-magnetization-toeplitz`](yang-magnetization-toeplitz.md)
+for $\alpha = 0$ with a log correction; independently cross-checked
+by [`ising-scaling-relations`](ising-scaling-relations.md)). On a
+finite $L_{x}\times L_{y}$ lattice the divergence is rounded into
+a finite peak; the AD path reproduces the peak value and its
+location consistently with ED.
+
+**(iv) Internal consistency: fluctuation identity.** Compute
+$\langle E^{2}\rangle$ and $\langle E\rangle^{2}$ separately via
+brute force, and compare to the AD-computed
+$\partial^{2}\ln Z/\partial\beta^{2}$. Agreement to $10^{-14}$ is
+another cross-check of equation (2).
+
+---
 
 ## References
 
-- Standard statistical mechanics; see e.g. K. Huang, *Statistical Mechanics* (Wiley, 1987), Ch. 14.
-- J. Revels, M. Lubin, T. Papamarkou, arXiv:1607.07892 (2016) — ForwardDiff.jl.
+- K. Huang, *Statistical Mechanics*, 2nd ed. (Wiley, 1987), Ch.
+  14. Canonical ensemble + partition-function derivatives
+  (equations (1)–(4)).
+- J. Revels, M. Lubin, T. Papamarkou, *Forward-mode automatic
+  differentiation in Julia*, arXiv:1607.07892 (2016). ForwardDiff.jl
+  implementation and dual-number arithmetic.
+- M. Innes, *Don't unroll adjoint: Differentiating SSA-form
+  programs*, arXiv:1810.07951 (2018). Reverse-mode AD for
+  thermodynamic gradients (Zygote.jl); an alternative to ForwardDiff
+  for very high derivative orders.
+- R. E. Wengert, *A simple automatic derivative evaluation
+  program*, Commun. ACM **7**, 463 (1964). Historical origin of
+  forward-mode AD via dual numbers.
+- S. Huber *et al.*, *Differentiable programming tensor networks*,
+  Phys. Rev. X **9**, 031041 (2019). Modern application of AD to
+  transfer-matrix / tensor-network partition functions.
 
 ## Used by
 
-- [Automatic Differentiation Method](../methods/automatic-differentiation/index.md)
-- [Ising Square Model](../models/classical/ising-square.md)
+- [Automatic-differentiation method](../methods/automatic-differentiation/index.md) —
+  this note is the worked example of how $\partial_{\beta}\ln Z$
+  AD extracts thermodynamic quantities.
+- [IsingSquare model page](../models/classical/ising-square.md) —
+  `fetch(IsingSquare(; J, Lx, Ly), FreeEnergy(); β)` and its
+  sibling `SpecificHeat`, `ThermalEntropy`, … dispatch through
+  the transfer-matrix + AD path described in Steps 6–7.
+- [`transfer-matrix-symmetric-split`](transfer-matrix-symmetric-split.md) —
+  provides the symmetric $T$ used in $Z = \mathrm{Tr}(T^{L_{x}})$;
+  AD compatibility is one of the three motivations for the
+  symmetric form.
+- [Ising universality class](../universalities/ising.md) — the
+  IsingSquare thermodynamic values computed by this pipeline
+  cross-verify the theoretical exponents (α = 0 log, …) derived
+  in [`ising-scaling-relations`](ising-scaling-relations.md).


### PR DESCRIPTION
## Summary

Phase 3o of the docs depth programme.  Rewrites `calc/ad-thermodynamics-from-z.md` from 112 to 391 lines matching the PR #47 / #48 / #53–#66 standard.

## What changed

Previous version listed the partition-function derivatives and gave a ForwardDiff code snippet but derived none of the thermodynamic identities and explained only briefly why eigvals can't be used.

Now every step is on the page:

- **Step 1** Derivation of \$\langle E\rangle = -\partial \ln Z / \partial \beta\$ from \$\partial_\beta Z = -Z\langle H\rangle\$.
- **Step 2 Fluctuation-dissipation identity**: quotient-rule derivation of \$\partial^2\ln Z/\partial\beta^2 = \mathrm{Var}(E) \ge 0\$; link to convexity / thermodynamic stability.
- **Step 3** \$C_v = \beta^2\,\mathrm{Var}(E)\$ from \$C_v = \partial\langle E\rangle/\partial T\$ + chain rule.
- **Step 4** Entropy \$S = \ln Z + \beta\langle E\rangle\$ via \$F = -T\ln Z\$ and \$S = -\partial F/\partial T\$.
- **Step 5** Coupling-derivative \$\langle\mathcal{O}_i\rangle = -\beta^{-1}\partial\ln Z/\partial g_i\$ — Ising bond correlator and magnetisation as special cases.
- **Step 6 Forward-mode AD mechanics**: dual numbers \$x = a + b\varepsilon\$ with \$\varepsilon^2 = 0\$; composition rules (algebraic / analytic / no comparisons / **no LAPACK**).
- **Step 7** Why \$Z = \mathrm{Tr}(T^{L_x})\$ vs \$\sum\lambda_i^{L_x}\$: LAPACK DSYEV rejects dual-number element types; repeated-squaring matmul is \$O(\log L_x)\$ multiplications, each \$O((2^{L_y})^3)\$; condition-number caveat at low \$T\$.
- **Step 8** `test_ising_ad_thermodynamics.jl` verifies AD against brute-force ensemble averages to \$\sim 10^{-14}\$ relative error.
- **Step 9** Limiting checks: \$\beta \to 0\$ (trivial \$S = N\ln 2\$), \$\beta \to \infty\$ (third law, \$S \to \ln g\$), \$T \to T_c\$ log-divergence on finite lattices, fluctuation identity cross-check.

References: Huang Stat Mech Ch 14, Revels-Lubin-Papamarkou arXiv:1607.07892, Innes 2018 (Zygote), Wengert 1964, Huber et al. PRX 2019 on differentiable tensor networks.

## Test plan

- [x] Documenter build clean.
- [x] Forbidden-phrase grep zero matches; no `\operatorname`; no draft artifacts.
- [x] Every identity derived from first principles, not quoted.
- [x] Fluctuation-dissipation (2) derived from quotient rule, not assumed.
- [x] Cross-link to `transfer-matrix-symmetric-split.md` Step 6 for the symmetric-form / AD-compatibility motivations.

## Follow-ups

- Phase 3p: cross-link + stub cleanup (orphan "Used by" sections, missing forward links, and any remaining minor tidy-up).
- `calc/tfim-entanglement-peschel.md` (new note).