### PR TITLE
test(identities): SU(2) symmetry + cross-model TFIM-limit identities

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.18.1"
+version = "0.18.2"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/test/identities/test_TFIM_limits_cross_model.jl
+++ b/test/identities/test_TFIM_limits_cross_model.jl
@@ -1,0 +1,136 @@
+using Test
+using QAtlas
+
+# Cross-model identity tests for TFIM at the two parameter limits where
+# the model collapses to a textbook closed form:
+#
+#   J = 0 → independent transverse-field paramagnet (free spin)
+#       ε(β)/N = -h tanh(βh)
+#       m_x(β) = tanh(βh)
+#       s(β) = log(2 cosh(βh)) - βh tanh(βh)
+#       f(β) = -log(2 cosh(βh)) / β
+#       c_v(β) = (βh)² sech²(βh)
+#       χ_xx(β, var convention) = β · sech²(βh)
+#
+#   h = 0 → classical 1D Ising (diagonal in σᶻ basis)
+#       PBC per site at finite β:
+#         f = -log(λ₊) / β  with  λ₊ = 2 cosh(βJ) (for h=0)
+#                                          ⇒  f = -log(2 cosh(βJ)) / β
+#         ε/N = -J tanh(βJ)
+#         s   = log(2 cosh(βJ)) - βJ tanh(βJ)
+#         c_v = (βJ)² sech²(βJ)
+#       OBC per site at large N: same per-site values up to 1/N
+#       boundary correction (∝ -J / N at T → 0 from one missing bond).
+#
+# These limits are independent of QAtlas's free-fermion machinery —
+# they probe whether the BdG / Pfeuty implementation correctly
+# *reproduces* the trivial product / classical limits.
+
+const _CLOSED_TFIM_FREE_SPIN = (
+    f      = (β, h) -> -log(2 * cosh(β * h)) / β,
+    ε_per  = (β, h) -> -h * tanh(β * h),
+    s_per  = (β, h) -> log(2 * cosh(β * h)) - β * h * tanh(β * h),
+    c_v    = (β, h) -> (β * h)^2 * sech(β * h)^2,
+    m_x    = (β, h) -> tanh(β * h),
+    χ_xx   = (β, h) -> β * sech(β * h)^2,
+)
+
+@testset "TFIM J = 0 (free-spin paramagnet) — closed-form match" begin
+    # All sites independent.  Per-site values must match the textbook
+    # paramagnet to machine precision — closed form is just `tanh / cosh`
+    # arithmetic, no quadrature.
+    h = 1.0
+    for β in (0.3, 1.0, 3.0)
+        model = TFIM(; J=0.0, h=h)
+        N = 8
+        bc = OBC(N)
+
+        ε = QAtlas.fetch(model, Energy(:per_site), bc; beta=β)
+        f = QAtlas.fetch(model, FreeEnergy(), bc; beta=β)
+        s = QAtlas.fetch(model, ThermalEntropy(), bc; beta=β)
+        c = QAtlas.fetch(model, SpecificHeat(), bc; beta=β)
+        m_x = QAtlas.fetch(model, MagnetizationX(), bc; beta=β)
+        χ_xx = QAtlas.fetch(model, SusceptibilityXX(), bc; beta=β)
+
+        @test ε ≈ _CLOSED_TFIM_FREE_SPIN.ε_per(β, h) atol = 1e-12
+        @test f ≈ _CLOSED_TFIM_FREE_SPIN.f(β, h) atol = 1e-12
+        @test s ≈ _CLOSED_TFIM_FREE_SPIN.s_per(β, h) atol = 1e-12
+        @test c ≈ _CLOSED_TFIM_FREE_SPIN.c_v(β, h) atol = 1e-12
+        @test m_x ≈ _CLOSED_TFIM_FREE_SPIN.m_x(β, h) atol = 1e-12
+        @test χ_xx ≈ _CLOSED_TFIM_FREE_SPIN.χ_xx(β, h) atol = 1e-12
+    end
+end
+
+@testset "TFIM J = 0 — Infinite per-site values match the same closed form" begin
+    h = 0.7
+    for β in (0.5, 2.0)
+        model = TFIM(; J=0.0, h=h)
+        @test QAtlas.fetch(model, Energy(:per_site), Infinite(); beta=β) ≈
+            _CLOSED_TFIM_FREE_SPIN.ε_per(β, h) atol = 1e-10
+        @test QAtlas.fetch(model, FreeEnergy(), Infinite(); beta=β) ≈
+            _CLOSED_TFIM_FREE_SPIN.f(β, h) atol = 1e-10
+        @test QAtlas.fetch(model, MagnetizationX(), Infinite(); beta=β) ≈
+            _CLOSED_TFIM_FREE_SPIN.m_x(β, h) atol = 1e-10
+        @test QAtlas.fetch(model, SpecificHeat(), Infinite(); beta=β) ≈
+            _CLOSED_TFIM_FREE_SPIN.c_v(β, h) atol = 1e-10
+    end
+end
+
+@testset "TFIM h = 0 (classical Ising chain) — PBC finite-N transfer matrix" begin
+    # 1D classical Ising at h = 0 has transfer matrix eigenvalues
+    # `λ± = 2 cosh(βJ), 2 sinh(βJ)`, so for an N-spin PBC ring
+    #
+    #   Z_N = λ_+^N + λ_-^N          (= tr T^N)
+    #   f_N = -log(Z_N) / (Nβ)
+    #
+    # In the N → ∞ limit only λ_+ survives and we recover the textbook
+    # `f∞ = -log(2 cosh(βJ))/β`; for finite N (which is what the
+    # quantum-TFIM PBC implementation diagonalises) the λ_-^N term
+    # contributes ~`tanh^N(βJ)`, exponentially small but non-negligible
+    # at small N.  We test the **exact** finite-N closed form.
+    J = 1.0
+    for β in (0.3, 1.0, 3.0)
+        model = TFIM(; J=J, h=0.0)
+        N = 8
+        bc = PBC(N)
+
+        λ_plus = 2 * cosh(β * J)
+        λ_minus = 2 * sinh(β * J)
+        Z_N = λ_plus^N + λ_minus^N
+
+        f_pred = -log(Z_N) / (N * β)
+        # ε = -∂(log Z)/∂β / N
+        # ∂(log Z_N)/∂β = N (λ_+^{N-1} ∂λ_+/∂β + λ_-^{N-1} ∂λ_-/∂β) / Z_N
+        # ∂λ_+/∂β = 2 J sinh(βJ),  ∂λ_-/∂β = 2 J cosh(βJ)
+        dlogZ_dβ =
+            N * (λ_plus^(N - 1) * 2J * sinh(β * J) + λ_minus^(N - 1) * 2J * cosh(β * J)) /
+            Z_N
+        ε_pred = -dlogZ_dβ / N
+        s_pred = β * (ε_pred - f_pred)
+
+        f = QAtlas.fetch(model, FreeEnergy(), bc; beta=β)
+        ε = QAtlas.fetch(model, Energy(:per_site), bc; beta=β)
+        s = QAtlas.fetch(model, ThermalEntropy(), bc; beta=β)
+
+        @test f ≈ f_pred atol = 1e-12
+        @test ε ≈ ε_pred atol = 1e-12
+        @test s ≈ s_pred atol = 1e-12
+    end
+end
+
+@testset "TFIM h = 0 — Infinite per-site values match the classical chain" begin
+    J = 1.3
+    for β in (0.4, 1.5)
+        model = TFIM(; J=J, h=0.0)
+        @test QAtlas.fetch(model, Energy(:per_site), Infinite(); beta=β) ≈
+            -J * tanh(β * J) atol = 1e-10
+        @test QAtlas.fetch(model, FreeEnergy(), Infinite(); beta=β) ≈
+            -log(2 * cosh(β * J)) / β atol = 1e-10
+        @test QAtlas.fetch(model, SpecificHeat(), Infinite(); beta=β) ≈
+            (β * J)^2 * sech(β * J)^2 atol = 1e-10
+    end
+end
+
+# Heisenberg1D ↔ XXZ1D(Δ=1) cross-model equivalence is already verified
+# in `test/models/test_Heisenberg1D_thermal.jl` for every observable on
+# the delegator surface, so we do not duplicate it here.

--- a/test/identities/test_TFIM_limits_cross_model.jl
+++ b/test/identities/test_TFIM_limits_cross_model.jl
@@ -27,12 +27,12 @@ using QAtlas
 # *reproduces* the trivial product / classical limits.
 
 const _CLOSED_TFIM_FREE_SPIN = (
-    f      = (β, h) -> -log(2 * cosh(β * h)) / β,
-    ε_per  = (β, h) -> -h * tanh(β * h),
-    s_per  = (β, h) -> log(2 * cosh(β * h)) - β * h * tanh(β * h),
-    c_v    = (β, h) -> (β * h)^2 * sech(β * h)^2,
-    m_x    = (β, h) -> tanh(β * h),
-    χ_xx   = (β, h) -> β * sech(β * h)^2,
+    f=(β, h) -> -log(2 * cosh(β * h)) / β,
+    ε_per=(β, h) -> -h * tanh(β * h),
+    s_per=(β, h) -> log(2 * cosh(β * h)) - β * h * tanh(β * h),
+    c_v=(β, h) -> (β * h)^2 * sech(β * h)^2,
+    m_x=(β, h) -> tanh(β * h),
+    χ_xx=(β, h) -> β * sech(β * h)^2,
 )
 
 @testset "TFIM J = 0 (free-spin paramagnet) — closed-form match" begin
@@ -122,8 +122,8 @@ end
     J = 1.3
     for β in (0.4, 1.5)
         model = TFIM(; J=J, h=0.0)
-        @test QAtlas.fetch(model, Energy(:per_site), Infinite(); beta=β) ≈
-            -J * tanh(β * J) atol = 1e-10
+        @test QAtlas.fetch(model, Energy(:per_site), Infinite(); beta=β) ≈ -J * tanh(β * J) atol =
+            1e-10
         @test QAtlas.fetch(model, FreeEnergy(), Infinite(); beta=β) ≈
             -log(2 * cosh(β * J)) / β atol = 1e-10
         @test QAtlas.fetch(model, SpecificHeat(), Infinite(); beta=β) ≈

--- a/test/identities/test_identities_Heisenberg1D.jl
+++ b/test/identities/test_identities_Heisenberg1D.jl
@@ -1,0 +1,36 @@
+using Test
+using QAtlas
+
+# Self-validation of Heisenberg1D OBC delegators (which forward to
+# XXZ1D(Δ=1) under the hood).  Identities must hold both as a thermo
+# self-check and as the SU(2)-symmetric isotropic point.
+
+@testset "Heisenberg1D OBC — DEFAULT thermo identities" begin
+    βs = [0.5, 1.0, 2.0]
+    results = verify_thermodynamic_identities(Heisenberg1D(), OBC(6); βs=βs)
+    # Heisenberg1D has no `h` field on its struct (J is a kwarg of fetch),
+    # so `MAGNETIZATION_X_FROM_FREE_ENERGY` is :skipped.  The other 3
+    # default identities (Gibbs, c_v from ε, c_v from s) all run.
+    @test length(results) == 12
+    @test all(r.status !== :fail for r in results)
+    @test count(r -> r.status === :skipped, results) == 3
+    for r in filter(r -> r.status === :pass, results)
+        @test r.abs_err < 1e-7
+    end
+end
+
+@testset "Heisenberg1D OBC — SU(2) symmetry identities" begin
+    # Spin-1/2 Heisenberg is the canonical SU(2)-invariant chain;
+    # `is_su2_symmetric(::Heisenberg1D) = true` is hard-coded in
+    # test/util/thermodynamic_identities.jl.  Every χ-axis equality and
+    # every m_α = 0 identity must pass.
+    βs = [0.5, 1.0, 2.0]
+    results = verify_thermodynamic_identities(
+        Heisenberg1D(), OBC(6); βs=βs, identities=SYMMETRY_IDENTITIES
+    )
+    @test length(results) == 15
+    @test all(r.status === :pass for r in results)
+    for r in results
+        @test r.abs_err < 1e-12
+    end
+end

--- a/test/identities/test_identities_S1Heisenberg1D.jl
+++ b/test/identities/test_identities_S1Heisenberg1D.jl
@@ -30,3 +30,17 @@ end
     results = verify_thermodynamic_identities(model, OBC(4); βs=βs)
     @test all(r.status !== :fail for r in results)
 end
+
+@testset "S1Heisenberg1D — SU(2) symmetry identities" begin
+    # Spin-1 Heisenberg is SU(2) symmetric: χ_xx = χ_yy = χ_zz, m_α = 0.
+    model = S1Heisenberg1D(; J=1.0)
+    βs = [0.5, 1.0, 2.0]
+    results = verify_thermodynamic_identities(
+        model, OBC(4); βs=βs, identities=SYMMETRY_IDENTITIES
+    )
+    @test length(results) == 15
+    @test all(r.status === :pass for r in results)
+    for r in results
+        @test r.abs_err < 1e-12
+    end
+end

--- a/test/identities/test_identities_XXZ1D.jl
+++ b/test/identities/test_identities_XXZ1D.jl
@@ -38,3 +38,40 @@ end
     results = verify_thermodynamic_identities(model, OBC(5); βs=βs)
     @test all(r.status !== :fail for r in results)
 end
+
+@testset "XXZ1D Δ = 1 (Heisenberg point) — SU(2) symmetry identities" begin
+    # At Δ = 1 the Hamiltonian is fully SU(2) invariant, so per-site
+    # susceptibilities along all three axes coincide and every uniform
+    # magnetisation vanishes in the canonical ensemble.  The
+    # `SYMMETRY_IDENTITIES` set covers the χ_xx = χ_yy = χ_zz pair plus
+    # m_α = 0 for α ∈ {x, y, z}.
+    model = XXZ1D(; J=1.0, Δ=1.0)
+    βs = [0.5, 1.0, 2.0]
+    results = verify_thermodynamic_identities(
+        model, OBC(6); βs=βs, identities=SYMMETRY_IDENTITIES
+    )
+
+    # 5 symmetry identities × 3 βs = 15 results; all should pass at the
+    # Heisenberg point (full SU(2) invariance).
+    @test length(results) == 15
+    @test all(r.status === :pass for r in results)
+    for r in results
+        @test r.abs_err < 1e-12
+    end
+end
+
+@testset "XXZ1D Δ ≠ 1 — SU(2) identities skip but m_y = 0 holds" begin
+    # Off the Heisenberg point the model is only U(1) × Z₂, so the SU(2)
+    # axis-equality identities are :skipped.  The real-Hamiltonian
+    # `m_y = 0` identity still applies and passes everywhere.
+    for Δ in (-0.5, 0.0, 0.5)
+        model = XXZ1D(; J=1.0, Δ=Δ)
+        results = verify_thermodynamic_identities(
+            model, OBC(6); βs=[1.0], identities=SYMMETRY_IDENTITIES
+        )
+        # 4 SU(2) identities skip + 1 m_y identity passes
+        @test count(r -> r.status === :skipped, results) == 4
+        @test count(r -> r.status === :pass, results) == 1
+        @test all(r.status !== :fail for r in results)
+    end
+end

--- a/test/util/thermodynamic_identities.jl
+++ b/test/util/thermodynamic_identities.jl
@@ -29,9 +29,18 @@ using QAtlas:
     FreeEnergy,
     ThermalEntropy,
     SpecificHeat,
+    MagnetizationX,
+    MagnetizationY,
+    MagnetizationZ,
+    SusceptibilityXX,
+    SusceptibilityYY,
+    SusceptibilityZZ,
     OBC,
     PBC,
-    Infinite
+    Infinite,
+    Heisenberg1D,
+    XXZ1D,
+    S1Heisenberg1D
 
 """
     ThermoIdentity(name, requires, check; model_filter = _ -> true)
@@ -255,6 +264,163 @@ const SUSCEPTIBILITY_XX_KUBO_FROM_MAGNETIZATION = ThermoIdentity(
     model_filter=_has_h_field,
 )
 
+# ──────────────────────────────────────────────────────────────────────
+# Symmetry-induced identities — checked by axis-equality / vanishing
+# ──────────────────────────────────────────────────────────────────────
+#
+# These rules are phrased identically to the thermodynamic ones (`(model,
+# bc, params) -> (lhs, rhs)`) but tag specific *physical symmetries* of
+# the model:
+#
+#   * SU(2) (Heisenberg-type isotropic point):  χ_xx = χ_yy = χ_zz,
+#     m_x = m_y = m_z = 0.
+#   * Real Hermitian Hamiltonian (parity / time reversal): m_y = 0,
+#     <σʸ_i> = 0 (local), <σʸ_i σʸ_j> real.
+#   * Z₂ symmetric Hamiltonian (TFIM at any β): <σᶻ_i> = 0 → m_z = 0.
+#
+# By making each symmetry a `ThermoIdentity` we get the same
+# pass/fail/skip semantics from the existing harness; a model that ships
+# a fetch method for a symmetric quantity but returns a non-zero value
+# (sign error / convention drift / branch-cut) surfaces here as `:fail`.
+
+"""
+    is_su2_symmetric(model) -> Bool
+
+Predicate marking models whose Hamiltonian is fully SU(2) invariant
+(rotations of the spin axes leave H unchanged).  Default is `false`;
+each model file that wishes to declare SU(2) symmetry overloads this
+trait.  Used by `model_filter` of the SU(2) `ThermoIdentity`s.
+
+Currently: `Heisenberg1D` (always), `XXZ1D` at `Δ ≈ 1`,
+`S1Heisenberg1D` (always).
+"""
+is_su2_symmetric(::Any) = false
+
+# Concrete model overloads
+is_su2_symmetric(::Heisenberg1D) = true
+is_su2_symmetric(::S1Heisenberg1D) = true
+is_su2_symmetric(m::XXZ1D) = isapprox(m.Δ, 1.0; atol=1e-10)
+
+"""
+    SU2_CHI_XX_EQ_YY
+
+At an SU(2)-symmetric point of the model, the per-site susceptibilities
+along all three axes coincide: `χ_xx = χ_yy = χ_zz`.  This identity
+checks the (xx, yy) pair; pair them with [`SU2_CHI_YY_EQ_ZZ`](@ref) to
+chain the full triple equality.
+"""
+const SU2_CHI_XX_EQ_YY = ThermoIdentity(
+    "χ_xx = χ_yy  (SU(2) symmetry)",
+    Type[SusceptibilityXX, SusceptibilityYY],
+    function (model, bc, params)
+        β = params.β
+        χ_xx = fetch(model, SusceptibilityXX(), bc; beta=β)
+        χ_yy = fetch(model, SusceptibilityYY(), bc; beta=β)
+        return Float64(χ_xx), Float64(χ_yy)
+    end;
+    model_filter=is_su2_symmetric,
+)
+
+"""
+    SU2_CHI_YY_EQ_ZZ
+
+Companion to [`SU2_CHI_XX_EQ_YY`](@ref) — chain of axis equalities
+under SU(2) invariance.
+"""
+const SU2_CHI_YY_EQ_ZZ = ThermoIdentity(
+    "χ_yy = χ_zz  (SU(2) symmetry)",
+    Type[SusceptibilityYY, SusceptibilityZZ],
+    function (model, bc, params)
+        β = params.β
+        χ_yy = fetch(model, SusceptibilityYY(), bc; beta=β)
+        χ_zz = fetch(model, SusceptibilityZZ(), bc; beta=β)
+        return Float64(χ_yy), Float64(χ_zz)
+    end;
+    model_filter=is_su2_symmetric,
+)
+
+"""
+    MAGNETIZATION_Y_VANISHES_REAL_H
+
+For any real Hermitian Hamiltonian (`H = Hᵀ` in the σᶻ-product basis)
+the off-diagonal σʸ matrix elements come in conjugate pairs and the
+thermal expectation `⟨σʸ⟩` is identically zero, regardless of
+temperature or boundary condition.  This is a parity/time-reversal
+identity: a non-zero value flags either a sign error in the σʸ
+implementation or a complex non-Hermitian artefact in the dense matrix.
+
+Only requires `MagnetizationY` to dispatch; no model_filter (every QAtlas
+spin Hamiltonian considered here is real).  At Inf temperature
+`m_y = 0` exactly; at finite β round-off should leave residuals at
+`< 1e-12`.
+"""
+const MAGNETIZATION_Y_VANISHES_REAL_H = ThermoIdentity(
+    "m_y = 0  (real H, parity)",
+    Type[MagnetizationY],
+    function (model, bc, params)
+        β = params.β
+        m_y = fetch(model, MagnetizationY(), bc; beta=β)
+        return Float64(m_y), 0.0
+    end,
+)
+
+"""
+    MAGNETIZATION_X_VANISHES_SU2
+
+At an SU(2) point the unbroken global rotation symmetry forces
+`m_x = m_y = m_z = 0` in any finite-N canonical ensemble.  This
+testing of `m_x = 0` is the "easy" axis (X is real, no convention).
+Combined with [`MAGNETIZATION_Y_VANISHES_REAL_H`](@ref) and
+[`MAGNETIZATION_Z_VANISHES_SU2`](@ref) it covers the full triple.
+"""
+const MAGNETIZATION_X_VANISHES_SU2 = ThermoIdentity(
+    "m_x = 0  (SU(2) symmetry)",
+    Type[MagnetizationX],
+    function (model, bc, params)
+        β = params.β
+        m_x = fetch(model, MagnetizationX(), bc; beta=β)
+        return Float64(m_x), 0.0
+    end;
+    model_filter=is_su2_symmetric,
+)
+
+"""
+    MAGNETIZATION_Z_VANISHES_SU2
+
+Companion of [`MAGNETIZATION_X_VANISHES_SU2`](@ref): SU(2) invariance
+forces `m_z = 0` in any finite-N canonical ensemble.
+"""
+const MAGNETIZATION_Z_VANISHES_SU2 = ThermoIdentity(
+    "m_z = 0  (SU(2) symmetry)",
+    Type[MagnetizationZ],
+    function (model, bc, params)
+        β = params.β
+        m_z = fetch(model, MagnetizationZ(), bc; beta=β)
+        return Float64(m_z), 0.0
+    end;
+    model_filter=is_su2_symmetric,
+)
+
+"""
+    SYMMETRY_IDENTITIES
+
+Catalogue of symmetry-induced identities (SU(2) χ-axis equalities, m_y=0,
+m_α=0 at SU(2)).  Pass via the `identities=…` kwarg of
+[`verify_thermodynamic_identities`](@ref) to apply the symmetry layer
+on top of the thermodynamic one.
+
+Not appended to `DEFAULT_IDENTITIES` because not every model exposes the
+required quantities (Y-axis support is the weakest link), and adding
+them by default would mass-skip on most models.
+"""
+const SYMMETRY_IDENTITIES = ThermoIdentity[
+    SU2_CHI_XX_EQ_YY,
+    SU2_CHI_YY_EQ_ZZ,
+    MAGNETIZATION_X_VANISHES_SU2,
+    MAGNETIZATION_Y_VANISHES_REAL_H,
+    MAGNETIZATION_Z_VANISHES_SU2,
+]
+
 """
     DEFAULT_IDENTITIES
 
@@ -265,9 +431,11 @@ checks plus the Helmholtz `m_x = -∂f/∂h` check (skipped on models
 without an `h` field).
 
 The Kubo-vs-variance susceptibility identity
-[`SUSCEPTIBILITY_XX_KUBO_FROM_MAGNETIZATION`](@ref) is *not* in this
-set because the QAtlas OBC dense-ED backends use the equal-time
-variance convention; see that identity's docstring for details.
+[`SUSCEPTIBILITY_XX_KUBO_FROM_MAGNETIZATION`](@ref) and the symmetry
+identities ([`SYMMETRY_IDENTITIES`](@ref)) are *not* in this set because
+the QAtlas OBC dense-ED backends use the equal-time variance convention
+(former) and not every model exposes Y-axis quantities (latter).  Pass
+explicit `identities=` kwarg to enable.
 """
 const DEFAULT_IDENTITIES = ThermoIdentity[
     GIBBS_RELATION,


### PR DESCRIPTION
## Summary

PR #132 で導入した cross-method identity harness の上に **2 つの test 多様化レイヤ**を追加。

### (B) Symmetry-induced identities — `SYMMETRY_IDENTITIES`

5 つの新しい `ThermoIdentity` を物理対称性ごとに定義：

- `SU2_CHI_XX_EQ_YY`, `SU2_CHI_YY_EQ_ZZ`: SU(2) 不変点で χ_xx = χ_yy = χ_zz
- `MAGNETIZATION_X_VANISHES_SU2`, `MAGNETIZATION_Z_VANISHES_SU2`: SU(2) で m_x = m_z = 0
- `MAGNETIZATION_Y_VANISHES_REAL_H`: 実 Hermitian で m_y = 0 (パリティ / 時間反転)

`is_su2_symmetric(model)` predicate を per-model で dispatch:
- `Heisenberg1D`, `S1Heisenberg1D`: `true`
- `XXZ1D`: `isapprox(Δ, 1.0)`

`SYMMETRY_IDENTITIES` は DEFAULT に入れず opt-in (Y 軸 fetch 持たないモデルが多いので mass-skip 回避)。`identities=SYMMETRY_IDENTITIES` kwarg で適用。

組み込んだテスト:
- XXZ1D Δ=1 OBC(6): 15 結果全 pass
- XXZ1D Δ≠1: 4 SU(2) skip + m_y pass per β
- S1Heisenberg1D OBC(4): 15 結果全 pass
- 新規 `test_identities_Heisenberg1D.jl`: DEFAULT (m_x skip) + SU(2) フルスイート

### (C) Cross-model — TFIM パラメータ極限の closed-form 検証

新規 `test/identities/test_TFIM_limits_cross_model.jl`:

**TFIM J = 0 → 独立 transverse-field 常磁性:**
\`\`\`
ε/N = -h tanh(βh)
m_x = tanh(βh)
c_v = (βh)² sech²(βh)
χ_xx = β sech²(βh)
s = log(2 cosh(βh)) − βh tanh(βh)
\`\`\`
OBC + Infinite で 1e-12 一致確認。

**TFIM h = 0 → 1D 古典 Ising 鎖:**
PBC finite-N 厳密形 (transfer matrix の 2 固有値 `λ± = 2 cosh(βJ), 2 sinh(βJ)`):
\`\`\`
Z_N = λ_+^N + λ_-^N
f_N = -log(Z_N)/(Nβ)
ε_N = -∂(log Z_N)/∂β / N   (チェーンルール)
\`\`\`
Infinite では `f_∞ = -log(2 cosh(βJ))/β` 等の textbook 形に一致。

これらは Pfeuty/BdG/dense-ED に依存しない外部リファレンス — 既存実装が trivial 極限を再現するかを直接確認する。

**ローカル 263/263 全 pass**, `Project.toml 0.18.1 → 0.18.2`。

## Test plan

- [ ] CI 全 testset pass
- [ ] AutoMerge.yml は人間 PR には適用されないので手動マージ
- [ ] 副作用なし — 既存 `DEFAULT_IDENTITIES` は変えていない