### PR TITLE
test(aqua): hard-fail ambiguity check

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.15.1"
+version = "0.15.2"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -3,13 +3,16 @@ using Aqua
 # Aqua.jl: static QA checks (ambiguities, unbound args, stale deps,
 # undocumented public names, persistent tasks, piracy, project.toml).
 #
-# `ambiguities` is left opt-in (we inspect it manually below) because
-# LinearAlgebra + QuadGK overloads commonly surface benign ambiguities
-# that we do not want to make CI-blocking while still being visible.
+# `deps_compat` / `stale_deps` / `undocumented_names` family is the set
+# of checks that genuinely catch drift between `Project.toml` and the
+# source tree — keep them on.
 #
-# The `deps_compat` / `stale_deps` / `undocumented_names` family is the
-# set of checks that genuinely catch drift between `Project.toml` and
-# the source tree — keep them on.
+# `ambiguities` is hard-fail (closed in #100) — `Aqua.detect_ambiguities`
+# on the QAtlas module currently returns `[]`, and any new method added
+# in src/ that introduces an ambiguity should be caught at PR time.
+# Stdlib-inherited ambiguities (LinearAlgebra + QuadGK) live outside
+# QAtlas's own method tables and therefore do not surface from
+# `recursive=false`.
 
 @testset "Aqua QA" begin
     Aqua.test_all(
@@ -27,12 +30,11 @@ using Aqua
         unbound_args=true,
     )
 
-    @testset "ambiguities (soft)" begin
-        # Report but do not fail — many are inherited from stdlib combinations.
+    @testset "ambiguities (hard)" begin
         amb = Aqua.detect_ambiguities(QAtlas; recursive=false)
         if !isempty(amb)
-            @info "Aqua: ambiguities detected (non-fatal)" count = length(amb)
+            @error "Aqua: ambiguities introduced in QAtlas — fix or document" amb
         end
-        @test true  # soft check always passes
+        @test isempty(amb)
     end
 end


### PR DESCRIPTION
## Summary
- Closes #100.
- `test/test_aqua.jl` previously did `@test true` after `Aqua.detect_ambiguities` — soft-pass that wouldn't catch a regression.
- Switch to `@test isempty(amb)` and surface the offending methods via `@error` so a future PR introducing an ambiguity sees the list in test output.

## State of the world
- Local check: `Aqua.detect_ambiguities(QAtlas; recursive=false)` returns `[]` on the current main, so flipping to hard is safe with no exclusion list needed.
- `recursive=false` deliberately limits scope to QAtlas's own method tables — stdlib-inherited ambiguities (LinearAlgebra + QuadGK) stay out of CI's path.

## Version
- 0.15.1 → 0.15.2 (patch).

## Labels
- `bug`

## Test plan
- [x] `julia --project=. test/test_aqua.jl` — 11/11 pass.
- [ ] CI green.