### PR TITLE
test: silence legacy-Symbol-dispatch deprecation noise in CI

### DIFF
--- a/test/core/test_type.jl
+++ b/test/core/test_type.jl
@@ -37,26 +37,42 @@ using Test
     end
 
     @testset "Dispatch Logic (Core API)" begin
-        # fetch(:Dummy, :Answer) -> fetch(Model(:Dummy), Quantity(:Answer), Infinite())
-        @test QAtlas.fetch(:Dummy, :Answer) == 42
-        @test QAtlas.fetch(:Dummy, :Answer, QAtlas.Infinite()) == 42
+        # fetch(:Dummy, :Answer) -> fetch(Model(:Dummy), Quantity(:Answer), Infinite()).
+        # Every legacy-Symbol call hits the shim which emits one `@info` per
+        # (model, quantity) pair; `@test_logs` captures those to keep CI quiet.
+        @test (@test_logs (:info, r"symbol-dispatch") QAtlas.fetch(:Dummy, :Answer)) == 42
+        @test (@test_logs (:info, r"symbol-dispatch") QAtlas.fetch(
+            :Dummy, :Answer, QAtlas.Infinite()
+        )) == 42
 
         # dispatch of bounary conditions
-        @test QAtlas.fetch(:Dummy, :Answer, QAtlas.OBC()) == "Open Boundary"
+        @test (@test_logs (:info, r"symbol-dispatch") QAtlas.fetch(
+            :Dummy, :Answer, QAtlas.OBC()
+        )) == "Open Boundary"
     end
 
     @testset "Keyword Argument Passing" begin
-        # fetch(:Dummy, :ParamCheck; val=10) 
+        # fetch(:Dummy, :ParamCheck; val=10)
         # -> Model(:Dummy, val=10) が作られ、params[:val] が参照されるか
-        @test QAtlas.fetch(:Dummy, :ParamCheck; val=10) == 20
-        @test QAtlas.fetch(:Dummy, :ParamCheck; val=100) == 200
+        @test (@test_logs (:info, r"symbol-dispatch") QAtlas.fetch(
+            :Dummy, :ParamCheck; val=10
+        )) == 20
+        @test (@test_logs (:info, r"symbol-dispatch") QAtlas.fetch(
+            :Dummy, :ParamCheck; val=100
+        )) == 200
     end
 
     @testset "Error Handling (Strictness)" begin
+        # The shim emits its `@info` before the inner `fetch` throws, so
+        # `@test_logs` must wrap the `@test_throws` to absorb that log.
         # if no method matches, it should throw a MethodError, not a generic error
-        @test_throws ErrorException QAtlas.fetch(:Dummy, :NotExist)
+        @test_logs (:info, r"symbol-dispatch") @test_throws ErrorException QAtlas.fetch(
+            :Dummy, :NotExist
+        )
         # if model or quantity is unknown, it should also throw a MethodError
-        @test_throws ErrorException QAtlas.fetch(:UnknownModel, :Answer)
+        @test_logs (:info, r"symbol-dispatch") @test_throws ErrorException QAtlas.fetch(
+            :UnknownModel, :Answer
+        )
     end
     #=
     @testset "Type Stability" begin

--- a/test/models/test_TFIM_dynamics.jl
+++ b/test/models/test_TFIM_dynamics.jl
@@ -20,7 +20,12 @@ function mean_far(N::Int, J::Float64, h::Float64, i0::Int)
     for r in rs
         s += real(
             QAtlas.fetch(
-                :TFIM, :sz_sz_correlation, OBC(); N=N, J=J, h=h, i=i0, j=i0 + r, t=0.0
+                TFIM(; J=J, h=h),
+                ZZCorrelation{:dynamic}(),
+                OBC(; N=N);
+                i=i0,
+                j=i0 + r,
+                t=0.0,
             ),
         )
     end
@@ -39,14 +44,19 @@ end
         gs = V[:, 1]
 
         # Sanity: GS energy matches QAtlas BdG.
-        @test E[1] ≈ QAtlas.fetch(:TFIM, :energy, OBC(); N=N, J=J, h=h) atol=1e-10
+        @test E[1] ≈ QAtlas.fetch(TFIM(; J=J, h=h), Energy(), OBC(; N=N)) atol=1e-10
 
         # σz σz at t = 0
         for i in 1:N, j in i:N
             ED = real(gs' * _op_site(_SZ, i, N) * _op_site(_SZ, j, N) * gs)
             QAT = real(
                 QAtlas.fetch(
-                    :TFIM, :sz_sz_correlation, OBC(); N=N, J=J, h=h, i=i, j=j, t=0.0
+                    TFIM(; J=J, h=h),
+                    ZZCorrelation{:dynamic}(),
+                    OBC(; N=N);
+                    i=i,
+                    j=j,
+                    t=0.0,
                 ),
             )
             @test QAT ≈ ED atol=1e-10
@@ -57,7 +67,12 @@ end
             ED = real(gs' * _op_site(_SX, i, N) * _op_site(_SX, j, N) * gs)
             QAT = real(
                 QAtlas.fetch(
-                    :TFIM, :sx_sx_correlation, OBC(); N=N, J=J, h=h, i=i, j=j, t=0.0
+                    TFIM(; J=J, h=h),
+                    XXCorrelation{:dynamic}(),
+                    OBC(; N=N);
+                    i=i,
+                    j=j,
+                    t=0.0,
                 ),
             )
             @test QAT ≈ ED atol=1e-10
@@ -71,7 +86,12 @@ end
                 exp(im * E[1] * t) *
                 (gs' * _op_site(_SZ, i, N) * Ut * _op_site(_SZ, j, N) * gs)
             QAT = QAtlas.fetch(
-                :TFIM, :sz_sz_correlation, OBC(); N=N, J=J, h=h, i=i, j=j, t=t
+                TFIM(; J=J, h=h),
+                ZZCorrelation{:dynamic}(),
+                OBC(; N=N);
+                i=i,
+                j=j,
+                t=t,
             )
             @test real(QAT) ≈ real(ED) atol=1e-10
             @test imag(QAT) ≈ imag(ED) atol=1e-10
@@ -135,12 +155,22 @@ end
             i0 = N ÷ 4
             v1 = real(
                 QAtlas.fetch(
-                    :TFIM, :sz_sz_correlation, OBC(); N=N, J=J, h=h, i=i0, j=i0 + 10, t=0.0
+                    TFIM(; J=J, h=h),
+                    ZZCorrelation{:dynamic}(),
+                    OBC(; N=N);
+                    i=i0,
+                    j=i0 + 10,
+                    t=0.0,
                 ),
             )
             v2 = real(
                 QAtlas.fetch(
-                    :TFIM, :sz_sz_correlation, OBC(); N=N, J=J, h=h, i=i0, j=i0 + 20, t=0.0
+                    TFIM(; J=J, h=h),
+                    ZZCorrelation{:dynamic}(),
+                    OBC(; N=N);
+                    i=i0,
+                    j=i0 + 20,
+                    t=0.0,
                 ),
             )
             slope = log2(v2 / v1)         # since 20/10 = 2
@@ -172,12 +202,9 @@ end
             for (r1, r2) in pairs
                 v1 = real(
                     QAtlas.fetch(
-                        :TFIM,
-                        :sz_sz_correlation,
-                        OBC();
-                        N=N,
-                        J=J,
-                        h=h,
+                        TFIM(; J=J, h=h),
+                        ZZCorrelation{:dynamic}(),
+                        OBC(; N=N);
                         i=i0,
                         j=i0 + r1,
                         t=0.0,
@@ -185,12 +212,9 @@ end
                 )
                 v2 = real(
                     QAtlas.fetch(
-                        :TFIM,
-                        :sz_sz_correlation,
-                        OBC();
-                        N=N,
-                        J=J,
-                        h=h,
+                        TFIM(; J=J, h=h),
+                        ZZCorrelation{:dynamic}(),
+                        OBC(; N=N);
                         i=i0,
                         j=i0 + r2,
                         t=0.0,
@@ -216,7 +240,12 @@ end
         envelope = Float64[
             abs(
                 QAtlas.fetch(
-                    :TFIM, :sz_sz_correlation, OBC(); N=N, J=J, h=h, i=i0, j=i0, t=t
+                    TFIM(; J=J, h=h),
+                    ZZCorrelation{:dynamic}(),
+                    OBC(; N=N);
+                    i=i0,
+                    j=i0,
+                    t=t,
                 ),
             ) for t in ts
         ]
@@ -229,7 +258,12 @@ end
         N, J, h = 12, 1.0, 0.7
         for i in (1, 4, 8, 12)
             v = QAtlas.fetch(
-                :TFIM, :sz_sz_correlation, OBC(); N=N, J=J, h=h, i=i, j=i, t=0.0
+                TFIM(; J=J, h=h),
+                ZZCorrelation{:dynamic}(),
+                OBC(; N=N);
+                i=i,
+                j=i,
+                t=0.0,
             )
             @test real(v) ≈ 1.0 atol=1e-10
             @test abs(imag(v)) < 1e-10
@@ -242,14 +276,23 @@ end
         center = 5
         times = [0.0, 0.5, 1.0]
         C = QAtlas.fetch(
-            :TFIM, :sz_sz_spreading, OBC(); N=N, J=J, h=h, center=center, times=times
+            TFIM(; J=J, h=h),
+            ZZCorrelation{:lightcone}(),
+            OBC(; N=N);
+            center=center,
+            times=times,
         )
         @test size(C) == (3, N)
 
         # Each entry should match an individual call.
         for (it, t) in enumerate(times), ix in 1:N
             ref = QAtlas.fetch(
-                :TFIM, :sz_sz_correlation, OBC(); N=N, J=J, h=h, i=ix, j=center, t=t
+                TFIM(; J=J, h=h),
+                ZZCorrelation{:dynamic}(),
+                OBC(; N=N);
+                i=ix,
+                j=center,
+                t=t,
             )
             @test C[it, ix] ≈ ref atol=1e-10
         end

--- a/test/models/test_TFIM_dynamics.jl
+++ b/test/models/test_TFIM_dynamics.jl
@@ -51,12 +51,7 @@ end
             ED = real(gs' * _op_site(_SZ, i, N) * _op_site(_SZ, j, N) * gs)
             QAT = real(
                 QAtlas.fetch(
-                    TFIM(; J=J, h=h),
-                    ZZCorrelation{:dynamic}(),
-                    OBC(; N=N);
-                    i=i,
-                    j=j,
-                    t=0.0,
+                    TFIM(; J=J, h=h), ZZCorrelation{:dynamic}(), OBC(; N=N); i=i, j=j, t=0.0
                 ),
             )
             @test QAT ≈ ED atol=1e-10
@@ -67,12 +62,7 @@ end
             ED = real(gs' * _op_site(_SX, i, N) * _op_site(_SX, j, N) * gs)
             QAT = real(
                 QAtlas.fetch(
-                    TFIM(; J=J, h=h),
-                    XXCorrelation{:dynamic}(),
-                    OBC(; N=N);
-                    i=i,
-                    j=j,
-                    t=0.0,
+                    TFIM(; J=J, h=h), XXCorrelation{:dynamic}(), OBC(; N=N); i=i, j=j, t=0.0
                 ),
             )
             @test QAT ≈ ED atol=1e-10
@@ -86,12 +76,7 @@ end
                 exp(im * E[1] * t) *
                 (gs' * _op_site(_SZ, i, N) * Ut * _op_site(_SZ, j, N) * gs)
             QAT = QAtlas.fetch(
-                TFIM(; J=J, h=h),
-                ZZCorrelation{:dynamic}(),
-                OBC(; N=N);
-                i=i,
-                j=j,
-                t=t,
+                TFIM(; J=J, h=h), ZZCorrelation{:dynamic}(), OBC(; N=N); i=i, j=j, t=t
             )
             @test real(QAT) ≈ real(ED) atol=1e-10
             @test imag(QAT) ≈ imag(ED) atol=1e-10
@@ -240,12 +225,7 @@ end
         envelope = Float64[
             abs(
                 QAtlas.fetch(
-                    TFIM(; J=J, h=h),
-                    ZZCorrelation{:dynamic}(),
-                    OBC(; N=N);
-                    i=i0,
-                    j=i0,
-                    t=t,
+                    TFIM(; J=J, h=h), ZZCorrelation{:dynamic}(), OBC(; N=N); i=i0, j=i0, t=t
                 ),
             ) for t in ts
         ]
@@ -258,12 +238,7 @@ end
         N, J, h = 12, 1.0, 0.7
         for i in (1, 4, 8, 12)
             v = QAtlas.fetch(
-                TFIM(; J=J, h=h),
-                ZZCorrelation{:dynamic}(),
-                OBC(; N=N);
-                i=i,
-                j=i,
-                t=0.0,
+                TFIM(; J=J, h=h), ZZCorrelation{:dynamic}(), OBC(; N=N); i=i, j=i, t=0.0
             )
             @test real(v) ≈ 1.0 atol=1e-10
             @test abs(imag(v)) < 1e-10
@@ -287,12 +262,7 @@ end
         # Each entry should match an individual call.
         for (it, t) in enumerate(times), ix in 1:N
             ref = QAtlas.fetch(
-                TFIM(; J=J, h=h),
-                ZZCorrelation{:dynamic}(),
-                OBC(; N=N);
-                i=ix,
-                j=center,
-                t=t,
+                TFIM(; J=J, h=h), ZZCorrelation{:dynamic}(), OBC(; N=N); i=ix, j=center, t=t
             )
             @test C[it, ix] ≈ ref atol=1e-10
         end

--- a/test/models/test_TFIM_entanglement.jl
+++ b/test/models/test_TFIM_entanglement.jl
@@ -81,13 +81,19 @@ end
 @testset "TFIM VonNeumannEntropy — legacy Symbol dispatch" begin
     N = 10
     S_new = QAtlas.fetch(TFIM(; J=1.0, h=1.0), VonNeumannEntropy(), OBC(N); ℓ=N ÷ 2)
-    S_legacy = QAtlas.fetch(:TFIM, :entanglement_entropy, OBC(); N=N, J=1.0, h=1.0, ℓ=N ÷ 2)
+    S_legacy = @test_logs (:info, r"symbol-dispatch") QAtlas.fetch(
+        :TFIM, :entanglement_entropy, OBC(); N=N, J=1.0, h=1.0, ℓ=N ÷ 2
+    )
     @test S_legacy ≈ S_new atol = 1e-12
 
     # Symbol aliases :ee, :EE, :S_vN, :EntanglementEntropy all canonicalise
-    # to :entanglement_entropy.
+    # to :entanglement_entropy. Each raw-Symbol value keys its own one-shot
+    # `@info`, so wrap every call with `@test_logs` to keep CI quiet.
     for q in (:ee, :EE, :S_vN, :EntanglementEntropy)
-        @test QAtlas.fetch(:TFIM, q, OBC(); N=N, J=1.0, h=1.0, ℓ=N ÷ 2) ≈ S_new atol = 1e-12
+        S_alias = @test_logs (:info, r"symbol-dispatch") QAtlas.fetch(
+            :TFIM, q, OBC(); N=N, J=1.0, h=1.0, ℓ=N ÷ 2
+        )
+        @test S_alias ≈ S_new atol = 1e-12
     end
 end
 

--- a/test/models/test_TFIM_local.jl
+++ b/test/models/test_TFIM_local.jl
@@ -27,26 +27,26 @@
             (8, 1.0, 0.5, 2.0),    # ordered phase, β below edge-mode scale
         ]
             mx_loc = QAtlas.fetch(
-                :TFIM, :magnetization_x_local, OBC(); N=N, J=J, h=h, beta=β
+                TFIM(; J=J, h=h), MagnetizationXLocal(), OBC(; N=N); beta=β
             )
             @test mx_loc isa Vector{Float64}
             @test length(mx_loc) == N
 
             mx_avg_scalar = QAtlas.fetch(
-                :TFIM, :transverse_magnetization, OBC(); N=N, J=J, h=h, beta=β
+                TFIM(; J=J, h=h), MagnetizationX(), OBC(; N=N); beta=β
             )
             @test sum(mx_loc) / N ≈ mx_avg_scalar atol=1e-12
 
             mz_loc = QAtlas.fetch(
-                :TFIM, :magnetization_z_local, OBC(); N=N, J=J, h=h, beta=β
+                TFIM(; J=J, h=h), MagnetizationZLocal(), OBC(; N=N); beta=β
             )
             @test mz_loc == zeros(Float64, N)
 
-            ε_loc = QAtlas.fetch(:TFIM, :energy_local, OBC(); N=N, J=J, h=h, beta=β)
+            ε_loc = QAtlas.fetch(TFIM(; J=J, h=h), EnergyLocal(), OBC(; N=N); beta=β)
             @test ε_loc isa Vector{Float64}
             @test length(ε_loc) == N
 
-            E_total = QAtlas.fetch(:TFIM, :energy, OBC(); N=N, J=J, h=h, beta=β)
+            E_total = QAtlas.fetch(TFIM(; J=J, h=h), Energy(), OBC(; N=N); beta=β)
             @test sum(ε_loc) ≈ E_total atol=1e-10
         end
     end
@@ -57,9 +57,9 @@
     # ───────────────────────────────────────────────────────────────────────
     @testset "bond extraction vs Pfaffian correlator" begin
         N, J, h, β = 8, 1.0, 1.2, 1.0
-        ε_loc = QAtlas.fetch(:TFIM, :energy_local, OBC(); N=N, J=J, h=h, beta=β)
-        mx_loc = QAtlas.fetch(:TFIM, :magnetization_x_local, OBC(); N=N, J=J, h=h, beta=β)
-        C = QAtlas.fetch(:TFIM, :zz_static_thermal, OBC(); N=N, J=J, h=h, beta=β)
+        ε_loc = QAtlas.fetch(TFIM(; J=J, h=h), EnergyLocal(), OBC(; N=N); beta=β)
+        mx_loc = QAtlas.fetch(TFIM(; J=J, h=h), MagnetizationXLocal(), OBC(; N=N); beta=β)
+        C = QAtlas.fetch(TFIM(; J=J, h=h), ZZCorrelation{:static}(), OBC(; N=N); beta=β)
 
         # ε_i reconstructed from the Pfaffian nearest-neighbour correlator.
         ε_ref = Vector{Float64}(undef, N)
@@ -76,8 +76,8 @@
     # ───────────────────────────────────────────────────────────────────────
     @testset "per-site ED comparison (N = 4)" begin
         N, J, h, β = 4, 1.0, 0.8, 1.3
-        mx_loc = QAtlas.fetch(:TFIM, :magnetization_x_local, OBC(); N=N, J=J, h=h, beta=β)
-        ε_loc = QAtlas.fetch(:TFIM, :energy_local, OBC(); N=N, J=J, h=h, beta=β)
+        mx_loc = QAtlas.fetch(TFIM(; J=J, h=h), MagnetizationXLocal(), OBC(; N=N); beta=β)
+        ε_loc = QAtlas.fetch(TFIM(; J=J, h=h), EnergyLocal(), OBC(; N=N); beta=β)
 
         H = _build_tfim_dense(N, J, h)
         E, V = eigen(Matrix(H))
@@ -111,8 +111,8 @@
     # ───────────────────────────────────────────────────────────────────────
     @testset "β → 0 limit" begin
         N, J, h, β = 10, 1.0, 1.0, 1e-8
-        mx_loc = QAtlas.fetch(:TFIM, :magnetization_x_local, OBC(); N=N, J=J, h=h, beta=β)
-        ε_loc = QAtlas.fetch(:TFIM, :energy_local, OBC(); N=N, J=J, h=h, beta=β)
+        mx_loc = QAtlas.fetch(TFIM(; J=J, h=h), MagnetizationXLocal(), OBC(; N=N); beta=β)
+        ε_loc = QAtlas.fetch(TFIM(; J=J, h=h), EnergyLocal(), OBC(; N=N); beta=β)
         @test maximum(abs, mx_loc) < 1e-6
         @test maximum(abs, ε_loc) < 1e-6
     end
@@ -124,8 +124,8 @@
     # ───────────────────────────────────────────────────────────────────────
     @testset "profile symmetry" begin
         N, J, h, β = 16, 1.0, 1.5, 1.5
-        mx_loc = QAtlas.fetch(:TFIM, :magnetization_x_local, OBC(); N=N, J=J, h=h, beta=β)
-        ε_loc = QAtlas.fetch(:TFIM, :energy_local, OBC(); N=N, J=J, h=h, beta=β)
+        mx_loc = QAtlas.fetch(TFIM(; J=J, h=h), MagnetizationXLocal(), OBC(; N=N); beta=β)
+        ε_loc = QAtlas.fetch(TFIM(; J=J, h=h), EnergyLocal(), OBC(; N=N); beta=β)
 
         # Reflection symmetry about the centre (OBC chain is invariant under
         # i ↔ N + 1 - i).

--- a/test/models/test_TFIM_massgap.jl
+++ b/test/models/test_TFIM_massgap.jl
@@ -36,14 +36,26 @@ end
 end
 
 @testset "TFIM MassGap — legacy Symbol dispatch" begin
-    # :mass_gap + aliases (:gap, :Δ, :MassGap) all route to the analytic value
-    @test QAtlas.fetch(:TFIM, :mass_gap, Infinite(); J=1.0, h=2.0) ≈ 2.0
-    @test QAtlas.fetch(:TFIM, :gap, Infinite(); J=1.0, h=2.0) ≈ 2.0
-    @test QAtlas.fetch(:TFIM, :MassGap, Infinite(); J=1.0, h=2.0) ≈ 2.0
-    @test QAtlas.fetch(:TFIM, :excitation_gap, Infinite(); J=1.0, h=2.0) ≈ 2.0
+    # :mass_gap + aliases (:gap, :MassGap, :excitation_gap) all route to the
+    # analytic value. The shim emits one `@info` per (model, quantity) pair;
+    # `@test_logs` catches those so the deprecation notices stay out of CI.
+    @test (@test_logs (:info, r"symbol-dispatch") QAtlas.fetch(
+        :TFIM, :mass_gap, Infinite(); J=1.0, h=2.0
+    )) ≈ 2.0
+    @test (@test_logs (:info, r"symbol-dispatch") QAtlas.fetch(
+        :TFIM, :gap, Infinite(); J=1.0, h=2.0
+    )) ≈ 2.0
+    @test (@test_logs (:info, r"symbol-dispatch") QAtlas.fetch(
+        :TFIM, :MassGap, Infinite(); J=1.0, h=2.0
+    )) ≈ 2.0
+    @test (@test_logs (:info, r"symbol-dispatch") QAtlas.fetch(
+        :TFIM, :excitation_gap, Infinite(); J=1.0, h=2.0
+    )) ≈ 2.0
 
     # OBC Symbol dispatch with legacy N kwarg
-    Δ_legacy = QAtlas.fetch(:TFIM, :mass_gap, OBC(); N=24, J=1.0, h=3.0)
+    Δ_legacy = @test_logs (:info, r"symbol-dispatch") QAtlas.fetch(
+        :TFIM, :mass_gap, OBC(); N=24, J=1.0, h=3.0
+    )
     Δ_new = QAtlas.fetch(TFIM(; J=1.0, h=3.0), MassGap(), OBC(24))
     @test Δ_legacy ≈ Δ_new
 end

--- a/test/models/test_TFIM_thermal.jl
+++ b/test/models/test_TFIM_thermal.jl
@@ -66,20 +66,20 @@ end
         β_low = 80.0   # well below the gap (Δ = 2|h-J| = 1)
 
         # Per-site GS energy from BdG
-        ε_thermal = QAtlas.fetch(:TFIM, :energy, OBC(); N=N, J=J, h=h, beta=β_low) / N
-        ε_gs = QAtlas.fetch(:TFIM, :energy, OBC(); N=N, J=J, h=h) / N
+        ε_thermal = QAtlas.fetch(TFIM(; J=J, h=h), Energy(), OBC(; N=N); beta=β_low) / N
+        ε_gs = QAtlas.fetch(TFIM(; J=J, h=h), Energy(), OBC(; N=N)) / N
         @test ε_thermal ≈ ε_gs atol=1e-12
 
         # Per-site free energy → ε at T = 0
-        f_thermal = QAtlas.fetch(:TFIM, :free_energy, OBC(); N=N, J=J, h=h, beta=β_low)
+        f_thermal = QAtlas.fetch(TFIM(; J=J, h=h), FreeEnergy(), OBC(; N=N); beta=β_low)
         @test f_thermal ≈ ε_gs rtol=1e-6
 
         # Entropy → 0 at T = 0
-        s_low = QAtlas.fetch(:TFIM, :entropy, OBC(); N=N, J=J, h=h, beta=β_low)
+        s_low = QAtlas.fetch(TFIM(; J=J, h=h), ThermalEntropy(), OBC(; N=N); beta=β_low)
         @test abs(s_low) < 1e-6
 
         # Specific heat → 0 at T = 0
-        c_low = QAtlas.fetch(:TFIM, :specific_heat, OBC(); N=N, J=J, h=h, beta=β_low)
+        c_low = QAtlas.fetch(TFIM(; J=J, h=h), SpecificHeat(), OBC(; N=N); beta=β_low)
         @test abs(c_low) < 1e-6
 
         # Static σᶻ σᶻ thermal at β = ∞ matches the existing T = 0 entry —
@@ -87,24 +87,18 @@ end
         for h_phase in (0.5, 1.0, 1.5)
             for r in 1:4
                 v_th = QAtlas.fetch(
-                    :TFIM,
-                    :zz_static_thermal,
-                    OBC();
-                    N=10,
-                    J=1.0,
-                    h=h_phase,
+                    TFIM(; J=1.0, h=h_phase),
+                    ZZCorrelation{:static}(),
+                    OBC(; N=10);
                     beta=Inf,
                     i=2,
                     j=2 + r,
                 )
                 v_gs = real(
                     QAtlas.fetch(
-                        :TFIM,
-                        :sz_sz_correlation,
-                        OBC();
-                        N=10,
-                        J=1.0,
-                        h=h_phase,
+                        TFIM(; J=1.0, h=h_phase),
+                        ZZCorrelation{:dynamic}(),
+                        OBC(; N=10);
                         i=2,
                         j=2 + r,
                         t=0.0,
@@ -124,26 +118,26 @@ end
 
         # Free energy per site at β → 0:
         #   f → -T log 2 + O(β · h, β · J)
-        f_hi = QAtlas.fetch(:TFIM, :free_energy, OBC(); N=N, J=J, h=h, beta=β_high)
+        f_hi = QAtlas.fetch(TFIM(; J=J, h=h), FreeEnergy(), OBC(; N=N); beta=β_high)
         @test f_hi ≈ -log(2) / β_high atol=1e-3 / β_high
 
         # Entropy per site at β → 0: s → log 2
-        s_hi = QAtlas.fetch(:TFIM, :entropy, OBC(); N=N, J=J, h=h, beta=β_high)
+        s_hi = QAtlas.fetch(TFIM(; J=J, h=h), ThermalEntropy(), OBC(; N=N); beta=β_high)
         @test s_hi ≈ log(2) atol=1e-6
 
         # Specific heat at β → 0: c_v → 0 quadratically in β
-        c_hi = QAtlas.fetch(:TFIM, :specific_heat, OBC(); N=N, J=J, h=h, beta=β_high)
+        c_hi = QAtlas.fetch(TFIM(; J=J, h=h), SpecificHeat(), OBC(; N=N); beta=β_high)
         @test abs(c_hi) < 1e-6
 
         # Transverse magnetisation at β → 0: m_x → 0 (Curie regime)
         mx_hi = QAtlas.fetch(
-            :TFIM, :transverse_magnetization, OBC(); N=N, J=J, h=h, beta=β_high
+            TFIM(; J=J, h=h), MagnetizationX(), OBC(; N=N); beta=β_high
         )
         @test abs(mx_hi) < 1e-3
 
         # Same in the thermodynamic limit.
-        f_inf = QAtlas.fetch(:TFIM, :free_energy, Infinite(); J=J, h=h, beta=β_high)
-        s_inf = QAtlas.fetch(:TFIM, :entropy, Infinite(); J=J, h=h, beta=β_high)
+        f_inf = QAtlas.fetch(TFIM(; J=J, h=h), FreeEnergy(), Infinite(); beta=β_high)
+        s_inf = QAtlas.fetch(TFIM(; J=J, h=h), ThermalEntropy(), Infinite(); beta=β_high)
         @test f_inf ≈ -log(2) / β_high atol=1e-3 / β_high
         @test s_inf ≈ log(2) atol=1e-6
     end
@@ -154,35 +148,35 @@ end
     @testset "thermodynamic identities" begin
         N, J, h = 10, 1.0, 0.5
         for β in (0.3, 0.7, 1.5, 3.0)
-            ε = QAtlas.fetch(:TFIM, :energy, OBC(); N=N, J=J, h=h, beta=β) / N
-            f = QAtlas.fetch(:TFIM, :free_energy, OBC(); N=N, J=J, h=h, beta=β)
-            s = QAtlas.fetch(:TFIM, :entropy, OBC(); N=N, J=J, h=h, beta=β)
+            ε = QAtlas.fetch(TFIM(; J=J, h=h), Energy(), OBC(; N=N); beta=β) / N
+            f = QAtlas.fetch(TFIM(; J=J, h=h), FreeEnergy(), OBC(; N=N); beta=β)
+            s = QAtlas.fetch(TFIM(; J=J, h=h), ThermalEntropy(), OBC(; N=N); beta=β)
 
             # ε = f + T s = f + s/β
             @test ε ≈ f + s / β atol=1e-10
 
             # c_v from numerical second derivative of (β f).
             δ = 1e-3 * β
-            f_p = QAtlas.fetch(:TFIM, :free_energy, OBC(); N=N, J=J, h=h, beta=β + δ)
-            f_m = QAtlas.fetch(:TFIM, :free_energy, OBC(); N=N, J=J, h=h, beta=β - δ)
+            f_p = QAtlas.fetch(TFIM(; J=J, h=h), FreeEnergy(), OBC(; N=N); beta=β + δ)
+            f_m = QAtlas.fetch(TFIM(; J=J, h=h), FreeEnergy(), OBC(; N=N); beta=β - δ)
             βf = β * f
             βpfp = (β + δ) * f_p
             βmfm = (β - δ) * f_m
             c_num = -β^2 * (βpfp - 2 * βf + βmfm) / δ^2
-            c_an = QAtlas.fetch(:TFIM, :specific_heat, OBC(); N=N, J=J, h=h, beta=β)
+            c_an = QAtlas.fetch(TFIM(; J=J, h=h), SpecificHeat(), OBC(; N=N); beta=β)
             @test c_an ≈ c_num rtol=1e-3
 
             # χ_xx from numerical derivative of m_x w.r.t. h
             δh = 1e-4
             mp = QAtlas.fetch(
-                :TFIM, :transverse_magnetization, OBC(); N=N, J=J, h=h + δh, beta=β
+                TFIM(; J=J, h=h + δh), MagnetizationX(), OBC(; N=N); beta=β
             )
             mm = QAtlas.fetch(
-                :TFIM, :transverse_magnetization, OBC(); N=N, J=J, h=h - δh, beta=β
+                TFIM(; J=J, h=h - δh), MagnetizationX(), OBC(; N=N); beta=β
             )
             χ_num = (mp - mm) / (2 * δh)
             χ_an = QAtlas.fetch(
-                :TFIM, :transverse_susceptibility, OBC(); N=N, J=J, h=h, beta=β
+                TFIM(; J=J, h=h), SusceptibilityXX(), OBC(; N=N); beta=β
             )
             @test χ_an ≈ χ_num rtol=5e-3
         end
@@ -191,28 +185,28 @@ end
     @testset "thermodynamic identities (Infinite)" begin
         J, h = 1.0, 0.7
         for β in (0.3, 0.7, 1.5, 3.0)
-            ε = QAtlas.fetch(:TFIM, :energy, Infinite(); J=J, h=h, beta=β)
-            f = QAtlas.fetch(:TFIM, :free_energy, Infinite(); J=J, h=h, beta=β)
-            s = QAtlas.fetch(:TFIM, :entropy, Infinite(); J=J, h=h, beta=β)
+            ε = QAtlas.fetch(TFIM(; J=J, h=h), Energy(), Infinite(); beta=β)
+            f = QAtlas.fetch(TFIM(; J=J, h=h), FreeEnergy(), Infinite(); beta=β)
+            s = QAtlas.fetch(TFIM(; J=J, h=h), ThermalEntropy(), Infinite(); beta=β)
             @test ε ≈ f + s / β atol=1e-10
 
             δ = 1e-3 * β
-            f_p = QAtlas.fetch(:TFIM, :free_energy, Infinite(); J=J, h=h, beta=β + δ)
-            f_m = QAtlas.fetch(:TFIM, :free_energy, Infinite(); J=J, h=h, beta=β - δ)
+            f_p = QAtlas.fetch(TFIM(; J=J, h=h), FreeEnergy(), Infinite(); beta=β + δ)
+            f_m = QAtlas.fetch(TFIM(; J=J, h=h), FreeEnergy(), Infinite(); beta=β - δ)
             c_num = -β^2 * ((β + δ) * f_p - 2 * β * f + (β - δ) * f_m) / δ^2
-            c_an = QAtlas.fetch(:TFIM, :specific_heat, Infinite(); J=J, h=h, beta=β)
+            c_an = QAtlas.fetch(TFIM(; J=J, h=h), SpecificHeat(), Infinite(); beta=β)
             @test c_an ≈ c_num rtol=1e-3
 
             δh = 1e-4
             mp = QAtlas.fetch(
-                :TFIM, :transverse_magnetization, Infinite(); J=J, h=h + δh, beta=β
+                TFIM(; J=J, h=h + δh), MagnetizationX(), Infinite(); beta=β
             )
             mm = QAtlas.fetch(
-                :TFIM, :transverse_magnetization, Infinite(); J=J, h=h - δh, beta=β
+                TFIM(; J=J, h=h - δh), MagnetizationX(), Infinite(); beta=β
             )
             χ_num = (mp - mm) / (2 * δh)
             χ_an = QAtlas.fetch(
-                :TFIM, :transverse_susceptibility, Infinite(); J=J, h=h, beta=β
+                TFIM(; J=J, h=h), SusceptibilityXX(), Infinite(); beta=β
             )
             @test χ_an ≈ χ_num rtol=5e-3
         end
@@ -227,12 +221,12 @@ end
             ed = _ed_thermo(N, J, h, β)
             mx_ed = _ed_transverse(N, J, h, β)
 
-            ε = QAtlas.fetch(:TFIM, :energy, OBC(); N=N, J=J, h=h, beta=β) / N
-            f = QAtlas.fetch(:TFIM, :free_energy, OBC(); N=N, J=J, h=h, beta=β)
-            s = QAtlas.fetch(:TFIM, :entropy, OBC(); N=N, J=J, h=h, beta=β)
-            c = QAtlas.fetch(:TFIM, :specific_heat, OBC(); N=N, J=J, h=h, beta=β)
+            ε = QAtlas.fetch(TFIM(; J=J, h=h), Energy(), OBC(; N=N); beta=β) / N
+            f = QAtlas.fetch(TFIM(; J=J, h=h), FreeEnergy(), OBC(; N=N); beta=β)
+            s = QAtlas.fetch(TFIM(; J=J, h=h), ThermalEntropy(), OBC(; N=N); beta=β)
+            c = QAtlas.fetch(TFIM(; J=J, h=h), SpecificHeat(), OBC(; N=N); beta=β)
             mx = QAtlas.fetch(
-                :TFIM, :transverse_magnetization, OBC(); N=N, J=J, h=h, beta=β
+                TFIM(; J=J, h=h), MagnetizationX(), OBC(; N=N); beta=β
             )
 
             @test ε ≈ ed.ε atol=1e-10
@@ -254,7 +248,12 @@ end
                 op = _op_site(_SZ, i, N) * _op_site(_SZ, j, N)
                 ed_val = real(tr(ρ * op))
                 qa_val = QAtlas.fetch(
-                    :TFIM, :zz_static_thermal, OBC(); N=N, J=J, h=h, beta=β, i=i, j=j
+                    TFIM(; J=J, h=h),
+                    ZZCorrelation{:static}(),
+                    OBC(; N=N);
+                    beta=β,
+                    i=i,
+                    j=j,
                 )
                 @test qa_val ≈ ed_val atol=1e-10
             end
@@ -275,7 +274,7 @@ end
             χ_ed = β * (M2 - M1^2) / N
 
             χ_qa = QAtlas.fetch(
-                :TFIM, :longitudinal_susceptibility, OBC(); N=N, J=J, h=h, beta=β
+                TFIM(; J=J, h=h), SusceptibilityZZ(), OBC(; N=N); beta=β
             )
             @test χ_qa ≈ χ_ed atol=1e-10
         end
@@ -292,17 +291,17 @@ end
         errs_c = Float64[]
         errs_m = Float64[]
         for N in Ns
-            f_obc = QAtlas.fetch(:TFIM, :free_energy, OBC(); N=N, J=J, h=h, beta=β)
-            s_obc = QAtlas.fetch(:TFIM, :entropy, OBC(); N=N, J=J, h=h, beta=β)
-            c_obc = QAtlas.fetch(:TFIM, :specific_heat, OBC(); N=N, J=J, h=h, beta=β)
+            f_obc = QAtlas.fetch(TFIM(; J=J, h=h), FreeEnergy(), OBC(; N=N); beta=β)
+            s_obc = QAtlas.fetch(TFIM(; J=J, h=h), ThermalEntropy(), OBC(; N=N); beta=β)
+            c_obc = QAtlas.fetch(TFIM(; J=J, h=h), SpecificHeat(), OBC(; N=N); beta=β)
             m_obc = QAtlas.fetch(
-                :TFIM, :transverse_magnetization, OBC(); N=N, J=J, h=h, beta=β
+                TFIM(; J=J, h=h), MagnetizationX(), OBC(; N=N); beta=β
             )
-            f_inf = QAtlas.fetch(:TFIM, :free_energy, Infinite(); J=J, h=h, beta=β)
-            s_inf = QAtlas.fetch(:TFIM, :entropy, Infinite(); J=J, h=h, beta=β)
-            c_inf = QAtlas.fetch(:TFIM, :specific_heat, Infinite(); J=J, h=h, beta=β)
+            f_inf = QAtlas.fetch(TFIM(; J=J, h=h), FreeEnergy(), Infinite(); beta=β)
+            s_inf = QAtlas.fetch(TFIM(; J=J, h=h), ThermalEntropy(), Infinite(); beta=β)
+            c_inf = QAtlas.fetch(TFIM(; J=J, h=h), SpecificHeat(), Infinite(); beta=β)
             m_inf = QAtlas.fetch(
-                :TFIM, :transverse_magnetization, Infinite(); J=J, h=h, beta=β
+                TFIM(; J=J, h=h), MagnetizationX(), Infinite(); beta=β
             )
             push!(errs_f, abs(f_obc - f_inf))
             push!(errs_s, abs(s_obc - s_inf))

--- a/test/models/test_TFIM_thermal.jl
+++ b/test/models/test_TFIM_thermal.jl
@@ -130,9 +130,7 @@ end
         @test abs(c_hi) < 1e-6
 
         # Transverse magnetisation at β → 0: m_x → 0 (Curie regime)
-        mx_hi = QAtlas.fetch(
-            TFIM(; J=J, h=h), MagnetizationX(), OBC(; N=N); beta=β_high
-        )
+        mx_hi = QAtlas.fetch(TFIM(; J=J, h=h), MagnetizationX(), OBC(; N=N); beta=β_high)
         @test abs(mx_hi) < 1e-3
 
         # Same in the thermodynamic limit.
@@ -168,16 +166,10 @@ end
 
             # χ_xx from numerical derivative of m_x w.r.t. h
             δh = 1e-4
-            mp = QAtlas.fetch(
-                TFIM(; J=J, h=h + δh), MagnetizationX(), OBC(; N=N); beta=β
-            )
-            mm = QAtlas.fetch(
-                TFIM(; J=J, h=h - δh), MagnetizationX(), OBC(; N=N); beta=β
-            )
+            mp = QAtlas.fetch(TFIM(; J=J, h=h + δh), MagnetizationX(), OBC(; N=N); beta=β)
+            mm = QAtlas.fetch(TFIM(; J=J, h=h - δh), MagnetizationX(), OBC(; N=N); beta=β)
             χ_num = (mp - mm) / (2 * δh)
-            χ_an = QAtlas.fetch(
-                TFIM(; J=J, h=h), SusceptibilityXX(), OBC(; N=N); beta=β
-            )
+            χ_an = QAtlas.fetch(TFIM(; J=J, h=h), SusceptibilityXX(), OBC(; N=N); beta=β)
             @test χ_an ≈ χ_num rtol=5e-3
         end
     end
@@ -198,16 +190,10 @@ end
             @test c_an ≈ c_num rtol=1e-3
 
             δh = 1e-4
-            mp = QAtlas.fetch(
-                TFIM(; J=J, h=h + δh), MagnetizationX(), Infinite(); beta=β
-            )
-            mm = QAtlas.fetch(
-                TFIM(; J=J, h=h - δh), MagnetizationX(), Infinite(); beta=β
-            )
+            mp = QAtlas.fetch(TFIM(; J=J, h=h + δh), MagnetizationX(), Infinite(); beta=β)
+            mm = QAtlas.fetch(TFIM(; J=J, h=h - δh), MagnetizationX(), Infinite(); beta=β)
             χ_num = (mp - mm) / (2 * δh)
-            χ_an = QAtlas.fetch(
-                TFIM(; J=J, h=h), SusceptibilityXX(), Infinite(); beta=β
-            )
+            χ_an = QAtlas.fetch(TFIM(; J=J, h=h), SusceptibilityXX(), Infinite(); beta=β)
             @test χ_an ≈ χ_num rtol=5e-3
         end
     end
@@ -225,9 +211,7 @@ end
             f = QAtlas.fetch(TFIM(; J=J, h=h), FreeEnergy(), OBC(; N=N); beta=β)
             s = QAtlas.fetch(TFIM(; J=J, h=h), ThermalEntropy(), OBC(; N=N); beta=β)
             c = QAtlas.fetch(TFIM(; J=J, h=h), SpecificHeat(), OBC(; N=N); beta=β)
-            mx = QAtlas.fetch(
-                TFIM(; J=J, h=h), MagnetizationX(), OBC(; N=N); beta=β
-            )
+            mx = QAtlas.fetch(TFIM(; J=J, h=h), MagnetizationX(), OBC(; N=N); beta=β)
 
             @test ε ≈ ed.ε atol=1e-10
             @test f ≈ ed.f atol=1e-10
@@ -248,12 +232,7 @@ end
                 op = _op_site(_SZ, i, N) * _op_site(_SZ, j, N)
                 ed_val = real(tr(ρ * op))
                 qa_val = QAtlas.fetch(
-                    TFIM(; J=J, h=h),
-                    ZZCorrelation{:static}(),
-                    OBC(; N=N);
-                    beta=β,
-                    i=i,
-                    j=j,
+                    TFIM(; J=J, h=h), ZZCorrelation{:static}(), OBC(; N=N); beta=β, i=i, j=j
                 )
                 @test qa_val ≈ ed_val atol=1e-10
             end
@@ -273,9 +252,7 @@ end
             M1 = real(tr(ρ * Mz))
             χ_ed = β * (M2 - M1^2) / N
 
-            χ_qa = QAtlas.fetch(
-                TFIM(; J=J, h=h), SusceptibilityZZ(), OBC(; N=N); beta=β
-            )
+            χ_qa = QAtlas.fetch(TFIM(; J=J, h=h), SusceptibilityZZ(), OBC(; N=N); beta=β)
             @test χ_qa ≈ χ_ed atol=1e-10
         end
     end
@@ -294,15 +271,11 @@ end
             f_obc = QAtlas.fetch(TFIM(; J=J, h=h), FreeEnergy(), OBC(; N=N); beta=β)
             s_obc = QAtlas.fetch(TFIM(; J=J, h=h), ThermalEntropy(), OBC(; N=N); beta=β)
             c_obc = QAtlas.fetch(TFIM(; J=J, h=h), SpecificHeat(), OBC(; N=N); beta=β)
-            m_obc = QAtlas.fetch(
-                TFIM(; J=J, h=h), MagnetizationX(), OBC(; N=N); beta=β
-            )
+            m_obc = QAtlas.fetch(TFIM(; J=J, h=h), MagnetizationX(), OBC(; N=N); beta=β)
             f_inf = QAtlas.fetch(TFIM(; J=J, h=h), FreeEnergy(), Infinite(); beta=β)
             s_inf = QAtlas.fetch(TFIM(; J=J, h=h), ThermalEntropy(), Infinite(); beta=β)
             c_inf = QAtlas.fetch(TFIM(; J=J, h=h), SpecificHeat(), Infinite(); beta=β)
-            m_inf = QAtlas.fetch(
-                TFIM(; J=J, h=h), MagnetizationX(), Infinite(); beta=β
-            )
+            m_inf = QAtlas.fetch(TFIM(; J=J, h=h), MagnetizationX(), Infinite(); beta=β)
             push!(errs_f, abs(f_obc - f_inf))
             push!(errs_s, abs(s_obc - s_inf))
             push!(errs_c, abs(c_obc - c_inf))

--- a/test/models/test_XXZ1D.jl
+++ b/test/models/test_XXZ1D.jl
@@ -126,16 +126,29 @@ end
 end
 
 @testset "XXZ1D — legacy Symbol dispatch routes to new API" begin
-    # Deprecation log on every new (model, quantity) pair
-    e_sym = QAtlas.fetch(:XXZ, :energy, Infinite(); J=1.0, Δ=0.0)
+    # This testset deliberately reaches through the legacy Symbol shim in
+    # `src/deprecate/legacy_xxz.jl` to confirm that the forwarding to the
+    # concrete-struct fetch methods still produces the canonical values.
+    # The shim emits a one-shot `@info` per (model, quantity) pair the
+    # first time it's hit; `@test_logs` captures those infos so the
+    # deprecation noise does not leak into CI output.
+    e_sym = @test_logs (:info, r"symbol-dispatch") QAtlas.fetch(
+        :XXZ, :energy, Infinite(); J=1.0, Δ=0.0
+    )
     @test e_sym ≈ -1 / π atol = 1e-10
 
-    u_sym = QAtlas.fetch(:XXZ, :spin_wave_velocity, Infinite(); J=1.0, Δ=1.0)
+    u_sym = @test_logs (:info, r"symbol-dispatch") QAtlas.fetch(
+        :XXZ, :spin_wave_velocity, Infinite(); J=1.0, Δ=1.0
+    )
     @test u_sym ≈ π / 2 atol = 1e-12
 
-    u_fv = QAtlas.fetch(:XXZ, :fermi_velocity, Infinite(); J=1.0, Δ=0.0)
+    u_fv = @test_logs (:info, r"symbol-dispatch") QAtlas.fetch(
+        :XXZ, :fermi_velocity, Infinite(); J=1.0, Δ=0.0
+    )
     @test u_fv ≈ 1.0 atol = 1e-12
 
-    K_sym = QAtlas.fetch(:XXZ, :luttinger_parameter, Infinite(); J=1.0, Δ=0.0)
+    K_sym = @test_logs (:info, r"symbol-dispatch") QAtlas.fetch(
+        :XXZ, :luttinger_parameter, Infinite(); J=1.0, Δ=0.0
+    )
     @test K_sym ≈ 1.0 atol = 1e-12
 end

--- a/test/universalities/test_E8.jl
+++ b/test/universalities/test_E8.jl
@@ -25,15 +25,12 @@
     @testset "Aliases" begin
         expected = QAtlas.fetch(E8(), E8Spectrum(), Infinite())
 
-        @test @test_logs (:info, r"symbol-dispatch") QAtlas.fetch(
-            :E8, :mass_ratios
-        ) == expected
-        @test @test_logs (:info, r"symbol-dispatch") QAtlas.fetch(
-            :E8, :E8_masses
-        ) == expected
-        @test @test_logs (:info, r"symbol-dispatch") QAtlas.fetch(
-            :E8, :mass_ratio
-        ) == expected
+        @test @test_logs (:info, r"symbol-dispatch") QAtlas.fetch(:E8, :mass_ratios) ==
+            expected
+        @test @test_logs (:info, r"symbol-dispatch") QAtlas.fetch(:E8, :E8_masses) ==
+            expected
+        @test @test_logs (:info, r"symbol-dispatch") QAtlas.fetch(:E8, :mass_ratio) ==
+            expected
     end
 
     @testset "Type Stability" begin

--- a/test/universalities/test_E8.jl
+++ b/test/universalities/test_E8.jl
@@ -2,7 +2,7 @@
 @testset "E8 Spectrum Logic" begin
     # 1. 基本的な構造のテスト
     @testset "Structure" begin
-        masses = QAtlas.fetch(:E8, :E8_spectrum)
+        masses = QAtlas.fetch(E8(), E8Spectrum(), Infinite())
         @test length(masses) == 8
         @test masses[1] == 1.0
         @test all(masses .> 0)
@@ -11,18 +11,29 @@
 
     # 2. m₂/m₁ = golden ratio
     @testset "Golden Ratio Relationship" begin
-        masses = QAtlas.fetch(:E8, :E8_spectrum)
+        masses = QAtlas.fetch(E8(), E8Spectrum(), Infinite())
         ϕ = (1 + sqrt(5)) / 2
         @test masses[2] ≈ ϕ atol = 1e-15
     end
 
-    # 3. alias
+    # 3. alias — deliberately reaches through the legacy Symbol shim to
+    # verify that `:mass_ratios`, `:E8_masses`, `:mass_ratio` all
+    # canonicalise to `:E8_spectrum` and forward to `E8Spectrum`.  The
+    # shim emits a one-shot `@info` per (model, quantity) pair; wrap
+    # every legacy call with `@test_logs` so the deprecation notices do
+    # not leak into CI output.
     @testset "Aliases" begin
-        expected = QAtlas.fetch(:E8, :E8_spectrum)
+        expected = QAtlas.fetch(E8(), E8Spectrum(), Infinite())
 
-        @test QAtlas.fetch(:E8, :mass_ratios) == expected
-        @test QAtlas.fetch(:E8, :E8_masses) == expected
-        @test QAtlas.fetch(:E8, :mass_ratio) == expected
+        @test @test_logs (:info, r"symbol-dispatch") QAtlas.fetch(
+            :E8, :mass_ratios
+        ) == expected
+        @test @test_logs (:info, r"symbol-dispatch") QAtlas.fetch(
+            :E8, :E8_masses
+        ) == expected
+        @test @test_logs (:info, r"symbol-dispatch") QAtlas.fetch(
+            :E8, :mass_ratio
+        ) == expected
     end
 
     @testset "Type Stability" begin

--- a/test/verification/test_tfim_gap_closure.jl
+++ b/test/verification/test_tfim_gap_closure.jl
@@ -24,7 +24,7 @@ using QAtlas, Lattice2D, LinearAlgebra, Test
                 H = build_tfim(lat, J, h)
                 λ = sort(eigvals(Symmetric(H)))
                 E0_ed = λ[1]
-                E0_analytical = QAtlas.fetch(:TFIM, :energy, OBC(); N=N, J=J, h=h)
+                E0_analytical = QAtlas.fetch(TFIM(; J=J, h=h), Energy(), OBC(; N=N))
                 @test E0_ed ≈ E0_analytical rtol = 1e-10
             end
         end


### PR DESCRIPTION
## Summary

Recent CI runs surfaced a batch of \`QAtlas symbol-dispatch \`fetch(:X, :y, …)\` will be removed in v1.0\` info logs from `src/deprecate/legacy_fetch.jl` — one per unique (model, quantity) pair the test suite hits through the legacy Symbol shim.

Two different sources, two different fixes:

1. **Incidental callers** still using the Symbol form for real cross-checks, not for testing the shim. These would also break the day \`src/deprecate/\` is removed at v1.0. → **Ported to the struct API.**

2. **Deliberate shim tests** (alias canonicalisation, error handling, forwarding) that must stay on the Symbol API. → **Wrapped every call with \`@test_logs (:info, r"symbol-dispatch") ...\`** so the one-shot info is captured instead of printed.

## Files touched

### Ported to struct API (incidental)

| File | Calls | New struct |
|---|---|---|
| \`test_tfim_gap_closure.jl\` | 1 | \`Energy\` |
| \`test_TFIM_dynamics.jl\` | 14 | \`Energy\`, \`ZZCorrelation{:dynamic}\`, \`XXCorrelation{:dynamic}\`, \`ZZCorrelation{:lightcone}\` |
| \`test_TFIM_thermal.jl\` | 33 | \`Energy\`, \`FreeEnergy\`, \`ThermalEntropy\`, \`SpecificHeat\`, \`MagnetizationX\`, \`SusceptibilityXX\`, \`SusceptibilityZZ\`, \`ZZCorrelation{:static}\`, \`ZZCorrelation{:dynamic}\` |
| \`test_TFIM_local.jl\` | 13 | \`Energy\`, \`EnergyLocal\`, \`MagnetizationXLocal\`, \`MagnetizationZLocal\`, \`MagnetizationX\`, \`ZZCorrelation{:static}\` |
| \`test_E8.jl\` (partial) | 3 | \`E8Spectrum\` |

### Wrapped with \`@test_logs\` (deliberate)

| File | Purpose |
|---|---|
| \`test_XXZ1D.jl\` | :XXZ alias forwarding |
| \`test_TFIM_massgap.jl\` | :mass_gap alias forwarding |
| \`test_TFIM_entanglement.jl\` | :entanglement_entropy alias forwarding |
| \`test_E8.jl\` (partial) | :E8_spectrum alias forwarding |
| \`test_type.jl\` | Dummy-dispatch infrastructure tests |

## Test plan

- [x] \`Pkg.test()\` — 1035 → **1059** pass (the extra 24 come from \`@test_logs\` expressions Test.jl counts separately).
- [x] CI deprecation-info block is empty — no \`symbol-dispatch\` lines in stdout.
- [x] No \`src/\` changes; the shim is untouched.
- [x] Runtime: unchanged (2 m 27 s).