### PR TITLE
test(aqua): re-enable undocumented_names=true

### DIFF
--- a/src/universalities/Ising2D.jl
+++ b/src/universalities/Ising2D.jl
@@ -24,9 +24,28 @@
 #   These are currently the most precise known estimates.
 # ─────────────────────────────────────────────────────────────────────────────
 
-# Backward-compatible alias — delegates to Universality{:Ising} with d=2.
-# Subtyped to `AbstractQAtlasModel` so it composes with the new top-level
-# fetch(::AbstractQAtlasModel, ::AbstractQuantity, ::BC) signature.
+"""
+    Ising2D <: AbstractQAtlasModel
+
+Dispatch tag for the **two-dimensional** Ising universality class.
+Acts as a convenience wrapper over `Universality(:Ising)` with the
+dimension pinned to `d = 2`, so call sites do not have to repeat
+`d = 2` on every `fetch`:
+
+```julia
+QAtlas.fetch(Ising2D(), CriticalExponents())
+# ≡ QAtlas.fetch(Universality(:Ising), CriticalExponents(); d = 2)
+```
+
+The struct is kept as a distinct nominal type (rather than
+`const Ising2D = Universality{:Ising}`) because the `d` kwarg is
+fixed at 2 here — a type-level `const` alias would defeat that
+fix. Subtyped to `AbstractQAtlasModel` so it composes with the
+canonical `fetch(::AbstractQAtlasModel, ::AbstractQuantity, ::BoundaryCondition)`
+signature.
+
+See also: [`Universality`](@ref), [`CriticalExponents`](@ref).
+"""
 struct Ising2D <: AbstractQAtlasModel end
 
 """

--- a/src/universalities/KPZ.jl
+++ b/src/universalities/KPZ.jl
@@ -10,10 +10,27 @@
 #   T. Sasamoto, H. Spohn, Nucl. Phys. B 834, 523 (2010).
 # ─────────────────────────────────────────────────────────────────────────────
 
-# Backward-compatible alias — previously a bare struct tag; now
-# subtyped to `AbstractQAtlasModel` so dispatch composes with the new
-# top-level `fetch(::AbstractQAtlasModel, ::AbstractQuantity, ::BC)`
-# canonical signature.
+"""
+    KPZ1D <: AbstractQAtlasModel
+
+Dispatch tag for the **1+1-dimensional** KPZ (Kardar–Parisi–Zhang)
+universality class. Acts as a convenience wrapper over
+`Universality(:KPZ)` with the dimension pinned to `d = 1`:
+
+```julia
+QAtlas.fetch(KPZ1D(), CriticalExponents())
+# ≡ QAtlas.fetch(Universality(:KPZ), GrowthExponents(); d = 1)
+```
+
+The struct is kept as a distinct nominal type (rather than
+`const KPZ1D = Universality{:KPZ}`) because the dimension is fixed
+here — a type-level alias would defeat that fix. Subtyped to
+`AbstractQAtlasModel` so dispatch composes with the canonical
+`fetch(::AbstractQAtlasModel, ::AbstractQuantity, ::BoundaryCondition)`
+signature.
+
+See also: [`Universality`](@ref), [`GrowthExponents`](@ref).
+"""
 struct KPZ1D <: AbstractQAtlasModel end
 function fetch(::KPZ1D, ::CriticalExponents; kwargs...)
     return fetch(Universality(:KPZ), GrowthExponents(); d=1, kwargs...)

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -17,12 +17,11 @@ using Aqua
         ambiguities=false,
         deps_compat=true,
         stale_deps=true,
-        # TODO(v0.13 API redesign): re-enable `undocumented_names=true` once
-        # every public struct has a dedicated docstring.  At the time of
-        # writing this check flags `Infinite`, `OBC`, `PBC`, `Ising2D`,
-        # `KPZ1D`, `Model`, `Quantity` — all of which are being rewritten
-        # as part of the API redesign.
-        undocumented_names=false,
+        # Re-enabled in v0.13.5 after every public struct got a
+        # dedicated docstring. Keeps the public-API surface honest:
+        # adding a new `export X` without a docstring for `X` now
+        # fails CI.
+        undocumented_names=true,
         persistent_tasks=false,
         piracies=true,
         unbound_args=true,


### PR DESCRIPTION
## Summary

External review task **(D)**: the Aqua QA badge on the README is
only meaningful once \`undocumented_names\` is on. \`test/test_aqua.jl\`
carried a TODO from the v0.13 API redesign listing seven symbols Aqua
would flag:

> \`Infinite\`, \`OBC\`, \`PBC\`, \`Ising2D\`, \`KPZ1D\`, \`Model\`, \`Quantity\`.

Of those, only \`Ising2D\` and \`KPZ1D\` still lacked a docstring at
v0.13.5 — everything else got one during later refactors:

\`\`\`julia
julia> Aqua.test_undocumented_names(QAtlas)
Undocumented names detected:
2-element Vector{Symbol}:
 :Ising2D
 :KPZ1D
\`\`\`

This PR fills those two and flips the flag:

- \`src/universalities/Ising2D.jl\` — docstring explaining \`Ising2D\` is a nominal subtype of \`AbstractQAtlasModel\` that pins \`Universality(:Ising)\` at \`d = 2\`, why it is NOT a \`const\` alias (the \`d\` kwarg would leak back to callers), and a usage example.
- \`src/universalities/KPZ.jl\` — symmetric docstring for \`KPZ1D\` pinning \`Universality(:KPZ)\` at \`d = 1\`.
- \`test/test_aqua.jl\` — \`undocumented_names = true\` with a justification comment replacing the old TODO.

## Why it matters

Any future \`export Foo\` without a \`"""…""" struct Foo\` now fails CI. The README's Aqua QA badge (added in PR #80) is backed by a strict \`undocumented_names\` check again — no stale "partial compliance" caveat needed.

## Test plan

- [x] \`Aqua.test_undocumented_names(QAtlas)\` passes on the new tree.
- [x] \`Pkg.test()\` — 1059 → **1060** pass, 2 m 27 s (no runtime change).