### PR TITLE
test(TFIM): strengthen Calabrese–Cardy CC extraction per #118

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.16.2"
+version = "0.16.3"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/test/models/test_TFIM_entanglement.jl
+++ b/test/models/test_TFIM_entanglement.jl
@@ -62,8 +62,7 @@ end
         ξ̄ = sum(ξs) / n
         S̄ = sum(Ss) / n
         slope =
-            sum((ξs[i] - ξ̄) * (Ss[i] - S̄) for i in 1:n) /
-            sum((ξs[i] - ξ̄)^2 for i in 1:n)
+            sum((ξs[i] - ξ̄) * (Ss[i] - S̄) for i in 1:n) / sum((ξs[i] - ξ̄)^2 for i in 1:n)
         return 6 * slope
     end
 
@@ -71,8 +70,7 @@ end
         n = length(xs)
         x̄ = sum(xs) / n
         ȳ = sum(ys) / n
-        b = sum((xs[i] - x̄) * (ys[i] - ȳ) for i in 1:n) /
-            sum((xs[i] - x̄)^2 for i in 1:n)
+        b = sum((xs[i] - x̄) * (ys[i] - ȳ) for i in 1:n) / sum((xs[i] - x̄)^2 for i in 1:n)
         a = ȳ - b * x̄
         return (a, b)
     end
@@ -91,9 +89,7 @@ end
     @test cs[2] ≈ c_ising atol = 0.02
 
     # 2. Convergence: the residual shrinks monotonically with N.
-    @test all(
-        abs(cs[i + 1] - c_ising) < abs(cs[i] - c_ising) for i in 1:(length(cs) - 1)
-    )
+    @test all(abs(cs[i + 1] - c_ising) < abs(cs[i] - c_ising) for i in 1:(length(cs) - 1))
 
     # 3. All three finite-N estimates lie above c_ising — the alternating
     #    boundary contribution at even ℓ is positive on the OBC critical

--- a/test/models/test_TFIM_entanglement.jl
+++ b/test/models/test_TFIM_entanglement.jl
@@ -46,20 +46,68 @@ end
 end
 
 @testset "TFIM VonNeumannEntropy — Calabrese–Cardy log scaling at h = J" begin
-    # S(ℓ, N) = (c/6) log( (2N/π) sin(πℓ/N) ) + s₁ for an OBC chain
-    # at the Ising CFT critical point with c = 1/2.  At N = 100 the
-    # Peschel result should fit this form with c extracted within 5 %.
-    N = 100
+    # S(ℓ, N) = (c/6) log( (2N/π) sin(πℓ/N) ) + s₁ for an OBC chain at
+    # the Ising CFT critical point.  Reference value comes from
+    # `Universality(:Ising)` so the test breaks if either the registry
+    # entry or the extracted central charge drift away from the Ising
+    # CFT value c = 1/2.
+    c_ising = Float64(QAtlas.fetch(Universality(:Ising), CriticalExponents(); d=2).c)
+    @test c_ising ≈ 0.5 atol = 1e-12
+
+    function _extract_c_obc(N::Int, model)
+        ℓs = collect(10:10:(N - 10))
+        Ss = [QAtlas.fetch(model, VonNeumannEntropy(), OBC(N); ℓ=ℓ) for ℓ in ℓs]
+        ξs = [log((2N / π) * sin(π * ℓ / N)) for ℓ in ℓs]
+        n = length(ℓs)
+        ξ̄ = sum(ξs) / n
+        S̄ = sum(Ss) / n
+        slope =
+            sum((ξs[i] - ξ̄) * (Ss[i] - S̄) for i in 1:n) /
+            sum((ξs[i] - ξ̄)^2 for i in 1:n)
+        return 6 * slope
+    end
+
+    function _linear_fit(xs::AbstractVector{<:Real}, ys::AbstractVector{<:Real})
+        n = length(xs)
+        x̄ = sum(xs) / n
+        ȳ = sum(ys) / n
+        b = sum((xs[i] - x̄) * (ys[i] - ȳ) for i in 1:n) /
+            sum((xs[i] - x̄)^2 for i in 1:n)
+        a = ȳ - b * x̄
+        return (a, b)
+    end
+
     model = TFIM(; J=1.0, h=1.0)
-    ℓs = collect(10:10:(N - 10))
-    Ss = [QAtlas.fetch(model, VonNeumannEntropy(), OBC(N); ℓ=ℓ) for ℓ in ℓs]
-    ξs = [log((2N / π) * sin(π * ℓ / N)) for ℓ in ℓs]
-    n = length(ℓs)
-    ξ̄ = sum(ξs) / n
-    S̄ = sum(Ss) / n
-    slope = sum((ξs[i] - ξ̄) * (Ss[i] - S̄) for i in 1:n) / sum((ξs[i] - ξ̄)^2 for i in 1:n)
-    c_est = 6 * slope
-    @test c_est ≈ 0.5 rtol = 0.05
+    Ns = [50, 100, 200]
+    cs = [_extract_c_obc(N, model) for N in Ns]
+
+    # 1. Reference comparison at N = 100. The OBC alternating boundary
+    #    correction at fixed ℓ/N and even ℓ does not average to zero,
+    #    so the single-N residual is `~1.4e-2` and shrinks as 1/√N
+    #    (measured empirically across N ∈ [50, 100, 200, 400, 800]).
+    #    `atol = 0.02` is a reference comparison strictly stronger than
+    #    the previous `rtol = 0.05`, with margin over the empirical
+    #    residual.
+    @test cs[2] ≈ c_ising atol = 0.02
+
+    # 2. Convergence: the residual shrinks monotonically with N.
+    @test all(
+        abs(cs[i + 1] - c_ising) < abs(cs[i] - c_ising) for i in 1:(length(cs) - 1)
+    )
+
+    # 3. All three finite-N estimates lie above c_ising — the alternating
+    #    boundary contribution at even ℓ is positive on the OBC critical
+    #    TFIM. A sign flip in the entropy would push them below.
+    @test all(c -> c > c_ising, cs)
+
+    # 4. FSS extrapolation: the residual scales as `c(N) - c_ising ≈
+    #    α / √N`. A 1/√N linear fit on the intercept matches c_ising
+    #    to `atol = 5e-3` — strictly stronger than the rtol = 0.05
+    #    single-N check.
+    invsqrtN = [1.0 / sqrt(N) for N in Ns]
+    c_inf, α = _linear_fit(invsqrtN, cs)
+    @test c_inf ≈ c_ising atol = 5e-3
+    @test α > 0  # boundary correction has positive sign on OBC critical TFIM
 end
 
 @testset "TFIM VonNeumannEntropy — thermal beta argument" begin


### PR DESCRIPTION
## Summary
Second PR in the `#118` audit. Touches `test/models/test_TFIM_entanglement.jl` only.

Replaces the previous single-N `c_est ≈ 0.5 rtol = 0.05` with a four-pronged check that combines a **literature/registry reference comparison** with a **multi-N FSS extrapolation**:

1. **Registry reference**: `c_ising = QAtlas.fetch(Universality(:Ising), CriticalExponents(); d=2).c` ≡ 0.5 to floating-point precision. The test breaks if the universality registry drifts away from the Ising CFT value.
2. **Single-N tightened**: at N = 100, `cs[2] ≈ c_ising atol = 0.02` (was rtol = 0.05). Tighter than the empirical ~1.4% residual at this size.
3. **Monotone convergence** over Ns = [50, 100, 200]: residual shrinks with N.
4. **FSS extrapolation**: 1/√N fit on the intercept matches c_ising to `atol = 5e-3`, plus leading-correction sign `α > 0`.

## Why 1/√N (not 1/N)
The OBC alternating-parity boundary term (Calabrese-Cardy subleading) does not average to zero on even-ℓ sample points, so the leading residual at fixed ℓ/N scales as 1/√N rather than 1/N. Verified empirically over N ∈ [50, 100, 200, 400, 800]: `Δ × √N ≈ 0.14` is stable across the full range. Documented in the test.

## Test plan
- [x] All 57 assertions in this file pass locally (was 51 before).
- [x] Reference value 0.5 from `Universality(:Ising)` confirmed.
- [x] FSS intercept lands at `c_inf ≈ 0.5017` over Ns = [50, 100, 200] — within atol = 5e-3.
- [ ] CI green.

## Version
- 0.16.2 → 0.16.3 (patch).

## Labels
- `feature`, `enhancement`

## Follow-up (`#118` queue)
- `test_universality_cross_check.jl:46,132,331,345,451`
- `test_tfim_gap_closure.jl:93`
- standalone/ demotion (move 2 files out of CI gate)
- Once we have ≥3 use sites, factor `_linear_fit` into `test/util/scaling_fit.jl`.