### PR TITLE
feat(registry): declarative implementation map + drift guard (TFIM)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.16.6"
+version = "0.16.7"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -27,8 +27,12 @@ export S1Heisenberg1D                                    # spin-1 (Haldane chain
 include("core/alias.jl")
 include("core/type.jl")
 include("core/quantities.jl")
+include("core/registry.jl")
 include("core/pfaffian.jl")
 include("core/dense_ed.jl")
+
+# --- Implementation registry public API ---
+export Implementation, implementation_status, implementation_status_markdown
 
 # --- Quantity struct exports (new, axis-explicit naming) ---
 export Energy, FreeEnergy, SpecificHeat, MassGap, FidelitySusceptibility
@@ -69,6 +73,7 @@ include("models/quantum/TFIM/TFIM_dynamics.jl")
 include("models/quantum/TFIM/TFIM_thermal.jl")
 include("models/quantum/TFIM/TFIM_local.jl")
 include("models/quantum/TFIM/TFIM_entanglement.jl")
+include("models/quantum/TFIM/TFIM_registry.jl")  # populates REGISTRY for TFIM
 include("models/quantum/Heisenberg/Heisenberg.jl")
 include("models/quantum/Heisenberg/HeisenbergS1.jl")
 include("models/quantum/KitaevHoneycomb/KitaevHoneycomb.jl")

--- a/src/core/registry.jl
+++ b/src/core/registry.jl
@@ -1,0 +1,240 @@
+# core/registry.jl — declarative implementation registry.
+#
+# Each (model, quantity, bc) triple that has a directly-implemented
+# `fetch` method also gets a one-liner `@register` declaration next to
+# it, capturing the human metadata that `methods(fetch)` cannot:
+#   * `method`      — algorithm tag (`:bdg`, `:dense_ed`, `:analytic`,
+#                      `:transfer_matrix`, `:bethe_ansatz`, `:tba`, `:pfaffian`,
+#                      `:not_implemented`, …)
+#   * `reliability` — `:high` (closed-form + literature-tested),
+#                      `:medium` (ED only / cross-check),
+#                      `:low` (heuristic, not validated),
+#                      `:not_implemented`.  Aligned with the
+#                      (a)/(b)/(c) test categories in #118.
+#   * `tested_in`   — relative path to the test file that validates
+#                      this triple (or `nothing` if no dedicated test).
+#   * `references`  — short literature pointers (author + year).
+#   * `notes`       — caller-facing caveats (granularity, kwargs, …).
+#
+# `implementation_status()` returns the registry as
+# `Vector{NamedTuple}`, which is `Tables.jl`-compatible without us
+# taking a Tables dependency — downstream users wanting a `DataFrame`
+# can call `DataFrame(implementation_status())` themselves.
+#
+# Conversion fallbacks (e.g. `Energy(:per_site)` at OBC routed through
+# the `Energy(:total)` native + `÷ N`) are *not* registered separately:
+# the registry reflects native implementations, and the routing is
+# automatic by design.
+
+"""
+    Implementation
+
+A single `(model, quantity, bc)` row of the QAtlas implementation
+registry.  See [`@register`](@ref) for how rows are added and
+[`implementation_status`](@ref) for how to query them.
+"""
+struct Implementation
+    model::Type
+    quantity::Type
+    bc::Type
+    method::Symbol
+    reliability::Symbol
+    tested_in::Union{String,Nothing}
+    references::Vector{String}
+    notes::String
+end
+
+"""
+    REGISTRY :: Vector{Implementation}
+
+Module-level mutable vector populated at include-time by `@register`
+calls scattered across `src/models/.../<Model>_registry.jl` files.
+Public read API: [`implementation_status`](@ref).
+"""
+const REGISTRY = Implementation[]
+
+"""
+    register!(model_T, quantity_T, bc_T;
+              method=:unknown, reliability=:unknown,
+              tested_in=nothing, references=String[], notes="")
+
+Push a new [`Implementation`](@ref) row into [`REGISTRY`](@ref).
+Usually called via the [`@register`](@ref) macro for ergonomics.
+"""
+function register!(
+    model_T::Type, quantity_T::Type, bc_T::Type;
+    method::Symbol=:unknown,
+    reliability::Symbol=:unknown,
+    tested_in::Union{String,Nothing}=nothing,
+    references::AbstractVector{<:AbstractString}=String[],
+    notes::AbstractString="",
+)
+    push!(
+        REGISTRY,
+        Implementation(
+            model_T, quantity_T, bc_T,
+            method, reliability,
+            tested_in, String[r for r in references], String(notes),
+        ),
+    )
+    return nothing
+end
+
+"""
+    @register Model Quantity BC method=… reliability=… tested_in=… references=… notes=…
+
+Thin macro around [`register!`](@ref).  Lets each model file register
+its native fetch methods declaratively, e.g.
+
+```julia
+@register TFIM Energy{:total} OBC method=:bdg reliability=:high \\
+    tested_in="test/models/test_TFIM_thermal.jl" \\
+    references=["Pfeuty 1970"]
+```
+
+The three positional arguments are spliced as types; the remaining
+`key=value` pairs are forwarded as keyword arguments to
+[`register!`](@ref).
+"""
+macro register(model_T, quantity_T, bc_T, kwargs...)
+    kw_exprs = map(kwargs) do kw
+        kw isa Expr && kw.head === :(=) ||
+            error("@register: expected key=value, got $kw")
+        return Expr(:kw, kw.args[1], esc(kw.args[2]))
+    end
+    return Expr(
+        :call, register!,
+        Expr(:parameters, kw_exprs...),
+        esc(model_T), esc(quantity_T), esc(bc_T),
+    )
+end
+
+# ──────────────────────────────────────────────────────────────────────
+# Smoke-check helper: distinguish "registered + fetch method exists" from
+# "registered but only the catch-all error method matches".  The
+# catch-all lives in core/type.jl; we capture it here at registry load
+# time so future fetch additions can't accidentally re-shadow it.
+# ──────────────────────────────────────────────────────────────────────
+
+const _CATCH_ALL_FETCH_METHOD = which(
+    fetch, Tuple{AbstractQAtlasModel,AbstractQuantity,BoundaryCondition}
+)
+
+"""
+    has_native_fetch(impl::Implementation) -> Bool
+
+`true` iff `which(fetch, (impl.model, impl.quantity, impl.bc))` resolves
+to a method *more specific* than the catch-all in `core/type.jl`.
+Conversion fallbacks (e.g. the generic `Energy{:per_site}` ↔
+`Energy{:total}` router) count as "native" because they are a real
+dispatchable implementation — they just live above the model layer.
+
+Used by `test/core/test_registry.jl` to detect registry rows that
+silently lost their backing fetch method.
+"""
+function has_native_fetch(impl::Implementation)
+    m = which(fetch, Tuple{impl.model,impl.quantity,impl.bc})
+    return m !== _CATCH_ALL_FETCH_METHOD
+end
+
+# ──────────────────────────────────────────────────────────────────────
+# Query API
+# ──────────────────────────────────────────────────────────────────────
+
+_to_nt(e::Implementation) = (
+    model=e.model, quantity=e.quantity, bc=e.bc,
+    method=e.method, reliability=e.reliability,
+    tested_in=e.tested_in, references=e.references, notes=e.notes,
+)
+
+"""
+    implementation_status() -> Vector{NamedTuple}
+    implementation_status(model::AbstractQAtlasModel)
+    implementation_status(::Type{<:AbstractQAtlasModel})
+    implementation_status(quantity::AbstractQuantity)
+    implementation_status(::Type{<:AbstractQuantity})
+    implementation_status(queue::AbstractVector)
+
+Return registry rows as `NamedTuple`s (`Tables.jl`-compatible without a
+Tables dependency).
+
+- No-arg: every registered triple.
+- `model` / `quantity` (instance or type): rows whose corresponding type
+  field matches exactly (no subtype walking — model parameters are part
+  of the identity here).
+- `queue`: a vector of `(model, quantity, bc)` triples (each component
+  may be either an instance or a type).  Returns one row per queue
+  entry that is registered, dropping entries that are not.
+
+Use this to plan downstream work — e.g. before writing tests for a new
+ThermalMPS workload, query the queue you intend to validate against.
+"""
+implementation_status() = [_to_nt(e) for e in REGISTRY]
+
+implementation_status(::Type{M}) where {M<:AbstractQAtlasModel} =
+    [_to_nt(e) for e in REGISTRY if e.model === M]
+implementation_status(model::AbstractQAtlasModel) = implementation_status(typeof(model))
+
+implementation_status(::Type{Q}) where {Q<:AbstractQuantity} =
+    [_to_nt(e) for e in REGISTRY if e.quantity === Q]
+implementation_status(quantity::AbstractQuantity) = implementation_status(typeof(quantity))
+
+function implementation_status(queue::AbstractVector)
+    out = NamedTuple[]
+    for q in queue
+        length(q) == 3 || error(
+            "implementation_status(queue): each element must be a " *
+            "(model, quantity, bc) triple; got length $(length(q))",
+        )
+        m_T = q[1] isa Type ? q[1] : typeof(q[1])
+        q_T = q[2] isa Type ? q[2] : typeof(q[2])
+        bc_T = q[3] isa Type ? q[3] : typeof(q[3])
+        for e in REGISTRY
+            if e.model === m_T && e.quantity === q_T && e.bc === bc_T
+                push!(out, _to_nt(e))
+                break
+            end
+        end
+    end
+    return out
+end
+
+# ──────────────────────────────────────────────────────────────────────
+# Markdown rendering
+# ──────────────────────────────────────────────────────────────────────
+
+# Strip the leading `QAtlas.` (and any submodule prefix) from a `Type`
+# so the rendered table reads `TFIM`, `Energy{:total}`, `OBC` rather
+# than `QAtlas.TFIM` etc.
+function _short_type(T::Type)
+    s = string(T)
+    return replace(s, r"^QAtlas\.|Main\.QAtlas\." => "")
+end
+
+"""
+    implementation_status_markdown([io::IO=stdout], entries=implementation_status())
+
+Render `entries` (any iterable of `NamedTuple` rows from
+[`implementation_status`](@ref)) as a GitHub-flavoured Markdown table
+to `io`.
+"""
+function implementation_status_markdown(
+    io::IO=stdout, entries=implementation_status()
+)
+    println(io, "| Model | Quantity | BC | Method | Reliability | Tested in | References |")
+    println(io, "|---|---|---|---|---|---|---|")
+    for e in entries
+        println(
+            io,
+            "| ", _short_type(e.model),
+            " | ", _short_type(e.quantity),
+            " | ", _short_type(e.bc),
+            " | `", e.method, "`",
+            " | `", e.reliability, "`",
+            " | ", something(e.tested_in, "—"),
+            " | ", isempty(e.references) ? "—" : join(e.references, "; "),
+            " |",
+        )
+    end
+    return nothing
+end

--- a/src/core/registry.jl
+++ b/src/core/registry.jl
@@ -62,7 +62,9 @@ Push a new [`Implementation`](@ref) row into [`REGISTRY`](@ref).
 Usually called via the [`@register`](@ref) macro for ergonomics.
 """
 function register!(
-    model_T::Type, quantity_T::Type, bc_T::Type;
+    model_T::Type,
+    quantity_T::Type,
+    bc_T::Type;
     method::Symbol=:unknown,
     reliability::Symbol=:unknown,
     tested_in::Union{String,Nothing}=nothing,
@@ -72,9 +74,14 @@ function register!(
     push!(
         REGISTRY,
         Implementation(
-            model_T, quantity_T, bc_T,
-            method, reliability,
-            tested_in, String[r for r in references], String(notes),
+            model_T,
+            quantity_T,
+            bc_T,
+            method,
+            reliability,
+            tested_in,
+            String[r for r in references],
+            String(notes),
         ),
     )
     return nothing
@@ -98,14 +105,16 @@ The three positional arguments are spliced as types; the remaining
 """
 macro register(model_T, quantity_T, bc_T, kwargs...)
     kw_exprs = map(kwargs) do kw
-        kw isa Expr && kw.head === :(=) ||
-            error("@register: expected key=value, got $kw")
+        kw isa Expr && kw.head === :(=) || error("@register: expected key=value, got $kw")
         return Expr(:kw, kw.args[1], esc(kw.args[2]))
     end
     return Expr(
-        :call, register!,
+        :call,
+        register!,
         Expr(:parameters, kw_exprs...),
-        esc(model_T), esc(quantity_T), esc(bc_T),
+        esc(model_T),
+        esc(quantity_T),
+        esc(bc_T),
     )
 end
 
@@ -141,11 +150,18 @@ end
 # Query API
 # ──────────────────────────────────────────────────────────────────────
 
-_to_nt(e::Implementation) = (
-    model=e.model, quantity=e.quantity, bc=e.bc,
-    method=e.method, reliability=e.reliability,
-    tested_in=e.tested_in, references=e.references, notes=e.notes,
-)
+function _to_nt(e::Implementation)
+    (
+        model=e.model,
+        quantity=e.quantity,
+        bc=e.bc,
+        method=e.method,
+        reliability=e.reliability,
+        tested_in=e.tested_in,
+        references=e.references,
+        notes=e.notes,
+    )
+end
 
 """
     implementation_status() -> Vector{NamedTuple}
@@ -171,12 +187,14 @@ ThermalMPS workload, query the queue you intend to validate against.
 """
 implementation_status() = [_to_nt(e) for e in REGISTRY]
 
-implementation_status(::Type{M}) where {M<:AbstractQAtlasModel} =
+function implementation_status(::Type{M}) where {M<:AbstractQAtlasModel}
     [_to_nt(e) for e in REGISTRY if e.model === M]
+end
 implementation_status(model::AbstractQAtlasModel) = implementation_status(typeof(model))
 
-implementation_status(::Type{Q}) where {Q<:AbstractQuantity} =
+function implementation_status(::Type{Q}) where {Q<:AbstractQuantity}
     [_to_nt(e) for e in REGISTRY if e.quantity === Q]
+end
 implementation_status(quantity::AbstractQuantity) = implementation_status(typeof(quantity))
 
 function implementation_status(queue::AbstractVector)
@@ -218,21 +236,28 @@ Render `entries` (any iterable of `NamedTuple` rows from
 [`implementation_status`](@ref)) as a GitHub-flavoured Markdown table
 to `io`.
 """
-function implementation_status_markdown(
-    io::IO=stdout, entries=implementation_status()
-)
+function implementation_status_markdown(io::IO=stdout, entries=implementation_status())
     println(io, "| Model | Quantity | BC | Method | Reliability | Tested in | References |")
     println(io, "|---|---|---|---|---|---|---|")
     for e in entries
         println(
             io,
-            "| ", _short_type(e.model),
-            " | ", _short_type(e.quantity),
-            " | ", _short_type(e.bc),
-            " | `", e.method, "`",
-            " | `", e.reliability, "`",
-            " | ", something(e.tested_in, "—"),
-            " | ", isempty(e.references) ? "—" : join(e.references, "; "),
+            "| ",
+            _short_type(e.model),
+            " | ",
+            _short_type(e.quantity),
+            " | ",
+            _short_type(e.bc),
+            " | `",
+            e.method,
+            "`",
+            " | `",
+            e.reliability,
+            "`",
+            " | ",
+            something(e.tested_in, "—"),
+            " | ",
+            isempty(e.references) ? "—" : join(e.references, "; "),
             " |",
         )
     end

--- a/src/models/quantum/TFIM/TFIM_registry.jl
+++ b/src/models/quantum/TFIM/TFIM_registry.jl
@@ -1,0 +1,94 @@
+# models/quantum/TFIM/TFIM_registry.jl — declarative implementation map.
+#
+# One `@register` line per natively-implemented (model, quantity, bc)
+# triple.  Conversion fallbacks (e.g. `Energy(:per_site)` at OBC routed
+# through the `Energy(:total)` native + `÷ N`) are *not* listed here:
+# the registry tracks native implementations and the routing is
+# automatic.  See `src/core/registry.jl` for the metadata schema.
+#
+# When you add a new fetch method to TFIM, add a sibling `@register`
+# line here.  `test/core/test_registry.jl` will fail loudly if the
+# registry and the dispatch table drift apart.
+
+# ── Energy (granularity-aware) ─────────────────────────────────────────
+@register(
+    TFIM, Energy{:total}, OBC,
+    method=:bdg, reliability=:high,
+    tested_in="test/models/test_TFIM_thermal.jl",
+    references=["Pfeuty 1970"],
+    notes="Total ⟨H⟩(β) via the BdG spectrum; ground state when no β kwarg.",
+)
+@register(
+    TFIM, Energy{:per_site}, Infinite,
+    method=:bdg, reliability=:high,
+    tested_in="test/models/test_TFIM_thermal.jl",
+    references=["Pfeuty 1970"],
+    notes="Per-site ε(β) by QuadGK over the PBC dispersion Λ(k).",
+)
+
+# ── Spectrum / criticality ────────────────────────────────────────────
+@register(
+    TFIM, MassGap, Infinite,
+    method=:analytic, reliability=:high,
+    tested_in="test/models/test_TFIM_massgap.jl",
+    references=["Pfeuty 1970"],
+    notes="Δ_∞(J,h) = 2|h - J| — closed-form Ising gap.",
+)
+@register(
+    TFIM, MassGap, OBC,
+    method=:bdg, reliability=:high,
+    tested_in="test/models/test_TFIM_massgap.jl",
+    references=["Pfeuty 1970"],
+    notes="Smallest positive BdG eigenvalue of the OBC chain.",
+)
+@register(
+    TFIM, CentralCharge, Infinite,
+    method=:analytic, reliability=:high,
+    tested_in="test/models/test_TFIM_central_charge.jl",
+    references=["Belavin-Polyakov-Zamolodchikov 1984"],
+    notes="c = 1/2 at the critical point (h = J), 0 otherwise.",
+)
+
+# ── Free-fermion thermal (per-site) — meta-defined in TFIM_thermal.jl ──
+@register(TFIM, FreeEnergy,       OBC,      method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_thermal.jl")
+@register(TFIM, FreeEnergy,       Infinite, method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_thermal.jl")
+@register(TFIM, ThermalEntropy,   OBC,      method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_thermal.jl")
+@register(TFIM, ThermalEntropy,   Infinite, method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_thermal.jl")
+@register(TFIM, SpecificHeat,     OBC,      method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_thermal.jl")
+@register(TFIM, SpecificHeat,     Infinite, method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_thermal.jl")
+@register(TFIM, MagnetizationX,   OBC,      method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_thermal.jl")
+@register(TFIM, MagnetizationX,   Infinite, method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_thermal.jl")
+@register(TFIM, SusceptibilityXX, OBC,      method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_thermal.jl")
+@register(TFIM, SusceptibilityXX, Infinite, method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_thermal.jl")
+
+# ── Local one-site observables (per-site index, not bulk-averaged) ────
+@register(TFIM, EnergyLocal,         OBC, method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_local.jl")
+@register(TFIM, MagnetizationXLocal, OBC, method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_local.jl")
+@register(TFIM, MagnetizationZLocal, OBC, method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_local.jl")
+
+# ── Z-axis dynamics + correlations (BdG time evolution) ───────────────
+@register(TFIM, SusceptibilityZZ,    OBC, method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_dynamics.jl")
+@register(TFIM, ZZStructureFactor,   OBC, method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_dynamics.jl")
+@register(TFIM, ZZCorrelation{:static}, OBC, method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_dynamics.jl")
+@register(
+    TFIM, ZZCorrelation{:dynamic}, OBC,
+    method=:bdg, reliability=:high,
+    tested_in="test/models/test_TFIM_dynamics.jl",
+    notes="Single (i, j, t) point; for sweeps loop the kwargs.",
+)
+@register(
+    TFIM, ZZCorrelation{:lightcone}, OBC,
+    method=:bdg, reliability=:high,
+    tested_in="test/models/test_TFIM_dynamics.jl",
+    notes="C(r,t) lightcone slice for fixed center; takes a `times` vector.",
+)
+@register(TFIM, XXCorrelation{:dynamic}, OBC, method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_dynamics.jl")
+
+# ── Entanglement (T = 0; β kwarg defaults to Inf) ─────────────────────
+@register(
+    TFIM, VonNeumannEntropy, OBC,
+    method=:bdg, reliability=:high,
+    tested_in="test/models/test_TFIM_entanglement.jl",
+    references=["Peschel 2003"],
+    notes="Free-fermion correlation-matrix method; pass subsystem length ℓ.",
+)

--- a/src/models/quantum/TFIM/TFIM_registry.jl
+++ b/src/models/quantum/TFIM/TFIM_registry.jl
@@ -12,15 +12,21 @@
 
 # ── Energy (granularity-aware) ─────────────────────────────────────────
 @register(
-    TFIM, Energy{:total}, OBC,
-    method=:bdg, reliability=:high,
+    TFIM,
+    Energy{:total},
+    OBC,
+    method=:bdg,
+    reliability=:high,
     tested_in="test/models/test_TFIM_thermal.jl",
     references=["Pfeuty 1970"],
     notes="Total ⟨H⟩(β) via the BdG spectrum; ground state when no β kwarg.",
 )
 @register(
-    TFIM, Energy{:per_site}, Infinite,
-    method=:bdg, reliability=:high,
+    TFIM,
+    Energy{:per_site},
+    Infinite,
+    method=:bdg,
+    reliability=:high,
     tested_in="test/models/test_TFIM_thermal.jl",
     references=["Pfeuty 1970"],
     notes="Per-site ε(β) by QuadGK over the PBC dispersion Λ(k).",
@@ -28,66 +34,203 @@
 
 # ── Spectrum / criticality ────────────────────────────────────────────
 @register(
-    TFIM, MassGap, Infinite,
-    method=:analytic, reliability=:high,
+    TFIM,
+    MassGap,
+    Infinite,
+    method=:analytic,
+    reliability=:high,
     tested_in="test/models/test_TFIM_massgap.jl",
     references=["Pfeuty 1970"],
     notes="Δ_∞(J,h) = 2|h - J| — closed-form Ising gap.",
 )
 @register(
-    TFIM, MassGap, OBC,
-    method=:bdg, reliability=:high,
+    TFIM,
+    MassGap,
+    OBC,
+    method=:bdg,
+    reliability=:high,
     tested_in="test/models/test_TFIM_massgap.jl",
     references=["Pfeuty 1970"],
     notes="Smallest positive BdG eigenvalue of the OBC chain.",
 )
 @register(
-    TFIM, CentralCharge, Infinite,
-    method=:analytic, reliability=:high,
+    TFIM,
+    CentralCharge,
+    Infinite,
+    method=:analytic,
+    reliability=:high,
     tested_in="test/models/test_TFIM_central_charge.jl",
     references=["Belavin-Polyakov-Zamolodchikov 1984"],
     notes="c = 1/2 at the critical point (h = J), 0 otherwise.",
 )
 
 # ── Free-fermion thermal (per-site) — meta-defined in TFIM_thermal.jl ──
-@register(TFIM, FreeEnergy,       OBC,      method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_thermal.jl")
-@register(TFIM, FreeEnergy,       Infinite, method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_thermal.jl")
-@register(TFIM, ThermalEntropy,   OBC,      method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_thermal.jl")
-@register(TFIM, ThermalEntropy,   Infinite, method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_thermal.jl")
-@register(TFIM, SpecificHeat,     OBC,      method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_thermal.jl")
-@register(TFIM, SpecificHeat,     Infinite, method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_thermal.jl")
-@register(TFIM, MagnetizationX,   OBC,      method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_thermal.jl")
-@register(TFIM, MagnetizationX,   Infinite, method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_thermal.jl")
-@register(TFIM, SusceptibilityXX, OBC,      method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_thermal.jl")
-@register(TFIM, SusceptibilityXX, Infinite, method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_thermal.jl")
+@register(
+    TFIM,
+    FreeEnergy,
+    OBC,
+    method=:bdg,
+    reliability=:high,
+    tested_in="test/models/test_TFIM_thermal.jl"
+)
+@register(
+    TFIM,
+    FreeEnergy,
+    Infinite,
+    method=:bdg,
+    reliability=:high,
+    tested_in="test/models/test_TFIM_thermal.jl"
+)
+@register(
+    TFIM,
+    ThermalEntropy,
+    OBC,
+    method=:bdg,
+    reliability=:high,
+    tested_in="test/models/test_TFIM_thermal.jl"
+)
+@register(
+    TFIM,
+    ThermalEntropy,
+    Infinite,
+    method=:bdg,
+    reliability=:high,
+    tested_in="test/models/test_TFIM_thermal.jl"
+)
+@register(
+    TFIM,
+    SpecificHeat,
+    OBC,
+    method=:bdg,
+    reliability=:high,
+    tested_in="test/models/test_TFIM_thermal.jl"
+)
+@register(
+    TFIM,
+    SpecificHeat,
+    Infinite,
+    method=:bdg,
+    reliability=:high,
+    tested_in="test/models/test_TFIM_thermal.jl"
+)
+@register(
+    TFIM,
+    MagnetizationX,
+    OBC,
+    method=:bdg,
+    reliability=:high,
+    tested_in="test/models/test_TFIM_thermal.jl"
+)
+@register(
+    TFIM,
+    MagnetizationX,
+    Infinite,
+    method=:bdg,
+    reliability=:high,
+    tested_in="test/models/test_TFIM_thermal.jl"
+)
+@register(
+    TFIM,
+    SusceptibilityXX,
+    OBC,
+    method=:bdg,
+    reliability=:high,
+    tested_in="test/models/test_TFIM_thermal.jl"
+)
+@register(
+    TFIM,
+    SusceptibilityXX,
+    Infinite,
+    method=:bdg,
+    reliability=:high,
+    tested_in="test/models/test_TFIM_thermal.jl"
+)
 
 # ── Local one-site observables (per-site index, not bulk-averaged) ────
-@register(TFIM, EnergyLocal,         OBC, method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_local.jl")
-@register(TFIM, MagnetizationXLocal, OBC, method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_local.jl")
-@register(TFIM, MagnetizationZLocal, OBC, method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_local.jl")
+@register(
+    TFIM,
+    EnergyLocal,
+    OBC,
+    method=:bdg,
+    reliability=:high,
+    tested_in="test/models/test_TFIM_local.jl"
+)
+@register(
+    TFIM,
+    MagnetizationXLocal,
+    OBC,
+    method=:bdg,
+    reliability=:high,
+    tested_in="test/models/test_TFIM_local.jl"
+)
+@register(
+    TFIM,
+    MagnetizationZLocal,
+    OBC,
+    method=:bdg,
+    reliability=:high,
+    tested_in="test/models/test_TFIM_local.jl"
+)
 
 # ── Z-axis dynamics + correlations (BdG time evolution) ───────────────
-@register(TFIM, SusceptibilityZZ,    OBC, method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_dynamics.jl")
-@register(TFIM, ZZStructureFactor,   OBC, method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_dynamics.jl")
-@register(TFIM, ZZCorrelation{:static}, OBC, method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_dynamics.jl")
 @register(
-    TFIM, ZZCorrelation{:dynamic}, OBC,
-    method=:bdg, reliability=:high,
+    TFIM,
+    SusceptibilityZZ,
+    OBC,
+    method=:bdg,
+    reliability=:high,
+    tested_in="test/models/test_TFIM_dynamics.jl"
+)
+@register(
+    TFIM,
+    ZZStructureFactor,
+    OBC,
+    method=:bdg,
+    reliability=:high,
+    tested_in="test/models/test_TFIM_dynamics.jl"
+)
+@register(
+    TFIM,
+    ZZCorrelation{:static},
+    OBC,
+    method=:bdg,
+    reliability=:high,
+    tested_in="test/models/test_TFIM_dynamics.jl"
+)
+@register(
+    TFIM,
+    ZZCorrelation{:dynamic},
+    OBC,
+    method=:bdg,
+    reliability=:high,
     tested_in="test/models/test_TFIM_dynamics.jl",
     notes="Single (i, j, t) point; for sweeps loop the kwargs.",
 )
 @register(
-    TFIM, ZZCorrelation{:lightcone}, OBC,
-    method=:bdg, reliability=:high,
+    TFIM,
+    ZZCorrelation{:lightcone},
+    OBC,
+    method=:bdg,
+    reliability=:high,
     tested_in="test/models/test_TFIM_dynamics.jl",
     notes="C(r,t) lightcone slice for fixed center; takes a `times` vector.",
 )
-@register(TFIM, XXCorrelation{:dynamic}, OBC, method=:bdg, reliability=:high, tested_in="test/models/test_TFIM_dynamics.jl")
+@register(
+    TFIM,
+    XXCorrelation{:dynamic},
+    OBC,
+    method=:bdg,
+    reliability=:high,
+    tested_in="test/models/test_TFIM_dynamics.jl"
+)
 
 # ── Entanglement (T = 0; β kwarg defaults to Inf) ─────────────────────
 @register(
-    TFIM, VonNeumannEntropy, OBC,
-    method=:bdg, reliability=:high,
+    TFIM,
+    VonNeumannEntropy,
+    OBC,
+    method=:bdg,
+    reliability=:high,
     tested_in="test/models/test_TFIM_entanglement.jl",
     references=["Peschel 2003"],
     notes="Free-fermion correlation-matrix method; pass subsystem length ℓ.",

--- a/test/core/test_registry.jl
+++ b/test/core/test_registry.jl
@@ -1,12 +1,32 @@
 using Test
 using QAtlas
-using QAtlas: TFIM, Energy, MassGap, CentralCharge, FreeEnergy,
-    ThermalEntropy, SpecificHeat, MagnetizationX, MagnetizationXLocal,
-    MagnetizationZLocal, EnergyLocal, SusceptibilityXX, SusceptibilityZZ,
-    ZZStructureFactor, ZZCorrelation, XXCorrelation, VonNeumannEntropy,
-    FidelitySusceptibility, OBC, PBC, Infinite, Implementation,
-    implementation_status, implementation_status_markdown,
-    has_native_fetch, REGISTRY
+using QAtlas:
+    TFIM,
+    Energy,
+    MassGap,
+    CentralCharge,
+    FreeEnergy,
+    ThermalEntropy,
+    SpecificHeat,
+    MagnetizationX,
+    MagnetizationXLocal,
+    MagnetizationZLocal,
+    EnergyLocal,
+    SusceptibilityXX,
+    SusceptibilityZZ,
+    ZZStructureFactor,
+    ZZCorrelation,
+    XXCorrelation,
+    VonNeumannEntropy,
+    FidelitySusceptibility,
+    OBC,
+    PBC,
+    Infinite,
+    Implementation,
+    implementation_status,
+    implementation_status_markdown,
+    has_native_fetch,
+    REGISTRY
 
 # Tests for the declarative implementation registry (`src/core/registry.jl`
 # + `src/models/quantum/TFIM/TFIM_registry.jl`).  The registry exists so
@@ -24,8 +44,9 @@ using QAtlas: TFIM, Energy, MassGap, CentralCharge, FreeEnergy,
 @testset "REGISTRY is populated for TFIM at load time" begin
     @test !isempty(REGISTRY)
     @test all(e isa Implementation for e in REGISTRY)
-    @test any(e.model === TFIM && e.quantity === Energy{:total} && e.bc === OBC
-              for e in REGISTRY)
+    @test any(
+        e.model === TFIM && e.quantity === Energy{:total} && e.bc === OBC for e in REGISTRY
+    )
 end
 
 @testset "implementation_status() returns Tables.jl-shaped rows" begin
@@ -34,8 +55,9 @@ end
     @test !isempty(rows)
     sample = first(rows)
     # NamedTuple with the documented field set
-    expected_keys = (:model, :quantity, :bc, :method, :reliability,
-                     :tested_in, :references, :notes)
+    expected_keys = (
+        :model, :quantity, :bc, :method, :reliability, :tested_in, :references, :notes
+    )
     @test keys(sample) === expected_keys
     @test sample.model isa Type
     @test sample.quantity isa Type
@@ -72,8 +94,8 @@ end
 @testset "implementation_status(queue) returns one row per registered triple" begin
     m = TFIM(; J=1.0, h=1.0)
     queue = [
-        (m, Energy(:total),       OBC(8)),       # registered
-        (m, MassGap(),            Infinite()),   # registered
+        (m, Energy(:total), OBC(8)),       # registered
+        (m, MassGap(), Infinite()),   # registered
         (m, FidelitySusceptibility(), OBC(8)),   # NOT registered → dropped
     ]
     rows = implementation_status(queue)
@@ -82,8 +104,7 @@ end
     @test rows[2].quantity === MassGap
 
     # Type-only triples (no instances needed)
-    type_queue = [(TFIM, Energy{:per_site}, Infinite),
-                  (TFIM, CentralCharge,     Infinite)]
+    type_queue = [(TFIM, Energy{:per_site}, Infinite), (TFIM, CentralCharge, Infinite)]
     rows_t = implementation_status(type_queue)
     @test length(rows_t) == 2
     @test rows_t[1].quantity === Energy{:per_site}

--- a/test/core/test_registry.jl
+++ b/test/core/test_registry.jl
@@ -1,0 +1,132 @@
+using Test
+using QAtlas
+using QAtlas: TFIM, Energy, MassGap, CentralCharge, FreeEnergy,
+    ThermalEntropy, SpecificHeat, MagnetizationX, MagnetizationXLocal,
+    MagnetizationZLocal, EnergyLocal, SusceptibilityXX, SusceptibilityZZ,
+    ZZStructureFactor, ZZCorrelation, XXCorrelation, VonNeumannEntropy,
+    FidelitySusceptibility, OBC, PBC, Infinite, Implementation,
+    implementation_status, implementation_status_markdown,
+    has_native_fetch, REGISTRY
+
+# Tests for the declarative implementation registry (`src/core/registry.jl`
+# + `src/models/quantum/TFIM/TFIM_registry.jl`).  The registry exists so
+# that downstream consumers can query "which (model, quantity, bc)
+# triples does QAtlas implement, and how reliable are they?" without
+# grepping `src/`.  Two safety properties live here:
+#
+#   1. Query API correctness — filters return the rows the caller asked
+#      for and nothing else.
+#   2. Drift detection — every registered row corresponds to a real
+#      `fetch` method (more specific than the catch-all in
+#      `src/core/type.jl`).  This catches the silent regression where
+#      a future PR removes a fetch method but forgets the registry row.
+
+@testset "REGISTRY is populated for TFIM at load time" begin
+    @test !isempty(REGISTRY)
+    @test all(e isa Implementation for e in REGISTRY)
+    @test any(e.model === TFIM && e.quantity === Energy{:total} && e.bc === OBC
+              for e in REGISTRY)
+end
+
+@testset "implementation_status() returns Tables.jl-shaped rows" begin
+    rows = implementation_status()
+    @test rows isa Vector
+    @test !isempty(rows)
+    sample = first(rows)
+    # NamedTuple with the documented field set
+    expected_keys = (:model, :quantity, :bc, :method, :reliability,
+                     :tested_in, :references, :notes)
+    @test keys(sample) === expected_keys
+    @test sample.model isa Type
+    @test sample.quantity isa Type
+    @test sample.bc isa Type
+    @test sample.method isa Symbol
+    @test sample.reliability isa Symbol
+    @test sample.tested_in isa Union{String,Nothing}
+    @test sample.references isa Vector{String}
+    @test sample.notes isa String
+end
+
+@testset "implementation_status filtering" begin
+    # By model type
+    tfim_rows = implementation_status(TFIM)
+    @test !isempty(tfim_rows)
+    @test all(r.model === TFIM for r in tfim_rows)
+
+    # By model instance
+    @test implementation_status(TFIM(; J=1.0, h=1.0)) == tfim_rows
+
+    # By quantity type
+    energy_total_rows = implementation_status(Energy{:total})
+    @test !isempty(energy_total_rows)
+    @test all(r.quantity === Energy{:total} for r in energy_total_rows)
+
+    # By quantity instance
+    @test implementation_status(Energy(:total)) == energy_total_rows
+
+    # Unregistered quantity returns empty (FidelitySusceptibility has no
+    # fetch implementation yet, so the registry must not list it).
+    @test isempty(implementation_status(FidelitySusceptibility()))
+end
+
+@testset "implementation_status(queue) returns one row per registered triple" begin
+    m = TFIM(; J=1.0, h=1.0)
+    queue = [
+        (m, Energy(:total),       OBC(8)),       # registered
+        (m, MassGap(),            Infinite()),   # registered
+        (m, FidelitySusceptibility(), OBC(8)),   # NOT registered → dropped
+    ]
+    rows = implementation_status(queue)
+    @test length(rows) == 2
+    @test rows[1].quantity === Energy{:total}
+    @test rows[2].quantity === MassGap
+
+    # Type-only triples (no instances needed)
+    type_queue = [(TFIM, Energy{:per_site}, Infinite),
+                  (TFIM, CentralCharge,     Infinite)]
+    rows_t = implementation_status(type_queue)
+    @test length(rows_t) == 2
+    @test rows_t[1].quantity === Energy{:per_site}
+    @test rows_t[2].quantity === CentralCharge
+
+    # Malformed queue element triggers a clear error
+    @test_throws ErrorException implementation_status([(m, Energy(:total))])
+end
+
+@testset "Drift guard: every registered TFIM row has a non-catch-all fetch" begin
+    # If this fails, a registry row is lying about its backing fetch
+    # method — either delete the row or restore the implementation.
+    for e in REGISTRY
+        @test has_native_fetch(e)
+    end
+end
+
+@testset "Markdown rendering produces a non-empty GFM table" begin
+    io = IOBuffer()
+    implementation_status_markdown(io, implementation_status()[1:3])
+    md = String(take!(io))
+    # Header + alignment row + 3 data rows = 5 lines minimum
+    lines = split(strip(md), '\n')
+    @test length(lines) ≥ 5
+    @test startswith(lines[1], "| Model | Quantity | BC")
+    @test occursin("|---|", lines[2])
+    # First TFIM row should be reachable via short-type rendering
+    @test any(occursin("TFIM", line) for line in lines[3:end])
+end
+
+@testset "Reliability values are drawn from the documented vocabulary" begin
+    allowed = (:high, :medium, :low, :not_implemented, :unknown)
+    for e in REGISTRY
+        @test e.reliability in allowed
+    end
+end
+
+@testset "Method values are non-:unknown for the populated TFIM rows" begin
+    # All TFIM rows in this PR have a real algorithm tag.  This test
+    # pins the convention so future TFIM additions can't silently leave
+    # `method=:unknown` behind.
+    for e in REGISTRY
+        e.model === TFIM || continue
+        @test e.method !== :unknown
+    end
+end


### PR DESCRIPTION
## Summary

Addresses the framework half of #116 — give downstream a way to ask "which `(model, quantity, bc)` triples does QAtlas implement, and how reliable are they?" without grepping `src/`.

- New `src/core/registry.jl`: `Implementation` struct, module-level `REGISTRY`, `@register` macro for one-line declarations next to fetch methods, `implementation_status(...)` queries returning `Tables.jl`-compatible `Vector{NamedTuple}` (zero new deps), GFM markdown renderer.
- New `src/models/quantum/TFIM/TFIM_registry.jl`: 25 declarations covering the full TFIM thermal / dynamical / entanglement surface.
- New `test/core/test_registry.jl`: query tests + a **drift guard** that calls `which(fetch, ...)` on every registered triple and fails if it resolves to the catch-all in `core/type.jl` (i.e. if a future PR removes a fetch method but forgets the registry row).

## Why this shape

- **Macro, not pure data**: registration sits next to fetch methods in the model file, so removing a method without removing its registry entry is visible in code review.
- **TFIM only this PR**: lets us pressure-test the registry shape on one real model (25 entries spanning many quantity flavours) before mechanically populating XXZ1D / Heisenberg1D / S1Heisenberg1D / IsingSquare / KitaevHoneycomb in follow-up PRs.
- **`Vector{NamedTuple}` return**: Tables.jl-compatible without taking a Tables dependency. Downstream wanting a `DataFrame` does `DataFrame(implementation_status())`.
- **Conversion fallbacks not registered**: e.g. `Energy(:per_site)` at OBC works via the generic `:total ÷ N` fallback added in #124 — but the registry only tracks native implementations. The fallback is automatic by design.

## What `implementation_status()` looks like

```
| Model | Quantity | BC | Method | Reliability | Tested in | References |
|---|---|---|---|---|---|---|
| TFIM | Energy{:total} | OBC | `bdg` | `high` | test/models/test_TFIM_thermal.jl | Pfeuty 1970 |
| TFIM | Energy{:per_site} | Infinite | `bdg` | `high` | test/models/test_TFIM_thermal.jl | Pfeuty 1970 |
| TFIM | MassGap | Infinite | `analytic` | `high` | test/models/test_TFIM_massgap.jl | Pfeuty 1970 |
| TFIM | MassGap | OBC | `bdg` | `high` | test/models/test_TFIM_massgap.jl | Pfeuty 1970 |
| TFIM | CentralCharge | Infinite | `analytic` | `high` | test/models/test_TFIM_central_charge.jl | Belavin-Polyakov-Zamolodchikov 1984 |
```

Queue mode for downstream planning:

```julia
queue = [(TFIM(J=1,h=1), Energy(:total),    OBC(8)),
         (TFIM(J=1,h=1), MassGap(),         Infinite()),
         (TFIM(J=1,h=1), FidelitySusceptibility(), OBC(8))]  # not registered
implementation_status(queue)
# returns the first 2 rows; the third is silently dropped (= "no reference yet").
```

## Reliability vocabulary (aligns with #118 test categories)

- `:high` — closed-form + literature-tested
- `:medium` — ED-only or cross-checked numerically
- `:low` — heuristic, not validated
- `:not_implemented` — placeholder row for "we know we want this but no fetch yet"
- `:unknown` — default if `@register` omits it (test pins TFIM rows away from this)

## Test plan

- [x] 1496 / 1496 tests passing (1389 pre-PR + 107 new).
- [x] Query tests cover model / quantity (instance + type) / queue filters.
- [x] Drift guard: `has_native_fetch(impl)` checks `which(fetch, ...)` is more specific than the catch-all — runs against all 25 TFIM rows.
- [x] Markdown render produces a well-formed GFM table.
- [x] Reliability + method values pinned to the documented vocabulary.

## Next

Issue #116 stays open until XXZ1D / Heisenberg1D / S1Heisenberg1D / IsingSquare / KitaevHoneycomb each get their own `<Model>_registry.jl`. Each follow-up is a mechanical 1-file PR (~20-40 lines).