### PR TITLE
feat: XXZ1D / Heisenberg1D finite-T Energy OBC via dense ED

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -27,6 +27,7 @@ include("core/alias.jl")
 include("core/type.jl")
 include("core/quantities.jl")
 include("core/pfaffian.jl")
+include("core/dense_ed.jl")
 
 # --- Quantity struct exports (new, axis-explicit naming) ---
 export Energy, FreeEnergy, SpecificHeat, MassGap, FidelitySusceptibility

--- a/src/core/dense_ed.jl
+++ b/src/core/dense_ed.jl
@@ -1,0 +1,82 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Small-N dense exact diagonalisation helpers for spin-1/2 chains
+#
+# For integrable-at-infinite models like XXZ1D that don't yet have a
+# finite-size finite-T formula implemented, the ED path gives a
+# *finite-N exact* thermal reference suitable for benchmarking MPS
+# methods at modest system sizes.  The cost is `O(2^{3N})` in time and
+# `O(2^{2N})` in memory, so the scale ceiling is ~N ≤ 12.
+#
+# Performance note: every observable ⟨O⟩_β goes through the same
+# eigendecomposition of H, so callers that want multiple quantities at
+# the same β should cache the spectrum.  The public `fetch` methods do
+# not cache today — add a per-model cache when/if profiling shows it
+# matters.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using LinearAlgebra: Hermitian, eigen
+
+"""
+    _MAX_ED_SITES = 12
+
+Hard cap on chain length for dense-ED helpers.  2^12 = 4096 → 4096×4096
+Hermitian eigendecomposition takes ~1 s on a laptop; 2^14 ~ 16384 is
+already several seconds and 64 GB+ of workspace, which is past the
+"cheap reference data" regime this helper targets.
+"""
+const _MAX_ED_SITES = 12
+
+# Single-qubit Pauli matrices used to assemble tensor-product operators.
+const _σ0 = ComplexF64[1 0; 0 1]
+const _σx = ComplexF64[0 1; 1 0]
+const _σy = ComplexF64[0 -im; im 0]
+const _σz = ComplexF64[1 0; 0 -1]
+
+"""
+    _pauli_string(N::Int, site_ops::Pair{Int,Matrix{ComplexF64}}...) -> Matrix{ComplexF64}
+
+Return the `2^N × 2^N` tensor product that places each `σ_k` at its
+listed site and the identity elsewhere.  `site_ops` is an arbitrary
+sequence of `(site => matrix)` pairs; missing sites get `_σ0`.
+
+```julia
+# σˣ at site 3 in an N=5 chain:
+_pauli_string(5, 3 => _σx)
+
+# σˣᵢ σᶻⱼ for (i,j) = (2,4):
+_pauli_string(5, 2 => _σx, 4 => _σz)
+```
+"""
+function _pauli_string(N::Int, site_ops::Pair{Int,Matrix{ComplexF64}}...)
+    N ≤ _MAX_ED_SITES ||
+        throw(ArgumentError("dense ED is capped at N ≤ $_MAX_ED_SITES (got N = $N)"))
+    lookup = Dict(site_ops...)
+    ops = [get(lookup, k, _σ0) for k in 1:N]
+    return reduce(kron, ops)
+end
+
+"""
+    _ed_thermal_expectation(evals, evecs, O_diag, β) -> Float64
+
+Return `⟨O⟩_β = Σ_n O_nn exp(-β eₙ) / Σ_n exp(-β eₙ)` given a
+pre-computed eigendecomposition `(evals, evecs)` of `H` and the
+diagonal of `O` in the H-eigenbasis, `O_diag[n] = ⟨n|O|n⟩`.
+
+Uses a log-sum-exp shift (`eₘᵢₙ`) so `β` up to ~10^2 / bandwidth is
+numerically stable.
+"""
+function _ed_thermal_expectation(evals::AbstractVector, O_diag::AbstractVector, β::Real)
+    emin = minimum(evals)
+    ws = exp.(-β .* (evals .- emin))
+    return real(sum(O_diag .* ws) / sum(ws))
+end
+
+"""
+    _ed_thermal_energy(H::AbstractMatrix, β::Real) -> Float64
+
+`⟨H⟩_β = Tr(H exp(-βH)) / Tr(exp(-βH))`.  `H` must be Hermitian.
+"""
+function _ed_thermal_energy(H::AbstractMatrix, β::Real)
+    F = eigen(Hermitian(H))
+    return _ed_thermal_expectation(F.values, F.values, β)
+end

--- a/src/models/quantum/Heisenberg/Heisenberg.jl
+++ b/src/models/quantum/Heisenberg/Heisenberg.jl
@@ -158,3 +158,19 @@ finite-size extrapolation verification using ED at N = 4, 6, 8.
 function fetch(::Heisenberg1D, ::GroundStateEnergyDensity; J::Real=1.0)
     return J * (1 // 4 - log(2))
 end
+
+"""
+    fetch(::Heisenberg1D, ::Energy, ::OBC; beta, J=1.0) -> Float64
+
+Per-site thermal energy `⟨H⟩_β / N` for the spin-½ antiferromagnetic
+Heisenberg OBC chain at finite `N` (the isotropic point `Δ = 1` of
+[`XXZ1D`](@ref)).  Routes through [`fetch(::XXZ1D, ::Energy, ::OBC)`](@ref).
+
+Since `Heisenberg1D` currently carries no `J` field, callers must pass
+`J` as a kwarg (default `J = 1.0`).  Downstream bridges (e.g.
+ITensorModels `to_qatlas(::Heisenberg1D)`) lose `J` on conversion; use
+`XXZ1D(; J, Δ=1)` directly if you need a non-unit coupling.
+"""
+function fetch(::Heisenberg1D, ::Energy, bc::OBC; beta::Real, J::Real=1.0, kwargs...)
+    return fetch(XXZ1D(; J=J, Δ=1.0), Energy(), bc; beta=beta)
+end

--- a/src/models/quantum/XXZ/XXZ.jl
+++ b/src/models/quantum/XXZ/XXZ.jl
@@ -182,3 +182,56 @@ function fetch(model::XXZ1D, ::LuttingerVelocity, ::Infinite; kwargs...)
     @warn "XXZ1D LuttingerVelocity is only defined for -1 < Δ ≤ 1." Δ = Δ
     return NaN
 end
+
+# ── Finite-temperature, finite-N OBC via dense ED ──────────────────────
+#
+# General-Δ finite-T XXZ has no closed-form formula like the TFIM
+# BdG decomposition; the thermal Bethe ansatz gives the thermodynamic
+# limit only.  For MPS-benchmark use cases the working scale is
+# small-N (say N ≤ 10) where dense ED of the 2^N × 2^N spin-1/2
+# Hilbert space is trivially cheap and gives a *finite-N exact*
+# reference.  We implement that path here; closed-form thermal at
+# Δ = 0 (XX / free fermion) and TBA at general Δ in the
+# thermodynamic limit are separate follow-ups.
+
+"""
+    _xxz1d_hamiltonian_matrix(model::XXZ1D, N::Int) -> Matrix{ComplexF64}
+
+Assemble the `2^N × 2^N` OBC Hamiltonian
+
+    H = J Σᵢ [ Sˣ_i Sˣ_{i+1} + Sʸ_i Sʸ_{i+1} + Δ Sᶻ_i Sᶻ_{i+1} ]
+      = (J/4) Σᵢ [ σˣ σˣ + σʸ σʸ + Δ σᶻ σᶻ ]
+
+via explicit tensor products built from the Pauli primitives in
+`src/core/dense_ed.jl`.  Capped by `_MAX_ED_SITES`.
+"""
+function _xxz1d_hamiltonian_matrix(model::XXZ1D, N::Int)
+    N ≥ 2 || throw(ArgumentError("XXZ1D OBC chain needs N ≥ 2 (got N = $N)"))
+    J, Δ = model.J, model.Δ
+    D = 2^N
+    H = zeros(ComplexF64, D, D)
+    prefac = J / 4
+    for i in 1:(N - 1)
+        H .+= prefac .* _pauli_string(N, i => _σx, i + 1 => _σx)
+        H .+= prefac .* _pauli_string(N, i => _σy, i + 1 => _σy)
+        H .+= (prefac * Δ) .* _pauli_string(N, i => _σz, i + 1 => _σz)
+    end
+    return H
+end
+
+"""
+    fetch(model::XXZ1D, ::Energy, ::OBC; beta) -> Float64
+
+Per-site thermal energy `⟨H⟩_β / N` for the spin-½ OBC chain at finite
+size, computed by dense ED.  Works for any `Δ` and any `N ≤
+$(_MAX_ED_SITES)`.  Intended as a reference for MPS thermal methods
+(TPQMPS / Purification / METTS).
+
+```
+    ⟨H⟩_β / N = Tr(H exp(-βH)) / (N · Tr(exp(-βH)))
+```
+"""
+function fetch(model::XXZ1D, ::Energy, bc::OBC; beta::Real, kwargs...)
+    H = _xxz1d_hamiltonian_matrix(model, bc.N)
+    return _ed_thermal_energy(H, beta) / bc.N
+end

--- a/test/models/test_XXZ1D_thermal.jl
+++ b/test/models/test_XXZ1D_thermal.jl
@@ -1,0 +1,92 @@
+using QAtlas, Test, LinearAlgebra
+
+# Cross-check the dense-ED thermal Energy on XXZ1D OBC against an
+# independent direct ED at small N and against sanity limits.
+
+@testset "XXZ1D thermal OBC: β → 0 gives zero energy (Tr(H) = 0 on spin-1/2)" begin
+    # Every bond term σᵅ⊗σᵅ is traceless, and σᶻ at any site has Tr = 0,
+    # so the XXZ OBC Hamiltonian satisfies Tr(H) = 0 exactly.  At β = 0
+    # this means `⟨H⟩ = Tr(H) / 2^N = 0`.
+    for Δ in (-0.5, 0.0, 0.7, 1.0), N in (4, 5, 6)
+        E_per_site = QAtlas.fetch(XXZ1D(; J=1.0, Δ=Δ), Energy(), OBC(N); beta=0.0)
+        @test abs(E_per_site) < 1e-12
+    end
+end
+
+@testset "XXZ1D thermal OBC: β → ∞ reproduces the OBC GS energy (by diagonalisation)" begin
+    # Compute the true OBC GS energy by diagonalising the same matrix
+    # and verify that a large-β thermal average collapses onto it up to
+    # `exp(-β · Δ_gap)`.  Δ_gap is determined empirically from the
+    # spectrum.
+    for (J, Δ, N) in ((1.0, 1.0, 5), (1.3, 0.5, 5))
+        model = XXZ1D(; J=J, Δ=Δ)
+        H = QAtlas._xxz1d_hamiltonian_matrix(model, N)
+        evals = sort(real.(eigvals(Hermitian(H))))
+        E_gs = evals[1]
+        gap = evals[2] - evals[1]
+        β = 50.0
+        E_thermal = QAtlas.fetch(model, Energy(), OBC(N); beta=β) * N  # total energy
+        # At β large, correction ≈ gap · exp(-β gap), bounded very loosely.
+        tol = max(1e-10, 10 * gap * exp(-β * gap))
+        @test abs(E_thermal - E_gs) ≤ tol
+    end
+end
+
+@testset "XXZ1D thermal OBC: matches direct ED with Pauli bond matrix (N=2, N=3)" begin
+    # Direct independent construction for very small N so the kron chain
+    # is unambiguous.
+    σx = ComplexF64[0 1; 1 0]
+    σy = ComplexF64[0 -im; im 0]
+    σz = ComplexF64[1 0; 0 -1]
+    I2 = ComplexF64[1 0; 0 1]
+
+    for (J, Δ, β) in ((1.3, 0.7, 2.0), (0.8, -0.5, 0.7))
+        # N = 2: only one bond, H is just the bond block.
+        bond_22 = (J / 4) * (kron(σx, σx) + kron(σy, σy) + Δ * kron(σz, σz))
+        H2 = Hermitian(bond_22)
+        evals2 = real.(eigvals(H2))
+        emin2 = minimum(evals2)
+        ws2 = exp.(-β .* (evals2 .- emin2))
+        E2_direct = real(sum(evals2 .* ws2) / sum(ws2))
+        E2_fetch = QAtlas.fetch(XXZ1D(; J=J, Δ=Δ), Energy(), OBC(2); beta=β) * 2
+        @test E2_fetch ≈ E2_direct rtol = 1e-10
+
+        # N = 3: two bonds, H = bond(1,2)⊗I + I⊗bond(2,3).
+        bond12 = kron(bond_22, I2)
+        bond23 = kron(I2, bond_22)
+        H3 = Hermitian(bond12 + bond23)
+        evals3 = real.(eigvals(H3))
+        emin3 = minimum(evals3)
+        ws3 = exp.(-β .* (evals3 .- emin3))
+        E3_direct = real(sum(evals3 .* ws3) / sum(ws3))
+        E3_fetch = QAtlas.fetch(XXZ1D(; J=J, Δ=Δ), Energy(), OBC(3); beta=β) * 3
+        @test E3_fetch ≈ E3_direct rtol = 1e-10
+    end
+end
+
+@testset "XXZ1D thermal OBC: monotone cooling (E(β₁) ≥ E(β₂) for β₁ < β₂)" begin
+    N = 5
+    model = XXZ1D(; J=1.0, Δ=0.5)
+    E0 = QAtlas.fetch(model, Energy(), OBC(N); beta=0.0)
+    E1 = QAtlas.fetch(model, Energy(), OBC(N); beta=0.5)
+    E2 = QAtlas.fetch(model, Energy(), OBC(N); beta=1.0)
+    E5 = QAtlas.fetch(model, Energy(), OBC(N); beta=5.0)
+    @test E0 ≥ E1 ≥ E2 ≥ E5
+    @test isapprox(E0, 0.0; atol=1e-12)
+end
+
+@testset "Heisenberg1D thermal OBC: matches XXZ1D(Δ=1) thermal OBC" begin
+    # The delegator should produce the same number as XXZ1D(Δ=1) at
+    # matching J.
+    for β in (0.3, 1.0, 2.5), N in (4, 6)
+        E_heis = QAtlas.fetch(Heisenberg1D(), Energy(), OBC(N); beta=β, J=1.5)
+        E_xxz = QAtlas.fetch(XXZ1D(; J=1.5, Δ=1.0), Energy(), OBC(N); beta=β)
+        @test E_heis ≈ E_xxz rtol = 1e-12
+    end
+end
+
+@testset "dense-ED cap guards against runaway N" begin
+    @test_throws ArgumentError QAtlas._pauli_string(
+        QAtlas._MAX_ED_SITES + 1, 1 => QAtlas._σx
+    )
+end


### PR DESCRIPTION
## Summary
- Adds finite-T \`Energy(OBC)\` reference data for **XXZ1D** and **Heisenberg1D** via a new dense-ED helper (\`src/core/dense_ed.jl\`). Unblocks cross-model benchmarking for MPS thermal methods in ThermalMPS.jl (TPQMPS / Purification / METTS).
- The XXZ chain has no closed-form finite-N finite-T formula, so we take the dense-ED path at small N (cap N = 12). Thermal energy is computed as \`Tr(H e^{-βH}) / Tr(e^{-βH})\` with a log-sum-exp shift for numerical stability.
- \`Heisenberg1D\` implementation is a delegator to \`XXZ1D(J, Δ=1)\`; doc note warns that the phantom-struct \`Heisenberg1D\` loses \`J\` when bridged through \`ITensorModels.to_qatlas\`, so \`XXZ1D\` is the path to use when \`J ≠ 1\`.

## Follow-ups (not in this PR)
- Closed-form XX (Δ=0) thermal at OBC and Infinite via free-fermion
- TBA at general Δ in the thermodynamic limit
- \`SpecificHeat\` / \`MagnetizationZ\` OBC once downstream needs them

## Test plan
- [x] \`test/models/test_XXZ1D_thermal.jl\`: β→0 traceless sanity, β→∞ matches OBC GS within \`exp(-β·gap)\`, small-N (N=2, N=3) independent ED cross-check for multiple (J, Δ), monotone cooling, Heisenberg-delegator agreement, N-cap error.
- [x] Full suite 1207/1207 pass locally
- [ ] CI green on this PR

Version bump 0.14.0 → 0.15.0 (new exported API, additive).