### PR TITLE
build: drop [sources] pin on Lattice2D / LatticeCore (v0.13.4)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,25 +1,17 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.13.3"
+version = "0.13.4"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 
-[sources.Lattice2D]
-rev = "v0.2.4"
-url = "https://github.com/sotashimozono/Lattice2D.jl.git"
-
-[sources.LatticeCore]
-rev = "v0.8.1"
-url = "https://github.com/sotashimozono/LatticeCore.jl.git"
-
 [compat]
 Aqua = "0.8"
 ForwardDiff = "0.10, 1"
 KrylovKit = "0.8, 0.9, 0.10"
-Lattice2D = "0.2"
+Lattice2D = "0.2.8"
 LatticeCore = "0.8"
 LinearAlgebra = "1.10"
 QuadGK = "2.11.2"

--- a/src/models/classical/IsingSquare/IsingSquare.jl
+++ b/src/models/classical/IsingSquare/IsingSquare.jl
@@ -78,9 +78,16 @@ where
     Eᵥ(σ,σ') = Σⱼ₌₁^Ly σⱼ σ'ⱼ             (vertical bonds between rows)
 
 Note: for Ly = 2, each horizontal bond is counted twice by the PBC sum
-(σ₁σ₂ + σ₂σ₁ = 2σ₁σ₂). This is consistent with the convention used by
-`Lattice2D`'s bond list, which also lists each bond of a 2-site periodic
-row twice.
+(σ₁σ₂ + σ₂σ₁ = 2σ₁σ₂). The same applies along the transfer direction:
+`tr(T^Lx)` double-counts the vertical bonds when Lx = 2, because the
+cyclic product `T[σ,σ'] T[σ',σ]` weights the single pair of rows with
+the vertical Boltzmann factor twice. This doubling is an intrinsic
+property of the PBC transfer-matrix formula at L = 2 and is used
+consistently by the brute-force cross-check in
+`test/util/classical_partition.jl` (its bond list is constructed to
+match this convention by enumerating
+`(i, j) ↔ (i, (j mod Ly) + 1)` and `(i, j) ↔ ((i mod Lx) + 1, j)`
+for every site).
 
 The function is generic in `β` and `J` so that automatic-differentiation
 dual numbers (e.g. `ForwardDiff.Dual`) propagate through the matrix
@@ -136,11 +143,14 @@ each row containing Ly spins and PBC along the Ly direction.
 
 # Bond-counting convention
 
-This function adopts the same bond-counting convention as `Lattice2D`'s
-pre-computed bond list: for small PBC systems where Lx = 2 or Ly = 2, each
-unique physical bond appears twice in the enumeration. Both the transfer-matrix
-result and the brute-force enumeration via `Lattice2D.bonds` are internally
-consistent under this convention.
+The transfer-matrix sum double-counts bonds along any dimension of length
+2 (PBC wraparound of a length-2 ring produces the factor
+`σ_1 σ_2 + σ_2 σ_1 = 2 σ_1 σ_2`). The brute-force enumeration in
+`test/util/classical_partition.jl` is built under the same PBC convention
+so that `Z_transfer-matrix == Z_bruteforce` exactly for every
+`(Lx, Ly, β, J)`. For `Lx ≥ 3` and `Ly ≥ 3` each physical bond is
+enumerated exactly once and the result coincides with the standard
+physical Z of a PBC lattice.
 
 # Special values
 

--- a/test/util/classical_partition.jl
+++ b/test/util/classical_partition.jl
@@ -1,42 +1,65 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # test/util/classical_partition.jl
 #
-# Brute-force exact partition function for classical Ising models.
+# Brute-force exact partition function for classical Ising models on a square
+# lattice with PBC in both directions.
 #
-# Dependencies (expected to be `using`'d by the including test file):
-#   Lattice2D  — provides `bonds(lat)`, `num_sites(lat)`
+# The bond list is constructed here (not taken from `Lattice2D.bonds`) to keep
+# the brute-force enumeration in sync with the transfer-matrix PBC convention:
+# for each site (i, j), the two bonds (i, j)–(i, (j mod Ly)+1) and
+# (i, j)–((i mod Lx)+1, j) are enumerated. When a lattice dimension has length
+# 2, each unique physical bond is enumerated twice, matching the
+# `σ_j σ_{(j mod L)+1}` sum used inside `_ising_sq_transfer_matrix` and the
+# two-edge cyclic trace `tr(T^Lx)`. This internal consistency is what makes
+# `Z_bruteforce == Z_transfer-matrix` hold for small PBC lattices.
 # ─────────────────────────────────────────────────────────────────────────────
 
 """
-    exact_partition(lat, J::Float64, β::Float64) -> Float64
+    square_pbc_bond_pairs(Lx, Ly) -> Vector{Tuple{Int,Int}}
 
-Exactly compute Z = Σ_σ exp(-β E(σ)) by enumerating all 2^N Ising spin
-configurations on `lat`.
+Enumerate site-pair endpoints for the `Lx × Ly` square lattice with PBC in both
+directions, in the transfer-matrix convention used by
+`_ising_sq_transfer_matrix`: each site contributes one horizontal bond
+`(i, j)–(i, (j mod Ly)+1)` and one vertical bond
+`(i, j)–((i mod Lx)+1, j)`. When `Lx == 2` or `Ly == 2`, this enumerates each
+unique physical bond twice — intentional, so that the brute-force sum matches
+`tr(T^Lx)` element-for-element.
 
-The energy is E(σ) = -J Σ_{b ∈ bonds(lat)} σ_{b.i} σ_{b.j}, using the
-pre-computed bond list from `Lattice2D`. This adopts the same bond-counting
-convention as `IsingSquare`'s transfer matrix: for PBC lattices where
-Lx = 2 or Ly = 2, each unique physical bond appears twice in the bond list,
-which doubles the effective coupling relative to an Lx,Ly ≥ 3 lattice.
-
-Both `exact_partition` and `fetch(IsingSquare(), PartitionFunction(); ...)`
-are internally consistent under this convention.
-
-# Arguments
-- `lat`: a finite `AbstractLattice` from `Lattice2D` (e.g., `build_lattice(Square, Lx, Ly)`)
-- `J::Float64`: Ising coupling constant (J > 0 ferromagnetic)
-- `β::Float64`: inverse temperature
-
-# Complexity
-O(2^N) — exact for any finite lattice; practical for N ≤ 20.
+Sites are row-major indexed: `(i, j) ↦ (i - 1) * Ly + j`, `i ∈ 1:Lx`,
+`j ∈ 1:Ly`.
 """
-function exact_partition(lat, J::Float64, β::Float64)
-    N = num_sites(lat)
-    bond_pairs = [(b.i, b.j) for b in bonds(lat)]
+function square_pbc_bond_pairs(Lx::Int, Ly::Int)
+    pairs = Vector{Tuple{Int,Int}}()
+    sizehint!(pairs, 2 * Lx * Ly)
+    idx(i, j) = (i - 1) * Ly + j
+    for i in 1:Lx
+        for j in 1:Ly
+            a = idx(i, j)
+            b_h = idx(i, (j % Ly) + 1)
+            b_v = idx((i % Lx) + 1, j)
+            push!(pairs, (a, b_h))
+            push!(pairs, (a, b_v))
+        end
+    end
+    return pairs
+end
+
+"""
+    exact_partition(Lx, Ly, J, β) -> Float64
+
+Exactly compute `Z = Σ_σ exp(-β E(σ))` by enumerating all `2^(Lx*Ly)` Ising
+configurations. The energy is `E(σ) = -J Σ_{(a,b) ∈ pairs} σ_a σ_b`, using the
+bond list from [`square_pbc_bond_pairs`](@ref).
+
+Complexity: `O(2^(Lx*Ly))` — practical up to `N = Lx*Ly ≤ 20`.
+"""
+function exact_partition(Lx::Int, Ly::Int, J::Float64, β::Float64)
+    N = Lx * Ly
+    pairs = square_pbc_bond_pairs(Lx, Ly)
     Z = 0.0
-    for σ_idx in 0:(2 ^ N - 1)
-        σ = Int[((σ_idx >> j) & 1) == 1 ? 1 : -1 for j in 0:(N - 1)]
-        E = -J * sum(σ[i] * σ[j] for (i, j) in bond_pairs)
+    for σ_idx in 0:(2^N - 1)
+        σ = Int[((σ_idx >> k) & 1) == 1 ? 1 : -1 for k in 0:(N - 1)]
+        E = -J * sum(σ[a] * σ[b] for (a, b) in pairs)
         Z += exp(-β * E)
     end
     return Z

--- a/test/util/classical_partition.jl
+++ b/test/util/classical_partition.jl
@@ -57,7 +57,7 @@ function exact_partition(Lx::Int, Ly::Int, J::Float64, β::Float64)
     N = Lx * Ly
     pairs = square_pbc_bond_pairs(Lx, Ly)
     Z = 0.0
-    for σ_idx in 0:(2^N - 1)
+    for σ_idx in 0:(2 ^ N - 1)
         σ = Int[((σ_idx >> k) & 1) == 1 ? 1 : -1 for k in 0:(N - 1)]
         E = -J * sum(σ[a] * σ[b] for (a, b) in pairs)
         Z += exp(-β * E)

--- a/test/verification/test_ising_2x2_classical.jl
+++ b/test/verification/test_ising_2x2_classical.jl
@@ -2,24 +2,25 @@
 # Verification: classical 2D Ising partition function
 #
 # Cross-validate QAtlas's transfer-matrix result against a brute-force
-# 2^N enumeration built on Lattice2D's pre-computed bond list.
+# 2^N enumeration. The bond list is built locally (see
+# `test/util/classical_partition.jl`) so the test is independent of the
+# bond-listing convention of any particular `Lattice2D` release — both sides
+# use the same PBC sum convention by construction.
 #
 # Test sizes: 2×2, 2×3, 3×3 (up to 9 sites = 512 configurations).
 # β values: sweep from 0 through a value near the infinite-volume Tc
 #            (βc = ln(1 + √2)/2 ≈ 0.4407) and into the ordered phase.
 # ─────────────────────────────────────────────────────────────────────────────
 
-using QAtlas, Lattice2D, Test
+using QAtlas, Test
 
 const J_ISING = 1.0
 
 @testset "IsingSquare — transfer-matrix vs brute-force" begin
     for (Lx, Ly) in [(2, 2), (2, 3), (3, 3)]
-        lat = build_lattice(Square, Lx, Ly)
-
         @testset "$(Lx)×$(Ly) square PBC" begin
             for β in [0.0, 0.1, 0.2, 0.44, 1.0, 2.0]
-                Z_bf = exact_partition(lat, J_ISING, β)
+                Z_bf = exact_partition(Lx, Ly, J_ISING, β)
                 Z_tm = QAtlas.fetch(
                     IsingSquare(), PartitionFunction(); Lx=Lx, Ly=Ly, β=β, J=J_ISING
                 )

--- a/test/verification/test_ising_ad_thermodynamics.jl
+++ b/test/verification/test_ising_ad_thermodynamics.jl
@@ -14,10 +14,11 @@
 #
 # Every equality must hold to machine precision because Z is the same
 # mathematical object on both sides — the AD path exercises QAtlas's
-# transfer-matrix Z, while the direct path uses `Lattice2D.bonds(lat)`.
+# transfer-matrix Z, and the direct path enumerates configurations under
+# the same PBC bond list (see `test/util/classical_partition.jl`).
 # ─────────────────────────────────────────────────────────────────────────────
 
-using QAtlas, Lattice2D, ForwardDiff, Test
+using QAtlas, ForwardDiff, Test
 
 # log Z as a generic function of (β, J) so ForwardDiff.Dual propagates.
 function _log_Z_tm(Lx::Int, Ly::Int, β, J)
@@ -25,22 +26,23 @@ function _log_Z_tm(Lx::Int, Ly::Int, β, J)
 end
 
 """
-    _direct_moments(lat, J, β) -> (⟨E⟩, ⟨E²⟩, ⟨Σσσ⟩)
+    _direct_moments(Lx, Ly, J, β) -> (⟨E⟩, ⟨E²⟩, ⟨Σσσ⟩)
 
 Directly compute the ensemble averages needed for the thermodynamic
-identities by brute-force enumeration. Uses `Lattice2D.bonds(lat)` and
-the same bond-counting convention as `exact_partition`.
+identities by brute-force enumeration. Uses the same PBC bond list as
+[`exact_partition`](@ref) so the comparison against the transfer-matrix
+observables is exact by construction.
 """
-function _direct_moments(lat, J::Float64, β::Float64)
-    N = num_sites(lat)
-    bond_pairs = [(b.i, b.j) for b in bonds(lat)]
+function _direct_moments(Lx::Int, Ly::Int, J::Float64, β::Float64)
+    N = Lx * Ly
+    bond_pairs = square_pbc_bond_pairs(Lx, Ly)
     Z = 0.0
     E1 = 0.0
     E2 = 0.0
     S1 = 0.0  # ⟨Σ σ_i σ_j⟩ (no J factor)
-    for σ_idx in 0:(2 ^ N - 1)
-        σ = Int[((σ_idx >> j) & 1) == 1 ? 1 : -1 for j in 0:(N - 1)]
-        bond_sum = sum(σ[i] * σ[j] for (i, j) in bond_pairs)
+    for σ_idx in 0:(2^N - 1)
+        σ = Int[((σ_idx >> k) & 1) == 1 ? 1 : -1 for k in 0:(N - 1)]
+        bond_sum = sum(σ[a] * σ[b] for (a, b) in bond_pairs)
         E = -J * bond_sum
         w = exp(-β * E)
         Z += w
@@ -55,8 +57,6 @@ const J_ISING = 1.0
 
 @testset "IsingSquare — thermodynamics from log Z (ForwardDiff)" begin
     for (Lx, Ly) in [(2, 2), (2, 3), (3, 3)]
-        lat = build_lattice(Square, Lx, Ly)
-
         @testset "$(Lx)×$(Ly) square PBC" begin
             for β in [0.1, 0.3, 0.5, 1.0]
                 # --- AD from transfer matrix ---
@@ -76,7 +76,9 @@ const J_ISING = 1.0
                     ForwardDiff.derivative(Jv -> _log_Z_tm(Lx, Ly, β, Jv), J_ISING)
 
                 # --- Direct ensemble averages ---
-                E_direct, E2_direct, bond_sum_direct = _direct_moments(lat, J_ISING, β)
+                E_direct, E2_direct, bond_sum_direct = _direct_moments(
+                    Lx, Ly, J_ISING, β
+                )
                 Cv_direct = β^2 * (E2_direct - E_direct^2)
 
                 @test E_ad ≈ E_direct rtol = 1e-10

--- a/test/verification/test_ising_ad_thermodynamics.jl
+++ b/test/verification/test_ising_ad_thermodynamics.jl
@@ -40,7 +40,7 @@ function _direct_moments(Lx::Int, Ly::Int, J::Float64, β::Float64)
     E1 = 0.0
     E2 = 0.0
     S1 = 0.0  # ⟨Σ σ_i σ_j⟩ (no J factor)
-    for σ_idx in 0:(2^N - 1)
+    for σ_idx in 0:(2 ^ N - 1)
         σ = Int[((σ_idx >> k) & 1) == 1 ? 1 : -1 for k in 0:(N - 1)]
         bond_sum = sum(σ[a] * σ[b] for (a, b) in bond_pairs)
         E = -J * bond_sum
@@ -76,9 +76,7 @@ const J_ISING = 1.0
                     ForwardDiff.derivative(Jv -> _log_Z_tm(Lx, Ly, β, Jv), J_ISING)
 
                 # --- Direct ensemble averages ---
-                E_direct, E2_direct, bond_sum_direct = _direct_moments(
-                    Lx, Ly, J_ISING, β
-                )
+                E_direct, E2_direct, bond_sum_direct = _direct_moments(Lx, Ly, J_ISING, β)
                 Cv_direct = β^2 * (E2_direct - E_direct^2)
 
                 @test E_ad ≈ E_direct rtol = 1e-10


### PR DESCRIPTION
## Summary

- Fix the IsingSquare cross-check so it works with registered Lattice2D (v0.2.8), unlocking removal of the `[sources]` block in `Project.toml` (final blocker for registry-only install).
- Bond enumeration for the 2^N brute-force enumeration is now constructed locally in `test/util/classical_partition.jl`, matching the transfer-matrix PBC convention (`σ_j σ_{(j mod L)+1}`) by construction. This double-counts bonds when a dimension has length 2, which is an intrinsic property of `tr(T^Lx)` at `L = 2` — previously it happened to match Lattice2D v0.2.4's (non-physical) double-counting bond list.
- Version bump: 0.13.3 → 0.13.4 (patch).

## Rationale

Lattice2D v0.2.5 switched its `bonds(lat)` enumeration to the physically-correct single-count for `Lx = 2` or `Ly = 2` PBC. The registered 0.2.8 release returns 4 bonds for 2×2 (not 8) and 9 bonds for 2×3 (not 12). QAtlas's transfer matrix, however, computes `tr(T^Lx)` which intrinsically double-counts those cases (via the PBC sum `σ_1 σ_2 + σ_2 σ_1 = 2 σ_1 σ_2` and the cyclic `T[σ, σ'] T[σ', σ]` trace). The fix isolates the test's bond-list construction so the two paths remain internally consistent, independent of Lattice2D's API.

No change to the src/ transfer-matrix logic — the docstring is rewritten to describe the L=2 PBC double-count as intrinsic to `tr(T^Lx)`, not as "matching Lattice2D's convention".

## Test plan

- [x] `Pkg.test()` — 1004 / 1004 pass (local).
- [x] `docs/make.jl` — clean build, no new warnings.
- [x] `Pkg.status()` — no `[sources]` entries resolving; registered Lattice2D v0.2.8 + LatticeCore v0.8.x used.