### PR TITLE
test(standalone): tighten Onsager-Yang β_eff + document Universality floor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.16.8"
+version = "0.16.9"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/test/standalone/test_ising_onsager_yang.jl
+++ b/test/standalone/test_ising_onsager_yang.jl
@@ -52,18 +52,24 @@ end
     end
 
     @testset "Critical exponent β = 1/8 near T_c" begin
-        # M ~ (T_c - T)^{1/8} as T → T_c⁻
-        # log M / log(T_c - T) → 1/8
-        # Test at two temperatures near T_c
-        δT1 = 0.001
-        δT2 = 0.01
+        # M ~ (T_c - T)^{1/8} as T → T_c⁻ ⟹ log(M₁/M₂) / log(δT₁/δT₂) → 1/8.
+        #
+        # The original test used δT = (1e-3, 1e-2) which has a real corrections-
+        # to-scaling residual of ~4e-4 — the previous `rtol = 0.05` was 100×
+        # looser than the physics actually warrants.  Pushing both points one
+        # decade closer to T_c (1e-7, 1e-6) drops the measured residual to
+        # ~3.9e-8 (Yang's closed form is analytic, so the only floor is
+        # roundoff from the small-δT log subtraction), giving a clean ~10×
+        # margin against `atol = 1e-7`.  Tracked under the #118 test-tolerance
+        # hygiene audit.
+        δT1 = 1e-7
+        δT2 = 1e-6
         T1 = Tc - δT1
         T2 = Tc - δT2
         M1 = QAtlas.fetch(IsingSquare(), SpontaneousMagnetization(); β=1 / T1)
         M2 = QAtlas.fetch(IsingSquare(), SpontaneousMagnetization(); β=1 / T2)
-        # Effective exponent: log(M1/M2) / log(δT1/δT2) ≈ β = 1/8
         β_eff = log(M1 / M2) / log(δT1 / δT2)
-        @test β_eff ≈ 1 / 8 rtol = 0.05  # within 5% of exact
+        @test β_eff ≈ 1 / 8 atol = 1e-7
     end
 
     @testset "J scaling" begin

--- a/test/standalone/test_universality_exponents.jl
+++ b/test/standalone/test_universality_exponents.jl
@@ -18,6 +18,23 @@ function check_scaling_relations(e; d::Int=0)
     end
 end
 
+# `atol = 0.01` is a *physics-imposed* floor, not laziness — see #118 audit.
+#
+# The 3D bootstrap exponents we ship (Ising / XY / Heisenberg) inherit the
+# precision of their source data (KPSDV 2016 etc.).  Worst-case residuals
+# of `α + 2β + γ - 2`, `γ - β(δ-1)`, `γ - ν(2-η)`, `2 - α - dν` measured
+# at PR time:
+#
+#   3D Ising       — max ≈ 1.0e-5  (could tighten to atol = 1e-4)
+#   3D XY          — max ≈ 7.1e-5  (could tighten to atol = 1e-3)
+#   3D Heisenberg  — max ≈ 4.5e-4  (cannot tighten below atol ≈ 1e-3)
+#
+# Heisenberg sets the floor: tightening per call site would only shave a
+# factor or two off the loosest class while opening every numerical-data
+# refresh to spurious failures.  The single `atol = 0.01` here gives ~20×
+# margin uniformly and stays robust to upstream value updates.  This is
+# the (a)/(b)/(c)-style classification from #118: a deliberately soft
+# tolerance with a one-line justification.
 function check_scaling_relations_approx(e; d::Int=0)
     @test e.α + 2 * e.β + e.γ ≈ 2 atol = 0.01      # Rushbrooke
     @test e.γ ≈ e.β * (e.δ - 1) atol = 0.01         # Widom


### PR DESCRIPTION
## Summary

The last two #118 audit-table residuals, both in `test/standalone/`, addressed in opposite directions because the physics tolerates a tighter assertion in one case but not the other.

### `test_ising_onsager_yang.jl:66` — tighten

β_eff extraction from Yang's closed form for spontaneous magnetisation. Original `δT = (1e-3, 1e-2)` with `rtol = 0.05` was 100× looser than the actual residual (~4e-4). Pushing both points to `(1e-7, 1e-6)` drops the measured residual to ~3.9e-8 (Yang is analytic; floor is small-δT log roundoff). New assertion: `atol = 1e-7` with ~10× margin.

### `test_universality_exponents.jl:21-28` — document, don't tighten

Scaling relations on 3D bootstrap exponents (Ising / XY / Heisenberg). Measured worst-case residuals at PR time:

| Class | Worst residual |
|---|---|
| 3D Ising | 1.0e-5 |
| 3D XY | 7.1e-5 |
| 3D Heisenberg | 4.5e-4 |

Heisenberg sets the floor: tightening per-class would only shave a factor or two off the loosest class while opening every numerical-data refresh to spurious failures. Existing `atol = 0.01` (~20× margin uniformly) is the right shape — gets a docstring explaining it's a *physics-imposed floor* (bootstrap-data precision), not a sloppy `rtol = 5%`-style placeholder. This is the (a)/(b)/(c) classification spirit from #118: a deliberately soft tolerance with a one-line justification rather than a silent loose `@test`.

## Test plan

- [x] 1516 / 1516 passing.
- [x] Both files remain CI-gated (no rename / no exclusion).
- [x] Onsager-Yang assertion measurably ~10× tighter than before.

## Closes / refs

This was the last open audit row from #118. With the framework PRs (#124 Energy{G} dispatch, #125 registry + drift guard, #126 identity harness) and the prior tightening PRs (#120-#123) all merged, the design strengthening pass kicked off in early review is complete.