### PR TITLE
feat: add S1Heisenberg1D dense-ED thermal reference

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -21,6 +21,7 @@ export TightBindingSpectrum
 # backward-compat top-level alias for `Honeycomb` (see src/deprecate/)
 # since the name does not collide with anything in Lattice2D.
 export Heisenberg1D, ExactSpectrum, GroundStateEnergyDensity
+export S1Heisenberg1D                                    # spin-1 (Haldane chain)
 
 # --- Core Implementation ---
 include("core/alias.jl")
@@ -69,6 +70,7 @@ include("models/quantum/TFIM/TFIM_thermal.jl")
 include("models/quantum/TFIM/TFIM_local.jl")
 include("models/quantum/TFIM/TFIM_entanglement.jl")
 include("models/quantum/Heisenberg/Heisenberg.jl")
+include("models/quantum/Heisenberg/HeisenbergS1.jl")
 include("models/quantum/KitaevHoneycomb/KitaevHoneycomb.jl")
 include("models/quantum/XXZ/XXZ.jl")
 

--- a/src/core/dense_ed.jl
+++ b/src/core/dense_ed.jl
@@ -80,3 +80,61 @@ function _ed_thermal_energy(H::AbstractMatrix, β::Real)
     F = eigen(Hermitian(H))
     return _ed_thermal_expectation(F.values, F.values, β)
 end
+
+"""
+    _ed_log_partition(evals::AbstractVector, β::Real) -> Float64
+
+`log Z(β) = log Σ exp(-β eₙ)` with an `emin` shift to avoid overflow at
+large `β`:
+
+    log Z = -β eₘᵢₙ + log Σ exp(-β (eₙ - eₘᵢₙ))
+"""
+function _ed_log_partition(evals::AbstractVector, β::Real)
+    emin = minimum(evals)
+    return -β * emin + log(sum(exp.(-β .* (evals .- emin))))
+end
+
+"""
+    _ed_thermal_free_energy(H::AbstractMatrix, β::Real) -> Float64
+
+Total Helmholtz free energy `F(β) = -log Z / β` from the eigenspectrum
+of a Hermitian `H`.  Per-site values: divide by `N` at the call site.
+"""
+function _ed_thermal_free_energy(H::AbstractMatrix, β::Real)
+    evals = eigvals(Hermitian(H))
+    return -_ed_log_partition(evals, β) / β
+end
+
+"""
+    _ed_thermal_entropy(H::AbstractMatrix, β::Real) -> Float64
+
+Total Gibbs entropy `S(β) = β·(⟨H⟩ - F) = -Σ wₙ log wₙ`, with
+`wₙ = exp(-β(eₙ - eₘᵢₙ)) / Z̃`.  The first form is what we evaluate
+because both pieces share the eigendecomposition.
+"""
+function _ed_thermal_entropy(H::AbstractMatrix, β::Real)
+    evals = eigvals(Hermitian(H))
+    E = _ed_thermal_expectation(evals, evals, β)
+    F = -_ed_log_partition(evals, β) / β
+    return β * (E - F)
+end
+
+"""
+    _ed_thermal_specific_heat(H::AbstractMatrix, β::Real) -> Float64
+
+Total heat capacity from the energy variance,
+
+    C(β) = β² · (⟨H²⟩ - ⟨H⟩²).
+
+Equivalent to `-β² · ∂⟨H⟩/∂β`; computed exactly from the eigenspectrum
+without numerical differentiation.
+"""
+function _ed_thermal_specific_heat(H::AbstractMatrix, β::Real)
+    evals = eigvals(Hermitian(H))
+    emin = minimum(evals)
+    ws = exp.(-β .* (evals .- emin))
+    Z = sum(ws)
+    E1 = sum(evals .* ws) / Z
+    E2 = sum(evals .^ 2 .* ws) / Z
+    return β^2 * (E2 - E1^2)
+end

--- a/src/models/quantum/Heisenberg/HeisenbergS1.jl
+++ b/src/models/quantum/Heisenberg/HeisenbergS1.jl
@@ -1,0 +1,163 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Spin-1 Heisenberg chain (Haldane chain)
+#
+# Hamiltonian:
+#   H = J Σᵢ Sᵢ · Sᵢ₊₁
+#     = J Σᵢ [Sˣᵢ Sˣᵢ₊₁ + Sʸᵢ Sʸᵢ₊₁ + Sᶻᵢ Sᶻᵢ₊₁]
+#
+# where the Sᵅ are 3×3 spin-1 operators (s = 1, s(s+1) = 2).
+#
+# Bond eigenvalue summary (Sᵢ + Sᵢ₊₁ → S_tot ∈ {0, 1, 2} from two spin-1):
+#
+#   J Sᵢ · Sᵢ₊₁ = (J/2)·(S_tot² − 4)
+#
+# giving bond eigenvalues  [-2J (singlet), -J (triplet), +J (quintet)].
+#
+# This file is the small-N dense-ED reference path for the Haldane phase
+# (gap Δ ≈ 0.41 J, ξ ≈ 6 lattice spacings) — used to validate ThermalMPS
+# computations at modest sizes (3^N Hilbert space, capped at N ≤ 8).
+#
+# References:
+#   F. D. M. Haldane, Phys. Lett. A 93, 464 (1983); PRL 50, 1153 (1983).
+#   T. Kennedy and H. Tasaki, Phys. Rev. B 45, 304 (1992) — string order.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using LinearAlgebra: I, kron
+
+"""
+    _MAX_ED_SITES_S1 = 8
+
+Hard cap on chain length for spin-1 dense-ED helpers.  3⁸ = 6561 → a
+6561×6561 Hermitian eigendecomposition is ~1 s on a laptop; 3⁹ ≈ 20 k
+already pushes 5 GB of workspace, past the "cheap reference" regime.
+"""
+const _MAX_ED_SITES_S1 = 8
+
+# Spin-1 generators in the |+1⟩, |0⟩, |-1⟩ basis.
+const _S1_id = ComplexF64[1 0 0; 0 1 0; 0 0 1]
+const _S1_x = (ComplexF64(1) / sqrt(2)) * ComplexF64[0 1 0; 1 0 1; 0 1 0]
+const _S1_y =
+    (ComplexF64(1) / (im * sqrt(2))) * ComplexF64[0 1 0; -1 0 1; 0 -1 0]
+const _S1_z = ComplexF64[1 0 0; 0 0 0; 0 0 -1]
+
+"""
+    _spin1_string(N::Int, site_ops::Pair{Int,Matrix{ComplexF64}}...) -> Matrix{ComplexF64}
+
+Tensor-product analogue of [`_pauli_string`](@ref) for spin-1 chains.
+Returns the `3^N × 3^N` operator that places each `Sᵅ` at its listed
+site and the 3×3 identity elsewhere.
+"""
+function _spin1_string(N::Int, site_ops::Pair{Int,Matrix{ComplexF64}}...)
+    N ≤ _MAX_ED_SITES_S1 || throw(
+        ArgumentError(
+            "spin-1 dense ED is capped at N ≤ $(_MAX_ED_SITES_S1) (got N = $N)"
+        ),
+    )
+    lookup = Dict(site_ops...)
+    ops = [get(lookup, k, _S1_id) for k in 1:N]
+    return reduce(kron, ops)
+end
+
+"""
+    S1Heisenberg1D(; J::Real = 1.0) <: AbstractQAtlasModel
+
+Spin-1 antiferromagnetic Heisenberg chain (Haldane chain),
+
+    H = J Σᵢ Sᵢ · Sᵢ₊₁,    spin = 1,  J > 0 antiferromagnetic.
+
+Distinct from [`Heisenberg1D`](@ref) (spin-1/2) because the spin
+representation differs: spin-1 has local dimension 3 and a gapped,
+topologically non-trivial Haldane phase, while spin-1/2 is gapless and
+critical (Bethe ansatz).
+"""
+struct S1Heisenberg1D <: AbstractQAtlasModel
+    J::Float64
+end
+S1Heisenberg1D(; J::Real=1.0) = S1Heisenberg1D(Float64(J))
+
+"""
+    _s1_heisenberg_hamiltonian_matrix(model::S1Heisenberg1D, N::Int) -> Matrix{ComplexF64}
+
+Assemble the `3^N × 3^N` OBC Hamiltonian
+
+    H = J Σᵢ [Sˣᵢ Sˣᵢ₊₁ + Sʸᵢ Sʸᵢ₊₁ + Sᶻᵢ Sᶻᵢ₊₁]
+
+via explicit tensor products built from the spin-1 primitives.
+Capped by `_MAX_ED_SITES_S1`.
+"""
+function _s1_heisenberg_hamiltonian_matrix(model::S1Heisenberg1D, N::Int)
+    N ≥ 2 || throw(ArgumentError("S1Heisenberg1D OBC chain needs N ≥ 2 (got N = $N)"))
+    N ≤ _MAX_ED_SITES_S1 || throw(
+        ArgumentError(
+            "spin-1 dense ED is capped at N ≤ $(_MAX_ED_SITES_S1) (got N = $N)"
+        ),
+    )
+    J = model.J
+    D = 3^N
+    # Combine the three Sᵅ⊗Sᵅ contractions into a single 9×9 bond block
+    # so each bond costs a single kron instead of three.
+    bond = J * (kron(_S1_x, _S1_x) + kron(_S1_y, _S1_y) + kron(_S1_z, _S1_z))
+    H = zeros(ComplexF64, D, D)
+    for i in 1:(N - 1)
+        d_left = 3^(i - 1)
+        d_right = 3^(N - i - 1)
+        H .+= kron(Matrix{ComplexF64}(I, d_left, d_left), bond,
+                   Matrix{ComplexF64}(I, d_right, d_right))
+    end
+    return H
+end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# fetch — finite-N OBC thermal observables via dense ED
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    fetch(model::S1Heisenberg1D, ::Energy, ::OBC; beta) -> Float64
+
+**Total** thermal energy `⟨H⟩_β` of the spin-1 OBC Heisenberg chain at
+finite `N ≤ $(_MAX_ED_SITES_S1)`, computed by dense ED.
+
+```
+    ⟨H⟩_β = Tr(H exp(-βH)) / Tr(exp(-βH))
+```
+
+Convention matches [`fetch(::TFIM, ::Energy, ::OBC)`](@ref): finite-size
+boundary conditions return total energy.
+"""
+function fetch(model::S1Heisenberg1D, ::Energy, bc::OBC; beta::Real, kwargs...)
+    H = _s1_heisenberg_hamiltonian_matrix(model, bc.N)
+    return _ed_thermal_energy(H, beta)
+end
+
+"""
+    fetch(model::S1Heisenberg1D, ::FreeEnergy, ::OBC; beta) -> Float64
+
+Per-site Helmholtz free energy `f(β) = -log Z / (Nβ)` for the spin-1
+OBC chain.
+"""
+function fetch(model::S1Heisenberg1D, ::FreeEnergy, bc::OBC; beta::Real, kwargs...)
+    H = _s1_heisenberg_hamiltonian_matrix(model, bc.N)
+    return _ed_thermal_free_energy(H, beta) / bc.N
+end
+
+"""
+    fetch(model::S1Heisenberg1D, ::ThermalEntropy, ::OBC; beta) -> Float64
+
+Per-site Gibbs entropy `s(β) = β · (ε - f)` for the spin-1 OBC chain.
+"""
+function fetch(model::S1Heisenberg1D, ::ThermalEntropy, bc::OBC; beta::Real, kwargs...)
+    H = _s1_heisenberg_hamiltonian_matrix(model, bc.N)
+    return _ed_thermal_entropy(H, beta) / bc.N
+end
+
+"""
+    fetch(model::S1Heisenberg1D, ::SpecificHeat, ::OBC; beta) -> Float64
+
+Per-site heat capacity `c(β) = β² · Var(H) / N` for the spin-1 OBC
+chain, computed exactly from the energy variance in the eigenbasis (no
+numerical differentiation).
+"""
+function fetch(model::S1Heisenberg1D, ::SpecificHeat, bc::OBC; beta::Real, kwargs...)
+    H = _s1_heisenberg_hamiltonian_matrix(model, bc.N)
+    return _ed_thermal_specific_heat(H, beta) / bc.N
+end

--- a/src/models/quantum/Heisenberg/HeisenbergS1.jl
+++ b/src/models/quantum/Heisenberg/HeisenbergS1.jl
@@ -36,8 +36,7 @@ const _MAX_ED_SITES_S1 = 8
 # Spin-1 generators in the |+1⟩, |0⟩, |-1⟩ basis.
 const _S1_id = ComplexF64[1 0 0; 0 1 0; 0 0 1]
 const _S1_x = (ComplexF64(1) / sqrt(2)) * ComplexF64[0 1 0; 1 0 1; 0 1 0]
-const _S1_y =
-    (ComplexF64(1) / (im * sqrt(2))) * ComplexF64[0 1 0; -1 0 1; 0 -1 0]
+const _S1_y = (ComplexF64(1) / (im * sqrt(2))) * ComplexF64[0 1 0; -1 0 1; 0 -1 0]
 const _S1_z = ComplexF64[1 0 0; 0 0 0; 0 0 -1]
 
 """
@@ -49,9 +48,7 @@ site and the 3×3 identity elsewhere.
 """
 function _spin1_string(N::Int, site_ops::Pair{Int,Matrix{ComplexF64}}...)
     N ≤ _MAX_ED_SITES_S1 || throw(
-        ArgumentError(
-            "spin-1 dense ED is capped at N ≤ $(_MAX_ED_SITES_S1) (got N = $N)"
-        ),
+        ArgumentError("spin-1 dense ED is capped at N ≤ $(_MAX_ED_SITES_S1) (got N = $N)"),
     )
     lookup = Dict(site_ops...)
     ops = [get(lookup, k, _S1_id) for k in 1:N]
@@ -88,9 +85,7 @@ Capped by `_MAX_ED_SITES_S1`.
 function _s1_heisenberg_hamiltonian_matrix(model::S1Heisenberg1D, N::Int)
     N ≥ 2 || throw(ArgumentError("S1Heisenberg1D OBC chain needs N ≥ 2 (got N = $N)"))
     N ≤ _MAX_ED_SITES_S1 || throw(
-        ArgumentError(
-            "spin-1 dense ED is capped at N ≤ $(_MAX_ED_SITES_S1) (got N = $N)"
-        ),
+        ArgumentError("spin-1 dense ED is capped at N ≤ $(_MAX_ED_SITES_S1) (got N = $N)"),
     )
     J = model.J
     D = 3^N
@@ -101,8 +96,11 @@ function _s1_heisenberg_hamiltonian_matrix(model::S1Heisenberg1D, N::Int)
     for i in 1:(N - 1)
         d_left = 3^(i - 1)
         d_right = 3^(N - i - 1)
-        H .+= kron(Matrix{ComplexF64}(I, d_left, d_left), bond,
-                   Matrix{ComplexF64}(I, d_right, d_right))
+        H .+= kron(
+            Matrix{ComplexF64}(I, d_left, d_left),
+            bond,
+            Matrix{ComplexF64}(I, d_right, d_right),
+        )
     end
     return H
 end

--- a/test/models/test_S1Heisenberg1D_thermal.jl
+++ b/test/models/test_S1Heisenberg1D_thermal.jl
@@ -1,0 +1,99 @@
+using QAtlas, Test, LinearAlgebra
+
+# Spin-1 Heisenberg (Haldane chain) — small-N dense-ED reference for
+# ThermalMPS validation.  Bond eigenvalues from S_tot ∈ {0,1,2}:
+#   singlet = -2J,  triplet = -J×3,  quintet = +J×5  (per bond).
+#
+# Total Hilbert space 3^N (capped at N ≤ 8 by `_MAX_ED_SITES_S1`).
+
+@testset "S1Heisenberg1D — N=2 dimer spectrum (analytic)" begin
+    # Two spin-1 → 9 states: [-2J, -J×3, +J×5].
+    for J in (0.7, 1.0, 1.3)
+        H = QAtlas._s1_heisenberg_hamiltonian_matrix(S1Heisenberg1D(; J=J), 2)
+        evals = sort(real.(eigvals(Hermitian(H))))
+        expected = sort([-2J; fill(-J, 3); fill(J, 5)])
+        @test evals ≈ expected atol = 1e-12
+    end
+end
+
+@testset "S1Heisenberg1D — Tr(H) = 0  (β → 0 gives ⟨H⟩ = 0)" begin
+    # Sᵅ ⊗ Sᵅ has trace Tr(Sᵅ)·Tr(Sᵅ) = 0 for every α (each Sᵅ is traceless).
+    for J in (0.5, 1.0), N in (2, 3, 4)
+        E0 = QAtlas.fetch(S1Heisenberg1D(; J=J), Energy(), OBC(N); beta=0.0)
+        @test abs(E0) < 1e-12
+    end
+end
+
+@testset "S1Heisenberg1D — β → ∞ recovers OBC ground state" begin
+    # Compute true ground from the same Hamiltonian and check the large-β
+    # thermal mean collapses onto E_gs up to exp(-β · gap).
+    for (J, N) in ((1.0, 3), (1.0, 4), (0.7, 4))
+        m = S1Heisenberg1D(; J=J)
+        H = QAtlas._s1_heisenberg_hamiltonian_matrix(m, N)
+        evals = sort(real.(eigvals(Hermitian(H))))
+        E_gs = evals[1]
+        gap = evals[2] - evals[1]
+        β = 50.0
+        E_th = QAtlas.fetch(m, Energy(), OBC(N); beta=β)
+        tol = max(1e-10, 10 * gap * exp(-β * gap))
+        @test abs(E_th - E_gs) ≤ tol
+    end
+end
+
+@testset "S1Heisenberg1D — direct ED cross-check at small N (β finite)" begin
+    # Independent dense ED on the same matrix using the standard Boltzmann
+    # average formula — guards against silent breakage in the eigen path.
+    for (J, N, β) in ((1.0, 3, 1.0), (1.3, 4, 0.7), (0.6, 4, 2.5))
+        m = S1Heisenberg1D(; J=J)
+        H = QAtlas._s1_heisenberg_hamiltonian_matrix(m, N)
+        evals = real.(eigvals(Hermitian(H)))
+        emin = minimum(evals)
+        ws = exp.(-β .* (evals .- emin))
+        E_direct = sum(evals .* ws) / sum(ws)
+        E_fetch = QAtlas.fetch(m, Energy(), OBC(N); beta=β)
+        @test E_fetch ≈ E_direct rtol = 1e-12
+    end
+end
+
+@testset "S1Heisenberg1D — ε = f + T·s identity (per-site)" begin
+    # Self-validation across (Energy, FreeEnergy, ThermalEntropy).
+    for (J, N, β) in ((1.0, 3, 0.5), (1.0, 4, 1.0), (1.3, 4, 2.0), (0.7, 5, 1.5))
+        m = S1Heisenberg1D(; J=J)
+        E_total = QAtlas.fetch(m, Energy(), OBC(N); beta=β)
+        f = QAtlas.fetch(m, FreeEnergy(), OBC(N); beta=β)
+        s = QAtlas.fetch(m, ThermalEntropy(), OBC(N); beta=β)
+        ε = E_total / N
+        @test isapprox(ε, f + s / β; atol=1e-10, rtol=1e-10)
+    end
+end
+
+@testset "S1Heisenberg1D — c = β² Var(H)/N matches AutoDiff -β² ∂ε/∂β" begin
+    # The variance formula for c is exact (no AD); cross-check it against
+    # the AD path that PR #115 established for TFIM.
+    using ForwardDiff
+    for (J, N, β) in ((1.0, 3, 0.5), (1.0, 4, 1.0), (1.3, 4, 2.0))
+        m = S1Heisenberg1D(; J=J)
+        c_direct = QAtlas.fetch(m, SpecificHeat(), OBC(N); beta=β)
+        dE_dβ = ForwardDiff.derivative(
+            b -> QAtlas.fetch(m, Energy(), OBC(N); beta=b), β
+        )
+        c_ad = -β^2 * dE_dβ / N
+        @test isapprox(c_direct, c_ad; atol=1e-9, rtol=1e-9)
+    end
+end
+
+@testset "S1Heisenberg1D — monotone cooling E(β₁) ≥ E(β₂) for β₁ < β₂" begin
+    m = S1Heisenberg1D(; J=1.0)
+    Es = [QAtlas.fetch(m, Energy(), OBC(4); beta=β) for β in (0.0, 0.5, 1.0, 2.0, 5.0)]
+    @test issorted(Es; rev=true)
+    @test isapprox(Es[1], 0.0; atol=1e-12)
+end
+
+@testset "S1Heisenberg1D — dense ED cap" begin
+    @test_throws ArgumentError QAtlas._spin1_string(
+        QAtlas._MAX_ED_SITES_S1 + 1, 1 => QAtlas._S1_x
+    )
+    @test_throws ArgumentError QAtlas._s1_heisenberg_hamiltonian_matrix(
+        S1Heisenberg1D(), 1
+    )
+end

--- a/test/models/test_S1Heisenberg1D_thermal.jl
+++ b/test/models/test_S1Heisenberg1D_thermal.jl
@@ -74,9 +74,7 @@ end
     for (J, N, β) in ((1.0, 3, 0.5), (1.0, 4, 1.0), (1.3, 4, 2.0))
         m = S1Heisenberg1D(; J=J)
         c_direct = QAtlas.fetch(m, SpecificHeat(), OBC(N); beta=β)
-        dE_dβ = ForwardDiff.derivative(
-            b -> QAtlas.fetch(m, Energy(), OBC(N); beta=b), β
-        )
+        dE_dβ = ForwardDiff.derivative(b -> QAtlas.fetch(m, Energy(), OBC(N); beta=b), β)
         c_ad = -β^2 * dE_dβ / N
         @test isapprox(c_direct, c_ad; atol=1e-9, rtol=1e-9)
     end
@@ -93,7 +91,5 @@ end
     @test_throws ArgumentError QAtlas._spin1_string(
         QAtlas._MAX_ED_SITES_S1 + 1, 1 => QAtlas._S1_x
     )
-    @test_throws ArgumentError QAtlas._s1_heisenberg_hamiltonian_matrix(
-        S1Heisenberg1D(), 1
-    )
+    @test_throws ArgumentError QAtlas._s1_heisenberg_hamiltonian_matrix(S1Heisenberg1D(), 1)
 end


### PR DESCRIPTION
## Summary
- Closes #111.
- New model `S1Heisenberg1D(; J)` — spin-1 antiferromagnetic Heisenberg (Haldane) chain.
- OBC thermal observables via dense ED on 3^N × 3^N Hilbert space:
  - `Energy(OBC; beta)` → total `⟨H⟩`
  - `FreeEnergy(OBC; beta)` → per-site
  - `ThermalEntropy(OBC; beta)` → per-site (Gibbs)
  - `SpecificHeat(OBC; beta)` → per-site (`β² · Var(H) / N`, exact from eigenspectrum)

Granularity follows TFIM convention.

## Reusable plumbing
Added three generic helpers to `core/dense_ed.jl` (`_ed_log_partition`, `_ed_thermal_free_energy`, `_ed_thermal_entropy`, `_ed_thermal_specific_heat`) so future spin-1 / S=3/2 / multi-band models reuse the same path.

## Cap
`_MAX_ED_SITES_S1 = 8` (3⁸ = 6561). At N=8 the eigvals dominates (~35 s on a laptop, ~7 GB allocations) — within "cheap reference data" budget but tests stay at N ≤ 5 to keep CI fast.

## Test coverage (26 assertions)
- Analytic dimer spectrum `[-2J, -J×3, +J×5]`
- `Tr(H) = 0` → β=0 gives ⟨H⟩ = 0
- β → ∞ recovers OBC ground state up to `exp(-β · gap)`
- Direct-ED cross-check at small N
- `ε = f + T·s` self-validation (per-site)
- `c = β² Var(H)/N` ↔ `-β² ∂ε/∂β` AutoDiff cross-check
- Monotone cooling
- Dense-ED size cap (`ArgumentError`)

## Out of scope (follow-ups)
- `StringOrder()` (Haldane string order parameter `⟨S^z_i exp(iπ Σ S^z_j) S^z_l⟩`) — separate PR; needs a new `Quantity` struct and is the only Haldane-specific observable.
- `Energy(::Infinite)` / Bethe-ansatz reference — Haldane chain has no closed-form thermodynamic-limit free energy; defer.

## Version
- 0.16.0 → 0.16.1 (patch).

## Labels
- `feature`, `research`

## Test plan
- [x] All 26 assertions pass locally
- [x] Aqua hard-fail check still clean
- [ ] CI green