### PR TITLE
docs: AI-draft banner + per-section Report links + Edit-on-GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # QAtlas.jl
 
+> ⚠️ **AI-assisted draft — feedback welcome.**
+> Both the source code and every derivation note in the documentation are
+> generated with heavy LLM assistance (Claude) and are still being
+> independently reviewed. If you spot an error — in a formula, a proof
+> step, a citation, a type signature, anything — please
+> [**open an issue**](https://github.com/sotashimozono/QAtlas.jl/issues/new?labels=docs&title=%5Bdocs%5D%20error%20report)
+> or submit a pull request. Corrections and reviews are genuinely
+> appreciated; this package is in better shape the more eyes it gets.
+
 [![docs: stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://codes.sota-shimozono.com/QAtlas.jl/stable/)
 [![docs: dev](https://img.shields.io/badge/docs-dev-purple.svg)](https://codes.sota-shimozono.com/QAtlas.jl/dev/)
 [![Julia](https://img.shields.io/badge/julia-v1.12+-9558b2.svg)](https://julialang.org)
@@ -11,9 +20,9 @@
 
 **QAtlas** (QUAntum Reference Table for Exact Tests) is a Julia package providing a curated dictionary of **rigorous results** in quantum and statistical physics. Every stored value is traced to a specific publication and cross-validated against independent calculations.
 
-> **Status and Disclaimer**
+> **Status and verification policy**
 >
-> This package is under active development with AI-assisted code generation. While all stored values cite specific publications and are cross-checked against independent numerical computations (exact diagonalization, brute-force enumeration, automatic differentiation), **the maintainer has not personally verified every derivation in equal depth**.
+> While every stored value cites a specific publication and is cross-checked against independent numerical computations (exact diagonalization, brute-force enumeration, automatic differentiation), **the maintainer has not personally verified every derivation in equal depth**.
 >
 > Results that the maintainer can independently derive and has verified line-by-line (TFIM exact solution, Onsager critical temperature, Yang magnetization, Heisenberg dimer) carry the highest confidence. Other results (tight-binding Bloch formulas for various lattices, numerical universality exponents transcribed from the literature, E8 mass ratios) are tested against independent computations but the underlying derivations have not been checked by hand.
 >

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -26,11 +26,7 @@ makedocs(;
                 ),
             ),
         ),
-        assets=[
-            "assets/favicon.ico",
-            "assets/custom.css",
-            "assets/report-issue.js",
-        ],
+        assets=["assets/favicon.ico", "assets/custom.css", "assets/report-issue.js"],
     ),
     modules=[QAtlas],
     pages=[

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,9 +12,11 @@ Downloads.download("https://github.com/sotashimozono.png", logo_path)
 
 makedocs(;
     sitename="QAtlas.jl",
+    repo=Remotes.GitHub("sotashimozono", "QAtlas.jl"),
     format=Documenter.HTML(;
         canonical="https://codes.sota-shimozono.com/QAtlas.jl/stable/",
         prettyurls=get(ENV, "CI", "false") == "true",
+        edit_link="main",
         mathengine=MathJax3(
             Dict(
                 :tex => Dict(
@@ -24,7 +26,11 @@ makedocs(;
                 ),
             ),
         ),
-        assets=["assets/favicon.ico", "assets/custom.css"],
+        assets=[
+            "assets/favicon.ico",
+            "assets/custom.css",
+            "assets/report-issue.js",
+        ],
     ),
     modules=[QAtlas],
     pages=[

--- a/docs/src/assets/custom.css
+++ b/docs/src/assets/custom.css
@@ -5,3 +5,69 @@
     border: 1px solid rgba(255, 255, 255, 0.1);
     margin-bottom: 12px;
 }
+
+/* ──────────────────────────────────────────────────────────────────────── */
+/* AI-draft banner (injected at the top of every page by                   */
+/* assets/report-issue.js)                                                  */
+/* ──────────────────────────────────────────────────────────────────────── */
+.ai-draft-banner {
+    background: #fff8e1;
+    border-left: 4px solid #ffb300;
+    padding: 0.75em 1em;
+    margin: 0 0 1.5em 0;
+    border-radius: 4px;
+    font-size: 0.92em;
+    line-height: 1.5;
+}
+.ai-draft-banner strong {
+    color: #b26500;
+}
+.ai-draft-banner a {
+    font-weight: 600;
+}
+
+/* Dark-theme palette for the banner */
+html.theme--documenter-dark .ai-draft-banner {
+    background: #3a2e14;
+    border-left-color: #ffb300;
+    color: #f5d58a;
+}
+html.theme--documenter-dark .ai-draft-banner strong {
+    color: #ffd86b;
+}
+
+/* ──────────────────────────────────────────────────────────────────────── */
+/* Per-section "report" link appended next to h2 / h3 headings             */
+/* ──────────────────────────────────────────────────────────────────────── */
+.report-section-link {
+    font-size: 0.55em;
+    font-weight: 400;
+    margin-left: 0.6em;
+    padding: 0.1em 0.45em;
+    border-radius: 3px;
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    color: #888;
+    text-decoration: none;
+    vertical-align: middle;
+    opacity: 0;
+    transition: opacity 0.15s ease-in-out;
+}
+h2:hover > .report-section-link,
+h3:hover > .report-section-link,
+.report-section-link:hover,
+.report-section-link:focus {
+    opacity: 1;
+    color: #b26500;
+    border-color: #ffb300;
+    background: #fff8e1;
+}
+html.theme--documenter-dark .report-section-link {
+    border-color: rgba(255, 255, 255, 0.2);
+    color: #aaa;
+}
+html.theme--documenter-dark .report-section-link:hover,
+html.theme--documenter-dark .report-section-link:focus {
+    color: #ffd86b;
+    border-color: #ffb300;
+    background: #3a2e14;
+}

--- a/docs/src/assets/report-issue.js
+++ b/docs/src/assets/report-issue.js
@@ -1,0 +1,85 @@
+// QAtlas.jl documentation enhancements
+//
+// Two additions on every rendered page:
+//
+//   1. A banner at the top stating that the documentation is an
+//      AI-assisted draft and that error reports / PRs are welcome,
+//      with a direct link to open a new issue prefilled with the
+//      page URL.
+//
+//   2. A small "report" link appended to every h2 / h3 heading that
+//      opens a GitHub issue prefilled with the section title and
+//      page URL, so readers who spot something wrong in a single
+//      section can report it with one click.
+//
+// Both hooks target the GitHub repository `sotashimozono/QAtlas.jl`.
+
+(function () {
+    const REPO = "sotashimozono/QAtlas.jl";
+
+    function issueUrl(title, body) {
+        const params = new URLSearchParams({
+            title: title,
+            body: body,
+            labels: "docs",
+        });
+        return "https://github.com/" + REPO + "/issues/new?" + params.toString();
+    }
+
+    function init() {
+        const article = document.querySelector("article.docs-content") ||
+                        document.querySelector("article");
+        if (!article) return;
+
+        const pageUrl = window.location.href;
+
+        // ── 1. Top-of-page banner ────────────────────────────────────────
+        const banner = document.createElement("div");
+        banner.className = "ai-draft-banner";
+        banner.innerHTML =
+            '<strong>AI-assisted draft.</strong> ' +
+            'This documentation is largely generated with LLM assistance ' +
+            '(Claude) and every derivation is still being independently ' +
+            'reviewed. If you spot an error, please ' +
+            '<a href="' + issueUrl(
+                "[docs] error report",
+                "Page: " + pageUrl + "\n\nIssue:\n"
+            ) + '" target="_blank" rel="noopener">open an issue</a> ' +
+            'or submit a pull request via the ' +
+            '<em>Edit on GitHub</em> link at the bottom of the page. ' +
+            'Feedback and corrections are very welcome.';
+        article.insertBefore(banner, article.firstChild);
+
+        // ── 2. Per-section report links ──────────────────────────────────
+        article.querySelectorAll("h2, h3").forEach(function (h) {
+            // Skip the banner itself and Documenter-generated headings
+            // that shouldn't have a report link.
+            if (h.closest(".ai-draft-banner")) return;
+
+            // Heading text may contain math, anchors, etc.  Use the
+            // textContent as the issue title, but keep it short.
+            const sectionTitle = h.textContent.trim().replace(/\s+/g, " ");
+            if (!sectionTitle) return;
+
+            const link = document.createElement("a");
+            link.href = issueUrl(
+                "[docs] " + sectionTitle,
+                "Section: **" + sectionTitle + "**\n" +
+                "Page: " + pageUrl + "\n\nIssue:\n"
+            );
+            link.target = "_blank";
+            link.rel = "noopener";
+            link.className = "report-section-link";
+            link.title = "Report an issue with this section";
+            link.setAttribute("aria-label", "Report an issue with this section");
+            link.textContent = "report";
+            h.appendChild(link);
+        });
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", init);
+    } else {
+        init();
+    }
+})();


### PR DESCRIPTION
## Summary

Add three low-friction feedback channels to the documentation so any reader can flag an error they spot:

1. **Edit source on GitHub** — standard Documenter header button, now enabled via `makedocs(repo=Remotes.GitHub(...))` + `HTML(edit_link="main")`. Points each rendered page at its source file under `docs/src/` on `main`.
2. **Per-section "Report" link** — new asset `docs/src/assets/report-issue.js` scans every `h2` / `h3` heading and appends a small button. Clicking opens a new GitHub issue prefilled with the section title, the page URL, and the `docs` label. Fades in on heading hover so it stays out of the way while reading.
3. **Top-of-article AI-draft banner** — same JS injects a warm-amber callout at the top of every article stating that the docs are an AI-assisted draft and inviting error reports / PRs, with direct "open an issue" and "Edit on GitHub" links.

CSS styling in `docs/src/assets/custom.css` covers both the light and the dark Documenter themes. `README.md` is updated with a corresponding prominent callout immediately under the title.

## Test plan

- [x] `julia --project=docs docs/make.jl` — clean build, no new warnings.
- [x] Built HTML contains `<script src="../assets/report-issue.js"></script>` on every page and the Documenter-provided `title="Edit source on GitHub"` anchor.
- [ ] After deploy, spot-check on the live site: top banner renders, per-heading `report` links fade in on hover, prefilled issue URLs point at the correct repo.