### PR TITLE
test: XXZ(Δ=1) ↔ Heisenberg cross-check + port legacy Symbol API

### DIFF
--- a/test/models/test_XXZ1D.jl
+++ b/test/models/test_XXZ1D.jl
@@ -104,17 +104,15 @@ end
     for J in (1.0, 2.5, -0.7)
         e_heis = QAtlas.fetch(Heisenberg1D(), GroundStateEnergyDensity(); J=J)
         e_xxz_energy = QAtlas.fetch(XXZ1D(; J=J, Δ=1.0), Energy(), Infinite())
-        e_xxz_gs = QAtlas.fetch(
-            XXZ1D(; J=J, Δ=1.0), GroundStateEnergyDensity(), Infinite()
-        )
+        e_xxz_gs = QAtlas.fetch(XXZ1D(; J=J, Δ=1.0), GroundStateEnergyDensity(), Infinite())
         @test e_xxz_energy ≈ e_heis atol = 1e-12
         @test e_xxz_gs ≈ e_heis atol = 1e-12
     end
 
     # Sanity: Heisenberg1D value is exactly J·(1/4 − ln 2), so the XXZ
     # Δ=1 path also reproduces the literature closed form.
-    @test QAtlas.fetch(XXZ1D(; J=1.0, Δ=1.0), Energy(), Infinite()) ≈
-        0.25 - log(2.0) atol = 1e-12
+    @test QAtlas.fetch(XXZ1D(; J=1.0, Δ=1.0), Energy(), Infinite()) ≈ 0.25 - log(2.0) atol =
+        1e-12
 end
 
 @testset "XXZ1D — gapped regime is NaN (general-Δ deferred)" begin

--- a/test/models/test_XXZ1D.jl
+++ b/test/models/test_XXZ1D.jl
@@ -90,6 +90,33 @@ end
     )
 end
 
+@testset "XXZ1D (Δ=1) ↔ Heisenberg1D — dictionary cross-consistency" begin
+    # The AF Heisenberg chain is the Δ = 1 point of the XXZ chain. QAtlas
+    # exposes the ground-state energy density at this point through two
+    # independent code paths — the dedicated `Heisenberg1D` model (Hulthén
+    # closed form) and the generic `XXZ1D` model (Bethe-ansatz branch at
+    # Δ = 1). The two must return identical values for every J.
+    #
+    # This catches any future divergence between the two dispatch paths
+    # (e.g. a formula typo, a sign convention drift, an accidental J²
+    # factor). Without this test the two are independent dictionary
+    # entries that happen to compute the same physics.
+    for J in (1.0, 2.5, -0.7)
+        e_heis = QAtlas.fetch(Heisenberg1D(), GroundStateEnergyDensity(); J=J)
+        e_xxz_energy = QAtlas.fetch(XXZ1D(; J=J, Δ=1.0), Energy(), Infinite())
+        e_xxz_gs = QAtlas.fetch(
+            XXZ1D(; J=J, Δ=1.0), GroundStateEnergyDensity(), Infinite()
+        )
+        @test e_xxz_energy ≈ e_heis atol = 1e-12
+        @test e_xxz_gs ≈ e_heis atol = 1e-12
+    end
+
+    # Sanity: Heisenberg1D value is exactly J·(1/4 − ln 2), so the XXZ
+    # Δ=1 path also reproduces the literature closed form.
+    @test QAtlas.fetch(XXZ1D(; J=1.0, Δ=1.0), Energy(), Infinite()) ≈
+        0.25 - log(2.0) atol = 1e-12
+end
+
 @testset "XXZ1D — gapped regime is NaN (general-Δ deferred)" begin
     # |Δ| > 1: gapped; NaN + warning.  This is the same branch as the
     # generic-Δ path above (single deferred-implementation warning);

--- a/test/verification/test_universality_cross_check.jl
+++ b/test/verification/test_universality_cross_check.jl
@@ -123,7 +123,7 @@ end
 
     # Cross-check with the BdG analytical E₀ at each N
     for (i, N) in enumerate(Ns)
-        E0_analytical = QAtlas.fetch(:TFIM, :energy, OBC(); N=N, J=J, h=h)
+        E0_analytical = QAtlas.fetch(TFIM(; J=J, h=h), Energy(), OBC(; N=N))
         @test e0_per_site[i] * N ≈ E0_analytical rtol = 1e-10
     end
 end
@@ -337,7 +337,7 @@ end
     e_inf = -4J / π  # ≈ -1.2732
 
     Ns = [50, 100, 200, 400]
-    E0s = [QAtlas.fetch(:TFIM, :energy, OBC(); N=N, J=J, h=h) for N in Ns]
+    E0s = [QAtlas.fetch(TFIM(; J=J, h=h), Energy(), OBC(; N=N)) for N in Ns]
     e0_per_site = [E0s[i] / Ns[i] for i in eachindex(Ns)]
 
     # (a) Convergence: error decreases with N


### PR DESCRIPTION
## Summary

Addresses two of the four concerns from the recent documentation / test-coverage review:

1. **XXZ1D(Δ=1) ↔ Heisenberg1D cross-consistency** — The two dictionary entries compute the same physics (AF Heisenberg chain ground-state energy density) through independent code paths (Hulthén closed form vs the XXZ Bethe-ansatz Δ=1 branch), but nothing in the test suite asserted that the two return identical values. New \`@testset\` in \`test/models/test_XXZ1D.jl\` compares \`XXZ1D(; J, Δ=1).Energy/GroundStateEnergyDensity\` against \`Heisenberg1D().GroundStateEnergyDensity\` for J ∈ {1.0, 2.5, -0.7}, plus a sanity assertion against the literature closed form \`1/4 − ln 2\`.

2. **Legacy Symbol-dispatch API removed from the verification suite** — \`test/verification/test_universality_cross_check.jl\` had two call sites still using \`fetch(:TFIM, :energy, OBC(); N, J, h)\` (lines 126, 340). The Symbol shim lives under \`src/deprecate/\` and is scheduled for removal in v1.0; leaving these in the verification suite would break the suite on the day \`src/deprecate/\` is deleted. Both now use the concrete-struct form \`fetch(TFIM(; J, h), Energy(), OBC(; N))\`, which is the path the shim forwards to anyway — no behaviour change.

## Test plan

- [x] \`Pkg.test()\` — full suite passes (1004+3 assertions, ~2 min).
- [x] \`grep 'fetch(:TFIM' test/verification/\` returns no matches.
- [x] \`grep 'fetch(:' test/verification/\` — only non-deprecated \`@test_logs\` usages remain, none in production verification code paths.

## Follow-ups (not in this PR)

- \`(2)\` BdG E₀(N)/N convergence test currently loops inside the BdG pipeline; needs an independent sparse-ED cross-check.
- \`(3)\` Central-charge extraction uses \`rtol = 0.10\` / \`0.20\`; finite-size extrapolation would tighten the assertion meaningfully.
- \`(4)\` XXZ Luttinger parameter K and velocity u have no independent numerical verification yet.