### PR TITLE
fix(TFIM): CentralCharge returns 0 off-critical instead of NaN

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.15.1"
+version = "0.15.2"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/models/quantum/TFIM/TFIM.jl
+++ b/src/models/quantum/TFIM/TFIM.jl
@@ -213,13 +213,13 @@ end
 """
     fetch(model::TFIM, ::CentralCharge, ::Infinite) -> Float64
 
-Central charge of the TFIM critical point (h = J): c = 1/2 (Ising CFT).
-Returns NaN if not at the critical point (|h/J - 1| > 1e-6).
+Central charge of the TFIM:
+
+- `c = 1/2` at the critical point `h = J` (Ising CFT)
+- `c = 0`   in either gapped phase (`h ≠ J`) — no low-energy CFT description
+
+Criticality is detected by `|h/J - 1| ≤ 1e-6`.
 """
 function fetch(model::TFIM, ::CentralCharge, ::Infinite; kwargs...)
-    if abs(model.h / model.J - 1.0) > 1e-6
-        @warn "TFIM central charge c=1/2 only at the critical point h=J. Got h/J=$(model.h/model.J)."
-        return NaN
-    end
-    return 0.5
+    return abs(model.h / model.J - 1.0) ≤ 1e-6 ? 0.5 : 0.0
 end

--- a/test/models/test_TFIM_central_charge.jl
+++ b/test/models/test_TFIM_central_charge.jl
@@ -1,0 +1,24 @@
+using QAtlas, Test
+
+@testset "TFIM CentralCharge — Infinite" begin
+    # At the Ising critical point h = J, c = 1/2 (Ising CFT).
+    @test QAtlas.fetch(TFIM(; J=1.0, h=1.0), CentralCharge(), Infinite()) == 0.5
+    @test QAtlas.fetch(TFIM(; J=2.0, h=2.0), CentralCharge(), Infinite()) == 0.5
+    @test QAtlas.fetch(TFIM(; J=0.5, h=0.5), CentralCharge(), Infinite()) == 0.5
+
+    # Off-critical (gapped) phases return 0.0 — not NaN. The value 0 is the
+    # natural CFT-side answer for a gapped chain (no low-energy CFT).
+    @test QAtlas.fetch(TFIM(; J=1.0, h=0.0), CentralCharge(), Infinite()) == 0.0
+    @test QAtlas.fetch(TFIM(; J=1.0, h=0.5), CentralCharge(), Infinite()) == 0.0
+    @test QAtlas.fetch(TFIM(; J=1.0, h=2.0), CentralCharge(), Infinite()) == 0.0
+    @test QAtlas.fetch(TFIM(; J=1.0, h=10.0), CentralCharge(), Infinite()) == 0.0
+
+    # Result is plain Float64 — no NaN propagation.
+    c = QAtlas.fetch(TFIM(; J=1.0, h=0.3), CentralCharge(), Infinite())
+    @test c isa Float64
+    @test !isnan(c)
+
+    # Tolerance |h/J - 1| ≤ 1e-6 still detects criticality.
+    @test QAtlas.fetch(TFIM(; J=1.0, h=1.0 + 1e-9), CentralCharge(), Infinite()) == 0.5
+    @test QAtlas.fetch(TFIM(; J=1.0, h=1.0 + 1e-3), CentralCharge(), Infinite()) == 0.0
+end


### PR DESCRIPTION
## Summary
- Closes #103.
- `fetch(TFIM(J, h), CentralCharge(), Infinite())` now returns `0.0` for gapped phases (`h ≠ J`) instead of `NaN`.
- Critical point still returns `c = 1/2` under the same `|h/J - 1| ≤ 1e-6` tolerance.
- Drops the off-critical `@warn`: returning 0 is now documented behaviour, not an error.

## Why 0 (not NaN)
- The natural CFT-side answer for a gapped chain is `c = 0` (no low-energy CFT).
- `NaN` silently broke downstream code that does `isnan(c)` or `abs(c - c_ref)` checks.
- Aligns with how the rest of QAtlas treats "this scalar is well-defined here as a limit" cases.

## Labels
- `bug`

## Test plan
- [x] New `test/models/test_TFIM_central_charge.jl` (11 assertions): critical point ⇒ 0.5, off-critical ⇒ 0.0, no NaN propagation, tolerance boundary at 1e-6.
- [ ] CI green.