### PR TITLE
feat(XXZ1D, Heisenberg1D)!: harmonise OBC Energy to total

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.15.1"
+version = "0.16.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/models/quantum/Heisenberg/Heisenberg.jl
+++ b/src/models/quantum/Heisenberg/Heisenberg.jl
@@ -162,7 +162,7 @@ end
 """
     fetch(::Heisenberg1D, ::Energy, ::OBC; beta, J=1.0) -> Float64
 
-Per-site thermal energy `⟨H⟩_β / N` for the spin-½ antiferromagnetic
+**Total** thermal energy `⟨H⟩_β` for the spin-½ antiferromagnetic
 Heisenberg OBC chain at finite `N` (the isotropic point `Δ = 1` of
 [`XXZ1D`](@ref)).  Routes through [`fetch(::XXZ1D, ::Energy, ::OBC)`](@ref).
 

--- a/src/models/quantum/XXZ/XXZ.jl
+++ b/src/models/quantum/XXZ/XXZ.jl
@@ -222,16 +222,20 @@ end
 """
     fetch(model::XXZ1D, ::Energy, ::OBC; beta) -> Float64
 
-Per-site thermal energy `⟨H⟩_β / N` for the spin-½ OBC chain at finite
-size, computed by dense ED.  Works for any `Δ` and any `N ≤
-$(_MAX_ED_SITES)`.  Intended as a reference for MPS thermal methods
-(TPQMPS / Purification / METTS).
+**Total** thermal energy `⟨H⟩_β` for the spin-½ OBC chain at finite size,
+computed by dense ED.  Works for any `Δ` and any `N ≤ $(_MAX_ED_SITES)`.
+Intended as a reference for MPS thermal methods (TPQMPS / Purification /
+METTS).
 
 ```
-    ⟨H⟩_β / N = Tr(H exp(-βH)) / (N · Tr(exp(-βH)))
+    ⟨H⟩_β = Tr(H exp(-βH)) / Tr(exp(-βH))
 ```
+
+Convention matches [`fetch(::TFIM, ::Energy, ::OBC)`](@ref): finite-size
+boundary conditions return total energy; only `Infinite()` returns per-site
+(`⟨H⟩/N`, the only finite quantity in the thermodynamic limit).
 """
 function fetch(model::XXZ1D, ::Energy, bc::OBC; beta::Real, kwargs...)
     H = _xxz1d_hamiltonian_matrix(model, bc.N)
-    return _ed_thermal_energy(H, beta) / bc.N
+    return _ed_thermal_energy(H, beta)
 end

--- a/test/models/test_XXZ1D_thermal.jl
+++ b/test/models/test_XXZ1D_thermal.jl
@@ -8,8 +8,8 @@ using QAtlas, Test, LinearAlgebra
     # so the XXZ OBC Hamiltonian satisfies Tr(H) = 0 exactly.  At β = 0
     # this means `⟨H⟩ = Tr(H) / 2^N = 0`.
     for Δ in (-0.5, 0.0, 0.7, 1.0), N in (4, 5, 6)
-        E_per_site = QAtlas.fetch(XXZ1D(; J=1.0, Δ=Δ), Energy(), OBC(N); beta=0.0)
-        @test abs(E_per_site) < 1e-12
+        E_total = QAtlas.fetch(XXZ1D(; J=1.0, Δ=Δ), Energy(), OBC(N); beta=0.0)
+        @test abs(E_total) < 1e-12
     end
 end
 
@@ -25,7 +25,7 @@ end
         E_gs = evals[1]
         gap = evals[2] - evals[1]
         β = 50.0
-        E_thermal = QAtlas.fetch(model, Energy(), OBC(N); beta=β) * N  # total energy
+        E_thermal = QAtlas.fetch(model, Energy(), OBC(N); beta=β)  # total energy
         # At β large, correction ≈ gap · exp(-β gap), bounded very loosely.
         tol = max(1e-10, 10 * gap * exp(-β * gap))
         @test abs(E_thermal - E_gs) ≤ tol
@@ -48,7 +48,7 @@ end
         emin2 = minimum(evals2)
         ws2 = exp.(-β .* (evals2 .- emin2))
         E2_direct = real(sum(evals2 .* ws2) / sum(ws2))
-        E2_fetch = QAtlas.fetch(XXZ1D(; J=J, Δ=Δ), Energy(), OBC(2); beta=β) * 2
+        E2_fetch = QAtlas.fetch(XXZ1D(; J=J, Δ=Δ), Energy(), OBC(2); beta=β)
         @test E2_fetch ≈ E2_direct rtol = 1e-10
 
         # N = 3: two bonds, H = bond(1,2)⊗I + I⊗bond(2,3).
@@ -59,7 +59,7 @@ end
         emin3 = minimum(evals3)
         ws3 = exp.(-β .* (evals3 .- emin3))
         E3_direct = real(sum(evals3 .* ws3) / sum(ws3))
-        E3_fetch = QAtlas.fetch(XXZ1D(; J=J, Δ=Δ), Energy(), OBC(3); beta=β) * 3
+        E3_fetch = QAtlas.fetch(XXZ1D(; J=J, Δ=Δ), Energy(), OBC(3); beta=β)
         @test E3_fetch ≈ E3_direct rtol = 1e-10
     end
 end


### PR DESCRIPTION
## Summary
- Closes #107. **Breaking change.**
- `fetch(::XXZ1D, ::Energy, ::OBC; beta)` and `fetch(::Heisenberg1D, ::Energy, ::OBC; beta)` now return **total** `⟨H⟩` instead of per-site `⟨H⟩/N`.
- Brings these models in line with `fetch(::TFIM, ::Energy, ::OBC)`.

## Convention (now uniform across all models)
- Finite BC (OBC / PBC) → total energy `⟨H⟩`.
- `Infinite()` → per-site density (the only finite quantity in `N → ∞`).

## Migration
- ThermalMPS test suite can remove the `* N` workarounds documented at `ThermalMPS.jl/CLAUDE.md §2.4`.
- In-tree: three sites in `test/models/test_XXZ1D_thermal.jl` were multiplying by `N` to recover total — those `* N` factors are dropped.

## Version
- 0.15.1 → **0.16.0** (minor: breaking on a public API).

## Labels
- `bug`, `breaking`

## Test plan
- [x] `test_XXZ1D_thermal.jl` — all six testsets pass after dropping `* N`.
- [x] `test_XXZ1D.jl` — Infinite-limit tests unaffected (still per-site).
- [ ] CI green.