### PR TITLE
docs(README): brush-up for v0.13.6 state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # QAtlas.jl
 
 > ⚠️ **AI-assisted draft — feedback welcome.**
-> Both the source code and every derivation note in the documentation are
-> generated with heavy LLM assistance (Claude) and are still being
-> independently reviewed. If you spot an error — in a formula, a proof
-> step, a citation, a type signature, anything — please
+> The source code and the derivation notes under `docs/src/` are written
+> with heavy LLM assistance (Claude) and are being independently
+> reviewed. Found an error — a formula, a proof step, a citation, a
+> type signature? Please
 > [**open an issue**](https://github.com/sotashimozono/QAtlas.jl/issues/new?labels=docs&title=%5Bdocs%5D%20error%20report)
-> or submit a pull request. Corrections and reviews are genuinely
-> appreciated; this package is in better shape the more eyes it gets.
+> or a PR. Recent review cycles have already caught one flagship bug
+> (E₈ mass ratios `m₇`, `m₈` were 2× the literature value, fixed in
+> [PR #83](https://github.com/sotashimozono/QAtlas.jl/pull/83));
+> more eyes keep making the package better.
 
 [![docs: stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://codes.sota-shimozono.com/QAtlas.jl/stable/)
 [![docs: dev](https://img.shields.io/badge/docs-dev-purple.svg)](https://codes.sota-shimozono.com/QAtlas.jl/dev/)
@@ -19,113 +21,159 @@
 [![Build Status](https://github.com/sotashimozono/QAtlas.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/sotashimozono/QAtlas.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-**QAtlas** (QUAntum Reference Table for Exact Tests) is a Julia package providing a curated dictionary of **rigorous results** in quantum and statistical physics. Every stored value is traced to a specific publication and cross-validated against independent calculations.
+**QAtlas** (QUAntum Reference Table for Exact Tests) is a Julia
+package exposing a curated dictionary of **rigorous results** in
+quantum and statistical physics. Every stored value traces back to a
+specific publication and is cross-validated against independent
+numerical computations (dense / sparse exact diagonalisation,
+brute-force enumeration, Bloch diagonalisation, automatic
+differentiation, bipartite fluctuations, …).
 
-> **Status and verification policy**
->
-> While every stored value cites a specific publication and is cross-checked against independent numerical computations (exact diagonalization, brute-force enumeration, automatic differentiation), **the maintainer has not personally verified every derivation in equal depth**.
->
-> Results that the maintainer can independently derive and has verified line-by-line (TFIM exact solution, Onsager critical temperature, Yang magnetization, Heisenberg dimer) carry the highest confidence. Other results (tight-binding Bloch formulas for various lattices, numerical universality exponents transcribed from the literature, E8 mass ratios) are tested against independent computations but the underlying derivations have not been checked by hand.
->
-> **If you use QAtlas values in a publication, please verify them against the cited original references.** If you find a discrepancy, please open an issue.
+> **Confidence tiers.**
+> Results the maintainer can independently derive and has checked
+> line-by-line (TFIM BdG + thermodynamics, Onsager $T_c$, Yang $M(T)$,
+> Heisenberg dimer, bipartite-fluctuation Luttinger $K$, PBC
+> Calabrese–Cardy central charge) carry the highest confidence.
+> Others — tight-binding Bloch formulas, 3D O(N) bootstrap values,
+> $E_8$ mass ratios — are cross-checked against independent numerical
+> computations but the underlying derivations have not all been
+> re-done by hand.
+> **If you use QAtlas values in a publication, please verify them
+> against the cited original references.**
 
 ## Quick Start
 
 ```julia
 using QAtlas
 
-# Onsager's critical temperature for the 2D Ising model
-Tc = QAtlas.fetch(IsingSquare(), CriticalTemperature())  # 2J / ln(1 + √2)
+# ── Classical Ising on the 2D square lattice ─────────────────────
+# Onsager (1944) — critical temperature
+Tc = QAtlas.fetch(IsingSquare(; J = 1.0), CriticalTemperature())
+#  = 2J / ln(1 + √2)
 
-# Yang's spontaneous magnetization
-M = QAtlas.fetch(IsingSquare(), SpontaneousMagnetization(); β=0.5)
+# Yang (1952) — spontaneous magnetisation
+M = QAtlas.fetch(IsingSquare(; J = 1.0), SpontaneousMagnetization(); β = 0.5)
 
-# 2D Ising universality class: exact critical exponents
-e = QAtlas.fetch(Universality(:Ising), CriticalExponents(); d=2)
-# (β = 1//8, ν = 1//1, γ = 7//4, η = 1//4, δ = 15//1, α = 0//1, c = 1//2)
+# Transfer-matrix partition function on an Lx × Ly torus
+Z = QAtlas.fetch(IsingSquare(; J = 1.0, Lx = 4, Ly = 4), PartitionFunction(); β = 0.44)
 
-# 3D Ising: numerical estimates with uncertainty
-e3 = QAtlas.fetch(Universality(:Ising), CriticalExponents(); d=3)
-# (α = 0.11009, α_err = 1.0e-5, β = 0.32642, β_err = 1.0e-5, ...)
+# ── Universality classes ─────────────────────────────────────────
+# 2D Ising — exact rational exponents
+e2 = QAtlas.fetch(Universality(:Ising), CriticalExponents(); d = 2)
+#  (α = 0//1, β = 1//8, γ = 7//4, δ = 15//1, ν = 1//1, η = 1//4, c = 1//2)
 
-# Graphene tight-binding spectrum (honeycomb lattice)
-λ = QAtlas.fetch(Graphene(), TightBindingSpectrum(); Lx=3, Ly=3, t=1.0)
+# 3D Ising — Kos-Poland-Simmons-Duffin-Vichi 2016 bootstrap
+e3 = QAtlas.fetch(Universality(:Ising), CriticalExponents(); d = 3)
+#  (α = 0.11009, α_err = 1e-5, β = 0.32642, β_err = 1e-5, …)
 
-# Bethe ansatz: Heisenberg chain ground-state energy density
-e0 = QAtlas.fetch(Heisenberg1D(), GroundStateEnergyDensity())  # 1/4 − ln 2
+# E₈ mass spectrum (Zamolodchikov 1989) — normalised m₁ = 1
+masses = QAtlas.fetch(E8(), E8Spectrum(), Infinite())
+#  [1.0, φ, 1.989, 2.405, 2.956, 3.218, 3.891, 4.783]
 
-# Classical Ising partition function via transfer matrix
-Z = QAtlas.fetch(IsingSquare(), PartitionFunction(); Lx=4, Ly=4, β=0.44)
+# ── Quantum spin chains ──────────────────────────────────────────
+# Hulthén (1938) — AF Heisenberg ground-state energy density
+e0 = QAtlas.fetch(Heisenberg1D(), GroundStateEnergyDensity())  # J·(1/4 − ln 2)
+
+# TFIM BdG thermal observables (Pfeuty 1970 + free-fermion thermo)
+ε = QAtlas.fetch(TFIM(; J = 1.0, h = 0.5), Energy(), OBC(24); beta = 5.0)
+Δ = QAtlas.fetch(TFIM(; J = 1.0, h = 2.0), MassGap(), Infinite())   # = 2|h−J|
+
+# Bipartite-block von Neumann entropy (Peschel method, OBC)
+S = QAtlas.fetch(TFIM(; J = 1.0, h = 1.0), VonNeumannEntropy(), OBC(16); ℓ = 8)
+
+# XXZ chain — Luttinger parameter + spin-wave velocity (|Δ| < 1)
+K = QAtlas.fetch(XXZ1D(; J = 1.0, Δ = 0.5), LuttingerParameter(), Infinite())  # = 3/4
+u = QAtlas.fetch(XXZ1D(; J = 1.0, Δ = 1.0), SpinWaveVelocity(), Infinite())    # = π/2
+
+# ── Tight-binding band structures ────────────────────────────────
+# Honeycomb (Graphene) — exported alias `Graphene === QAtlas.Honeycomb`
+λ = QAtlas.fetch(Graphene(; t = 1.0, Lx = 6, Ly = 6), TightBindingSpectrum())
+# Kagome / Lieb / Triangular need the QAtlas. prefix (Lattice2D name clash)
+λ_kagome = QAtlas.fetch(QAtlas.Kagome(; t = 1.0, Lx = 6, Ly = 6), TightBindingSpectrum())
 ```
 
 ## What's Inside
 
 ### Models
 
-| Model | Quantities | Method |
+| Model | Example quantities | Method |
 | ----- | ---------- | ------ |
-| **IsingSquare** | Partition function Z(Lx, Ly, β) | Transfer matrix |
-| | Critical temperature T_c | Onsager (1944) exact |
-| | Spontaneous magnetization M(T) | Yang (1952) exact |
-| **Graphene** (honeycomb TB) | Single-particle spectrum | Bloch Hamiltonian |
-| **Kagome** TB | Spectrum + flat band at +2t | Bloch 3×3 |
-| **Lieb** TB | Spectrum + flat band at E=0 | Bloch 3×3 |
-| **Triangular** TB | Spectrum (frustrated) | Bloch scalar |
-| **Heisenberg1D** | Dimer spectrum {−3J/4, J/4³} | Exact |
-| | 4-site PBC spectrum | Exact |
-| | Ground-state energy density e₀ | Bethe ansatz |
-| **TFIM** | Energy, free energy, entropy, ... | BdG + quadrature |
+| **`IsingSquare`** | `PartitionFunction`, `CriticalTemperature`, `SpontaneousMagnetization` | Transfer matrix · Onsager 1944 · Yang 1952 |
+| **`TFIM`** | `Energy`, `FreeEnergy`, `ThermalEntropy`, `SpecificHeat`, `MassGap`, `MagnetizationX`, `SusceptibilityXX/ZZ`, `ZZCorrelation{:static,:dynamic,:lightcone}`, `VonNeumannEntropy` | Jordan-Wigner + BdG (Pfeuty 1970) · Peschel correlation matrix |
+| **`XXZ1D`** | `Energy` (Δ ∈ {−1, 0, 1}), `LuttingerParameter`, `LuttingerVelocity` / `SpinWaveVelocity`, `FermiVelocity`, `CentralCharge` | Bethe ansatz closed forms · bosonisation |
+| **`Heisenberg1D`** | `ExactSpectrum` (N=2 OBC, N=4 PBC), `GroundStateEnergyDensity` | Bethe ansatz (Hulthén 1938) |
+| **`Graphene`** / **`QAtlas.Honeycomb`** | `TightBindingSpectrum` | Bloch Hamiltonian (honeycomb) |
+| **`QAtlas.Kagome`** | Spectrum + flat band at +2t | Bloch 3×3 |
+| **`QAtlas.Lieb`** | Spectrum + flat band at E=0 | Bloch 3×3 |
+| **`QAtlas.Triangular`** | Spectrum (frustrated) | Bloch scalar |
+| **`E8`** | `E8Spectrum` — 8 mass ratios | Perron-Frobenius of $E_8$ Cartan matrix (Zamolodchikov 1989) |
 
-### Universality Classes
+Additional lattices (**Dice**, **UnionJack**, **ShastrySutherland**) are covered in the verification suite via the generic Bloch builder in `src/util/bloch.jl`.
 
-Access via `Universality{C}` with dimension `d`:
+### Universality classes
+
+Access via `Universality{C}` at dimension `d`:
 
 | Class | d | Type | Key exponents |
 | ----- | - | ---- | ------------- |
-| **Ising** | 2 | Exact (Rational) | β=1/8, ν=1, c=1/2 |
-| | 3 | Numerical (+err) | Conformal bootstrap |
-| | ≥4 | Mean-field | Landau |
-| **Percolation** | 2 | Exact | β=5/36, ν=4/3 |
-| **3-state Potts** | 2 | Exact | β=1/9 |
-| **4-state Potts** | 2 | Exact | β=1/12 |
-| **XY** | 2 | BKT | η=1/4 |
-| | 3 | Numerical | Bootstrap |
-| **Heisenberg** | 3 | Numerical | Bootstrap |
-| **KPZ** | 1+1D | Exact | β=1/3, z=3/2 |
-| **Mean-field** | any | Exact | β=1/2, ν=1/2 |
+| **Ising** | 2 | Exact (Rational) | β = 1/8, ν = 1, c = 1/2 |
+| | 3 | Bootstrap (Float64 + err) | β ≈ 0.32642(1), ν ≈ 0.62997(1) |
+| | ≥ 4 | Mean-field | β = 1/2, ν = 1/2 |
+| **Percolation** | 2 | Exact | β = 5/36, ν = 4/3 |
+| | 3 | Numerical | |
+| **3-state Potts** | 2 | Exact | β = 1/9, ν = 5/6 |
+| **4-state Potts** | 2 | Exact | β = 1/12, ν = 2/3 |
+| **XY** | 2 | BKT | η = 1/4 (universal jump) |
+| | 3 | Bootstrap (O(2)) | β ≈ 0.34869(7) |
+| **Heisenberg** | 3 | Bootstrap (O(3)) | β ≈ 0.3689(3) |
+| **KPZ** | 1 + 1 | Exact | z = 3/2, β = 1/3, α = 1/2 |
+| **Mean-field** | any | Exact | β = 1/2, ν = 1/2 |
+| **E₈** | — | Exact (integrable FT) | 8 mass ratios |
 
-Exact values use `Rational{Int}` — scaling relations hold with zero floating-point error:
+Exact exponents are `Rational{Int}`, so scaling relations hold **exactly** (no floating-point error):
 
 ```julia
-e = QAtlas.fetch(Universality(:Ising), CriticalExponents(); d=2)
-e.α + 2*e.β + e.γ == 2   # Rushbrooke: exactly true
-e.γ == e.β * (e.δ - 1)   # Widom: exactly true
+e = QAtlas.fetch(Universality(:Ising), CriticalExponents(); d = 2)
+e.α + 2 * e.β + e.γ == 2        # Rushbrooke
+e.γ == e.β * (e.δ - 1)           # Widom
+e.γ == e.ν * (2 - e.η)           # Fisher
+2 - e.α == 2 * e.ν               # Josephson
 ```
 
 ## Verification
 
-QAtlas is **self-verifying**: every result in `src/` is cross-checked against independent calculations in `test/`. The test suite (800+ tests) includes:
+QAtlas is **self-verifying**: every stored value in `src/` is cross-checked against independent computations in `test/`. At v0.13.6 the suite runs **1124 tests in ~2 min 30 s** on a 4-core CI runner (nightly with `QATLAS_TEST_FULL=1` extends to N = 16–20 sparse ED).
 
-- **Standalone tests**: Special values, scaling relations, limiting cases
-- **Lattice verification**: Real-space ED and Bloch diagonalization via [Lattice2D.jl](https://github.com/sotashimozono/Lattice2D.jl) on all 8 supported topologies
-- **AD verification**: ForwardDiff-based extraction of thermodynamic quantities from partition functions
-- **Cross-verification**: Universality exponents extracted from model-specific results (e.g., β=1/8 from Yang magnetization, z=1 from TFIM gap scaling)
+Layers of verification:
 
-## ForwardDiff Compatibility
+- **Standalone** — special values, limits, and scaling-relation identities asserted against closed-form rationals.
+- **Literature cross-check** (`test/verification/test_universality_literature_values.jl`) — numerical universality exponents match the cited paper's tabulated decimals at the quoted precision (Kos 2016, Chester 2020/2021).
+- **Lattice ED verification** — real-space exact diagonalisation (dense or sparse + KrylovKit Lanczos) on [Lattice2D.jl](https://github.com/sotashimozono/Lattice2D.jl) geometries for every tight-binding and TFIM / Heisenberg / XXZ / E₈ result.
+- **AD verification** — ForwardDiff-based derivation of thermodynamic quantities from `log Z`, cross-checked against direct ensemble averages.
+- **Cross-universality** — β = 1/8 extracted from Yang $M(T)$, z = 1 from the TFIM gap (PBC sparse ED, `rtol = 0.01`), c = 1/2 from PBC entanglement-entropy scaling, Luttinger $K$ from bipartite-fluctuation ED — each route tests a *different* stored dictionary entry.
 
-The partition function and related functions accept `ForwardDiff.Dual` numbers, enabling automatic differentiation of thermodynamic quantities:
+## ForwardDiff compatibility
+
+Every $Z$- and $\log Z$-like quantity accepts `ForwardDiff.Dual` numbers, so thermodynamic quantities can be obtained by differentiation. `ForwardDiff` is not a runtime dependency of QAtlas — install it alongside if you want this:
 
 ```julia
-using ForwardDiff
+using Pkg; Pkg.add("ForwardDiff")
+using ForwardDiff, QAtlas
 
-# Internal energy from partition function
-E = -ForwardDiff.derivative(β -> log(QAtlas.fetch(
-    IsingSquare(), PartitionFunction(); Lx=3, Ly=3, β=β)), 0.5)
+logZ(β) = log(QAtlas.fetch(IsingSquare(; J = 1.0, Lx = 3, Ly = 3),
+                           PartitionFunction(); β = β))
 
-# Heat capacity via second derivative
-C = β² * ForwardDiff.derivative(
-    β -> ForwardDiff.derivative(β -> log(Z(β)), β), β)
+β0 = 0.5
+
+# Internal energy ⟨E⟩ = -∂(log Z)/∂β
+E_avg = -ForwardDiff.derivative(logZ, β0)
+
+# Heat capacity  C_v = β² · ∂²(log Z)/∂β²
+d2 = ForwardDiff.derivative(β -> ForwardDiff.derivative(logZ, β), β0)
+Cv = β0^2 * d2
 ```
+
+The full fluctuation-dissipation derivation from $\ln Z$ to $(F, \langle E\rangle, C_v, S)$ is written out in [`docs/src/calc/ad-thermodynamics-from-z.md`](docs/src/calc/ad-thermodynamics-from-z.md).
 
 ## Installation
 
@@ -134,10 +182,12 @@ using Pkg
 Pkg.add("QAtlas")
 ```
 
+Requires Julia ≥ 1.12. Documentation: [codes.sota-shimozono.com/QAtlas.jl/stable](https://codes.sota-shimozono.com/QAtlas.jl/stable/).
+
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on adding new results, writing tests, and the citation standards we follow.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the depth standard applied to derivations in `docs/src/calc/`, the citation format, and the concrete-struct API conventions. Corrections to physics content, scaling-relation cross-checks, and independent-source confirmations are especially welcome.
 
 ## License
 
-MIT License. See [LICENSE](LICENSE) for details.
+MIT. See [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

General refresh of the project README to reflect the v0.13 concrete-struct API, current test-suite size, the new model / quantity coverage, and the recent review-driven verification push.

Diff is ~129 lines added / 79 removed (76% rewrite), but every existing section stays in roughly the same place.

## Highlights

- **Top banner** — still the prominent "AI-assisted draft, feedback welcome" box, now references the concrete outcome of recent reviews (the E₈ \`m₇\` / \`m₈\` factor-of-2 bug caught in PR #83) so the invitation reads as a live commitment rather than boilerplate.
- **Confidence-tier box** consolidated below the description; the two overlapping disclaimer blocks from the old README collapsed into one.
- **Quick Start** converted end-to-end to the v0.13 \`fetch(Model(;params...), Quantity(), bc; kwargs...)\` form, with flagship additions for E₈, TFIM \`MassGap\` + \`VonNeumannEntropy\`, XXZ Luttinger K / spin-wave velocity, and the \`QAtlas.Kagome(...)\` prefix pattern.
- **Models table** expanded with the full TFIM thermal + dynamical + entanglement surface, new rows for XXZ1D and E₈, and an explicit Graphene-vs-unexported-TB distinction.
- **Universality table** now lists 3D Ising / XY / Heisenberg bootstrap decimals and the E₈ entry.
- **Verification** section rewritten — old "800+ tests, self-verifying" line replaced with the current **1124 tests in ~2 m 30 s** figure and a five-layer breakdown (standalone / literature cross-check / lattice ED / AD / cross-universality).
- **ForwardDiff** example fixed — the previous snippet had an undefined \`Z(β)\` on the second-derivative line. Replaced with a single-definition \`logZ(β)\` used for both derivatives, plus a \`Pkg.add("ForwardDiff")\` reminder.

## Test plan

- [x] No source or test changes — README only.
- [x] Every code snippet in the new README smoke-tested locally against v0.13.6: classical Ising values match, E₈ spectrum returns the corrected mass ratios, TFIM / XXZ / Heisenberg calls execute, ForwardDiff \`E_avg\`, \`Cv\` evaluate without error.
- [x] \`docs/make.jl\` unaffected — README is not included in the public doc build.