### PR TITLE
docs(cleanup): Phase 3p cross-link + back-reference tidy-up

### DIFF
--- a/docs/src/methods/bloch-hamiltonian/index.md
+++ b/docs/src/methods/bloch-hamiltonian/index.md
@@ -96,6 +96,21 @@ spectrum_exact = QAtlas.fetch(Graphene(), BlochSpectrum(); Lx=6, Ly=6, t=1.0)
 
 ---
 
+## Full derivations
+
+Each lattice family has a dedicated step-by-step calc/ note
+covering the Fourier transform to the Bloch Hamiltonian, band
+structure, and key features:
+
+- **Honeycomb** (Dirac cones at $K, K'$ with $v_F = 3t/2$):
+  [`bloch-honeycomb-dispersion`](../../calc/bloch-honeycomb-dispersion.md)
+- **Kagome** (flat band at $E = +2t$ from destructive-interference
+  hexagonal compact-localised states):
+  [`bloch-kagome-flat-band`](../../calc/bloch-kagome-flat-band.md)
+- **Lieb** (flat band at $E = 0$ from bipartite sublattice
+  imbalance $1 : 2$ via Lieb's theorem):
+  [`bloch-lieb-flat-band`](../../calc/bloch-lieb-flat-band.md)
+
 ## References
 
 - N. W. Ashcroft, N. D. Mermin, *Solid State Physics*

--- a/docs/src/methods/calabrese-cardy/index.md
+++ b/docs/src/methods/calabrese-cardy/index.md
@@ -90,6 +90,16 @@ To extract $c$ from numerical entropy data $\{S(l)\}$:
 
 ---
 
+## Full derivation
+
+Step-by-step: replica trick, branch-point twist operators with
+scaling dimension $\Delta_n = (c/24)(n - 1/n)$, the cylinder →
+plane conformal map for PBC, the strip → upper half-plane map
+with method of images for OBC, explicit $n \to 1$ derivative to
+extract $S$, and the factor-of-2 origin tabulated:
+**[Calabrese–Cardy entanglement entropy: OBC vs PBC prefactor
+](../../calc/calabrese-cardy-obc-vs-pbc.md)**.
+
 ## References
 
 - P. Calabrese, J. Cardy, "Entanglement entropy and quantum field

--- a/docs/src/models/classical/ising-square.md
+++ b/docs/src/models/classical/ising-square.md
@@ -54,6 +54,17 @@ exponentiation rather than eigendecomposition, to support
 [automatic differentiation](../../methods/automatic-differentiation/index.md)
 with `ForwardDiff.Dual` numbers.
 
+Full derivation of the symmetric transfer matrix from the
+row-by-row factorisation:
+**[Transfer matrix: symmetric split construction
+](../../calc/transfer-matrix-symmetric-split.md)**.
+
+Full derivation of the AD path from $\ln Z$ to thermodynamic
+observables ($F$, $\langle E\rangle$, $C_v$, $S$, …) via
+forward-mode dual numbers:
+**[Thermodynamic quantities from $\partial \ln Z$ via AD
+](../../calc/ad-thermodynamics-from-z.md)**.
+
 ### References
 
 - L. Onsager, "Crystal Statistics. I. A Two-Dimensional Model with an
@@ -100,6 +111,11 @@ $$e^{-2K_c} = \tanh K_c \quad \Longleftrightarrow \quad \sinh(2K_c) = 1$$
 
 Solving: $K_c = \frac{1}{2}\mathrm{arcsinh}(1) = \frac{1}{2}\ln(1 + \sqrt{2})$.
 
+Full derivation of the Kramers–Wannier duality (classical + TFIM
+operator form) and the self-dual fixed point:
+**[Kramers–Wannier duality
+](../../calc/kramers-wannier-duality.md)**.
+
 ### References
 
 - H. A. Kramers, G. H. Wannier, "Statistics of the Two-Dimensional
@@ -141,6 +157,13 @@ Yang's calculation (1952) uses the Pfaffian method to evaluate the
 spontaneous magnetization of the infinite square lattice. The key step
 is computing $\langle \sigma_0 \rangle$ as a Toeplitz determinant, which
 in the thermodynamic limit gives the closed-form expression above.
+
+Full derivation of the Toeplitz-determinant reduction, the strong
+Szegő-theorem evaluation, and the emergence of the exponent
+$1/8$ from the Wiener–Hopf $1/2$ × Szegő $1/4$ × correlator
+$1/2$ factor chain:
+**[Yang's spontaneous magnetization via Toeplitz determinant
+](../../calc/yang-magnetization-toeplitz.md)**.
 
 ### Physical Context
 
@@ -185,3 +208,25 @@ M = QAtlas.fetch(IsingSquare(), SpontaneousMagnetization();
   computational details of the $\mathrm{tr}(T^{L_x})$ evaluation.
 - **AD verification**: [Automatic Differentiation](../../methods/automatic-differentiation/index.md) —
   thermodynamic quantities from $\partial(\ln Z)/\partial\beta$.
+
+### Underlying derivations
+
+Every stored value on this page is backed by a step-by-step
+derivation note under `docs/src/calc/`:
+
+- **Partition function** → [`transfer-matrix-symmetric-split`](../../calc/transfer-matrix-symmetric-split.md)
+  (row-by-row factorisation, symmetric-split construction of $T$,
+  $Z = \mathrm{Tr}(T^{L_x})$).
+- **Thermodynamic quantities from $Z$** → [`ad-thermodynamics-from-z`](../../calc/ad-thermodynamics-from-z.md)
+  (derivatives of $\ln Z$ via ForwardDiff, fluctuation-dissipation
+  identity).
+- **Critical temperature** → [`kramers-wannier-duality`](../../calc/kramers-wannier-duality.md)
+  (self-dual fixed point $\sinh(2K_c) = 1$).
+- **Spontaneous magnetisation** → [`yang-magnetization-toeplitz`](../../calc/yang-magnetization-toeplitz.md)
+  (Toeplitz determinant + strong Szegő theorem → $\beta = 1/8$).
+- **Critical exponents from CFT** → [`ising-cft-primary-operators`](../../calc/ising-cft-primary-operators.md)
+  (Kac table of $\mathcal{M}(3, 4)$; three primaries and their
+  scaling dimensions).
+- **Scaling relations among exponents** → [`ising-scaling-relations`](../../calc/ising-scaling-relations.md)
+  (Rushbrooke, Widom, Fisher, Josephson — all four from the Widom
+  scaling form).


### PR DESCRIPTION
## Summary

Phase 3p — the final mechanical step of the docs depth programme (PR #47 / #48 / #53–#67 established the depth standard across 16 calc/ notes). This PR adds the missing **forward-link** pointers from model / method pages to those calc/ notes, per `md/docs-conventions.md` §8.2.

The 16 calc/ notes already have `## Used by` backlinks (verified in the Phase-3p audit). The only gap was forward links:

1. `docs/src/models/classical/ising-square.md` had **zero** links to its six calc/ dependencies.
2. `docs/src/methods/calabrese-cardy/index.md` and `docs/src/methods/bloch-hamiltonian/index.md` did not reference the calc/ derivations used as their backbones.

## What changed

### [ising-square.md](docs/src/models/classical/ising-square.md)

Add "Full derivation:" pointers after each Derivation subsection (following the `xxz.md` pattern) and extend the Connections section with a dedicated "Underlying derivations" block listing every calc/ note backing a stored value on the page:

- Partition function → `transfer-matrix-symmetric-split.md`
- Thermodynamic quantities → `ad-thermodynamics-from-z.md`
- Critical temperature → `kramers-wannier-duality.md`
- Spontaneous magnetisation → `yang-magnetization-toeplitz.md`
- Critical exponents from CFT → `ising-cft-primary-operators.md`
- Scaling relations → `ising-scaling-relations.md`

### [methods/calabrese-cardy/index.md](docs/src/methods/calabrese-cardy/index.md)

Add "Full derivation" section → `calc/calabrese-cardy-obc-vs-pbc.md` (replica trick, twist-operator dimension $\Delta_n = (c/24)(n - 1/n)$, cylinder + strip conformal maps, factor-of-2 origin).

### [methods/bloch-hamiltonian/index.md](docs/src/methods/bloch-hamiltonian/index.md)

Add "Full derivations" section listing the three lattice-specific calc/ notes (honeycomb, kagome, Lieb).

## Test plan

- [x] Documenter build clean.
- [x] All six calc/ note filenames present in `ising-square.md` now (grep).
- [x] Cross-link pattern consistent with `xxz.md` (the established template).

## What this doesn't do

- Does not add content to the calc/ notes (those all passed Phase 3a–3o).
- Does not expand stub `index.md` pages (`models/classical/index.md` etc.) — noted but secondary.
- Does not add new notes (e.g. `calc/tfim-entanglement-peschel.md` is still pending as a future PR).

## Follow-ups

Queue remaining:
- New note: `calc/tfim-entanglement-peschel.md` (the Peschel implementation from PR #52 deserves its own derivation note linking the Majorana covariance of `jw-tfim-bdg.md` to the binary Bogoliubov-mode entropy formula).
- Source cleanup: fix the `Lattice2D` double-count compatibility issue that blocks removing the `[sources]` block from `Project.toml`.