### PR TITLE
test: thermodynamic identity ε = f + T·s + AutoDiff c_v

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.15.1"
+version = "0.15.2"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/models/quantum/TFIM/TFIM.jl
+++ b/src/models/quantum/TFIM/TFIM.jl
@@ -95,14 +95,14 @@ function fetch(
     model::TFIM,
     ::Energy,
     bc::OBC;
-    beta::Union{Float64,Nothing}=nothing,
-    betas::Union{AbstractVector{Float64},Nothing}=nothing,
+    beta::Union{Real,Nothing}=nothing,
+    betas::Union{AbstractVector{<:Real},Nothing}=nothing,
     kwargs...,
 )
     N = _bc_size(bc, kwargs)
     Λ = _tfim_bdg_spectrum(N, model.J, model.h)
     if betas !== nothing
-        return Float64[-sum(λ -> (λ / 2) * tanh(β * λ / 2), Λ) for β in betas]
+        return [-sum(λ -> (λ / 2) * tanh(β * λ / 2), Λ) for β in betas]
     elseif beta !== nothing
         return -sum(λ -> (λ / 2) * tanh(beta * λ / 2), Λ)
     else
@@ -134,8 +134,8 @@ function fetch(
     model::TFIM,
     ::Energy,
     ::Infinite;
-    beta::Union{Float64,Nothing}=nothing,
-    betas::Union{AbstractVector{Float64},Nothing}=nothing,
+    beta::Union{Real,Nothing}=nothing,
+    betas::Union{AbstractVector{<:Real},Nothing}=nothing,
     kwargs...,
 )
     J = model.J

--- a/src/models/quantum/TFIM/TFIM_thermal.jl
+++ b/src/models/quantum/TFIM/TFIM_thermal.jl
@@ -237,24 +237,24 @@ const _TFIM_THERMAL_METHODS = (
 for (QTy, qsym) in _TFIM_THERMAL_METHODS
     @eval begin
         """
-            fetch(model::TFIM, ::$($QTy), ::Infinite; beta::Float64, kwargs...)
+            fetch(model::TFIM, ::$($QTy), ::Infinite; beta::Real, kwargs...)
 
         Per-site $($(string(qsym))) of the TFIM in the thermodynamic limit at
         inverse temperature `beta`.  Uses adaptive Gauss-Kronrod quadrature
         over the BdG dispersion `Λ(k) = 2√(J² + h² − 2Jh cos k)`.
         """
-        function fetch(model::TFIM, ::$QTy, ::Infinite; beta::Float64, kwargs...)
+        function fetch(model::TFIM, ::$QTy, ::Infinite; beta::Real, kwargs...)
             return _tfim_thermo_infinite($(QuoteNode(qsym)), model.J, model.h, beta)
         end
 
         """
-            fetch(model::TFIM, ::$($QTy), bc::OBC; beta::Float64, kwargs...)
+            fetch(model::TFIM, ::$($QTy), bc::OBC; beta::Real, kwargs...)
 
         Per-site $($(string(qsym))) of the OBC TFIM with `N = bc.N` sites at
         inverse temperature `beta`.  Computed exactly via the BdG
         diagonalisation.
         """
-        function fetch(model::TFIM, ::$QTy, bc::OBC; beta::Float64, kwargs...)
+        function fetch(model::TFIM, ::$QTy, bc::OBC; beta::Real, kwargs...)
             N = _bc_size(bc, kwargs)
             return _tfim_thermo_obc($(QuoteNode(qsym)), N, model.J, model.h, beta)
         end

--- a/test/verification/test_thermo_identity_quantum.jl
+++ b/test/verification/test_thermo_identity_quantum.jl
@@ -15,9 +15,7 @@
 using QAtlas, ForwardDiff, Test
 
 @testset "TFIM ε = f + T·s — Infinite (per-site, all four)" begin
-    for (J, h) in ((1.0, 0.5), (1.0, 1.0), (1.0, 1.5)),
-        β in (0.5, 1.0, 2.0, 4.0)
-
+    for (J, h) in ((1.0, 0.5), (1.0, 1.0), (1.0, 1.5)), β in (0.5, 1.0, 2.0, 4.0)
         model = TFIM(; J=J, h=h)
         ε = QAtlas.fetch(model, Energy(), Infinite(); beta=β)
         f = QAtlas.fetch(model, FreeEnergy(), Infinite(); beta=β)
@@ -27,10 +25,7 @@ using QAtlas, ForwardDiff, Test
 end
 
 @testset "TFIM ε = f + T·s — OBC (Energy is total; divide by N)" begin
-    for (J, h) in ((1.0, 0.5), (1.0, 1.0), (1.0, 2.0)),
-        N in (4, 6, 8),
-        β in (0.5, 1.0, 2.0)
-
+    for (J, h) in ((1.0, 0.5), (1.0, 1.0), (1.0, 2.0)), N in (4, 6, 8), β in (0.5, 1.0, 2.0)
         model = TFIM(; J=J, h=h)
         E_total = QAtlas.fetch(model, Energy(), OBC(N); beta=β)
         f = QAtlas.fetch(model, FreeEnergy(), OBC(N); beta=β)  # per site
@@ -43,9 +38,7 @@ end
 @testset "TFIM c_v = -β² ∂ε/∂β — Infinite (AutoDiff cross-check)" begin
     # ForwardDiff differentiates through `quadgk` because the integrand
     # is a plain function of `β` (the BdG dispersion has no β dependence).
-    for (J, h) in ((1.0, 0.5), (1.0, 1.0), (1.0, 2.0)),
-        β in (0.5, 1.0, 2.0)
-
+    for (J, h) in ((1.0, 0.5), (1.0, 1.0), (1.0, 2.0)), β in (0.5, 1.0, 2.0)
         model = TFIM(; J=J, h=h)
         c_direct = QAtlas.fetch(model, SpecificHeat(), Infinite(); beta=β)
         dε_dβ = ForwardDiff.derivative(
@@ -59,10 +52,7 @@ end
 @testset "TFIM c_v = -β² ∂ε/∂β — OBC (AutoDiff cross-check)" begin
     # Energy(OBC) is total → divide by N to compare with per-site c_v.
     # ForwardDiff propagates β through the BdG sum without re-diagonalising.
-    for (J, h) in ((1.0, 0.5), (1.0, 1.0), (1.0, 2.0)),
-        N in (4, 6, 8),
-        β in (0.5, 1.0, 2.0)
-
+    for (J, h) in ((1.0, 0.5), (1.0, 1.0), (1.0, 2.0)), N in (4, 6, 8), β in (0.5, 1.0, 2.0)
         model = TFIM(; J=J, h=h)
         c_direct = QAtlas.fetch(model, SpecificHeat(), OBC(N); beta=β)
         dE_dβ = ForwardDiff.derivative(

--- a/test/verification/test_thermo_identity_quantum.jl
+++ b/test/verification/test_thermo_identity_quantum.jl
@@ -1,0 +1,74 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Verification: thermodynamic identities for quantum models
+#
+#   ε(β) = f(β) + T · s(β)        (per site)
+#   c_v(β) = -β² · ∂ε/∂β            (per site, from automatic differentiation)
+#
+# Catches a class of sign / normalisation / per-site-vs-total bugs that
+# pairwise (Energy ↔ Energy, FreeEnergy ↔ FreeEnergy) cross-checks miss.
+#
+# Convention reminder (TFIM): `Energy(OBC)` returns *total* ⟨H⟩;
+# `FreeEnergy`, `ThermalEntropy`, `SpecificHeat(OBC)` return *per-site*.
+# `Energy(Infinite)` is per-site (the only finite quantity in N → ∞).
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, ForwardDiff, Test
+
+@testset "TFIM ε = f + T·s — Infinite (per-site, all four)" begin
+    for (J, h) in ((1.0, 0.5), (1.0, 1.0), (1.0, 1.5)),
+        β in (0.5, 1.0, 2.0, 4.0)
+
+        model = TFIM(; J=J, h=h)
+        ε = QAtlas.fetch(model, Energy(), Infinite(); beta=β)
+        f = QAtlas.fetch(model, FreeEnergy(), Infinite(); beta=β)
+        s = QAtlas.fetch(model, ThermalEntropy(), Infinite(); beta=β)
+        @test isapprox(ε, f + s / β; atol=1e-9, rtol=1e-9)
+    end
+end
+
+@testset "TFIM ε = f + T·s — OBC (Energy is total; divide by N)" begin
+    for (J, h) in ((1.0, 0.5), (1.0, 1.0), (1.0, 2.0)),
+        N in (4, 6, 8),
+        β in (0.5, 1.0, 2.0)
+
+        model = TFIM(; J=J, h=h)
+        E_total = QAtlas.fetch(model, Energy(), OBC(N); beta=β)
+        f = QAtlas.fetch(model, FreeEnergy(), OBC(N); beta=β)  # per site
+        s = QAtlas.fetch(model, ThermalEntropy(), OBC(N); beta=β)  # per site
+        ε = E_total / N
+        @test isapprox(ε, f + s / β; atol=1e-10, rtol=1e-10)
+    end
+end
+
+@testset "TFIM c_v = -β² ∂ε/∂β — Infinite (AutoDiff cross-check)" begin
+    # ForwardDiff differentiates through `quadgk` because the integrand
+    # is a plain function of `β` (the BdG dispersion has no β dependence).
+    for (J, h) in ((1.0, 0.5), (1.0, 1.0), (1.0, 2.0)),
+        β in (0.5, 1.0, 2.0)
+
+        model = TFIM(; J=J, h=h)
+        c_direct = QAtlas.fetch(model, SpecificHeat(), Infinite(); beta=β)
+        dε_dβ = ForwardDiff.derivative(
+            b -> QAtlas.fetch(model, Energy(), Infinite(); beta=b), β
+        )
+        c_ad = -β^2 * dε_dβ
+        @test isapprox(c_direct, c_ad; atol=1e-8, rtol=1e-8)
+    end
+end
+
+@testset "TFIM c_v = -β² ∂ε/∂β — OBC (AutoDiff cross-check)" begin
+    # Energy(OBC) is total → divide by N to compare with per-site c_v.
+    # ForwardDiff propagates β through the BdG sum without re-diagonalising.
+    for (J, h) in ((1.0, 0.5), (1.0, 1.0), (1.0, 2.0)),
+        N in (4, 6, 8),
+        β in (0.5, 1.0, 2.0)
+
+        model = TFIM(; J=J, h=h)
+        c_direct = QAtlas.fetch(model, SpecificHeat(), OBC(N); beta=β)
+        dE_dβ = ForwardDiff.derivative(
+            b -> QAtlas.fetch(model, Energy(), OBC(N); beta=b), β
+        )
+        c_ad = -β^2 * dE_dβ / N
+        @test isapprox(c_direct, c_ad; atol=1e-9, rtol=1e-9)
+    end
+end


### PR DESCRIPTION
## Summary
- Closes #105.
- New `test/verification/test_thermo_identity_quantum.jl` covers TFIM (OBC + Infinite):
  - `ε(β) = f(β) + T·s(β)` — 39 assertions
  - `c_v = -β² ∂ε/∂β` via ForwardDiff — 36 assertions
- 75 assertions across `(J,h) ∈ {(1,0.5),(1,1),(1,2)}`, `N ∈ {4,6,8}`, `β ∈ {0.5,1,2,4}`.

## Why it's worth having
Catches an entire class of sign / normalisation / per-site-vs-total bugs that pairwise (Energy↔Energy, FreeEnergy↔FreeEnergy) cross-checks miss. In particular it locks the convention asymmetry on TFIM:
- `Energy(OBC)` → total `⟨H⟩` (divide by `N` in the identity)
- `FreeEnergy/ThermalEntropy/SpecificHeat(OBC)` → per-site

## Public API tweak
To let ForwardDiff propagate through `fetch(...; beta=...)`, the keyword type on TFIM thermal observables relaxes from `Float64` to `Real` (and `AbstractVector{<:Real}`). The internal helpers already accepted `::Real`; only the kwarg signatures were gating out `ForwardDiff.Dual`. **No behavioural change** for existing `Float64` callers.

## Out of scope
XXZ / Heisenberg are not yet covered because `FreeEnergy`, `ThermalEntropy`, `SpecificHeat` are not implemented for them yet — tracked at #93.

## Version
- 0.15.1 → 0.15.2 (patch).

## Labels
- `feature`

## Test plan
- [x] All 75 assertions pass locally.
- [ ] CI green.