### PR TITLE
docs: fix four consistency issues + add Aqua badge (review (A))

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 [![docs: dev](https://img.shields.io/badge/docs-dev-purple.svg)](https://codes.sota-shimozono.com/QAtlas.jl/dev/)
 [![Julia](https://img.shields.io/badge/julia-v1.12+-9558b2.svg)](https://julialang.org)
 [![Code Style: Blue](https://img.shields.io/badge/Code%20Style-Blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
+[![Aqua QA](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 
 [![codecov](https://codecov.io/gh/sotashimozono/QAtlas.jl/graph/badge.svg?token=dnvvwd7DVo)](https://codecov.io/gh/sotashimozono/QAtlas.jl)
 [![Build Status](https://github.com/sotashimozono/QAtlas.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/sotashimozono/QAtlas.jl/actions/workflows/CI.yml?query=branch%3Amain)

--- a/docs/src/calc/ising-cft-primary-operators.md
+++ b/docs/src/calc/ising-cft-primary-operators.md
@@ -351,13 +351,15 @@ non-negative conformal weights (0, 1/16, 1/2), consistent.
 
 **(iii) Numerical verification against finite-size ED.**
 $\sigma$-type operator: the two-point function of $\sigma^{z}$ on
-the critical TFIM decays as $|\mathbf{r}|^{-1/4}$, verified in
-`test/verification/test_tfim_central_charge.jl` via direct lattice ED.
-$\varepsilon$-type operator: the bond–bond correlator
-$\sigma^{z}_{i}\sigma^{z}_{i+1}\,\sigma^{z}_{j}\sigma^{z}_{j+1}$
-decays as $|i - j|^{-2}$ (matching $\Delta_{\varepsilon} = 1$).
-Both are cross-checked to $\sim 5\%$ at $N \le 16$ in the QAtlas
-test suite.
+the critical TFIM decays as $|\mathbf{r}|^{-1/4}$; the exponent is
+extracted from QAtlas's closed-form correlator in the
+`"criticality: scaling toward CFT exponent -1/4"` testset of
+`test/models/test_TFIM_dynamics.jl`, which asserts the effective
+doubling-ratio slope at $N \in \{80, 160, 240\}$ converges
+monotonically to $-1/4$ within $0.10$ at the largest $N$.
+The central charge $c = 1/2$ itself is extracted to $\lesssim 1\%$
+from the PBC entanglement entropy in
+`test/verification/test_entanglement_central_charge.jl`.
 
 **(iv) Yang-magnetisation exponent $\beta = 1/8$.** Derived
 independently from the Toeplitz determinant in

--- a/docs/src/models/quantum/tfim.md
+++ b/docs/src/models/quantum/tfim.md
@@ -297,5 +297,8 @@ Symbol aliases recognised by the legacy layer: `:entanglement_entropy`,
 - **Disordered version**: [Random TFIM](../../verification/disordered.md) —
   the Fisher IRFP at $[\ln J]_{\text{avg}} = [\ln h]_{\text{avg}}$.
 - **E8 spectrum**: [E8 universality](../../universalities/e8.md) —
-  adding a longitudinal field $\lambda \sigma^z$ at $h = J$ breaks
-  integrability and produces the E8 mass spectrum.
+  perturbing the critical TFIM at $h = J$ by a longitudinal field
+  $\lambda \sigma^z$ is the $\Phi_{(1,2)} = \sigma$ magnetic
+  perturbation of the Ising CFT. Zamolodchikov (1989) showed the
+  resulting massive field theory **remains integrable** and its
+  eight stable particles realise the $E_8$ mass spectrum.

--- a/docs/src/verification/disordered.md
+++ b/docs/src/verification/disordered.md
@@ -108,7 +108,7 @@ implemented. It is planned as a future verification target.
 ## QAtlas Test
 
 ```julia
-# test/verification/test_disordered.jl
+# test/verification/test_disordered_heisenberg.jl
 
 # Random-bond Heisenberg: singlet ground state
 E, psi = eigen(H_random_heisenberg)

--- a/md/roadmap.md
+++ b/md/roadmap.md
@@ -24,44 +24,45 @@ do not contain the full calculation. Specific gaps:
 These are candidates for deeper `calc/` sub-notes when expertise is
 available.
 
-### Peschel method for σ^z σ^z TFIM
+### ~~Peschel method for σ^z σ^z TFIM~~  ✅ Clarified (v0.13.3)
 
 The BdG eigenvectors for the TFIM in the σ^z σ^z convention give
 **dual-fermion** correlators (Kramers-Wannier dual), not spin-basis
-correlators. Computing the spin-basis entanglement entropy via the
-Peschel correlation-matrix method requires proper handling of the
-duality boundary conditions.
+correlators.  For a contiguous block `A = {1, …, ℓ}` the JW unitary
+factorises across the `A / Aᶜ` cut, so the spin-basis entanglement
+entropy and the fermion-basis entanglement entropy are equal
+(Fagotti–Calabrese 2010).  The derivation is written out in
+`docs/src/calc/tfim-entanglement-peschel.md` (v0.13.3 PR #69) and the
+`fetch(TFIM, VonNeumannEntropy, OBC(N); ℓ)` method uses the
+correlation-matrix algorithm in O(N³) for contiguous blocks.
 
-Current workaround: full ED (O(2^N), N ≤ 16 with 128GB RAM).
+Full ED (`O(2^N)`) is still used by `test_entanglement_central_charge.jl`
+to exercise both entropy-dispatch paths at N ≤ 16.  The duality caveat
+now applies only to single-site `σ^z` correlators reached via
+Pfaffians, not to contiguous-block entanglement entropy.
 
-Resolution path: implement the duality-aware Peschel method, or switch
-to the σ^x σ^x convention for the entanglement-specific code path.
+### ~~Central charge extraction precision~~  ✅ Tightened (v0.13.5)
 
-### Central charge extraction precision
+PR #75 switched the tight-signal central-charge extraction to PBC
+ground states via `build_tfim_sparse` / `build_spinhalf_heisenberg_sparse`
++ KrylovKit Lanczos:
 
-Current: c = 1/2 within ~10% at N=14 (TFIM), c = 1 within ~20% at
-N=12 (Heisenberg, even-l filtering).
+| model (PBC)        | extracted c      | exact c | assertion          |
+|--------------------|------------------|---------|--------------------|
+| TFIM at h = J      | c(N=14) = 0.5021 | 0.5     | rtol = 0.01        |
+| Heisenberg (1/N ext.) | c(∞) = 1.014 | 1.0     | rtol = 0.03        |
 
-The OBC Calabrese-Cardy formula already includes the log-sin finite-size
-correction. Remaining errors come from:
+The OBC testset (rtol = 0.10 / 0.20) is kept for open-boundary code-
+path coverage; both routes pass.
 
-1. Lattice discretization (irrelevant operators, O(1/N))
-2. Boundary effects not captured by the strip conformal mapping
-3. For Heisenberg: SU(2) alternating corrections (-1)^l f(l)
+### ~~Bond counting convention for small PBC lattices~~  ✅ Decoupled (v0.13.4)
 
-Potential improvements:
-- Use PBC chains (eliminate boundary corrections) — requires PBC ED or
-  fixing the Peschel method
-- Include subleading corrections in the fit model
-- Larger N via sparse Lanczos (ground state only)
-
-### Bond counting convention for small PBC lattices
-
-Lattice2D's `bonds(lat)` double-counts bonds when Lx = 2 or Ly = 2
-with PBC (each edge is traversed in both directions). The transfer
-matrix and brute-force enumeration use the same convention, so results
-agree — but the effective coupling is doubled compared to larger
-lattices. This is documented but can surprise new contributors.
+The IsingSquare transfer-matrix test no longer depends on whichever
+convention `Lattice2D.bonds(lat)` adopts; PR #71 moved the bond-list
+construction to `test/util/classical_partition.jl`'s
+`square_pbc_bond_pairs(Lx, Ly)` and dropped the `[sources]` pin on
+Lattice2D / LatticeCore.  Current `Lattice2D` (≥ 0.2.8) is the
+registered release.
 
 ### ~~Two API styles~~  ✅ Resolved (v0.13)
 
@@ -84,7 +85,12 @@ All models have been migrated to concrete parameter-carrying structs:
 - BCs `OBC(N)`, `PBC(N)` carry their own size; `Infinite()` unchanged.
 - Legacy Symbol-dispatch calls (`fetch(:TFIM, :energy, OBC(); N, J, h)`
   etc.) are routed through the deprecation shims in `src/deprecate/`
-  with a `maxlog=3` warning.  The directory can be `git rm`-ed
+  with a `maxlog=1` info log (keyed per `(model, quantity)` pair).
+  Incidental verification call sites have been ported to the concrete-
+  struct API (PRs #73, #78); only the dedicated
+  `"… legacy Symbol dispatch …"` testsets still reach the shims, and
+  those wrap each call with `@test_logs (:info, r"symbol-dispatch") …`
+  so CI output stays clean.  The directory can be `git rm`-ed
   wholesale at v1.0 cut.
 - Aqua.jl static checks are enabled in `test/test_aqua.jl`
   (ambiguities, deps_compat, stale_deps, piracies).
@@ -97,13 +103,13 @@ Version bumped to 0.13.0.  See PRs #40 (foundation), #41 (TFIM + E8),
 
 ### Near-term (infrastructure exists)
 
-**Sparse ED for larger N** (N = 18–22):
-- `build_tfim` and `build_spinhalf_heisenberg` currently produce dense
-  matrices. Sparse construction + iterative Lanczos (Arpack.jl or
-  KrylovKit.jl) would enable ground state computation at N ~ 20.
-- This would improve central charge extraction significantly
-  (c precision scales as 1/N).
-- Estimated effort: small (sparse matrix fill + `eigsolve` call).
+**~~Sparse ED for larger N~~** ✅ Landed (v0.13.3+):
+- `build_tfim_sparse`, `build_spinhalf_heisenberg_sparse` and
+  `build_xxz_sparse` in `test/util/sparse_ed.jl`, with
+  `ground_state_krylov` driving `KrylovKit.eigsolve`.  The PBC
+  entanglement-entropy, TFIM-BdG-vs-ED, z-exponent, and Luttinger-K
+  cross-checks now run at N ∈ {14, 16} on the default CI profile.
+  N = 18–20 remain accessible under `QATLAS_TEST_FULL = 1` (nightly).
 
 **More universality classes from Wikipedia table**:
 - Directed percolation (d=1,2,3: numerical, d≥4: MF)


### PR DESCRIPTION
## Summary

Addresses the four concrete inconsistencies from the external review under task **(A)**, plus the Aqua-badge request:

| # | Issue | Fix |
|---|---|---|
| 1 | \`docs/src/verification/disordered.md:111\` points at non-existent \`test/verification/test_disordered.jl\` | Retarget to \`test_disordered_heisenberg.jl\` |
| 2 | \`docs/src/calc/ising-cft-primary-operators.md:355\` points at non-existent \`test/verification/test_tfim_central_charge.jl\` | Retarget to the σ r^{-1/4} testset in \`test_TFIM_dynamics.jl\` and the PBC c = 1/2 extraction in \`test_entanglement_central_charge.jl\` |
| 3 | \`docs/src/models/quantum/tfim.md:299-301\` claims the σ perturbation **breaks** integrability — wrong; Zamolodchikov (1989) showed it is **preserved**, and that is exactly what makes the E8 spectrum non-trivial | Rewrote to match \`universalities/e8.md\` |
| 4 | \`md/roadmap.md\` listed several already-resolved items as open | Marked resolved with PR references (Peschel σᶻσᶻ → PR #69, central-charge precision → PR #75, bond-counting → PR #71, sparse ED infra → landed, legacy-shim \`maxlog\` corrected and porting status added from PR #73 / #78) |
| 5 | No Aqua badge in README | Added \`[![Aqua QA](...)](...)\` next to the other QA badges. Aqua already runs in CI via \`test/test_aqua.jl\`. |

## Test plan

- [x] No \`src/\` or \`test/\` changes in this PR — docs only.
- [x] \`julia --project=docs docs/make.jl\` clean, only pre-existing warnings (search-index over-size, \`docs/src/models/quantum/tightbinding/triangular.md\` \`\$\` interpolation). Inventory picks up \`version = "0.13.5"\` correctly.