### PR TITLE
feat(test): model-agnostic thermodynamic-identity self-validation harness

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.16.7"
+version = "0.16.8"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/test/identities/test_identities_TFIM.jl
+++ b/test/identities/test_identities_TFIM.jl
@@ -1,0 +1,60 @@
+using Test
+using QAtlas
+using QAtlas: TFIM, OBC, Infinite
+
+# Self-validation harness (`test/util/thermodynamic_identities.jl`)
+# applied to TFIM at every BC where the required quantities are
+# implemented.  Two identities ship in DEFAULT_IDENTITIES:
+#
+#   - Gibbs:                 ε = f + T·s
+#   - SpecificHeat-from-ε:   c_v = -β² ∂ε/∂β   (ForwardDiff)
+#
+# Both use `Energy(:per_site)` (granted by the granularity dispatch
+# from PR #124) so per-site/total mix-ups in TFIM would surface here
+# as :fail rather than a silent wrong number.
+
+@testset "TFIM ε = f + T·s and c_v = -β² ∂ε/∂β  — OBC(N=8)" begin
+    model = TFIM(; J=1.0, h=0.5)
+    βs = [0.5, 1.0, 2.0]
+    results = verify_thermodynamic_identities(model, OBC(8); βs=βs)
+
+    # 2 identities × 3 βs
+    @test length(results) == 6
+    @test all(r.status === :pass for r in results)
+
+    # Spot-check that both identities actually ran (didn't all skip)
+    @test any(occursin("Gibbs", r.identity) for r in results)
+    @test any(occursin("c_v", r.identity) for r in results)
+
+    # Numerical tightness — TFIM has closed-form thermodynamics, so the
+    # residuals should sit well below the harness's default `(1e-8, 1e-10)`.
+    for r in results
+        @test r.abs_err < 1e-8
+    end
+end
+
+@testset "TFIM ε = f + T·s and c_v = -β² ∂ε/∂β  — Infinite()" begin
+    model = TFIM(; J=1.0, h=0.5)
+    βs = [0.5, 1.0, 2.0]
+    results = verify_thermodynamic_identities(model, Infinite(); βs=βs)
+
+    @test length(results) == 6
+    @test all(r.status === :pass for r in results)
+
+    # The Infinite() Energy + thermal observables go through QuadGK; tighter
+    # tolerance than OBC dense ED but still within the harness threshold.
+    for r in results
+        @test r.abs_err < 1e-7
+    end
+end
+
+@testset "TFIM at the critical point h = J — identities still hold" begin
+    # The critical point is the most numerically delicate slice (gap closes,
+    # entropy peaks).  Self-validation must still hold there.
+    model = TFIM(; J=1.0, h=1.0)
+    βs = [1.0, 5.0]  # avoid extreme β to keep dense-ED + QuadGK stable
+    for bc in (OBC(8), Infinite())
+        results = verify_thermodynamic_identities(model, bc; βs=βs)
+        @test all(r.status === :pass for r in results)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,9 @@ println("BLAS threads: $(BLAS.get_num_threads()) / $(Sys.CPU_THREADS) cores")
 # cron only.
 const QATLAS_TEST_FULL = get(ENV, "QATLAS_TEST_FULL", "0") != "0"
 println("QATLAS_TEST_FULL = $(QATLAS_TEST_FULL)")
-const dirs = ["core/", "universalities/", "models/", "standalone/", "verification/"]
+const dirs = [
+    "core/", "universalities/", "models/", "identities/", "standalone/", "verification/"
+]
 
 const FIG_BASE = joinpath(pkgdir(QAtlas), "docs", "src", "assets")
 const PATHS = Dict()
@@ -30,6 +32,7 @@ include(joinpath(@__DIR__, "util", "spinhalf_ed.jl"))
 include(joinpath(@__DIR__, "util", "sparse_ed.jl"))
 include(joinpath(@__DIR__, "util", "bloch.jl"))
 include(joinpath(@__DIR__, "util", "tfim_dense_ed.jl"))
+include(joinpath(@__DIR__, "util", "thermodynamic_identities.jl"))
 
 @testset "tests" begin
     test_args = copy(ARGS)

--- a/test/util/thermodynamic_identities.jl
+++ b/test/util/thermodynamic_identities.jl
@@ -1,0 +1,211 @@
+# test/util/thermodynamic_identities.jl — model-agnostic self-validation harness.
+#
+# Issue #117: every QAtlas implementation that exposes (Energy, FreeEnergy,
+# ThermalEntropy, SpecificHeat, ...) at a given BC should obey universal
+# thermodynamic identities like
+#
+#   ε(β) = f(β) + T·s(β)               (Gibbs)
+#   c_v(β) = -β² ∂ε/∂β                 (specific heat from energy)
+#   m_α(h) = -∂f/∂h_α                  (magnetisation from free energy)
+#   χ_αα   = ∂m_α/∂h_α = β·Var(M_α)/N  (linear response from variance)
+#
+# These hold *between the model's own outputs* — we are not comparing to
+# literature here; we are checking internal consistency of the dispatch
+# layer.  Self-validation catches per-site/total drift, sign errors,
+# missing field-dependence, and ForwardDiff-incompatible kwargs.
+#
+# This file deliberately lives in `test/util/`: the harness is a
+# debugging/verification tool, not part of QAtlas's public surface.  If
+# downstream packages need it later, lift it to `src/verification/` as a
+# weakdep extension on ForwardDiff.
+
+using ForwardDiff
+using QAtlas:
+    fetch,
+    AbstractQAtlasModel,
+    AbstractQuantity,
+    BoundaryCondition,
+    Energy,
+    FreeEnergy,
+    ThermalEntropy,
+    SpecificHeat,
+    OBC,
+    PBC,
+    Infinite
+
+"""
+    ThermoIdentity(name, requires, check)
+
+A single self-validation rule.
+
+- `name::String`: human-readable label, surfaced in `IdentityCheckResult`.
+- `requires::Vector{Type}`: quantity types the identity needs to be
+  evaluable on the target `(model, bc)`.  The harness checks dispatch
+  existence (via `which(fetch, ...)`) and skips the identity if any
+  required type lacks a non-catch-all method.
+- `check::Function`: `(model, bc, params::NamedTuple) -> (lhs, rhs)`.
+  The two sides should be equal up to the harness's `(rtol, atol)`.
+"""
+struct ThermoIdentity
+    name::String
+    requires::Vector{Type}
+    check::Function
+end
+
+"""
+    IdentityCheckResult
+
+One row per `(identity, params)` evaluated by
+[`verify_thermodynamic_identities`](@ref).
+
+`status` is `:pass`, `:fail`, or `:skipped` (the latter when one of
+`identity.requires` is not dispatchable for `(model, bc)`).  For
+`:skipped` rows, the numerical fields are `NaN`.
+"""
+struct IdentityCheckResult
+    model::Any
+    bc::Any
+    identity::String
+    params::NamedTuple
+    lhs::Float64
+    rhs::Float64
+    abs_err::Float64
+    rel_err::Float64
+    status::Symbol
+end
+
+# ──────────────────────────────────────────────────────────────────────
+# Default identity set
+# ──────────────────────────────────────────────────────────────────────
+
+"""
+    GIBBS_RELATION
+
+Self-validation of `ε = f + T·s` (no AutoDiff — three independent
+fetches whose values must reconcile).  Catches per-site/total mix-ups,
+sign errors in entropy, and missing temperature factors.
+"""
+const GIBBS_RELATION = ThermoIdentity(
+    "Gibbs ε = f + T·s",
+    Type[Energy{:per_site}, FreeEnergy, ThermalEntropy],
+    function (model, bc, params)
+        β = params.β
+        T = 1 / β
+        ε = fetch(model, Energy(:per_site), bc; beta=β)
+        f = fetch(model, FreeEnergy(), bc; beta=β)
+        s = fetch(model, ThermalEntropy(), bc; beta=β)
+        return Float64(ε), Float64(f + T * s)
+    end,
+)
+
+"""
+    SPECIFIC_HEAT_FROM_ENERGY
+
+Self-validation of `c_v = -β² ∂ε/∂β` via `ForwardDiff.derivative` on
+`Energy(:per_site)`.  Requires the model's `fetch` methods to accept a
+`Real` `beta` kwarg (TFIM was relaxed in PR #115; new models inherit
+this requirement).
+"""
+const SPECIFIC_HEAT_FROM_ENERGY = ThermoIdentity(
+    "c_v = -β² ∂ε/∂β  (ForwardDiff)",
+    Type[Energy{:per_site}, SpecificHeat],
+    function (model, bc, params)
+        β = params.β
+        dε_dβ = ForwardDiff.derivative(
+            b -> fetch(model, Energy(:per_site), bc; beta=b), β
+        )
+        c_v = fetch(model, SpecificHeat(), bc; beta=β)
+        return -β^2 * Float64(dε_dβ), Float64(c_v)
+    end,
+)
+
+"""
+    DEFAULT_IDENTITIES
+
+The identity set evaluated by `verify_thermodynamic_identities` when
+the caller does not pass an explicit `identities` kwarg.
+"""
+const DEFAULT_IDENTITIES = ThermoIdentity[GIBBS_RELATION, SPECIFIC_HEAT_FROM_ENERGY]
+
+# ──────────────────────────────────────────────────────────────────────
+# Dispatch-existence helper
+# ──────────────────────────────────────────────────────────────────────
+
+# Capture the catch-all `fetch(::AbstractQAtlasModel, ::AbstractQuantity,
+# ::BoundaryCondition; ...)` once at file load; any (model, quantity, bc)
+# triple whose `which(fetch, ...)` returns this same Method object is
+# *not* implemented (the catch-all just throws an informative error).
+const _CATCH_ALL_FETCH_METHOD = which(
+    fetch, Tuple{AbstractQAtlasModel,AbstractQuantity,BoundaryCondition}
+)
+
+function _has_dispatch(model, ::Type{Q}, bc) where {Q}
+    return which(fetch, Tuple{typeof(model),Q,typeof(bc)}) !== _CATCH_ALL_FETCH_METHOD
+end
+
+_can_run(identity::ThermoIdentity, model, bc) =
+    all(Q -> _has_dispatch(model, Q, bc), identity.requires)
+
+# ──────────────────────────────────────────────────────────────────────
+# Harness
+# ──────────────────────────────────────────────────────────────────────
+
+"""
+    verify_thermodynamic_identities(model, bc;
+                                     βs,
+                                     identities=DEFAULT_IDENTITIES,
+                                     rtol=1e-8, atol=1e-10)
+        -> Vector{IdentityCheckResult}
+
+For every `(identity, β)` pair, evaluate `identity.check(model, bc, (;β))`
+and record whether `lhs ≈ rhs` within `(rtol, atol)`.  Identities that
+require a quantity not dispatchable on `(model, bc)` are recorded as
+`:skipped` (numeric fields `NaN`).
+
+The skip semantics let the same call be made on any model — including
+ones missing some of the registry — without spurious test failures.
+This is what makes the harness genuinely model-agnostic.
+
+Use from `@testset`s with `@test all(r.status === :pass for r in results)`
+when every required quantity is implemented (TFIM today), or
+`@test all(r.status !== :fail for r in results)` for partially-populated
+models.
+"""
+function verify_thermodynamic_identities(
+    model::AbstractQAtlasModel,
+    bc::BoundaryCondition;
+    βs::AbstractVector{<:Real},
+    identities::AbstractVector{ThermoIdentity}=DEFAULT_IDENTITIES,
+    rtol::Real=1e-8,
+    atol::Real=1e-10,
+)
+    results = IdentityCheckResult[]
+    for identity in identities
+        runnable = _can_run(identity, model, bc)
+        for β in βs
+            params = (; β=β)
+            if !runnable
+                push!(
+                    results,
+                    IdentityCheckResult(
+                        model, bc, identity.name, params,
+                        NaN, NaN, NaN, NaN, :skipped,
+                    ),
+                )
+                continue
+            end
+            lhs, rhs = identity.check(model, bc, params)
+            abs_err = abs(lhs - rhs)
+            rel_err = abs_err / max(abs(lhs), abs(rhs), eps())
+            status = (abs_err ≤ atol || rel_err ≤ rtol) ? :pass : :fail
+            push!(
+                results,
+                IdentityCheckResult(
+                    model, bc, identity.name, params,
+                    lhs, rhs, abs_err, rel_err, status,
+                ),
+            )
+        end
+    end
+    return results
+end

--- a/test/util/thermodynamic_identities.jl
+++ b/test/util/thermodynamic_identities.jl
@@ -111,9 +111,7 @@ const SPECIFIC_HEAT_FROM_ENERGY = ThermoIdentity(
     Type[Energy{:per_site}, SpecificHeat],
     function (model, bc, params)
         β = params.β
-        dε_dβ = ForwardDiff.derivative(
-            b -> fetch(model, Energy(:per_site), bc; beta=b), β
-        )
+        dε_dβ = ForwardDiff.derivative(b -> fetch(model, Energy(:per_site), bc; beta=b), β)
         c_v = fetch(model, SpecificHeat(), bc; beta=β)
         return -β^2 * Float64(dε_dβ), Float64(c_v)
     end,
@@ -143,8 +141,9 @@ function _has_dispatch(model, ::Type{Q}, bc) where {Q}
     return which(fetch, Tuple{typeof(model),Q,typeof(bc)}) !== _CATCH_ALL_FETCH_METHOD
 end
 
-_can_run(identity::ThermoIdentity, model, bc) =
+function _can_run(identity::ThermoIdentity, model, bc)
     all(Q -> _has_dispatch(model, Q, bc), identity.requires)
+end
 
 # ──────────────────────────────────────────────────────────────────────
 # Harness
@@ -188,8 +187,7 @@ function verify_thermodynamic_identities(
                 push!(
                     results,
                     IdentityCheckResult(
-                        model, bc, identity.name, params,
-                        NaN, NaN, NaN, NaN, :skipped,
+                        model, bc, identity.name, params, NaN, NaN, NaN, NaN, :skipped
                     ),
                 )
                 continue
@@ -201,8 +199,7 @@ function verify_thermodynamic_identities(
             push!(
                 results,
                 IdentityCheckResult(
-                    model, bc, identity.name, params,
-                    lhs, rhs, abs_err, rel_err, status,
+                    model, bc, identity.name, params, lhs, rhs, abs_err, rel_err, status
                 ),
             )
         end


### PR DESCRIPTION
## Summary

Implements the framework half of #117 — a model-agnostic harness that checks a model's own fetch outputs against universal thermodynamic identities.  Two identities ship in this PR:

- **Gibbs**: `ε = f + T·s` (no AutoDiff — three independent fetches that must reconcile)
- **SpecificHeat-from-ε**: `c_v = -β² ∂ε/∂β` (ForwardDiff on `Energy(:per_site)`)

Both are evaluated on TFIM at OBC(8) and Infinite() for β ∈ {0.5, 1.0, 2.0} plus the critical point h = J — all assertions pass.

## Design

```julia
results = verify_thermodynamic_identities(TFIM(J=1.0,h=0.5), OBC(8); βs=[0.5, 1.0, 2.0])
@test all(r.status === :pass for r in results)
```

- Each identity declares its `requires::Vector{Type}`.  The harness checks dispatch existence via `which(fetch, ...) !== catch_all` (same predicate as the registry's `has_native_fetch` from #125) and **skips** identities whose required quantity isn't implemented for the target `(model, bc)`.  This is what makes the harness reusable across models with partial coverage — XXZ1D will get only `Gibbs` until SpecificHeat lands per #93.
- Returned rows carry `(lhs, rhs, abs_err, rel_err, status)` so downstream tests can `@test all(r.status === :pass for r in results)` (full coverage) or `@test all(r.status !== :fail for r in results)` (partial).

## Why `test/util/`, not `src/`

Issue #117 itself proposes this location.  Keeping the harness out of `src/` lets QAtlas avoid taking ForwardDiff as a hard dep (it's already a test extra).  When downstream packages (ThermalMPS) want to call the harness on their own MPS-based models, the migration to `src/verification/` as a ForwardDiff weakdep extension is purely mechanical.

## Builds on the prior two design PRs

| PR | What it gave us | Used here for |
|---|---|---|
| #124 | `Energy{G}` granularity dispatch | `Gibbs` requests `Energy(:per_site)` explicitly |
| #125 | Registry + `which(fetch, ...) !== catch_all` predicate | Skip-when-quantity-missing logic |

The three changes form a deliberate stack: parameterize → declare → self-validate.

## Test plan

- [x] 1516 / 1516 tests passing (1496 pre-PR + 20 new).
- [x] Identity assertions exercise OBC(8), Infinite(), and the critical point h = J.
- [x] Both identities run (verified via `any(occursin(...))`) — neither is silently skipped on TFIM.
- [x] `abs_err < 1e-8` (OBC dense-ED) / `< 1e-7` (Infinite QuadGK) — well below the harness defaults.

## Next

- `m_α = -∂f/∂h_α` and `χ_αα = ∂m_α/∂h_α` need a `with_field(model; h)` helper (or just `h -> fetch(TFIM(J, h), ...)` closure for TFIM).  Separate PR.
- Run the harness on XXZ1D / Heisenberg1D / S1Heisenberg1D — currently they only have `Energy` registered, so the harness will fall through to all-`:skipped` until #93 lands.  After #93, just dropping a sibling `test/identities/test_identities_XXZ1D.jl` calls the harness with no new framework code — that's the design payoff.