### PR TITLE
feat(energy): parameterize Energy{G} + native_energy_granularity trait

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.16.5"
+version = "0.16.6"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -18,12 +18,59 @@
 # ─── Scalar thermodynamics ──────────────────────────────────────────────
 
 """
-    Energy() <: AbstractQuantity
+    Energy{G}() <: AbstractQuantity
+    Energy()                 # G = :natural — model-and-BC-natural granularity
+    Energy(:total)           # explicit ⟨H⟩
+    Energy(:per_site)        # explicit ⟨H⟩ / N
 
-Ground-state / thermal energy expectation.  Per-site or total depends on
-the model's convention (documented on the model's `fetch` method).
+Ground-state / thermal energy expectation.  The type parameter `G` makes
+the granularity (total vs per-site) a dispatch axis instead of a hidden
+docstring contract.
+
+`Energy()` resolves to the model's native granularity via the
+[`native_energy_granularity`](@ref) trait — keeping every existing
+`fetch(model, Energy(), bc; ...)` call site working unchanged.  Use the
+explicit constructors when the caller needs a specific granularity (e.g.
+the thermodynamic-identity harness comparing `f + T·s` against per-site
+`ε`).
+
+The non-native granularity is provided automatically by a generic
+conversion fallback for 1D BCs (`OBC` / `PBC`) that uses
+[`_bc_size`](@ref).  Models on lattices whose size is not captured by
+`bc.N` (e.g. 2D Kitaev with `Lx, Ly` kwargs) currently support only
+their declared native granularity.
 """
-struct Energy <: AbstractQuantity end
+struct Energy{G} <: AbstractQuantity
+    function Energy{G}() where {G}
+        G isa Symbol || error("Energy granularity must be a Symbol, got $(typeof(G))")
+        G in (:natural, :total, :per_site) ||
+            error("unknown Energy granularity :$G; expected :natural, :total, or :per_site")
+        return new{G}()
+    end
+end
+Energy() = Energy{:natural}()
+Energy(g::Symbol) = Energy{g}()
+
+"""
+    native_energy_granularity(model, bc) -> :total | :per_site
+
+Trait declaring which granularity the given `model` returns natively for
+[`Energy`](@ref) at boundary condition `bc`.  Used by the `Energy()`
+(`:natural`) router and by the generic conversion fallbacks.
+
+Every model that supports `Energy` must add a method per supported BC,
+e.g.
+
+```julia
+QAtlas.native_energy_granularity(::TFIM, ::OBC) = :total
+QAtlas.native_energy_granularity(::TFIM, ::Infinite) = :per_site
+```
+
+A missing method is caught at the call site as a `MethodError`, which
+is intentional: it forces new models to declare the convention rather
+than silently inheriting an unrelated default.
+"""
+function native_energy_granularity end
 
 """
     FreeEnergy() <: AbstractQuantity
@@ -330,3 +377,45 @@ struct E8Spectrum <: AbstractQuantity end
 # `GrowthExponents`) are currently defined in their respective model /
 # universality source files as bare `struct X end`.  Later commits
 # (M1.6-M1.8) subtype them to `AbstractQuantity` in place.
+
+# ─── Energy granularity routing (depends on BoundaryCondition / _bc_size) ───
+#
+# `Energy()` is dispatch-routed to the model's native granularity through the
+# `native_energy_granularity` trait.  The non-native granularity is provided
+# by a generic conversion fallback that uses `_bc_size`.  Models on lattices
+# whose system size is not encoded in `bc.N` (Kitaev's `Lx, Ly` kwargs) can
+# define `fetch(::Model, ::Energy{:total}, bc; ...)` directly to bypass the
+# fallback.
+
+function fetch(
+    model::AbstractQAtlasModel, ::Energy{:natural}, bc::BoundaryCondition; kwargs...
+)
+    g = native_energy_granularity(model, bc)
+    return fetch(model, Energy{g}(), bc; kwargs...)
+end
+
+function fetch(
+    model::AbstractQAtlasModel, ::Energy{:per_site}, bc::Union{OBC,PBC}; kwargs...
+)
+    g = native_energy_granularity(model, bc)
+    g === :per_site && error(
+        "QAtlas Energy(:per_site): $(typeof(model)) declares native :per_site at " *
+        "$(typeof(bc)) but no direct method is registered.  Implement " *
+        "`fetch(::$(typeof(model)), ::Energy{:per_site}, ::$(typeof(bc)); ...)` " *
+        "to register it.",
+    )
+    return fetch(model, Energy{:total}(), bc; kwargs...) / _bc_size(bc, kwargs)
+end
+
+function fetch(
+    model::AbstractQAtlasModel, ::Energy{:total}, bc::Union{OBC,PBC}; kwargs...
+)
+    g = native_energy_granularity(model, bc)
+    g === :total && error(
+        "QAtlas Energy(:total): $(typeof(model)) declares native :total at " *
+        "$(typeof(bc)) but no direct method is registered.  Implement " *
+        "`fetch(::$(typeof(model)), ::Energy{:total}, ::$(typeof(bc)); ...)` " *
+        "to register it.",
+    )
+    return fetch(model, Energy{:per_site}(), bc; kwargs...) * _bc_size(bc, kwargs)
+end

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -407,9 +407,7 @@ function fetch(
     return fetch(model, Energy{:total}(), bc; kwargs...) / _bc_size(bc, kwargs)
 end
 
-function fetch(
-    model::AbstractQAtlasModel, ::Energy{:total}, bc::Union{OBC,PBC}; kwargs...
-)
+function fetch(model::AbstractQAtlasModel, ::Energy{:total}, bc::Union{OBC,PBC}; kwargs...)
     g = native_energy_granularity(model, bc)
     g === :total && error(
         "QAtlas Energy(:total): $(typeof(model)) declares native :total at " *

--- a/src/models/quantum/Heisenberg/Heisenberg.jl
+++ b/src/models/quantum/Heisenberg/Heisenberg.jl
@@ -174,6 +174,8 @@ Since `Heisenberg1D` currently carries no `J` field, callers must pass
 ITensorModels `to_qatlas(::Heisenberg1D)`) lose `J` on conversion; use
 `XXZ1D(; J, Δ=1)` directly if you need a non-unit coupling.
 """
-function fetch(::Heisenberg1D, ::Energy{:total}, bc::OBC; beta::Real, J::Real=1.0, kwargs...)
+function fetch(
+    ::Heisenberg1D, ::Energy{:total}, bc::OBC; beta::Real, J::Real=1.0, kwargs...
+)
     return fetch(XXZ1D(; J=J, Δ=1.0), Energy{:total}(), bc; beta=beta)
 end

--- a/src/models/quantum/Heisenberg/Heisenberg.jl
+++ b/src/models/quantum/Heisenberg/Heisenberg.jl
@@ -36,7 +36,7 @@ chain (or more generally any finite spin-1/2 cluster). Hamiltonian:
 
     H = J Σ_{⟨i,j⟩} S_i · S_j,   spin-1/2, J > 0 antiferromagnetic
 """
-struct Heisenberg1D end
+struct Heisenberg1D <: AbstractQAtlasModel end
 
 """
     ExactSpectrum
@@ -159,18 +159,21 @@ function fetch(::Heisenberg1D, ::GroundStateEnergyDensity; J::Real=1.0)
     return J * (1 // 4 - log(2))
 end
 
+native_energy_granularity(::Heisenberg1D, ::OBC) = :total
+
 """
-    fetch(::Heisenberg1D, ::Energy, ::OBC; beta, J=1.0) -> Float64
+    fetch(::Heisenberg1D, ::Energy{:total}, ::OBC; beta, J=1.0) -> Float64
 
 **Total** thermal energy `⟨H⟩_β` for the spin-½ antiferromagnetic
 Heisenberg OBC chain at finite `N` (the isotropic point `Δ = 1` of
-[`XXZ1D`](@ref)).  Routes through [`fetch(::XXZ1D, ::Energy, ::OBC)`](@ref).
+[`XXZ1D`](@ref)).  Routes through
+[`fetch(::XXZ1D, ::Energy{:total}, ::OBC)`](@ref).
 
 Since `Heisenberg1D` currently carries no `J` field, callers must pass
 `J` as a kwarg (default `J = 1.0`).  Downstream bridges (e.g.
 ITensorModels `to_qatlas(::Heisenberg1D)`) lose `J` on conversion; use
 `XXZ1D(; J, Δ=1)` directly if you need a non-unit coupling.
 """
-function fetch(::Heisenberg1D, ::Energy, bc::OBC; beta::Real, J::Real=1.0, kwargs...)
-    return fetch(XXZ1D(; J=J, Δ=1.0), Energy(), bc; beta=beta)
+function fetch(::Heisenberg1D, ::Energy{:total}, bc::OBC; beta::Real, J::Real=1.0, kwargs...)
+    return fetch(XXZ1D(; J=J, Δ=1.0), Energy{:total}(), bc; beta=beta)
 end

--- a/src/models/quantum/Heisenberg/HeisenbergS1.jl
+++ b/src/models/quantum/Heisenberg/HeisenbergS1.jl
@@ -109,8 +109,10 @@ end
 # fetch — finite-N OBC thermal observables via dense ED
 # ═══════════════════════════════════════════════════════════════════════════════
 
+native_energy_granularity(::S1Heisenberg1D, ::OBC) = :total
+
 """
-    fetch(model::S1Heisenberg1D, ::Energy, ::OBC; beta) -> Float64
+    fetch(model::S1Heisenberg1D, ::Energy{:total}, ::OBC; beta) -> Float64
 
 **Total** thermal energy `⟨H⟩_β` of the spin-1 OBC Heisenberg chain at
 finite `N ≤ $(_MAX_ED_SITES_S1)`, computed by dense ED.
@@ -119,10 +121,10 @@ finite `N ≤ $(_MAX_ED_SITES_S1)`, computed by dense ED.
     ⟨H⟩_β = Tr(H exp(-βH)) / Tr(exp(-βH))
 ```
 
-Convention matches [`fetch(::TFIM, ::Energy, ::OBC)`](@ref): finite-size
-boundary conditions return total energy.
+Convention matches [`fetch(::TFIM, ::Energy{:total}, ::OBC)`](@ref):
+1D finite-size boundary conditions return total energy natively.
 """
-function fetch(model::S1Heisenberg1D, ::Energy, bc::OBC; beta::Real, kwargs...)
+function fetch(model::S1Heisenberg1D, ::Energy{:total}, bc::OBC; beta::Real, kwargs...)
     H = _s1_heisenberg_hamiltonian_matrix(model, bc.N)
     return _ed_thermal_energy(H, beta)
 end

--- a/src/models/quantum/KitaevHoneycomb/KitaevHoneycomb.jl
+++ b/src/models/quantum/KitaevHoneycomb/KitaevHoneycomb.jl
@@ -93,11 +93,23 @@ end
 )
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# Energy granularity convention: Kitaev is a 2D model — per-site is the
+# native granularity at every BC.  The total-energy generic conversion in
+# `src/core/quantities.jl` would need `_bc_size(bc, kwargs)` to read
+# `Lx, Ly` from kwargs; we leave `Energy(:total)` unsupported for now and
+# let it surface as the standard "no method registered" error.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+native_energy_granularity(::KitaevHoneycomb, ::OBC)      = :per_site
+native_energy_granularity(::KitaevHoneycomb, ::PBC)      = :per_site
+native_energy_granularity(::KitaevHoneycomb, ::Infinite) = :per_site
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # Energy — Infinite (per site)
 # ═══════════════════════════════════════════════════════════════════════════════
 
 """
-    fetch(model::KitaevHoneycomb, ::Energy, ::Infinite; rtol=1e-8) -> Float64
+    fetch(model::KitaevHoneycomb, ::Energy{:per_site}, ::Infinite; rtol=1e-8) -> Float64
 
 Ground state energy **per site** in the thermodynamic limit:
 
@@ -115,7 +127,7 @@ converge to this TL value within `~10⁻³` at `Lx = Ly = 8` and
 `~10⁻⁶` at `Lx = Ly = 64` — see
 `test/models/test_KitaevHoneycomb.jl`.
 """
-function fetch(model::KitaevHoneycomb, ::Energy, ::Infinite; rtol::Float64=1e-8, kwargs...)
+function fetch(model::KitaevHoneycomb, ::Energy{:per_site}, ::Infinite; rtol::Float64=1e-8, kwargs...)
     inner(θ₁) = first(
         quadgk(θ₂ -> _kitaev_fk_abs(model, θ₁, θ₂), 0.0, 2π; rtol=rtol * 10, atol=1e-14)
     )
@@ -169,7 +181,7 @@ function _kitaev_pbc_sector_energy(
 end
 
 """
-    fetch(model::KitaevHoneycomb, ::Energy, bc::PBC; Lx, Ly) -> Float64
+    fetch(model::KitaevHoneycomb, ::Energy{:per_site}, bc::PBC; Lx, Ly) -> Float64
 
 Per-site ground state energy on a `Lx × Ly` unit-cell torus (PBC in
 both lattice directions) — enumerates all four topological flux
@@ -186,7 +198,7 @@ individual Bloch-sum terms dominate; for small `L` sector choice is
 essential (e.g. `Lx = Ly = 2` gives distinct sector energies differing
 by `~10%`).
 """
-function fetch(model::KitaevHoneycomb, ::Energy, ::PBC; Lx::Integer, Ly::Integer)
+function fetch(model::KitaevHoneycomb, ::Energy{:per_site}, ::PBC; Lx::Integer, Ly::Integer)
     Lx > 0 && Ly > 0 ||
         error("KitaevHoneycomb PBC: Lx, Ly must be positive (got Lx=$Lx, Ly=$Ly).")
     return minimum(
@@ -233,7 +245,7 @@ function _obc_hopping_matrix(m::KitaevHoneycomb, Lx::Integer, Ly::Integer)
 end
 
 """
-    fetch(model::KitaevHoneycomb, ::Energy, ::OBC; Lx, Ly) -> Float64
+    fetch(model::KitaevHoneycomb, ::Energy{:per_site}, ::OBC; Lx, Ly) -> Float64
 
 Per-site ground state energy on a `Lx × Ly` honeycomb strip with open
 boundaries in both lattice directions. Uses the flux-free-sector
@@ -244,7 +256,7 @@ energy = `−Σₖ σₖ`; per site = that divided by `2·Lx·Ly`.
 
 `bc.N` is ignored; pass `Lx`, `Ly` explicitly.
 """
-function fetch(model::KitaevHoneycomb, ::Energy, ::OBC; Lx::Integer, Ly::Integer)
+function fetch(model::KitaevHoneycomb, ::Energy{:per_site}, ::OBC; Lx::Integer, Ly::Integer)
     Lx > 0 && Ly > 0 ||
         error("KitaevHoneycomb OBC: Lx, Ly must be positive (got Lx=$Lx, Ly=$Ly).")
     M = _obc_hopping_matrix(model, Lx, Ly)

--- a/src/models/quantum/KitaevHoneycomb/KitaevHoneycomb.jl
+++ b/src/models/quantum/KitaevHoneycomb/KitaevHoneycomb.jl
@@ -100,8 +100,8 @@ end
 # let it surface as the standard "no method registered" error.
 # ═══════════════════════════════════════════════════════════════════════════════
 
-native_energy_granularity(::KitaevHoneycomb, ::OBC)      = :per_site
-native_energy_granularity(::KitaevHoneycomb, ::PBC)      = :per_site
+native_energy_granularity(::KitaevHoneycomb, ::OBC) = :per_site
+native_energy_granularity(::KitaevHoneycomb, ::PBC) = :per_site
 native_energy_granularity(::KitaevHoneycomb, ::Infinite) = :per_site
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -127,7 +127,9 @@ converge to this TL value within `~10⁻³` at `Lx = Ly = 8` and
 `~10⁻⁶` at `Lx = Ly = 64` — see
 `test/models/test_KitaevHoneycomb.jl`.
 """
-function fetch(model::KitaevHoneycomb, ::Energy{:per_site}, ::Infinite; rtol::Float64=1e-8, kwargs...)
+function fetch(
+    model::KitaevHoneycomb, ::Energy{:per_site}, ::Infinite; rtol::Float64=1e-8, kwargs...
+)
     inner(θ₁) = first(
         quadgk(θ₂ -> _kitaev_fk_abs(model, θ₁, θ₂), 0.0, 2π; rtol=rtol * 10, atol=1e-14)
     )

--- a/src/models/quantum/TFIM/TFIM.jl
+++ b/src/models/quantum/TFIM/TFIM.jl
@@ -75,13 +75,22 @@ function _tfim_bdg_spectrum(N::Int, J::Float64, h::Float64)::Vector{Float64}
 end
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# Energy granularity convention (see src/core/quantities.jl)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+native_energy_granularity(::TFIM, ::OBC)      = :total
+native_energy_granularity(::TFIM, ::Infinite) = :per_site
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # Energy: OBC finite-N
 # ═══════════════════════════════════════════════════════════════════════════════
 
 """
-    fetch(model::TFIM, ::Energy, bc::OBC; beta, betas) -> Float64 or Vector{Float64}
+    fetch(model::TFIM, ::Energy{:total}, bc::OBC; beta, betas) -> Float64 or Vector{Float64}
 
-Total energy ⟨H⟩(β) for the OBC TFIM with N sites.
+Total energy ⟨H⟩(β) for the OBC TFIM with N sites.  Native granularity
+for finite-N TFIM (per-site is provided by the generic conversion
+fallback in `src/core/quantities.jl`).
 
 - `N` is read from `bc.N` (`OBC(N)` / `OBC(; N)`) or from `kwargs[:N]`
   as a legacy fallback.
@@ -93,7 +102,7 @@ Uses the exact BdG formula:  ⟨H⟩ = -Σₙ (Λₙ/2) tanh(β Λₙ / 2)
 """
 function fetch(
     model::TFIM,
-    ::Energy,
+    ::Energy{:total},
     bc::OBC;
     beta::Union{Real,Nothing}=nothing,
     betas::Union{AbstractVector{<:Real},Nothing}=nothing,
@@ -116,9 +125,11 @@ end
 # ═══════════════════════════════════════════════════════════════════════════════
 
 """
-    fetch(model::TFIM, ::Energy, ::Infinite; beta, betas) -> Float64 or Vector{Float64}
+    fetch(model::TFIM, ::Energy{:per_site}, ::Infinite; beta, betas) -> Float64 or Vector{Float64}
 
 Energy *per site* ⟨H⟩/N in the thermodynamic limit (PBC, N → ∞).
+Native granularity at `Infinite()` (total energy diverges and has no
+defined value here).
 
     ε(β) = -(1/π) ∫₀^π dk  Λ(k)/2 · tanh(β Λ(k) / 2)
 
@@ -132,7 +143,7 @@ Uses adaptive Gauss-Kronrod quadrature (QuadGK).
 """
 function fetch(
     model::TFIM,
-    ::Energy,
+    ::Energy{:per_site},
     ::Infinite;
     beta::Union{Real,Nothing}=nothing,
     betas::Union{AbstractVector{<:Real},Nothing}=nothing,

--- a/src/models/quantum/TFIM/TFIM.jl
+++ b/src/models/quantum/TFIM/TFIM.jl
@@ -78,7 +78,7 @@ end
 # Energy granularity convention (see src/core/quantities.jl)
 # ═══════════════════════════════════════════════════════════════════════════════
 
-native_energy_granularity(::TFIM, ::OBC)      = :total
+native_energy_granularity(::TFIM, ::OBC) = :total
 native_energy_granularity(::TFIM, ::Infinite) = :per_site
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/src/models/quantum/XXZ/XXZ.jl
+++ b/src/models/quantum/XXZ/XXZ.jl
@@ -75,7 +75,7 @@ _xxz1d_energy_free_fermion(J::Float64)::Float64 = -J / π
 _xxz1d_energy_heisenberg_af(J::Float64)::Float64 = J * (0.25 - log(2.0))
 _xxz1d_energy_heisenberg_fm(J::Float64)::Float64 = -J / 4
 
-native_energy_granularity(::XXZ1D, ::OBC)      = :total
+native_energy_granularity(::XXZ1D, ::OBC) = :total
 native_energy_granularity(::XXZ1D, ::Infinite) = :per_site
 
 """

--- a/src/models/quantum/XXZ/XXZ.jl
+++ b/src/models/quantum/XXZ/XXZ.jl
@@ -75,8 +75,11 @@ _xxz1d_energy_free_fermion(J::Float64)::Float64 = -J / π
 _xxz1d_energy_heisenberg_af(J::Float64)::Float64 = J * (0.25 - log(2.0))
 _xxz1d_energy_heisenberg_fm(J::Float64)::Float64 = -J / 4
 
+native_energy_granularity(::XXZ1D, ::OBC)      = :total
+native_energy_granularity(::XXZ1D, ::Infinite) = :per_site
+
 """
-    fetch(model::XXZ1D, ::Energy, ::Infinite) -> Float64
+    fetch(model::XXZ1D, ::Energy{:per_site}, ::Infinite) -> Float64
 
 Ground-state energy **per site** of the infinite XXZ chain in units of
 the Hamiltonian `J`.  Currently exposes the three canonical values:
@@ -88,7 +91,7 @@ the Hamiltonian `J`.  Currently exposes the three canonical values:
 For every other `Δ` a warning is emitted and `NaN` is returned — the
 general-`Δ` Bethe-ansatz integral is tracked as a v0.13 follow-up.
 """
-function fetch(model::XXZ1D, ::Energy, ::Infinite; kwargs...)
+function fetch(model::XXZ1D, ::Energy{:per_site}, ::Infinite; kwargs...)
     J, Δ = model.J, model.Δ
     if isapprox(Δ, 0.0; atol=1e-12)
         return _xxz1d_energy_free_fermion(J)
@@ -220,7 +223,7 @@ function _xxz1d_hamiltonian_matrix(model::XXZ1D, N::Int)
 end
 
 """
-    fetch(model::XXZ1D, ::Energy, ::OBC; beta) -> Float64
+    fetch(model::XXZ1D, ::Energy{:total}, ::OBC; beta) -> Float64
 
 **Total** thermal energy `⟨H⟩_β` for the spin-½ OBC chain at finite size,
 computed by dense ED.  Works for any `Δ` and any `N ≤ $(_MAX_ED_SITES)`.
@@ -235,7 +238,7 @@ Convention matches [`fetch(::TFIM, ::Energy, ::OBC)`](@ref): finite-size
 boundary conditions return total energy; only `Infinite()` returns per-site
 (`⟨H⟩/N`, the only finite quantity in the thermodynamic limit).
 """
-function fetch(model::XXZ1D, ::Energy, bc::OBC; beta::Real, kwargs...)
+function fetch(model::XXZ1D, ::Energy{:total}, bc::OBC; beta::Real, kwargs...)
     H = _xxz1d_hamiltonian_matrix(model, bc.N)
     return _ed_thermal_energy(H, beta)
 end

--- a/test/core/test_energy_granularity.jl
+++ b/test/core/test_energy_granularity.jl
@@ -1,0 +1,112 @@
+using Test
+using QAtlas
+using QAtlas: Energy, OBC, PBC, Infinite, TFIM, XXZ1D, Heisenberg1D,
+    S1Heisenberg1D, KitaevHoneycomb, native_energy_granularity, fetch
+
+# Tests for the parameterized `Energy{G}` dispatch surface introduced
+# alongside the `native_energy_granularity` trait.  Goal: pin down
+# (i) backward-compat of bare `Energy()`, (ii) explicit-granularity
+# round-trips through the generic conversion fallback, and (iii) the
+# Kitaev (2D, per-site native) corner where the `:total` fallback is
+# expected to error.
+
+@testset "Energy{G} constructors and aliases" begin
+    @test Energy() isa Energy{:natural}
+    @test Energy(:natural) isa Energy{:natural}
+    @test Energy(:total) isa Energy{:total}
+    @test Energy(:per_site) isa Energy{:per_site}
+    @test_throws ErrorException Energy(:bogus)
+    @test_throws ErrorException Energy{:bogus}()
+end
+
+@testset "native_energy_granularity declarations" begin
+    @test native_energy_granularity(TFIM(; J=1.0, h=1.0), OBC(8))      === :total
+    @test native_energy_granularity(TFIM(; J=1.0, h=1.0), Infinite())  === :per_site
+    @test native_energy_granularity(XXZ1D(; J=1.0, Δ=0.0), OBC(8))     === :total
+    @test native_energy_granularity(XXZ1D(; J=1.0, Δ=0.0), Infinite()) === :per_site
+    @test native_energy_granularity(Heisenberg1D(), OBC(8))            === :total
+    @test native_energy_granularity(S1Heisenberg1D(; J=1.0), OBC(4))   === :total
+    @test native_energy_granularity(KitaevHoneycomb(), OBC(0))         === :per_site
+    @test native_energy_granularity(KitaevHoneycomb(), PBC(0))         === :per_site
+    @test native_energy_granularity(KitaevHoneycomb(), Infinite())     === :per_site
+end
+
+@testset "Energy() :natural router routes to native granularity" begin
+    # TFIM OBC: :natural → :total
+    let m = TFIM(; J=1.0, h=0.5), N = 8, β = 1.0
+        @test fetch(m, Energy(),         OBC(N); beta=β) ==
+              fetch(m, Energy(:total),   OBC(N); beta=β)
+    end
+    # TFIM Infinite: :natural → :per_site
+    let m = TFIM(; J=1.0, h=0.5), β = 1.0
+        @test fetch(m, Energy(),           Infinite(); beta=β) ==
+              fetch(m, Energy(:per_site),  Infinite(); beta=β)
+    end
+    # Kitaev (per-site at every BC)
+    let m = KitaevHoneycomb()
+        @test fetch(m, Energy(),           Infinite()) ==
+              fetch(m, Energy(:per_site),  Infinite())
+        @test fetch(m, Energy(),           OBC(0); Lx=3, Ly=3) ==
+              fetch(m, Energy(:per_site),  OBC(0); Lx=3, Ly=3)
+        @test fetch(m, Energy(),           PBC(0); Lx=3, Ly=3) ==
+              fetch(m, Energy(:per_site),  PBC(0); Lx=3, Ly=3)
+    end
+end
+
+@testset "Energy(:per_site) at finite BC = Energy(:total) / N (1D conversion)" begin
+    # TFIM
+    for N in (4, 6, 8), β in (0.5, 1.0, 2.0)
+        m = TFIM(; J=1.0, h=0.7)
+        e_tot = fetch(m, Energy(:total),    OBC(N); beta=β)
+        e_ps  = fetch(m, Energy(:per_site), OBC(N); beta=β)
+        @test e_ps ≈ e_tot / N rtol=1e-12
+    end
+    # XXZ1D
+    for N in (4, 6), β in (0.5, 1.0), Δ in (-1.0, 0.0, 1.0)
+        m = XXZ1D(; J=1.0, Δ=Δ)
+        e_tot = fetch(m, Energy(:total),    OBC(N); beta=β)
+        e_ps  = fetch(m, Energy(:per_site), OBC(N); beta=β)
+        @test e_ps ≈ e_tot / N rtol=1e-12
+    end
+    # Heisenberg1D (delegates to XXZ1D)
+    for N in (4, 6), β in (0.5, 1.0)
+        e_tot = fetch(Heisenberg1D(), Energy(:total),    OBC(N); beta=β, J=1.5)
+        e_ps  = fetch(Heisenberg1D(), Energy(:per_site), OBC(N); beta=β, J=1.5)
+        @test e_ps ≈ e_tot / N rtol=1e-12
+    end
+    # S1Heisenberg1D
+    for N in (3, 4), β in (0.5, 1.0)
+        m = S1Heisenberg1D(; J=1.0)
+        e_tot = fetch(m, Energy(:total),    OBC(N); beta=β)
+        e_ps  = fetch(m, Energy(:per_site), OBC(N); beta=β)
+        @test e_ps ≈ e_tot / N rtol=1e-12
+    end
+end
+
+@testset "Energy(:total) at Infinite is undefined" begin
+    # Generic conversion only covers OBC/PBC; at Infinite no model
+    # registers Energy{:total} natively (total energy diverges in the
+    # thermodynamic limit), so the request falls through to QAtlas's
+    # informative catch-all `fetch` (`src/core/type.jl`), which raises
+    # an `ErrorException`.
+    @test_throws ErrorException fetch(TFIM(; J=1.0, h=1.0),
+        Energy(:total), Infinite(); beta=1.0)
+    @test_throws ErrorException fetch(XXZ1D(; J=1.0, Δ=0.0),
+        Energy(:total), Infinite())
+    @test_throws ErrorException fetch(KitaevHoneycomb(),
+        Energy(:total), Infinite())
+end
+
+@testset "Energy(:total) on 2D Kitaev: generic fallback fails (expected)" begin
+    # Kitaev declares native :per_site at OBC/PBC.  The generic :total
+    # fallback would call `_bc_size(bc, kwargs)`, but Kitaev encodes the
+    # system size in `Lx, Ly` kwargs rather than `bc.N`, so the conversion
+    # is intentionally unsupported and surfaces the standard "N
+    # unspecified" error.  This test pins the behaviour so a future Kitaev
+    # PR that adds 2D system_size support is forced to update both the
+    # implementation and this expectation.
+    @test_throws ErrorException fetch(KitaevHoneycomb(),
+        Energy(:total), OBC(0); Lx=3, Ly=3)
+    @test_throws ErrorException fetch(KitaevHoneycomb(),
+        Energy(:total), PBC(0); Lx=3, Ly=3)
+end

--- a/test/core/test_energy_granularity.jl
+++ b/test/core/test_energy_granularity.jl
@@ -1,7 +1,17 @@
 using Test
 using QAtlas
-using QAtlas: Energy, OBC, PBC, Infinite, TFIM, XXZ1D, Heisenberg1D,
-    S1Heisenberg1D, KitaevHoneycomb, native_energy_granularity, fetch
+using QAtlas:
+    Energy,
+    OBC,
+    PBC,
+    Infinite,
+    TFIM,
+    XXZ1D,
+    Heisenberg1D,
+    S1Heisenberg1D,
+    KitaevHoneycomb,
+    native_energy_granularity,
+    fetch
 
 # Tests for the parameterized `Energy{G}` dispatch surface introduced
 # alongside the `native_energy_granularity` trait.  Goal: pin down
@@ -20,36 +30,34 @@ using QAtlas: Energy, OBC, PBC, Infinite, TFIM, XXZ1D, Heisenberg1D,
 end
 
 @testset "native_energy_granularity declarations" begin
-    @test native_energy_granularity(TFIM(; J=1.0, h=1.0), OBC(8))      === :total
-    @test native_energy_granularity(TFIM(; J=1.0, h=1.0), Infinite())  === :per_site
-    @test native_energy_granularity(XXZ1D(; J=1.0, Δ=0.0), OBC(8))     === :total
+    @test native_energy_granularity(TFIM(; J=1.0, h=1.0), OBC(8)) === :total
+    @test native_energy_granularity(TFIM(; J=1.0, h=1.0), Infinite()) === :per_site
+    @test native_energy_granularity(XXZ1D(; J=1.0, Δ=0.0), OBC(8)) === :total
     @test native_energy_granularity(XXZ1D(; J=1.0, Δ=0.0), Infinite()) === :per_site
-    @test native_energy_granularity(Heisenberg1D(), OBC(8))            === :total
-    @test native_energy_granularity(S1Heisenberg1D(; J=1.0), OBC(4))   === :total
-    @test native_energy_granularity(KitaevHoneycomb(), OBC(0))         === :per_site
-    @test native_energy_granularity(KitaevHoneycomb(), PBC(0))         === :per_site
-    @test native_energy_granularity(KitaevHoneycomb(), Infinite())     === :per_site
+    @test native_energy_granularity(Heisenberg1D(), OBC(8)) === :total
+    @test native_energy_granularity(S1Heisenberg1D(; J=1.0), OBC(4)) === :total
+    @test native_energy_granularity(KitaevHoneycomb(), OBC(0)) === :per_site
+    @test native_energy_granularity(KitaevHoneycomb(), PBC(0)) === :per_site
+    @test native_energy_granularity(KitaevHoneycomb(), Infinite()) === :per_site
 end
 
 @testset "Energy() :natural router routes to native granularity" begin
     # TFIM OBC: :natural → :total
     let m = TFIM(; J=1.0, h=0.5), N = 8, β = 1.0
-        @test fetch(m, Energy(),         OBC(N); beta=β) ==
-              fetch(m, Energy(:total),   OBC(N); beta=β)
+        @test fetch(m, Energy(), OBC(N); beta=β) == fetch(m, Energy(:total), OBC(N); beta=β)
     end
     # TFIM Infinite: :natural → :per_site
     let m = TFIM(; J=1.0, h=0.5), β = 1.0
-        @test fetch(m, Energy(),           Infinite(); beta=β) ==
-              fetch(m, Energy(:per_site),  Infinite(); beta=β)
+        @test fetch(m, Energy(), Infinite(); beta=β) ==
+            fetch(m, Energy(:per_site), Infinite(); beta=β)
     end
     # Kitaev (per-site at every BC)
     let m = KitaevHoneycomb()
-        @test fetch(m, Energy(),           Infinite()) ==
-              fetch(m, Energy(:per_site),  Infinite())
-        @test fetch(m, Energy(),           OBC(0); Lx=3, Ly=3) ==
-              fetch(m, Energy(:per_site),  OBC(0); Lx=3, Ly=3)
-        @test fetch(m, Energy(),           PBC(0); Lx=3, Ly=3) ==
-              fetch(m, Energy(:per_site),  PBC(0); Lx=3, Ly=3)
+        @test fetch(m, Energy(), Infinite()) == fetch(m, Energy(:per_site), Infinite())
+        @test fetch(m, Energy(), OBC(0); Lx=3, Ly=3) ==
+            fetch(m, Energy(:per_site), OBC(0); Lx=3, Ly=3)
+        @test fetch(m, Energy(), PBC(0); Lx=3, Ly=3) ==
+            fetch(m, Energy(:per_site), PBC(0); Lx=3, Ly=3)
     end
 end
 
@@ -57,28 +65,28 @@ end
     # TFIM
     for N in (4, 6, 8), β in (0.5, 1.0, 2.0)
         m = TFIM(; J=1.0, h=0.7)
-        e_tot = fetch(m, Energy(:total),    OBC(N); beta=β)
-        e_ps  = fetch(m, Energy(:per_site), OBC(N); beta=β)
+        e_tot = fetch(m, Energy(:total), OBC(N); beta=β)
+        e_ps = fetch(m, Energy(:per_site), OBC(N); beta=β)
         @test e_ps ≈ e_tot / N rtol=1e-12
     end
     # XXZ1D
     for N in (4, 6), β in (0.5, 1.0), Δ in (-1.0, 0.0, 1.0)
         m = XXZ1D(; J=1.0, Δ=Δ)
-        e_tot = fetch(m, Energy(:total),    OBC(N); beta=β)
-        e_ps  = fetch(m, Energy(:per_site), OBC(N); beta=β)
+        e_tot = fetch(m, Energy(:total), OBC(N); beta=β)
+        e_ps = fetch(m, Energy(:per_site), OBC(N); beta=β)
         @test e_ps ≈ e_tot / N rtol=1e-12
     end
     # Heisenberg1D (delegates to XXZ1D)
     for N in (4, 6), β in (0.5, 1.0)
-        e_tot = fetch(Heisenberg1D(), Energy(:total),    OBC(N); beta=β, J=1.5)
-        e_ps  = fetch(Heisenberg1D(), Energy(:per_site), OBC(N); beta=β, J=1.5)
+        e_tot = fetch(Heisenberg1D(), Energy(:total), OBC(N); beta=β, J=1.5)
+        e_ps = fetch(Heisenberg1D(), Energy(:per_site), OBC(N); beta=β, J=1.5)
         @test e_ps ≈ e_tot / N rtol=1e-12
     end
     # S1Heisenberg1D
     for N in (3, 4), β in (0.5, 1.0)
         m = S1Heisenberg1D(; J=1.0)
-        e_tot = fetch(m, Energy(:total),    OBC(N); beta=β)
-        e_ps  = fetch(m, Energy(:per_site), OBC(N); beta=β)
+        e_tot = fetch(m, Energy(:total), OBC(N); beta=β)
+        e_ps = fetch(m, Energy(:per_site), OBC(N); beta=β)
         @test e_ps ≈ e_tot / N rtol=1e-12
     end
 end
@@ -89,12 +97,11 @@ end
     # thermodynamic limit), so the request falls through to QAtlas's
     # informative catch-all `fetch` (`src/core/type.jl`), which raises
     # an `ErrorException`.
-    @test_throws ErrorException fetch(TFIM(; J=1.0, h=1.0),
-        Energy(:total), Infinite(); beta=1.0)
-    @test_throws ErrorException fetch(XXZ1D(; J=1.0, Δ=0.0),
-        Energy(:total), Infinite())
-    @test_throws ErrorException fetch(KitaevHoneycomb(),
-        Energy(:total), Infinite())
+    @test_throws ErrorException fetch(
+        TFIM(; J=1.0, h=1.0), Energy(:total), Infinite(); beta=1.0
+    )
+    @test_throws ErrorException fetch(XXZ1D(; J=1.0, Δ=0.0), Energy(:total), Infinite())
+    @test_throws ErrorException fetch(KitaevHoneycomb(), Energy(:total), Infinite())
 end
 
 @testset "Energy(:total) on 2D Kitaev: generic fallback fails (expected)" begin
@@ -105,8 +112,6 @@ end
     # unspecified" error.  This test pins the behaviour so a future Kitaev
     # PR that adds 2D system_size support is forced to update both the
     # implementation and this expectation.
-    @test_throws ErrorException fetch(KitaevHoneycomb(),
-        Energy(:total), OBC(0); Lx=3, Ly=3)
-    @test_throws ErrorException fetch(KitaevHoneycomb(),
-        Energy(:total), PBC(0); Lx=3, Ly=3)
+    @test_throws ErrorException fetch(KitaevHoneycomb(), Energy(:total), OBC(0); Lx=3, Ly=3)
+    @test_throws ErrorException fetch(KitaevHoneycomb(), Energy(:total), PBC(0); Lx=3, Ly=3)
 end


### PR DESCRIPTION
## Summary

Encode the per-site / total convention in the `Energy` type itself instead of leaving it implicit in docstrings. Each model declares its native granularity per BC via the new `native_energy_granularity(model, bc)` trait; a generic conversion fallback covers the other granularity at finite 1D BCs (`OBC` / `PBC`).

- `Energy()` (no args) routes through `:natural` to the model's native granularity → **all existing call sites continue to work unchanged**.
- `Energy(:total)` and `Energy(:per_site)` are explicit overrides for callers that need a specific granularity (e.g. the upcoming AutoDiff thermodynamic-identity harness in #117).
- A new `_bc_size`-based fallback automatically converts `Energy(:per_site) ↔ Energy(:total)` at finite 1D BCs.

## Motivation

Reading through the open issues surfaced four design穴; this PR addresses **穴 3** — quantity granularity (`per-site` vs `total`) was a docstring contract rather than a dispatchable axis, which is exactly how the XXZ Energy convention drift in #94 happened. After this PR the convention lives in the type system, so:

- The harness in #117 can request `Energy(:per_site)` explicitly without ad-hoc `* N` / `/ N` glue.
- A new model that forgets to declare `native_energy_granularity` fails at the call site rather than silently inheriting an incorrect default.
- Kitaev's correct-but-different 2D convention (per-site at *every* BC including OBC/PBC) becomes an explicit trait declaration instead of a buried comment.

## Drive-by fixes (surfaced by the new dispatch)

- `Heisenberg1D` was the only model not subtyping `AbstractQAtlasModel`. The `:natural` router immediately exposed this via MethodError; one-line fix.
- Documented Kitaev's per-site-at-finite-BC convention as a trait rather than relying on the section comment in `KitaevHoneycomb.jl`.

## Test plan

- [x] All 1389 tests pass (1335 existing + 54 new).
- [x] New `test/core/test_energy_granularity.jl` covers:
  - constructors (`Energy()`, `Energy(:total)`, `Energy(:per_site)`, invalid symbol rejection),
  - `native_energy_granularity` declarations for every (model, BC) pair we ship,
  - `Energy()` `:natural` router agrees with the explicit native granularity for TFIM / Kitaev at every supported BC,
  - 1D conversion round-trip `Energy(:per_site) ≈ Energy(:total) / N` at multiple `(N, β)` for TFIM, XXZ1D, Heisenberg1D, S1Heisenberg1D,
  - error paths: `Energy(:total)` at `Infinite()` (no method) and `Energy(:total)` on 2D Kitaev (`_bc_size` cannot infer N from `Lx, Ly` kwargs).

## Related

- Unblocks #117 (model-agnostic AutoDiff thermodynamic-identity harness — needs `Energy(:per_site)` for `ε = f + T·s`).
- Closes the design half of #94 (the XXZ value already returns total at OBC; this PR makes future drift impossible for any new model).
- Foundation for #116 (implementation status table) — the `native_energy_granularity` trait is the first step toward declaration-driven model registration.