### PR TITLE
docs: comprehensive update for v0.17–0.18 observable surface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.18.5"
+version = "0.18.6"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -17,6 +17,14 @@ makedocs(;
         canonical="https://codes.sota-shimozono.com/QAtlas.jl/stable/",
         prettyurls=get(ENV, "CI", "false") == "true",
         edit_link="main",
+        # `index.md` includes a full `@autodocs` of every QAtlas binding; the
+        # generated HTML grew past the default 200 KiB threshold once the
+        # observable surface expanded in v0.17/0.18 (Tier 1 + Tier 2 brought
+        # ~80 new fetch methods).  Bump the size threshold instead of
+        # splitting the autodocs page (the user explicitly preserved the
+        # `Modules = [QAtlas]` API layout).
+        size_threshold=600_000,
+        size_threshold_warn=300_000,
         mathengine=MathJax3(
             Dict(
                 :tex => Dict(
@@ -42,6 +50,7 @@ makedocs(;
                 "TFIM" => "models/quantum/tfim.md",
                 "Heisenberg" => "models/quantum/heisenberg.md",
                 "XXZ" => "models/quantum/xxz.md",
+                "Kitaev Honeycomb" => "models/quantum/kitaev-honeycomb.md",
                 "Tight-Binding" => [
                     "models/quantum/tightbinding/index.md",
                     "Honeycomb" => "models/quantum/tightbinding/honeycomb.md",
@@ -66,6 +75,7 @@ makedocs(;
             "Cross-Checks" => "verification/cross-checks.md",
             "Entanglement" => "verification/entanglement.md",
             "Disordered" => "verification/disordered.md",
+            "Identity Harness" => "verification/identity-harness.md",
         ],
         "Methods" => [
             "methods/index.md",

--- a/docs/src/models/quantum/heisenberg.md
+++ b/docs/src/models/quantum/heisenberg.md
@@ -1,199 +1,132 @@
-# Heisenberg Chain
+# Heisenberg1D — Spin-1/2 AFM Heisenberg Chain
 
-## Overview
+!!! warning "Status: Unstable (v0.18.x)"
+    `Heisenberg1D` is a thin delegator over [XXZ1D](xxz.md) with
+    $\Delta = 1$. The struct itself carries **no fields**; the exchange
+    coupling $J$ is passed as a kwarg at fetch time. Method signatures
+    may change in v0.19. There is also a known wrinkle in the
+    `ITensorModels.to_qatlas(::Heisenberg1D)` bridge where $J$ can be
+    lost in conversion — for non-unit $J$ prefer `XXZ1D(; J, Δ=1.0)`
+    directly.
 
-The spin-1/2 antiferromagnetic Heisenberg chain is the paradigmatic
-model of quantum magnetism. Unlike the [TFIM](tfim.md), it is not
-mappable to free fermions; its exact solution requires the Bethe ansatz
-(1931), one of the earliest and most celebrated applications of
-integrability in condensed matter physics.
+## Hamiltonian
 
-$$H = J \sum_{i} \mathbf{S}_i \cdot \mathbf{S}_{i+1}$$
-
-where $\mathbf{S}_i = \tfrac{1}{2}\boldsymbol{\sigma}_i$ are spin-1/2
-operators and $J > 0$ is the antiferromagnetic exchange coupling.
-
-**Parameters**: Exchange coupling $J$ (default 1.0; $J > 0$ AFM,
-$J < 0$ FM).
-
-**Key physics**: The 1D Heisenberg chain is gapless with algebraically
-decaying spin correlations. At low energies it is described by a
-$c = 1$ conformal field theory (free boson / Luttinger liquid), in
-contrast to the $c = 1/2$ Ising CFT governing the [TFIM](tfim.md).
-The ground state is a spin singlet ($S_{\text{tot}} = 0$) for any
-finite even $N$ with AFM coupling.
-
----
-
-## Dimer Spectrum (N = 2, OBC)
-
-### Statement
-
-For two spin-1/2 sites coupled by $H = J\,\mathbf{S}_1 \cdot \mathbf{S}_2$,
-the Hilbert space $\mathbb{C}^2 \otimes \mathbb{C}^2$ decomposes into
-a singlet ($S_{\text{tot}} = 0$) and a triplet ($S_{\text{tot}} = 1$):
-
-$$\text{Spectrum} = \left\{-\frac{3J}{4},\; \frac{J}{4},\; \frac{J}{4},\; \frac{J}{4}\right\}$$
-
-The singlet--triplet gap is $\Delta = J$.
-
-### Derivation
-
-Rewriting the Hamiltonian via the total-spin identity
-
-$$\mathbf{S}_1 \cdot \mathbf{S}_2 = \frac{1}{2}\!\left[S_{\text{tot}}(S_{\text{tot}}+1) - \frac{3}{2}\right]$$
-
-immediately gives $E_s = -3J/4$ for $S_{\text{tot}} = 0$ and
-$E_t = J/4$ for $S_{\text{tot}} = 1$. Full details are in
-**[Heisenberg Dimer: Singlet-Triplet](../../calc/heisenberg-dimer-singlet-triplet.md)**.
-
-### References
-
-- A. Auerbach, *Interacting Electrons and Quantum Magnetism*
-  (Springer, 1994), Section 2 -- textbook derivation.
-- Any quantum mechanics textbook (e.g., Sakurai, Ch. 4).
-
-### QAtlas API
-
-```julia
-# Full 4-state spectrum of the dimer
-λ = QAtlas.fetch(Heisenberg1D(), ExactSpectrum(); N=2, J=1.0, bc=:OBC)
-# → [-0.75, 0.25, 0.25, 0.25]
+```math
+H = J \sum_{i} \mathbf{S}_i \cdot \mathbf{S}_{i+1},
+\qquad \mathbf{S}_i = \tfrac{1}{2}\boldsymbol{\sigma}_i,
+\qquad J > 0\ \text{(antiferromagnetic)}.
 ```
 
-### Verification
+The chain is gapless; the low-energy theory is a $c = 1$ Luttinger
+liquid (free compactified boson). The ground state is a singlet
+($S_\text{tot} = 0$) for any finite even $N$ with AFM coupling.
 
-| Test file | Method | What is checked |
-|-----------|--------|-----------------|
-| `test_heisenberg_dimer.jl` | Lattice2D ED ($2 \times 1$ OBC chain) | $\lambda_{\text{ED}} = \lambda_{\text{exact}}$ for $J = 1.0, 0.5, 2.0, -1.0$ |
-| `test_heisenberg_dimer.jl` | Analytical | Singlet--triplet gap $\Delta = J$ |
-| `test_heisenberg_dimer.jl` | Structural | $\text{tr}\,H = 0$, ground-state wavefunction is the antisymmetric singlet |
+## Status: thin delegator over XXZ1D(Δ = 1)
 
----
-
-## 4-Site PBC Ring (N = 4)
-
-### Statement
-
-For $N = 4$ spins on a periodic ring with Hamiltonian
-$H = J \sum_{i=1}^{4} \mathbf{S}_i \cdot \mathbf{S}_{i+1}$
-($\mathbf{S}_5 \equiv \mathbf{S}_1$), the $2^4 = 16$ eigenvalues are:
-
-| Energy | Degeneracy | Spin sector |
-|--------|------------|-------------|
-| $-2J$ | 1 | Singlet ($S = 0$) |
-| $-J$ | 3 | Triplet ($S = 1$) |
-| $0$ | 7 | Mixed ($1 \times S = 0 + 2 \times S = 1$) |
-| $+J$ | 5 | Quintet ($S = 2$) |
-
-The ground state $E_0 = -2J$ is a unique singlet. The ferromagnetic
-sector ($|\!\uparrow\uparrow\uparrow\uparrow\rangle$ etc.) sits at
-$E = +J$, since each of the 4 bonds contributes $S^z_i S^z_{i+1} = 1/4$.
-
-### Derivation
-
-The 4-site ring can be solved by direct diagonalization of the
-$16 \times 16$ Hamiltonian or by exploiting the full SU(2) symmetry
-and translational invariance. The result is also obtainable as a
-special case of the Bethe ansatz for $N = 4$.
-
-### References
-
-- A. Auerbach, *Interacting Electrons and Quantum Magnetism*
-  (Springer, 1994), Section 2.3.
-- H. Bethe, Z. Physik **71**, 205 (1931) -- original Bethe ansatz
-  (applicable to any $N$).
-
-### QAtlas API
+Every OBC observable on `Heisenberg1D` is implemented by forwarding
+to `XXZ1D(Δ=1.0, J=J)`:
 
 ```julia
-# Full 16-state spectrum of the 4-site PBC ring
-λ = QAtlas.fetch(Heisenberg1D(), ExactSpectrum(); N=4, J=1.0, bc=:PBC)
-# → [-2.0, -1.0, -1.0, -1.0, 0.0, ..., 1.0, 1.0, 1.0, 1.0, 1.0]
+QAtlas.fetch(Heisenberg1D(), Energy(), OBC(6); beta=1.0, J=1.5)
+# == QAtlas.fetch(XXZ1D(J=1.5, Δ=1.0), Energy(), OBC(6); beta=1.0)
 ```
 
-### Verification
+For $J = 1$ the kwarg can be omitted (default `1.0`).
 
-| Test file | Method | What is checked |
-|-----------|--------|-----------------|
-| `test_heisenberg_4site_pbc.jl` | Lattice2D ED ($4 \times 1$ PBC chain) | $\lambda_{\text{ED}} = \lambda_{\text{exact}}$ for $J = 1.0, 0.5, 2.0, -1.0$ |
-| `test_heisenberg_4site_pbc.jl` | Degeneracy counting | $\{1, 3, 7, 5\}$ at $\{-2J, -J, 0, +J\}$ |
-| `test_heisenberg_4site_pbc.jl` | Structural | $\text{tr}\,H = 0$, quintet eigenvalue via $\langle\uparrow\uparrow\uparrow\uparrow|H|\uparrow\uparrow\uparrow\uparrow\rangle = J$ |
-| `test_heisenberg_4site_pbc.jl` | Finite-size | $E_0/N = -0.5 < e_{\infty} \approx -0.443$ (overshoot from finite-size correction) |
+## Coverage Matrix
 
----
+All OBC rows delegate to `XXZ1D(Δ=1)` dense-ED ($N \le 12$). The
+infinite-chain ground-state energy density is the original Hulthén
+value.
 
-## Bethe Ansatz Ground-State Energy Density
+| Quantity | OBC | Infinite |
+|---|---|---|
+| `Energy` / `FreeEnergy` / `ThermalEntropy` / `SpecificHeat` | via XXZ1D | — |
+| `MagnetizationX` / `Y` / `Z` (+ `…Local`) | via XXZ1D | — |
+| `SusceptibilityXX` / `YY` / `ZZ` | via XXZ1D | — |
+| `XXCorrelation` / `YY` / `ZZ` (`:static`, `:connected`) | via XXZ1D | — |
+| `VonNeumannEntropy` / `RenyiEntropy` | via XXZ1D | — |
+| `MassGap` | via XXZ1D ED gap | $0$ (gapless Luttinger) |
+| `CentralCharge` | — | $1$ (free boson) |
+| `GroundStateEnergyDensity` | — | $J(1/4 - \ln 2)$ (Hulthén 1938) |
+| `ExactSpectrum` | $N = 2$ OBC dimer + $N = 4$ PBC ring | — |
 
-### Statement
+The closed-form $N = 2$ dimer and $N = 4$ ring spectra are exposed
+through `ExactSpectrum` and used as harness anchors.
 
-In the thermodynamic limit ($N \to \infty$, PBC), the ground-state
-energy per site of the spin-1/2 AFM Heisenberg chain is
+## SU(2) Symmetry Identities
 
-$$e_0 = J\!\left(\frac{1}{4} - \ln 2\right) \approx -0.4431\,J$$
+`is_su2_symmetric(::Heisenberg1D) === true`, so the SU(2) row of
+`SYMMETRY_IDENTITIES` (PR #133) is automatically applied by the test
+harness. The identities checked numerically are
 
-This exact result was first obtained by Hulthen (1938) from the Bethe
-ansatz solution.
+```math
+\chi_{xx} = \chi_{yy} = \chi_{zz},
+\qquad m_\alpha = 0\ \ (\alpha \in \{x, y, z\}).
+```
 
-### Derivation
+These hold to ED precision because the dense-ED kernel diagonalises
+the full SU(2)-symmetric Hamiltonian without breaking the rotation.
 
-The Bethe ansatz parameterizes eigenstates in the $M$-down-spin sector
-by a set of rapidities $\{\lambda_j\}$ satisfying the Bethe equations.
-In the thermodynamic limit, the ground-state rapidity distribution
-satisfies a linear integral equation whose solution yields the energy
-through integration. The full calculation is given in
-**[Bethe Ansatz: Heisenberg $e_0$](../../calc/bethe-ansatz-heisenberg-e0.md)**.
-
-### Finite-size corrections
-
-For a PBC chain of $N$ sites:
-
-$$\frac{E_0(N)}{N} = e_0 + O\!\left(\frac{1}{N^2}\right)$$
-
-with logarithmic corrections also present. Due to the negative sign
-of the leading finite-size correction (PBC), $E_0(N)/N < e_0$ for
-finite $N$.
-
-### References
-
-- H. Bethe, "Zur Theorie der Metalle. I. Eigenwerte und Eigenfunktionen
-  der linearen Atomkette", Z. Physik **71**, 205 (1931) -- original
-  Bethe ansatz.
-- L. Hulthen, "Uber das Austauschproblem eines Kristalles",
-  Ark. Mat. Astron. Fys. **26A**, No. 11, 1 (1938) -- first evaluation
-  of $e_0 = 1/4 - \ln 2$.
-
-### QAtlas API
+## Quick-look code
 
 ```julia
-# Exact thermodynamic-limit ground-state energy per site
-e₀ = QAtlas.fetch(Heisenberg1D(), GroundStateEnergyDensity(); J=1.0)
-# → -0.44314718055994530
+using QAtlas
+
+m = Heisenberg1D()
+β = 1.0
+N = 6
+
+QAtlas.fetch(m, Energy(),                OBC(N); beta=β, J=1.0)
+QAtlas.fetch(m, SpecificHeat(),          OBC(N); beta=β, J=1.0)
+QAtlas.fetch(m, MassGap(),               OBC(N);          J=1.0)
+QAtlas.fetch(m, MassGap(),               Infinite();      J=1.0)   # 0
+QAtlas.fetch(m, GroundStateEnergyDensity(), Infinite();   J=1.0)   # J(1/4 - ln 2)
+
+# Closed-form spectra (used as test anchors)
+QAtlas.fetch(m, ExactSpectrum(); N=2, J=1.0, bc=:OBC)   # dimer
+QAtlas.fetch(m, ExactSpectrum(); N=4, J=1.0, bc=:PBC)   # 4-site ring
 ```
 
-### Verification
+## Closed-form anchors
 
-| Test file | Method | What is checked |
-|-----------|--------|-----------------|
-| `test_bethe_ansatz.jl` | Numerical value | $e_0 \approx J(1/4 - \ln 2)$ to machine precision |
-| `test_bethe_ansatz.jl` | $J$ scaling | $e_0(J) = J \cdot e_0(1)$ |
-| `test_bethe_ansatz.jl` | Consistency | $E_0(N=4)/4 < e_0$ (finite-size overshoot) |
-| `test_universality_cross_check.jl` | ED at $N = 4, 6, 8$ PBC | $|E_0(N)/N - e_0|$ decreases with $N$; $N = 8$ within 5% |
+### Dimer ($N = 2$, OBC)
 
----
+The two-site Hilbert space splits into a singlet and a triplet:
 
-## Connections
+```math
+\text{Spec}(H) = \left\{-\tfrac{3J}{4},\; \tfrac{J}{4},\; \tfrac{J}{4},\; \tfrac{J}{4}\right\}
+```
 
-- **Universality**: The low-energy physics of the Heisenberg chain is
-  described by a $c = 1$ Luttinger liquid (free boson CFT), **not** the
-  $c = 1/2$ Ising CFT. This is a fundamentally different universality
-  class from the [TFIM](tfim.md) / [IsingSquare](../classical/ising-square.md).
-- **Entanglement verification**: The Heisenberg chain provides a
-  $c = 1$ test case for the
-  [Calabrese--Cardy formula](../../methods/calabrese-cardy/index.md),
-  complementing the $c = 1/2$ test from the TFIM.
-- **Cross-verification**: The Bethe ansatz $e_0$ is cross-checked against
-  finite-size ED in
-  [test_universality_cross_check.jl](../../verification/cross-checks.md),
-  constituting an independent physical verification from two different
-  theoretical lines (Bethe ansatz vs exact diagonalization).
+Singlet–triplet gap $\Delta = J$; full derivation in
+[Heisenberg dimer: singlet–triplet](../../calc/heisenberg-dimer-singlet-triplet.md).
+
+### 4-site PBC ring
+
+The 16-dimensional spectrum decomposes into a unique singlet ground
+state at $E_0 = -2J$, a triplet at $-J$, mixed states at $0$, and a
+quintet at $+J$. Used as a finite-size cross-check against the Bethe
+ansatz.
+
+### Thermodynamic-limit ground-state energy
+
+```math
+e_0 = J\!\left(\tfrac{1}{4} - \ln 2\right) \approx -0.4431\,J
+```
+
+Full Bethe-ansatz derivation in
+[Bethe ansatz: Heisenberg $e_0$](../../calc/bethe-ansatz-heisenberg-e0.md).
+
+## References
+
+- H. Bethe, Z. Physik **71**, 205 (1931) — original Bethe ansatz.
+- L. Hulthén, Ark. Mat. Astron. Fys. **26A**, No. 11 (1938) — $e_0 = J(1/4 - \ln 2)$.
+- A. Auerbach, *Interacting Electrons and Quantum Magnetism* (Springer, 1994).
+- T. Giamarchi, *Quantum Physics in One Dimension* (Oxford, 2004), Ch. 6.
+
+## Related
+
+- [XXZ1D](xxz.md) — anisotropic generalisation; Heisenberg lives at $\Delta = 1$.
+- [S1Heisenberg1D](s1heisenberg.md) — spin-1 cousin in the Haldane phase
+  (gapped, topologically non-trivial).
+- [TFIM](tfim.md) — $c = 1/2$ Ising critical line for contrast.

--- a/docs/src/models/quantum/kitaev-honeycomb.md
+++ b/docs/src/models/quantum/kitaev-honeycomb.md
@@ -1,0 +1,91 @@
+# KitaevHoneycomb — Honeycomb Lattice Kitaev Model
+
+!!! warning "Status: Unstable (v0.18.x)"
+    Matter-Majorana finite-T サーフェスは v0.17 で導入。**flux-free 近似**であり flux gap T ≪ Δ_v でのみ valid。`SusceptibilityXX/YY/ZZ` および `Magnetization{X,Y,Z}` は **未実装** — σᵅ matrix elements が flux pair を励起するため flux-free sector で恒等的に消える。完全な finite-T は flux-sector Monte Carlo (Nasu et al. 2014) が必要、今回の射程外。
+
+## Hamiltonian
+
+H = − Σ_{⟨ij⟩ ∈ x-bonds} K_x σˣᵢ σˣⱼ
+    − Σ_{⟨ij⟩ ∈ y-bonds} K_y σʸᵢ σʸⱼ
+    − Σ_{⟨ij⟩ ∈ z-bonds} K_z σᶻᵢ σᶻⱼ
+
+(σ-convention; eigenvalues ±1)
+
+## Phases (Kitaev 2006)
+
+- isotropic gapless (B-phase): each |K_α| ≤ sum of others
+- anisotropic gapped (A_x, A_y, A_z phases): one K dominates
+- gap: Δ = 2·max(0, |K_max| − |K_other₁| − |K_other₂|)
+
+## Coverage Matrix
+
+| Quantity | OBC | PBC | Infinite |
+|---|---|---|---|
+| Energy{:per_site} (T=0) | ✅ SVD on hopping matrix | ✅ 4-flux-sector min | ✅ BZ integral |
+| Energy{:per_site} (T>0) | ✅ matter sum | (deferred) | ✅ BZ integral |
+| FreeEnergy / Entropy / SpecificHeat | ✅ matter sum | — | ✅ BZ integral |
+| MassGap | — | — | ✅ analytic |
+| Mag{X,Y,Z} / Susc{XX,YY,ZZ} | not implemented (deferred) | — | not implemented |
+| ZZStructureFactor | — | — | static + dynamic via TFIM-style proxy* |
+
+*ZZStructureFactor router を参照 (TFIM_infinite_dynamics.jl に同様の実装あり; Kitaev 自身の動的 SF は別 issue)。
+
+## v0.17 Highlights — Matter-Majorana Free-Fermion Finite-T
+
+Lieb 1994: GS は flux-free sector に固定。flux-free セクター内では matter Majorana が自由フェルミオン hopping を成し、
+
+    Z_matter(β) = ∏_k 2 cosh(β λ_k)
+
+(λ_k は bipartite hopping matrix M の正の SVD 値; λ_k は full Majorana eigenvalue 規約 — 半固有値ではなく)。
+
+per-site (= per Majorana site, 2 atoms per unit cell) 物理量:
+
+```
+ε(β) = -(1/N_sites) Σ_k λ_k tanh(β λ_k)
+f(β) = -(1/(N_sites β)) Σ_k log(2 cosh(β λ_k))
+s(β) = (1/N_sites) Σ_k [log(2 cosh(βλ)) − βλ tanh(βλ)]
+c_v(β) = (1/N_sites) Σ_k (βλ)² sech²(βλ)
+```
+
+Infinite では `Σ_k → ∫_BZ d²θ / (2π)²` (factor 2 で 2 atoms/cell)。
+
+## Code Examples
+
+```julia
+m = KitaevHoneycomb(Kx=1.0, Ky=1.0, Kz=1.0)  # isotropic gapless
+
+# T = 0 GS
+QAtlas.fetch(m, Energy(:per_site), Infinite())   # Baskaran-Mandal-Shankar 2007 ≈ -0.787
+QAtlas.fetch(m, Energy(:per_site), OBC(0); Lx=4, Ly=4)
+QAtlas.fetch(m, Energy(:per_site), PBC(0); Lx=4, Ly=4)
+QAtlas.fetch(m, MassGap(), Infinite())  # = 0 (gapless)
+
+# T > 0 matter sector
+β = 5.0
+QAtlas.fetch(m, FreeEnergy(), Infinite(); beta=β)
+QAtlas.fetch(m, SpecificHeat(), Infinite(); beta=β)
+
+# Anisotropic gapped phase
+m_az = KitaevHoneycomb(Kx=0.5, Ky=0.5, Kz=2.0)
+QAtlas.fetch(m_az, MassGap(), Infinite())  # = 2(2 − 1) = 2
+```
+
+## Validity Boundary of Matter-Sector Finite-T
+
+flux gap Δ_v ≈ 0.07 |K| (isotropic) — 凍結する温度スケール。
+
+| Regime | matter-only valid? |
+|---|---|
+| T ≪ Δ_v | ✅ |
+| T ~ Δ_v | × (flux fluctuations dominate, Nasu-Udagawa-Motome 2014) |
+| T ≫ Δ_v ≪ K | × |
+
+## References
+- Kitaev 2006 — exactly solved model and beyond
+- Lieb 1994 — flux-free ground state theorem
+- Baskaran-Mandal-Shankar 2007 — TL ε_gs ≈ −0.787 |K|
+- Nasu-Udagawa-Motome 2014 — full flux-sector finite-T (sign-free QMC)
+- Loss-Pu 2008 — spin correlators (z-bond local, off-diagonal)
+
+## Related
+- `TFIM` — 1D version of "single Majorana species" (BdG hopping); Kitaev's matter sector is the 2D analogue

--- a/docs/src/models/quantum/s1heisenberg.md
+++ b/docs/src/models/quantum/s1heisenberg.md
@@ -1,0 +1,114 @@
+# S1Heisenberg1D — Spin-1 AFM Heisenberg Chain (Haldane Chain)
+
+!!! warning "Status: Unstable (v0.18.x)"
+    The spin-1 dense-ED observable surface debuted in v0.17. The local
+    Hilbert space is 3-dimensional, so the global space is $3^N$ and
+    the hard cap is $N \le 8$. Method signatures and kwarg names may
+    change in v0.19. `MagnetizationYLocal` is intentionally omitted
+    (Tier 3 in the observable issue) until a use case appears.
+
+## Hamiltonian
+
+```math
+H = J \sum_{i} \mathbf{S}_i \cdot \mathbf{S}_{i+1},
+\qquad S = 1\ (\text{3-dimensional local Hilbert space}).
+```
+
+The on-site spin operators are the standard $3 \times 3$ matrices
+`_S1_x`, `_S1_y`, `_S1_z` with eigenvalues $\{-1, 0, +1\}$.
+
+## Phases
+
+The spin-1 antiferromagnet is in the **Haldane phase**: a gapped,
+topologically non-trivial phase with hidden $\mathbb{Z}_2 \times
+\mathbb{Z}_2$ string order and (on OBC) free spin-1/2 edge modes.
+
+| Quantity | Value |
+|---|---|
+| Bulk gap $\Delta_\infty$ | $\approx 0.41048\,J$ (White–Huse 1993, DMRG) |
+| GS energy density $e_0$ | $\approx -1.401484\,J$ (White–Huse 1993, DMRG) |
+| Edge | gapless spin-1/2 doublet on each end (OBC) |
+
+There is no closed form for $\Delta_\infty$ or $e_0$ — they are exposed
+by QAtlas as `:literature_value` rows.
+
+## Coverage Matrix
+
+OBC rows are dense-ED with cap $N \le 8$ ($3^N \le 6561$).
+
+| Quantity | OBC ($N \le 8$) | Infinite |
+|---|---|---|
+| `Energy{:total}` | dense-ED | — |
+| `Energy{:per_site}` | conversion | $\approx -1.40148\,J$ (White–Huse 1993) |
+| `FreeEnergy` / `ThermalEntropy` / `SpecificHeat` | dense-ED | — |
+| `MagnetizationX` / `Y` / `Z` | dense-ED | — |
+| `MagnetizationXLocal` / `MagnetizationZLocal` | dense-ED | — |
+| `SusceptibilityXX` / `YY` / `ZZ` | dense-ED | — |
+| `XXCorrelation` / `YY` / `ZZ` (`:static`, `:connected`) | dense-ED | — |
+| `VonNeumannEntropy` / `RenyiEntropy` | partial trace | — |
+| `MassGap` | dense-ED ($E_1 - E_0$) | $\approx 0.41048\,J$ (Haldane gap) |
+| `EnergyLocal` | dense-ED (symmetric bond split) | — |
+
+`MagnetizationYLocal` is **not** registered (Tier 3, deferred).
+
+## Spin-1 Convention
+
+The on-site operators are the spin-1 matrices, so eigenvalues run over
+$\{-1, 0, +1\}$ (NOT the Pauli $\pm 1$ of TFIM/XXZ1D's $\sigma^\alpha$).
+All observables on `S1Heisenberg1D` use the $S^\alpha$ convention
+directly. When comparing against TFIM-style outputs that use
+$\sigma^\alpha = 2 S^\alpha$, factors of $2$ (linear) or $4$ (variance,
+two-point) are required.
+
+## SU(2) Symmetry Identities
+
+`is_su2_symmetric(::S1Heisenberg1D) === true`, so the SU(2) row of
+`SYMMETRY_IDENTITIES` (PR #133) is checked automatically:
+
+```math
+\chi_{xx} = \chi_{yy} = \chi_{zz},
+\qquad m_\alpha = 0\ \ (\alpha \in \{x, y, z\}).
+```
+
+This holds to ED precision since the dense kernel never breaks the
+spin rotation.
+
+## Code Examples
+
+```julia
+using QAtlas
+
+m = S1Heisenberg1D(J=1.0)
+N = 4
+β = 1.0
+
+QAtlas.fetch(m, Energy(),                     OBC(N); beta=β)
+QAtlas.fetch(m, MassGap(),                    OBC(N))             # finite-N gap
+QAtlas.fetch(m, MassGap(),                    Infinite())         # ≈ 0.41048
+QAtlas.fetch(m, ZZCorrelation{:static}(),     OBC(N); beta=β, i=1, j=4)
+QAtlas.fetch(m, VonNeumannEntropy(),          OBC(N); ℓ=2, beta=Inf)
+```
+
+For OBC $N \le 4$ the gap $E_1 - E_0$ is dominated by the spin-1/2
+edge-mode quasi-degeneracy, so it is much smaller than $\Delta_\infty$.
+The two values are not directly comparable until $N$ is large enough
+for bulk physics to dominate (typical DMRG convergence around $N \sim
+40$).
+
+## References
+
+- F. D. M. Haldane, Phys. Rev. Lett. **50**, 1153 (1983) —
+  $\sigma$-model prediction of the integer-spin gap.
+- S. R. White, D. A. Huse, Phys. Rev. B **48**, 3844 (1993) —
+  state-of-the-art DMRG values for $\Delta_\infty$ and $e_0$.
+- T. Kennedy, H. Tasaki, Phys. Rev. B **45**, 304 (1992) — string
+  order and hidden $\mathbb{Z}_2 \times \mathbb{Z}_2$ symmetry.
+- I. Affleck, J. Phys. Condens. Matter **1**, 3047 (1989) —
+  bosonisation of the spin-1 chain.
+
+## Related
+
+- [Heisenberg1D](heisenberg.md) — spin-1/2 cousin; gapless Luttinger
+  liquid, topologically trivial — a distinct phase.
+- [XXZ1D](xxz.md) — spin-1/2 anisotropic generalisation; SU(2)-symmetric
+  only at $\Delta = 1$.

--- a/docs/src/models/quantum/tfim.md
+++ b/docs/src/models/quantum/tfim.md
@@ -1,25 +1,73 @@
-# Transverse-Field Ising Model (TFIM)
+# TFIM — Transverse-Field Ising Model
 
 ## Overview
 
-The one-dimensional transverse-field Ising model is one of the simplest
-quantum many-body systems exhibiting a quantum phase transition. It is
-exactly solvable via [Jordan-Wigner transformation](../../methods/jordan-wigner/index.md)
-followed by Bogoliubov-de Gennes (BdG) diagonalization.
+The one-dimensional transverse-field Ising model is the canonical
+exactly-solvable quantum many-body system with a quantum phase
+transition. QAtlas solves it via the
+[Jordan-Wigner transformation](../../methods/jordan-wigner/index.md)
+followed by Bogoliubov-de Gennes (BdG) diagonalisation; PBC additionally
+requires parity-projected (NS+R) sectors.
 
-$$H = -J \sum_{i} \sigma^z_i \sigma^z_{i+1} - h \sum_{i} \sigma^x_i$$
+## Hamiltonian
 
-**Parameters**: Ising coupling $J$ (default 1.0), transverse field $h$.
+```math
+H = -J \sum_{i} \sigma^z_i \sigma^z_{i+1} - h \sum_{i} \sigma^x_i
+```
+
+(σ-convention: eigenvalues ±1.) **Parameters**: Ising coupling $J$
+(default 1.0), transverse field $h$.
 
 **Phase diagram**:
 
-- $h/J < 1$: Ferromagnetic ordered phase ($\langle \sigma^z \rangle \neq 0$)
-- $h/J = 1$: Quantum critical point ([Ising CFT, $c = 1/2$](../../universalities/ising.md))
-- $h/J > 1$: Quantum paramagnetic phase ($\langle \sigma^z \rangle = 0$)
+- $h/J < 1$: ferromagnetic ordered phase ($\langle \sigma^z\rangle\neq0$)
+- $h/J = 1$: quantum critical point ([Ising CFT, $c=1/2$](../../universalities/ising.md))
+- $h/J > 1$: quantum paramagnetic phase ($\langle \sigma^z\rangle = 0$)
 
-**Universality**: The critical point belongs to the
+**Universality**: the critical point belongs to the
 [2D Ising universality class](../../universalities/ising.md) via the
 quantum-classical mapping (1+1D quantum ↔ 2D classical).
+
+---
+
+## Coverage Matrix
+
+The table below reflects [`TFIM_registry.jl`](https://github.com/Vault/QAtlas.jl/blob/main/src/models/quantum/TFIM/TFIM_registry.jl) `@register` entries.
+✅ marks a native fetch method; "conversion" means routed through
+another granularity by `core/registry.jl`.
+
+| Quantity                                  | OBC                | PBC                | Infinite                                  |
+| ----------------------------------------- | ------------------ | ------------------ | ----------------------------------------- |
+| [`Energy`](@ref) `{:total}`               | ✅ BdG             | conversion         | —                                         |
+| [`Energy`](@ref) `{:per_site}`            | conversion         | ✅ BdG (NS+R)      | ✅ closed-form                            |
+| [`FreeEnergy`](@ref)                      | ✅                 | ✅ NS+R            | ✅                                        |
+| [`ThermalEntropy`](@ref)                  | ✅                 | ✅ NS+R            | ✅                                        |
+| [`SpecificHeat`](@ref)                    | ✅                 | ✅ NS+R            | ✅                                        |
+| [`MagnetizationX`](@ref)                  | ✅                 | ✅ NS+R            | ✅                                        |
+| [`MagnetizationZ`](@ref)                  | 0 by Z₂            | —                  | ✅ Pfeuty $m_z = (1-(h/J)^2)^{1/8}$        |
+| [`SusceptibilityXX`](@ref)                | ✅ variance        | ✅ NS+R            | ✅ Kubo (Calabrese-Mussardo)              |
+| [`SusceptibilityZZ`](@ref)                | ✅ Wick            | —                  | ✅ `N_proxy=80`                            |
+| [`CorrelationLength`](@ref)               | —                  | —                  | ✅ $\xi = 1/(2\lvert h-J\rvert)$           |
+| [`MassGap`](@ref)                         | ✅                 | ✅                 | ✅ $\Delta = 2\lvert h-J\rvert$            |
+| [`XXCorrelation`](@ref) `{:static}`       | ✅ Pfaffian        | —                  | ✅ proxy                                  |
+| [`XXCorrelation`](@ref) `{:connected}`    | ✅                 | —                  | ✅                                        |
+| [`XXCorrelation`](@ref) `{:dynamic}`      | ✅                 | —                  | —                                         |
+| [`ZZCorrelation`](@ref) `{:static}`       | ✅                 | —                  | —                                         |
+| [`ZZCorrelation`](@ref) `{:connected}`    | ✅ (= static, Z₂)  | —                  | —                                         |
+| [`ZZCorrelation`](@ref) `{:dynamic}`      | ✅                 | —                  | —                                         |
+| [`ZZCorrelation`](@ref) `{:lightcone}`    | ✅                 | —                  | —                                         |
+| [`ZZStructureFactor`](@ref)               | ✅                 | —                  | ✅ static + dynamic (proxy)               |
+| [`VonNeumannEntropy`](@ref)               | ✅ Peschel         | —                  | ✅ CC (T=0 crit/gapped + T>0 crit)         |
+| [`RenyiEntropy`](@ref)`(α)`               | ✅ Peschel         | —                  | ✅ CC                                     |
+| [`EnergyLocal`](@ref)                     | ✅                 | —                  | —                                         |
+| [`MagnetizationXLocal`](@ref)             | ✅                 | —                  | —                                         |
+| [`MagnetizationZLocal`](@ref)             | ✅                 | —                  | —                                         |
+| [`SpontaneousMagnetization`](@ref)        | —                  | —                  | ✅ alias of `MagnetizationZ`              |
+| [`CentralCharge`](@ref)                   | —                  | —                  | ✅ 1/2 (critical) / 0                     |
+
+YY observables (`YYCorrelation`, `SusceptibilityYY`, `MagnetizationY`)
+are intentionally **not** implemented — the σʸ JW string makes OBC
+contractions expensive; tracked as Tier 3 in issue #110.
 
 ---
 
@@ -28,20 +76,148 @@ quantum-classical mapping (1+1D quantum ↔ 2D classical).
 QAtlas supports three boundary conditions for the TFIM, each with
 different physical content:
 
-| BC       | `fetch` argument         | BdG size                   | Physical setting                        |
-| -------- | ------------------------ | -------------------------- | --------------------------------------- |
-| OBC      | `OBC()`                  | $2N \times 2N$ (numerical) | Open chain, $N$ sites, $N-1$ bonds      |
-| PBC      | (not directly supported) | —                          | Ring of $N$ sites, $N$ bonds            |
-| Infinite | `Infinite()`             | $k$-integral               | Thermodynamic limit, PBC $N \to \infty$ |
+| BC       | `fetch` argument | BdG size                   | Physical setting                        |
+| -------- | ---------------- | -------------------------- | --------------------------------------- |
+| OBC      | `OBC(N)`         | $2N \times 2N$ (numerical) | Open chain, $N$ sites, $N-1$ bonds      |
+| PBC      | `PBC(N)`         | parity-projected NS+R      | Ring of $N$ sites, $N$ bonds            |
+| Infinite | `Infinite()`     | $k$-integral               | Thermodynamic limit, PBC $N \to \infty$ |
 
-**OBC**: The BdG matrix is diagonalized numerically. Boundary effects
+**OBC**: the BdG matrix is diagonalised numerically. Boundary effects
 include the Z₂ tunneling splitting in the ordered phase and the
-boundary energy correction $O(1/N)$ at criticality. See
-[gap analysis](#energy-gap-and-quantum-phase-transition) for details.
+$O(1/N)$ boundary correction at criticality. See
+[gap analysis](#energy-gap-and-quantum-phase-transition) below.
 
-**Infinite**: The quasiparticle dispersion
-$\Lambda(k) = 2\sqrt{J^2 + h^2 - 2Jh\cos k}$ is integrated over
-the Brillouin zone using Gauss-Kronrod quadrature (QuadGK.jl).
+**PBC**: the JW transformation produces a fermion parity factor that
+splits the partition function into Neveu-Schwarz (anti-periodic) and
+Ramond (periodic) sectors with both signs of the parity projector
+(LSM). QAtlas evaluates all four (NS±, R±). The Ramond k=0 zero mode
+at criticality is handled explicitly.
+
+**Infinite**: the quasiparticle dispersion
+$\Lambda(k) = 2\sqrt{J^2 + h^2 - 2Jh\cos k}$ is integrated over the
+Brillouin zone using Gauss-Kronrod quadrature (QuadGK.jl).
+
+---
+
+## v0.17 / v0.18 Highlights
+
+!!! warning "Status: Unstable (v0.18.x)"
+    The PBC thermodynamics, Z-axis Infinite surface, XX static / connected
+    via Pfaffian, Calabrese-Cardy entanglement at Infinite, and dynamic
+    structure-factor helpers are **new in v0.17–v0.18**. Method
+    signatures, granularity conventions, and keyword-argument names
+    (`N_proxy`, `ω`, `ℓ`, `beta`) may change in v0.19. Call sites should
+    use the public `QAtlas.fetch(model, quantity, bc; ...)` interface and
+    must not depend on internal helpers (the `_tfim_*` prefixed
+    functions).
+
+### 1. PBC free-fermion thermodynamics (v0.17)
+
+Jordan-Wigner with a fermion parity factor splits $Z$ into
+Neveu-Schwarz and Ramond sectors with both parity-projector signs.
+QAtlas sums all four sectors (NS+, NS−, R+, R−); at the critical point
+the R-sector $k=0$ zero mode is handled explicitly.
+
+```julia
+m  = TFIM(; J=1.0, h=0.5)
+β  = 1.0
+QAtlas.fetch(m, FreeEnergy(),       PBC(8); beta=β)
+QAtlas.fetch(m, MagnetizationX(),   PBC(8); beta=β)
+QAtlas.fetch(m, SusceptibilityXX(), PBC(8); beta=β)
+QAtlas.fetch(m, MassGap(),          PBC(8))
+```
+
+References: Lieb-Schultz-Mattis (1961); Sachdev §4.2.
+Source: [`TFIM_pbc_thermal.jl`](https://github.com/Vault/QAtlas.jl/blob/main/src/models/quantum/TFIM/TFIM_pbc_thermal.jl).
+
+### 2. Z-axis Infinite — Pfeuty closed forms (v0.17)
+
+| Quantity                                          | Formula                                               |
+| ------------------------------------------------- | ----------------------------------------------------- |
+| [`MagnetizationZ`](@ref) (= [`SpontaneousMagnetization`](@ref)) | $m_z = (1 - (h/J)^2)^{1/8}\;\;(h<J)$, else 0           |
+| [`CorrelationLength`](@ref)                       | $\xi = 1/(2\lvert h-J\rvert)$ (Inf at criticality)     |
+| [`SusceptibilityZZ`](@ref)                        | OBC large-$N$ proxy via `N_proxy` kwarg                |
+| [`ZZStructureFactor`](@ref)                       | static $S_{zz}(q)$ from Fourier of large-$N$ correlator|
+
+```julia
+QAtlas.fetch(TFIM(; J=1.0, h=0.5), MagnetizationZ(),    Infinite())  # ≈ 0.985
+QAtlas.fetch(TFIM(; J=1.0, h=0.7), CorrelationLength(), Infinite())  # 1/0.6 ≈ 1.667
+```
+
+Source: [`TFIM_zaxis.jl`](https://github.com/Vault/QAtlas.jl/blob/main/src/models/quantum/TFIM/TFIM_zaxis.jl).
+
+### 3. XX static / connected via Pfaffian Wick (v0.18)
+
+OBC static $\langle\sigma^x_i\sigma^x_j\rangle$ is the $t=0$ limit of
+the existing dynamic Wick contraction, evaluated as a real Pfaffian
+over the Majorana covariance block. The connected variant subtracts
+$\langle\sigma^x_i\rangle\langle\sigma^x_j\rangle$. Infinite uses the
+OBC large-$N$ proxy (`N_proxy` kwarg).
+
+```julia
+m = TFIM(; J=1.0, h=0.7)
+QAtlas.fetch(m, XXCorrelation{:static}(),    OBC(8); beta=Inf, i=3, j=5)
+QAtlas.fetch(m, XXCorrelation{:connected}(), OBC(8); beta=Inf, i=3, j=5)
+QAtlas.fetch(m, XXCorrelation{:static}(),    Infinite(); i=3, j=5, N_proxy=80)
+```
+
+YY OBC remains unimplemented (issue #110, Tier 3).
+Source: [`TFIM_xx_static.jl`](https://github.com/Vault/QAtlas.jl/blob/main/src/models/quantum/TFIM/TFIM_xx_static.jl).
+
+### 4. Calabrese-Cardy Infinite entanglement (v0.18)
+
+The thermodynamic-limit von Neumann and Rényi entropies are evaluated
+in closed form via the Calabrese-Cardy formula. Coverage:
+
+| Region                   | $T = 0$                                              | $T > 0$                                                              |
+| ------------------------ | ---------------------------------------------------- | -------------------------------------------------------------------- |
+| Critical (h = J)         | $S = (c/3)\,\log(2\ell)$                             | $S = (c/3)\,\log\!\left[(2\beta/\pi)\sinh(\pi\ell/\beta)\right]$     |
+| Gapped (h ≠ J)           | $S = (c/6)\,\log(2\xi\,\sinh(\ell/\xi))$             | error (deferred — see issue #110)                                    |
+
+with $c = 1/2$ for Ising. The Rényi $\alpha\neq 1$ prefactor is
+$(c/12)(1 + 1/\alpha)$.
+
+```julia
+QAtlas.fetch(TFIM(; J=1.0, h=1.0), VonNeumannEntropy(), Infinite(); ℓ=50)
+# ≈ (1/6) log(100) — critical T=0
+
+QAtlas.fetch(TFIM(; J=1.0, h=0.5), RenyiEntropy(2.0),   Infinite(); ℓ=20)
+# Rényi-2, gapped CC
+
+QAtlas.fetch(TFIM(; J=1.0, h=1.0), VonNeumannEntropy(), Infinite();
+             ℓ=20, beta=4.0)
+# critical T>0
+```
+
+Source: [`TFIM_cft_entanglement.jl`](https://github.com/Vault/QAtlas.jl/blob/main/src/models/quantum/TFIM/TFIM_cft_entanglement.jl).
+
+### 5. Dynamic structure factor at Infinite (v0.18, proxy)
+
+[`ZZStructureFactor`](@ref) at `Infinite()` is router-dispatched on
+the optional `ω` keyword:
+
+- `ω === nothing` → existing static proxy (Fourier of static correlator)
+- `ω::Real`       → dynamic proxy (time-evolution + Fourier of dynamic
+  correlator)
+
+Two helpers are exported for analytic post-processing:
+
+- [`tfim_quasiparticle_dispersion`](@ref)`(model, k) -> Float64`
+  — closed-form Bogoliubov dispersion $\Lambda(k)$.
+- [`tfim_two_spinon_dos`](@ref)`(model, ω; q_total = 0.0) -> Float64`
+  — two-spinon density of states at fixed total momentum, used to
+  identify the continuum threshold.
+
+```julia
+m = TFIM(; J=1.0, h=1.0)
+QAtlas.fetch(m, ZZStructureFactor(), Infinite(); q=π/2, ω=1.5)
+tfim_quasiparticle_dispersion(m, π/2)
+tfim_two_spinon_dos(m, 1.5; q_total=0.0)
+```
+
+Closed-form form-factor expansion (Calabrese-Mussardo) is **not yet
+implemented** — issue #110.
+Source: [`TFIM_infinite_dynamics.jl`](https://github.com/Vault/QAtlas.jl/blob/main/src/models/quantum/TFIM/TFIM_infinite_dynamics.jl).
 
 ---
 
@@ -51,12 +227,16 @@ the Brillouin zone using Gauss-Kronrod quadrature (QuadGK.jl).
 
 The ground-state energy of the OBC TFIM with $N$ sites is
 
-$$E_0 = -\sum_{n=1}^{N} \frac{\Lambda_n}{2}$$
+```math
+E_0 = -\sum_{n=1}^{N} \frac{\Lambda_n}{2}
+```
 
 where $\{\Lambda_n\}$ are the positive eigenvalues of the $2N \times 2N$
 BdG matrix. At finite temperature $\beta = 1/(k_B T)$:
 
-$$\langle H \rangle(\beta) = -\sum_{n=1}^{N} \frac{\Lambda_n}{2} \tanh\!\left(\frac{\beta \Lambda_n}{2}\right)$$
+```math
+\langle H \rangle(\beta) = -\sum_{n=1}^{N} \frac{\Lambda_n}{2} \tanh\!\left(\frac{\beta \Lambda_n}{2}\right)
+```
 
 ### Derivation
 
@@ -74,13 +254,15 @@ eigenvalues come in $\pm\Lambda_n$ pairs. The positive eigenvalues
 $\Lambda_n > 0$ are the quasiparticle energies, and the total energy
 at inverse temperature $\beta$ is:
 
-$$\langle H \rangle = -\sum_n \frac{\Lambda_n}{2} \tanh\!\left(\frac{\beta \Lambda_n}{2}\right)$$
+```math
+\langle H \rangle = -\sum_n \frac{\Lambda_n}{2} \tanh\!\left(\frac{\beta \Lambda_n}{2}\right)
+```
 
 !!! note "Thermodynamic limit"
-For PBC in the $N \to \infty$ limit, the quasiparticle dispersion
-is $\Lambda(k) = 2\sqrt{J^2 + h^2 - 2Jh\cos k}$, and the energy
-per site becomes a $k$-integral evaluated by Gauss-Kronrod
-quadrature (QuadGK.jl).
+    For PBC in the $N \to \infty$ limit, the quasiparticle dispersion
+    is $\Lambda(k) = 2\sqrt{J^2 + h^2 - 2Jh\cos k}$, and the energy
+    per site becomes a $k$-integral evaluated by Gauss-Kronrod
+    quadrature (QuadGK.jl).
 
 ### References
 
@@ -95,14 +277,16 @@ quadrature (QuadGK.jl).
 ### QAtlas API
 
 ```julia
-# Ground-state energy (β → ∞), OBC, N=16
-E₀ = QAtlas.fetch(:TFIM, :energy, OBC(); N=16, J=1.0, h=0.5)
+m = TFIM(; J=1.0, h=0.5)
 
-# Finite-temperature energy
-E_β = QAtlas.fetch(:TFIM, :energy, OBC(); N=16, J=1.0, h=0.5, beta=2.0)
+# Ground-state energy (β → ∞), OBC, N=16 — total
+E₀ = QAtlas.fetch(m, Energy{:total}(), OBC(16))
 
-# Thermodynamic limit (PBC, N→∞)
-ε = QAtlas.fetch(:TFIM, :energy, Infinite(); J=1.0, h=0.5, beta=2.0)
+# Finite-temperature total energy
+Eβ = QAtlas.fetch(m, Energy{:total}(), OBC(16); beta=2.0)
+
+# Thermodynamic limit (PBC, N→∞) — per site
+ε  = QAtlas.fetch(m, Energy{:per_site}(), Infinite(); beta=2.0)
 ```
 
 ### Verification
@@ -121,40 +305,61 @@ E_β = QAtlas.fetch(:TFIM, :energy, OBC(); N=16, J=1.0, h=0.5, beta=2.0)
 At inverse temperature $\beta$ and for $N$ sites (OBC), the following
 quantities are computed from the BdG spectrum $\{\Lambda_n\}$:
 
-| Quantity      | Formula                                                                                  | Symbol           |
-| ------------- | ---------------------------------------------------------------------------------------- | ---------------- |
-| Free energy   | $F = -\frac{1}{\beta}\sum_n \ln\left[2\cosh\left(\frac{\beta\Lambda_n}{2}\right)\right]$ | `:free_energy`   |
-| Entropy       | $S = \beta(\langle H \rangle - F)$                                                       | `:entropy`       |
-| Specific heat | $C_v = -\beta^2 \frac{\partial \langle H \rangle}{\partial \beta}$                       | `:specific_heat` |
+| Quantity      | Formula                                                                                  | Type                       |
+| ------------- | ---------------------------------------------------------------------------------------- | -------------------------- |
+| Free energy   | $F = -\frac{1}{\beta}\sum_n \ln\!\left[2\cosh(\beta\Lambda_n/2)\right]$                  | [`FreeEnergy`](@ref)       |
+| Entropy       | $S = \beta(\langle H \rangle - F)$                                                       | [`ThermalEntropy`](@ref)   |
+| Specific heat | $C_v = -\beta^2\,\partial \langle H \rangle / \partial \beta$                            | [`SpecificHeat`](@ref)     |
+| Mag. (X)      | $\langle\sigma^x\rangle$ from the Bogoliubov occupation                                  | [`MagnetizationX`](@ref)   |
+| Susc. (XX)    | Variance of $\sum_i \sigma^x_i$ (OBC); Kubo at Infinite                                  | [`SusceptibilityXX`](@ref) |
+
+PBC ⇒ all of the above with parity-projected NS+R sums (v0.17).
 
 ### Derivation
 
 All quantities follow from the free-fermion partition function. For
 independent modes with energies $\Lambda_n$:
 
-$$\mathcal{Z} = \prod_n \left[2\cosh\!\left(\frac{\beta\Lambda_n}{2}\right)\right]$$
+```math
+\mathcal{Z} = \prod_n 2\cosh\!\left(\frac{\beta\Lambda_n}{2}\right)
+```
 
 The free energy is $F = -\beta^{-1}\ln\mathcal{Z}$, and all other
-thermodynamic quantities are obtained by appropriate $\beta$-derivatives.
+thermodynamic quantities follow from $\beta$-derivatives.
 
 ### References
 
 - S. Sachdev, _Quantum Phase Transitions_ (2011), Ch. 5.3.
-- QAtlas: `src/models/quantum/TFIM/TFIM_thermal.jl` — full implementation.
+- QAtlas: `src/models/quantum/TFIM/TFIM_thermal.jl`,
+  `TFIM_pbc_thermal.jl` — full implementation.
 
 ### QAtlas API
 
 ```julia
-F = QAtlas.fetch(:TFIM, :free_energy, OBC(); N=16, J=1.0, h=0.5, beta=2.0)
-S = QAtlas.fetch(:TFIM, :entropy, OBC(); N=16, J=1.0, h=0.5, beta=2.0)
-Cv = QAtlas.fetch(:TFIM, :specific_heat, OBC(); N=16, J=1.0, h=0.5, beta=2.0)
+m = TFIM(; J=1.0, h=0.5)
+β = 2.0
+
+F  = QAtlas.fetch(m, FreeEnergy(),       OBC(16); beta=β)
+S  = QAtlas.fetch(m, ThermalEntropy(),   OBC(16); beta=β)
+Cv = QAtlas.fetch(m, SpecificHeat(),     OBC(16); beta=β)
+Mx = QAtlas.fetch(m, MagnetizationX(),   OBC(16); beta=β)
+χ  = QAtlas.fetch(m, SusceptibilityXX(), OBC(16); beta=β)
+
+# PBC variants (NS+R) — v0.17
+F_pbc = QAtlas.fetch(m, FreeEnergy(),     PBC(16); beta=β)
+Mx_pbc = QAtlas.fetch(m, MagnetizationX(), PBC(16); beta=β)
+
+# Infinite — closed-form k-integrals
+F_inf  = QAtlas.fetch(m, FreeEnergy(),     Infinite(); beta=β)
+Mx_inf = QAtlas.fetch(m, MagnetizationX(), Infinite(); beta=β)
 ```
 
 ### Verification
 
-| Test file              | Method                 | What is checked                                       |
-| ---------------------- | ---------------------- | ----------------------------------------------------- |
-| `test_TFIM_thermal.jl` | Dense ED ($N \leq 10$) | Exact match of $F$, $S$, $C_v$ against independent ED |
+| Test file                  | Method                 | What is checked                                       |
+| -------------------------- | ---------------------- | ----------------------------------------------------- |
+| `test_TFIM_thermal.jl`     | Dense ED ($N \leq 10$) | Exact match of $F$, $S$, $C_v$, $M_x$ vs. ED          |
+| `test_TFIM_pbc_thermal.jl` | NS+R vs. ED ($N\leq8$) | PBC parity-projected sums match exact ring partition  |
 
 ---
 
@@ -165,7 +370,9 @@ Cv = QAtlas.fetch(:TFIM, :specific_heat, OBC(); N=16, J=1.0, h=0.5, beta=2.0)
 The many-body energy gap $\Delta = E_1 - E_0$ equals the smallest BdG
 quasiparticle energy $\Lambda_{\min}$. In the thermodynamic limit:
 
-$$\Delta = 2|J - h|$$
+```math
+\Delta = 2|J - h|
+```
 
 At the critical point $h = J$, the gap closes as $\Delta \sim N^{-z}$
 with dynamic exponent $z = 1$.
@@ -173,17 +380,15 @@ with dynamic exponent $z = 1$.
 ### Physical Context
 
 - **Ordered phase** ($h < J$): for OBC with finite $N$, the "gap" seen
-  by exact diagonalization is actually the Z₂ **tunneling splitting**
+  by exact diagonalisation is actually the Z₂ **tunneling splitting**
   between $|\!\uparrow\cdots\uparrow\rangle$ and
   $|\!\downarrow\cdots\downarrow\rangle$, which is exponentially small
   in $N$. This is distinct from the physical excitation gap
   $\Delta \approx 2(J - h)$.
-
-- **Critical point** ($h = J$): $\Delta \sim \pi/(N)$ (finite-size
-  gap for OBC).
-
-- **Disordered phase** ($h > J$): $\Delta \approx 2(h - J)$, i.e.,
-  the paramagnetic gap.
+- **Critical point** ($h = J$): $\Delta \sim \pi/N$ (finite-size gap
+  for OBC).
+- **Disordered phase** ($h > J$): $\Delta \approx 2(h - J)$, the
+  paramagnetic gap.
 
 ### References
 
@@ -194,111 +399,139 @@ with dynamic exponent $z = 1$.
 
 ```julia
 # Infinite chain — closed form Δ = 2|h − J|
-QAtlas.fetch(TFIM(; J=1.0, h=0.3), MassGap(), Infinite())
-# → 1.4
-
-QAtlas.fetch(TFIM(; J=1.0, h=1.0), MassGap(), Infinite())
-# → 0.0   (critical: gap closes)
+QAtlas.fetch(TFIM(; J=1.0, h=0.3), MassGap(), Infinite())   # 1.4
+QAtlas.fetch(TFIM(; J=1.0, h=1.0), MassGap(), Infinite())   # 0.0  (critical)
 
 # OBC finite-N — smallest positive BdG eigenvalue
-QAtlas.fetch(TFIM(; J=1.0, h=1.0), MassGap(), OBC(32))
-# → π J / N ≈ 0.098   (finite-size CFT gap)
-```
+QAtlas.fetch(TFIM(; J=1.0, h=1.0), MassGap(), OBC(32))      # ≈ π/N
 
-Symbol aliases recognised by the legacy layer include `:mass_gap`,
-`:gap`, `:Δ`, `:excitation_gap`, and the capitalised `:MassGap`.
+# PBC finite-N — smallest excitation across NS / R sectors (v0.17)
+QAtlas.fetch(TFIM(; J=1.0, h=1.0), MassGap(), PBC(16))
+```
 
 ### Verification
 
-| Test file                          | Method                  | What is checked                                           |
-| ---------------------------------- | ----------------------- | --------------------------------------------------------- | --- | -------------------------------------- |
-| `test_tfim_gap_closure.jl`         | Dense ED ($N = 4$–$12$) | Gap shrinks with $N$ at $h = J$                           |
-| `test_tfim_gap_closure.jl`         | ED                      | Ordered-phase gap is Z₂ tunneling ($< 10^{-3}$ for $N=6$) |
-| `test_universality_cross_check.jl` | BdG ($N = 200$)         | $\Delta \approx 2                                         | h-J | $; $\nu z = 1$ from log-log regression |
+| Test file                          | Method                  | What is checked                                                          |
+| ---------------------------------- | ----------------------- | ------------------------------------------------------------------------ |
+| `test_tfim_gap_closure.jl`         | Dense ED ($N = 4$–$12$) | Gap shrinks with $N$ at $h = J$                                          |
+| `test_tfim_gap_closure.jl`         | ED                      | Ordered-phase gap is Z₂ tunneling ($< 10^{-3}$ for $N=6$)                |
+| `test_universality_cross_check.jl` | BdG ($N = 200$)         | $\Delta \approx 2\lvert h-J\rvert$; $\nu z = 1$ from log-log regression  |
 
 ---
 
-## Central Charge from Entanglement Entropy
+## Entanglement Entropy at OBC (Peschel)
 
 ### Statement
 
-At the critical point $h = J$, the entanglement entropy of a
-subsystem of $l$ consecutive sites in an $N$-site OBC chain obeys
-the [Calabrese-Cardy formula](../../methods/calabrese-cardy/index.md):
+At the critical point $h = J$, the entanglement entropy of a contiguous
+block of $\ell$ sites in an $N$-site OBC chain obeys the
+[Calabrese-Cardy formula](../../methods/calabrese-cardy/index.md):
 
-$$S(l) = \frac{c}{6}\ln\!\left[\frac{2N}{\pi}\sin\!\left(\frac{\pi l}{N}\right)\right] + s_1$$
+```math
+S(\ell) = \frac{c}{6}\ln\!\left[\frac{2N}{\pi}\sin\!\left(\frac{\pi \ell}{N}\right)\right] + s_1
+```
 
 with central charge $c = 1/2$ (Ising CFT). See the
 [Calabrese-Cardy method page](../../methods/calabrese-cardy/index.md)
-for the general formula, OBC vs PBC prefactors, and extraction
-procedure.
+for OBC vs. PBC prefactors and extraction procedure.
 
 ### Physical Context
 
 The TFIM is a free-fermion system after Jordan-Wigner transformation,
 so the reduced density matrix on a contiguous block of $\ell$ spins
-is Gaussian and its von Neumann entropy is computable in $O(\ell^3)$
-from the Majorana covariance matrix restricted to that block
-(Peschel's correlation-matrix method). QAtlas exposes this directly
-via `fetch(TFIM(; J, h), VonNeumannEntropy(), OBC(N); ℓ)` — no
-Kramers-Wannier detour is needed, because the internal
+is Gaussian and its von Neumann (or Rényi) entropy is computable in
+$O(\ell^3)$ from the Majorana covariance matrix restricted to that
+block (Peschel's correlation-matrix method). QAtlas exposes this
+directly via [`VonNeumannEntropy`](@ref) and [`RenyiEntropy`](@ref) at
+OBC — no Kramers-Wannier detour is needed, because the internal
 $\sigma^x$-string JW convention puts the Majorana pair
 $(\gamma_{2i-1}, \gamma_{2i})$ on spin site $i$ directly, and the JW
 transformation factorises across any contiguous bipartition up to a
-parity factor on A that commutes with $\rho_A$ (Fagotti-Calabrese
+parity factor on $A$ that commutes with $\rho_A$ (Fagotti-Calabrese
 2010).
 
-Full derivation of the per-mode entropy formula $S_A = \sum_k
-s_2(\nu_k)$ from the Gaussian-preservation theorem, the Majorana-
-covariance canonical form, and the contiguous-block JW
+Full derivation of the per-mode entropy formula
+$S_A = \sum_k s_2(\nu_k)$ from the Gaussian-preservation theorem, the
+Majorana-covariance canonical form, and the contiguous-block JW
 factorisation:
-**[Peschel correlation-matrix method: TFIM entanglement entropy
-](../../calc/tfim-entanglement-peschel.md)**.
+**[Peschel correlation-matrix method](../../calc/tfim-entanglement-peschel.md)**.
 
 ### References
 
 - P. Calabrese, J. Cardy, J. Stat. Mech. **0406**, P06002 (2004), Eq. (19).
 - I. Peschel, J. Phys. A **36**, L205 (2003), Eq. (9).
-- G. Vidal, J. I. Latorre, E. Rico, A. Kitaev, Phys. Rev. Lett. **90**, 227902 (2003).
+- G. Vidal, J. I. Latorre, E. Rico, A. Kitaev, Phys. Rev. Lett. **90**,
+  227902 (2003).
 - M. Fagotti, P. Calabrese, Phys. Rev. Lett. **104**, 227203 (2010).
 
 ### QAtlas API
 
 ```julia
-# Ground state, block of ℓ = N/2 sites at criticality:
+# Ground-state von Neumann, ℓ = N/2 at criticality
 QAtlas.fetch(TFIM(; J=1.0, h=1.0), VonNeumannEntropy(), OBC(100); ℓ=50)
-# → 0.7256…  (matches (c/6) log((2N/π) sin(πℓ/N)) + s_1 with c = 1/2)
+# ≈ 0.7256  ((c/6) log((2N/π) sin(πℓ/N)) + s_1, c = 1/2)
 
-# Thermal state at β = 1:
+# Thermal von Neumann at β = 1
 QAtlas.fetch(TFIM(; J=1.0, h=1.0), VonNeumannEntropy(), OBC(100); ℓ=50, beta=1.0)
-```
 
-Symbol aliases recognised by the legacy layer: `:entanglement_entropy`,
-`:ee`, `:EE`, `:S_vN`, `:EntanglementEntropy`.
+# Rényi α ≠ 1 (v0.18)
+QAtlas.fetch(TFIM(; J=1.0, h=1.0), RenyiEntropy(2.0), OBC(100); ℓ=50)
+```
 
 ### Verification
 
-| Test file                             | Method                 | What is checked                                                       |
-| ------------------------------------- | ---------------------- | --------------------------------------------------------------------- |
-| `test_TFIM_entanglement.jl`           | Peschel vs full ED SVD | Machine-precision agreement for every $\ell$ at $N = 10$, three $(J, h)$ points |
-| `test_TFIM_entanglement.jl`           | Peschel $N = 100$      | Extracted $c \approx 0.5$ within 5% at criticality                    |
-| `test_TFIM_entanglement.jl`           | Peschel                | Symmetric $S(\ell) = S(N - \ell)$, area law away from criticality      |
-| `test_entanglement_central_charge.jl` | ED ($N \le 14$)        | $c_{\text{extracted}} \approx 0.5$ within 10%                         |
+| Test file                             | Method                 | What is checked                                                                  |
+| ------------------------------------- | ---------------------- | -------------------------------------------------------------------------------- |
+| `test_TFIM_entanglement.jl`           | Peschel vs. full ED SVD| Machine-precision agreement for every $\ell$ at $N = 10$, three $(J, h)$ points |
+| `test_TFIM_entanglement.jl`           | Peschel ($N = 100$)    | Extracted $c \approx 0.5$ within 5% at criticality                              |
+| `test_TFIM_entanglement.jl`           | Peschel                | Symmetric $S(\ell) = S(N-\ell)$, area law away from criticality                  |
+| `test_TFIM_renyi.jl`                  | Peschel α-trace        | Rényi $\alpha = 2, 3$ matches small-$N$ ED                                       |
+| `test_TFIM_cft_entanglement.jl`       | CC at Infinite         | Critical T=0/T>0 and gapped T=0 closed forms vs. analytic                        |
+| `test_entanglement_central_charge.jl` | ED ($N \le 14$)        | $c_{\text{extracted}} \approx 0.5$ within 10%                                    |
+
+---
+
+## Coverage by Reference
+
+Physical / methodological backing of each fetch surface:
+
+- **BdG (OBC ground / thermal)**: Pfeuty 1970.
+- **PBC parity projection (NS+R)**: Lieb-Schultz-Mattis 1961; Sachdev §4.2.
+- **Peschel correlation matrix (entanglement, OBC)**: Peschel 2003;
+  Calabrese-Cardy 2004; Fagotti-Calabrese 2010.
+- **Calabrese-Cardy (entanglement, Infinite)**: Calabrese-Cardy 2004,
+  2009.
+- **Pfaffian Wick (XX static / connected)**: Wick 1950 + free-fermion
+  Σ contraction.
+- **Pfeuty closed forms (Z-axis Infinite)**: Pfeuty 1970 (spontaneous
+  magnetisation, correlation length).
+- **Two-spinon DOS / dispersion helpers**: standard Bogoliubov
+  dispersion + convolution; see Calabrese-Mussardo for the form-factor
+  programme (not yet implemented).
 
 ---
 
 ## Connections
 
 - **Universality**: [Ising universality class](../../universalities/ising.md) —
-  the TFIM critical point has $c = 1/2$, $\nu = 1$, $z = 1$.
+  $c = 1/2$, $\nu = 1$, $z = 1$.
 - **Classical counterpart**: [IsingSquare](../classical/ising-square.md) —
   the 1+1D TFIM maps to the 2D classical Ising model via the
-  quantum-classical correspondence ($\beta_{\text{classical}} \leftrightarrow$ imaginary time).
+  quantum-classical correspondence
+  ($\beta_{\text{classical}} \leftrightarrow$ imaginary time).
 - **Disordered version**: [Random TFIM](../../verification/disordered.md) —
-  the Fisher IRFP at $[\ln J]_{\text{avg}} = [\ln h]_{\text{avg}}$.
+  the Fisher infinite-randomness fixed point at
+  $[\ln J]_{\text{avg}} = [\ln h]_{\text{avg}}$.
 - **E8 spectrum**: [E8 universality](../../universalities/e8.md) —
   perturbing the critical TFIM at $h = J$ by a longitudinal field
   $\lambda \sigma^z$ is the $\Phi_{(1,2)} = \sigma$ magnetic
   perturbation of the Ising CFT. Zamolodchikov (1989) showed the
   resulting massive field theory **remains integrable** and its
   eight stable particles realise the $E_8$ mass spectrum.
+
+## API
+
+`Modules = [QAtlas]` at the end of `index.md` already pulls
+docstrings for the exported observable types and TFIM helpers
+([`tfim_quasiparticle_dispersion`](@ref),
+[`tfim_two_spinon_dos`](@ref)); no `@autodocs` block is needed here.

--- a/docs/src/models/quantum/xxz.md
+++ b/docs/src/models/quantum/xxz.md
@@ -1,210 +1,125 @@
-# XXZ Chain (1D, spin-1/2)
+# XXZ1D — Spin-1/2 XXZ Chain
 
-## Overview
+!!! warning "Status: Unstable (v0.18.x)"
+    The XXZ1D OBC dense-ED full observable surface was introduced in
+    v0.17. Method signatures and kwarg names (`beta`, `i`, `j`, `ℓ`, …)
+    may change in v0.19. The infinite-system finite-temperature surface
+    is not yet implemented (TBA / NLIE work tracked in issue #108).
 
-The spin-1/2 XXZ chain generalises both the [Heisenberg
-chain](heisenberg.md) (isotropic $\Delta = 1$) and the XX / free-fermion
-point ($\Delta = 0$) through a single anisotropy parameter $\Delta$:
+## Hamiltonian
 
-$$H = J \sum_{i} \bigl[\, S^x_i S^x_{i+1} + S^y_i S^y_{i+1}
-                       + \Delta\, S^z_i S^z_{i+1} \,\bigr]$$
-
-with $\mathbf{S}_i = \tfrac{1}{2}\boldsymbol{\sigma}_i$ and $J > 0$ the
-antiferromagnetic exchange coupling.
-
-**Parameters**: $J$ (exchange coupling, default `1.0`), $\Delta$
-(anisotropy, default `0.0` = XX point).
-
-**Phase diagram**:
-
-| Regime | Phase | Description |
-|--------|-------|-------------|
-| $\Delta < -1$ | Gapped ferromagnet | Ising-like FM order |
-| $\Delta = -1$ | Saturated ferromagnet | $e_0/J = -1/4$ |
-| $-1 < \Delta \le 1$ | Luttinger liquid ($c = 1$) | Gapless, critical |
-| $\Delta = 0$ | XX / free fermion | $e_0/J = -1/\pi$ |
-| $\Delta = 1$ | Isotropic AF Heisenberg | $e_0/J = 1/4 - \ln 2$ |
-| $\Delta > 1$ | Gapped Néel antiferromagnet | Ising-like AFM order |
-
----
-
-## Ground-state energy density (infinite chain)
-
-### Statement
-
-QAtlas currently exposes the three canonical exact points:
-
-$$
-e_0/J =
-\begin{cases}
--\,\tfrac{1}{4} & (\Delta = -1,\ \text{FM saturated}) \\[2pt]
--\,\tfrac{1}{\pi} & (\Delta = 0,\ \text{XX / free fermion}) \\[2pt]
-\tfrac{1}{4} - \ln 2 & (\Delta = 1,\ \text{AF Heisenberg, Hulthén 1938})
-\end{cases}
-$$
-
-For every other $\Delta$ the call returns `NaN` and emits a warning —
-the general-$\Delta$ Yang–Yang integral has multiple inequivalent
-normalisations in the literature and is tracked as a follow-up PR.
-
-### References
-
-- L. Hulthén, Ark. Mat. Astron. Fys. **26A**, No. 11 (1938) — evaluation
-  at $\Delta = 1$.
-- C. N. Yang, C. P. Yang, Phys. Rev. **150**, 321 (1966) — general
-  Bethe-ansatz integral equation.
-- M. Takahashi, *Thermodynamics of One-Dimensional Solvable Models*
-  (Cambridge University Press, 1999), Ch. 4.
-
-### QAtlas API
-
-```julia
-e_xx = QAtlas.fetch(XXZ1D(; J=1.0, Δ=0.0), Energy(), Infinite())
-# → -0.3183098861837907          (= -1/π)
-
-e_af = QAtlas.fetch(XXZ1D(; J=1.0, Δ=1.0), Energy(), Infinite())
-# → -0.4431471805599453          (= 1/4 - ln 2)
-
-e_fm = QAtlas.fetch(XXZ1D(; J=1.0, Δ=-1.0), Energy(), Infinite())
-# → -0.25
+```math
+H = J \sum_{i} \bigl[\, S^x_i S^x_{i+1} + S^y_i S^y_{i+1}
+                       + \Delta\, S^z_i S^z_{i+1} \,\bigr]
 ```
 
-The `GroundStateEnergyDensity()` quantity is an alias returning the
-same value.
+with $\mathbf{S}_i = \tfrac{1}{2}\boldsymbol{\sigma}_i$, exchange
+coupling $J$ (default `1.0`), and anisotropy $\Delta$ (default `0.0`,
+the XX point).
 
-### Verification
+## Phases
 
-| Test | Method | What is checked |
-|------|--------|-----------------|
-| `test_XXZ1D.jl` | Analytical | $e_0(\Delta = 0) = -1/\pi$ to $10^{-10}$ |
-| `test_XXZ1D.jl` | Analytical | $e_0(\Delta = 1) = 1/4 - \ln 2$ to $10^{-10}$ |
-| `test_XXZ1D.jl` | Analytical | $e_0(\Delta = -1) = -1/4$ to $10^{-14}$ |
-| `test_XXZ1D.jl` | Warning behaviour | `NaN` + `general-Δ` warning for any other $\Delta$ |
+| Regime | Phase | Closed form on the GS energy |
+|--------|-------|------------------------------|
+| $\Delta < -1$ | Gapped ferromagnet (Ising-like FM) | — (TBA, deferred) |
+| $\Delta = -1$ | Saturated ferromagnet | $e_0/J = -1/4$ |
+| $-1 < \Delta < 1$ | Luttinger liquid, $c = 1$ | — (general $\Delta$ TBA) |
+| $\Delta = 0$ | XX / free fermion | $e_0/J = -1/\pi$ |
+| $\Delta = 1$ | Isotropic AF Heisenberg | $e_0/J = 1/4 - \ln 2$ (Hulthén 1938) |
+| $\Delta > 1$ | Gapped Néel AFM | — (TBA, deferred) |
 
----
+## Coverage Matrix
 
-## Central charge (critical regime only)
+OBC rows are dense-ED (Hilbert dim $2^N$, cap $N \le 12$). Infinite
+rows are analytic / Bethe-ansatz closed forms.
 
-### Statement
+| Quantity | OBC | Infinite |
+|---|---|---|
+| `Energy{:total}` (any $\Delta$) | dense-ED | — |
+| `Energy{:per_site}` | conversion via $E/N$ | $\Delta \in \{-1, 0, 1\}$ only (issue #108) |
+| `FreeEnergy` / `ThermalEntropy` / `SpecificHeat` | dense-ED | — (TBA not yet) |
+| `MagnetizationX` / `Y` / `Z` (+ `…Local`) | dense-ED | — |
+| `SusceptibilityXX` / `YY` / `ZZ` | variance | — |
+| `XXCorrelation` / `YY` / `ZZ` (`:static`, `:connected`) | dense-ED | — |
+| `VonNeumannEntropy` / `RenyiEntropy` | partial trace | — |
+| `MassGap` | dense-ED ($E_1 - E_0$) | $0$ on $-1 < \Delta \le 1$, `NaN` otherwise |
+| `CentralCharge` | — | $1$ on critical regime, `NaN` otherwise |
+| `LuttingerParameter` | — | $K = \pi / (2(\pi - \gamma))$, $\gamma = \arccos\Delta$ |
+| `LuttingerVelocity` | — | $u = (\pi J / 2)\,\sin\gamma / \gamma$ |
+| `EnergyLocal` | dense-ED (symmetric bond split) | — |
+
+`SpinWaveVelocity` is a type-level alias of `LuttingerVelocity`.
+
+## v0.17 Highlights — Dense-ED Full Suite
+
+A single `_xxz1d_thermal_kernel(model, N, β)` performs one
+eigendecomposition of the $2^N \times 2^N$ Hamiltonian and reuses the
+spectrum / eigenvectors across every observable on the OBC row. The
+hard cap is `N ≤ 12` (Hilbert dimension `2^12 = 4096`).
+
+```julia
+using QAtlas
+
+m = XXZ1D(J=1.0, Δ=0.5)
+β = 1.0
+
+QAtlas.fetch(m, FreeEnergy(),         OBC(6); beta=β)
+QAtlas.fetch(m, SpecificHeat(),       OBC(6); beta=β)
+QAtlas.fetch(m, MagnetizationZ(),     OBC(6); beta=β)         # = 0  (U(1) conservation)
+QAtlas.fetch(m, ZZCorrelation{:static}(), OBC(6); beta=β, i=2, j=4)
+QAtlas.fetch(m, RenyiEntropy(2.0),    OBC(6); ℓ=3, beta=Inf)
+```
+
+### Δ = 1 isotropic point: SU(2) symmetry identities
+
+At $\Delta = 1$ the chain is SU(2)-symmetric, so every observable
+satisfies the harness-checked identities
+
+```math
+\chi_{xx} = \chi_{yy} = \chi_{zz}, \qquad m_\alpha = 0\ \ (\alpha \in \{x,y,z\}).
+```
+
+```julia
+m_iso = XXZ1D(J=1.0, Δ=1.0)
+QAtlas.fetch(m_iso, SusceptibilityXX(), OBC(6); beta=1.0)  # =
+QAtlas.fetch(m_iso, SusceptibilityYY(), OBC(6); beta=1.0)  # =
+QAtlas.fetch(m_iso, SusceptibilityZZ(), OBC(6); beta=1.0)
+```
+
+These three calls return the same value to ED precision, and are
+checked by the SU(2) row of `SYMMETRY_IDENTITIES` (PR #133).
+
+## Critical-regime CFT data
 
 For $-1 < \Delta < 1$ the chain flows to a $c = 1$ compactified-boson
-(Luttinger-liquid) CFT in the IR:
-
-$$c(\Delta) = 1, \qquad -1 < \Delta < 1.$$
-
-Outside this window the chain is gapped; QAtlas returns `NaN` with a
-warning.
-
-### QAtlas API
+CFT with continuously varying compactification radius. QAtlas exposes
+the standard triplet:
 
 ```julia
-QAtlas.fetch(XXZ1D(; Δ=0.3), CentralCharge(), Infinite())  # → 1.0
-QAtlas.fetch(XXZ1D(; Δ=1.5), CentralCharge(), Infinite())  # → NaN (+ warn)
-```
-
----
-
-## Luttinger parameter $K$
-
-### Statement
-
-Across the full critical regime $-1 < \Delta \le 1$,
-
-$$\boxed{\,K(\Delta) = \frac{\pi}{2\,(\pi - \gamma)},
-         \qquad \gamma \equiv \arccos \Delta\,}$$
-
-Canonical values:
-
-| $\Delta$ | $\gamma$ | $K$ | Interpretation |
-|----------|----------|-----|-----------------|
-| $-1^{+}$ | $\pi^{-}$ | $\to \infty$ | FM boundary |
-| $0$ | $\pi/2$ | $1$ | XX / free fermion |
-| $1$ | $0$ | $1/2$ | AF Heisenberg |
-
-Monotone decreasing in $\Delta$.
-
-Full derivation: **[XXZ Luttinger parameters from Bethe ansatz
-](../../calc/xxz-luttinger-parameters.md)**.
-
-### References
-
-- T. Giamarchi, *Quantum Physics in One Dimension* (Oxford, 2004),
-  Ch. 6.
-- F. D. M. Haldane, Phys. Rev. Lett. **45**, 1358 (1980);
-  Phys. Rev. Lett. **47**, 1840 (1981) — bosonisation of the XXZ chain.
-
-### QAtlas API
-
-```julia
+QAtlas.fetch(XXZ1D(; Δ=0.3), CentralCharge(),     Infinite())  # → 1.0
 QAtlas.fetch(XXZ1D(; Δ=0.0), LuttingerParameter(), Infinite())  # → 1.0
-QAtlas.fetch(XXZ1D(; Δ=1.0), LuttingerParameter(), Infinite())  # → 0.5
+QAtlas.fetch(XXZ1D(; Δ=1.0), LuttingerVelocity(),  Infinite())  # → π/2
+QAtlas.fetch(XXZ1D(; Δ=1.5), CentralCharge(),     Infinite())  # → NaN (+ warn)
 ```
 
----
+Full derivation: [XXZ Luttinger parameters from Bethe
+ansatz](../../calc/xxz-luttinger-parameters.md).
 
-## Luttinger / spin-wave velocity $u$
+## References
 
-### Statement
+- H. Bethe, Z. Physik **71**, 205 (1931).
+- L. Hulthén, Ark. Mat. Astron. Fys. **26A**, No. 11 (1938) — $\Delta = 1$ value.
+- C. N. Yang, C. P. Yang, Phys. Rev. **150**, 321 (1966) — general-$\Delta$
+  Bethe-ansatz integral equation.
+- M. Takahashi, *Thermodynamics of One-Dimensional Solvable Models*
+  (Cambridge UP, 1999), Ch. 4.
+- T. Giamarchi, *Quantum Physics in One Dimension* (Oxford, 2004), Ch. 6.
 
-$$\boxed{\,u(\Delta) = J\cdot \frac{\pi}{2}\,\frac{\sin\gamma}{\gamma},
-         \qquad \gamma \equiv \arccos \Delta\,}$$
+## Related
 
-Canonical values:
-
-| $\Delta$ | $u / J$ | Identification |
-|----------|---------|----------------|
-| $0$ | $1$ | Free-fermion Fermi velocity $v_F$ |
-| $1$ | $\pi/2$ | des Cloizeaux–Pearson spin-wave velocity |
-
-`SpinWaveVelocity` is a **type-level alias** of `LuttingerVelocity`
-(`const SpinWaveVelocity = LuttingerVelocity`). The two names denote
-the same physical quantity for 1D critical spin chains; the alias
-exists purely for readability in spin-chain contexts.
-
-Full derivation: **[XXZ Luttinger parameters from Bethe ansatz
-](../../calc/xxz-luttinger-parameters.md)**.
-
-### QAtlas API
-
-```julia
-QAtlas.fetch(XXZ1D(; J=1.0, Δ=0.0), LuttingerVelocity(), Infinite())
-# → 1.0
-
-QAtlas.fetch(XXZ1D(; J=1.0, Δ=1.0), SpinWaveVelocity(), Infinite())
-# → 1.5707963267948966  (= π/2)
-```
-
----
-
-## Legacy Symbol API
-
-Symbol-dispatch calls are still routed through the v0.13 deprecation
-layer (`src/deprecate/legacy_xxz.jl`):
-
-```julia
-QAtlas.fetch(:XXZ, :energy, Infinite(); J=1.0, Δ=0.0)              # → -1/π
-QAtlas.fetch(:XXZ, :spin_wave_velocity, Infinite(); J=1.0, Δ=1.0)  # → π/2
-QAtlas.fetch(:XXZ, :luttinger_parameter, Infinite(); J=1.0, Δ=0.0) # → 1.0
-```
-
-Recognised quantity aliases for the velocity family include
-`:v_F`, `:v_LL`, `:fermi_velocity`, `:spin_wave_velocity`,
-`:sound_velocity`, and the capitalised struct names.
-
----
-
-## Connections
-
-- **Heisenberg limit**: $\Delta = 1$ reproduces the Hulthén result
-  cached in the [Heisenberg model page](heisenberg.md). The Heisenberg
-  chain is the isotropic SU(2)-symmetric point of the XXZ family.
-- **Free-fermion limit**: $\Delta = 0$ reduces to the XX chain, which
-  Jordan–Wigner-maps to a 1D nearest-neighbour tight-binding model.
-  The value $-1/\pi$ can equivalently be read off the free-fermion
-  cosine band — see [JW → TFIM BdG](../../calc/jw-tfim-bdg.md) for the
-  analogous mapping on the Ising side.
-- **Universality**: The entire $-1 < \Delta < 1$ window sits in the
-  $c = 1$ compactified-boson universality class (Luttinger liquid).
-  The compactification radius varies continuously with $\Delta$ via
-  $K(\Delta)$, which controls every long-distance exponent of the
-  chain.
+- [Heisenberg1D](heisenberg.md) — isotropic SU(2) point ($\Delta = 1$); a
+  thin delegator to `XXZ1D(Δ=1.0)`.
+- [S1Heisenberg1D](s1heisenberg.md) — spin-1 generalisation; gapped
+  Haldane phase, distinct universality.
+- [TFIM](tfim.md) — $c = 1/2$ Ising chain for contrast with the
+  $c = 1$ XXZ critical line.

--- a/docs/src/verification/identity-harness.md
+++ b/docs/src/verification/identity-harness.md
@@ -1,0 +1,117 @@
+# Identity-Based Self-Validation Harness
+
+!!! warning "Status: Unstable (v0.18.x)"
+    `verify_thermodynamic_identities` ハーネスと `SYMMETRY_IDENTITIES` 系の identity 集合は v0.17–0.18 で導入された新サーフェス。`ThermoIdentity` 構造体や `model_filter` predicate の signature は v0.19 で変更される可能性があります。テストファイル (`test/identities/`) は public API ではなく **internal verification infrastructure** であり、外部から直接 import しないでください。
+
+## What Identities Catch
+
+QAtlas の `fetch` メソッド群が物理的に整合しているかを **複数の独立な経路で同じ量を計算して一致するか** で機械的に検証。観測量実装の sign error / convention drift / kwarg drift を ED ベースの単純比較より早く / 広く検出。
+
+## 6-axis Test Diversification
+
+QAtlas v0.18 では以下 6 軸の identity 検証層が並走する:
+
+| 軸 | 例 | 関連 PR |
+|---|---|---|
+| (A) Cross-method | `c_v` を `Var(H)` / `∂ε/∂β` / `∂s/∂β` の 3 経路で算出して一致 | #132 |
+| (B) Cross-symmetry | SU(2) 不変 model で `χ_xx = χ_yy = χ_zz`, `m_α = 0` | #133 |
+| (C) Cross-model | TFIM `J=0` / `h=0` の textbook closed form 帰着 | #133 |
+| (D) Cross-BC scaling | OBC/PBC `→` Infinite の `1/N`, `1/N²` 指数を fit | #135 |
+| (E) Property-based | random sweep + 不変量 (`Var ≥ 0`, `s ≥ 0`, `0 ≤ S_α ≤ ℓ log 2`) | #136 |
+| (F) Time-domain | dynamic 相関子の reflection symmetry / Hermiticity / locality | #134 |
+
+## Core API: `ThermoIdentity` and `verify_thermodynamic_identities`
+
+(`test/util/thermodynamic_identities.jl` 参照)
+
+```julia
+struct ThermoIdentity
+    name::String
+    requires::Vector{Type}              # required quantity types for dispatch lookup
+    check::Function                     # (model, bc, params) -> (lhs, rhs)
+    model_filter::Function              # default: m -> true
+end
+
+verify_thermodynamic_identities(model, bc; βs, identities=DEFAULT_IDENTITIES, rtol=1e-8, atol=1e-10)
+    -> Vector{IdentityCheckResult}
+```
+
+`IdentityCheckResult.status` は `:pass`, `:fail`, `:skipped` のいずれか。`:skipped` は `requires` の dispatch が無いか `model_filter` が false を返したケース (NaN, NaN)。
+
+## DEFAULT_IDENTITIES (4 universal)
+
+1. `GIBBS_RELATION` — `ε = f + T·s`
+2. `SPECIFIC_HEAT_FROM_ENERGY` — `c_v = -β² ∂ε/∂β` (ForwardDiff)
+3. `SPECIFIC_HEAT_FROM_ENTROPY` — `c_v = -β · ∂s/∂β` (ForwardDiff)
+4. `MAGNETIZATION_X_FROM_FREE_ENERGY` — `m_x = -∂f/∂h` (central diff; skipped if model has no `h` field)
+
+## SYMMETRY_IDENTITIES (5 opt-in)
+
+- `SU2_CHI_XX_EQ_YY`, `SU2_CHI_YY_EQ_ZZ` — SU(2) 不変点で χ 軸等値
+- `MAGNETIZATION_X_VANISHES_SU2`, `MAGNETIZATION_Z_VANISHES_SU2` — m_α = 0 (canonical, SU(2))
+- `MAGNETIZATION_Y_VANISHES_REAL_H` — 実 Hamiltonian で m_y = 0 (parity)
+
+`is_su2_symmetric(model)` predicate でモデル ごとに有効化:
+- `Heisenberg1D` → true
+- `S1Heisenberg1D` → true
+- `XXZ1D` → `isapprox(Δ, 1.0)`
+- 他 → false
+
+## SUSCEPTIBILITY_XX_KUBO_FROM_MAGNETIZATION (opt-in only)
+
+`χ_xx = ∂m_x/∂h` の Kubo 静的応答テスト。**OBC dense-ED 系 backend は equal-time variance 規約で `β·Var(M_x)/N` を返す**ため Kubo identity と不一致 — DEFAULT には入れない。Calabrese-Mussardo 系の closed-form (TFIM Infinite) でのみ pass。詳細は `test/util/thermodynamic_identities.jl` の docstring と PR #132 のレビュー。
+
+## Kubo vs Variance — Convention Note
+
+OBC `χ_xx` (TFIM/XXZ1D/S1Heisenberg) は equal-time variance:
+
+    χ_xx^(var) = β · Var(M_x) / N = (β/N) · Σᵢⱼ [⟨σˣᵢσˣⱼ⟩ − ⟨σˣᵢ⟩⟨σˣⱼ⟩]
+
+Infinite TFIM `χ_xx` は Calabrese-Mussardo Kubo 形:
+
+    χ_xx^(Kubo) = ∂m_x/∂h = (1/Nβ) ∂²(log Z)/∂h²
+
+古典極限 `[M_x, H] = 0` では一致するが、量子では operator-ordering 補正で異なる。harness はこの違いを検出可能 (PR #132)。
+
+## Per-model Identity Test Files
+
+各モデルの test/identities/test_identities_*.jl で harness を呼ぶ:
+
+- `test_identities_TFIM.jl`, `test_identities_TFIM_pbc.jl`
+- `test_identities_XXZ1D.jl`
+- `test_identities_S1Heisenberg1D.jl`
+- `test_identities_Heisenberg1D.jl`
+- `test_identities_KitaevHoneycomb.jl`
+- `test_TFIM_dynamic_symmetries.jl` — (F) time-domain
+- `test_TFIM_limits_cross_model.jl` — (C) cross-model
+- `test_cross_bc_scaling.jl` — (D) BC scaling
+- `test_property_invariants.jl` — (E) property-based
+
+合計 **約 1000+ identity-style tests** が CI で走る。
+
+## Adding a New Identity
+
+```julia
+const MY_IDENTITY = ThermoIdentity(
+    "lhs = rhs description",
+    Type[Quantity1, Quantity2],
+    function (model, bc, params)
+        β = params.β
+        lhs = fetch(model, ...)
+        rhs = fetch(model, ...)
+        return Float64(lhs), Float64(rhs)
+    end;
+    model_filter=is_su2_symmetric,  # optional, default _ -> true
+)
+```
+
+then either add to `DEFAULT_IDENTITIES` (universal) or pass via `identities=[MY_IDENTITY]` kwarg.
+
+## References
+
+- PR #126 (initial harness, #117 issue)
+- PR #132 (cross-method, Kubo vs variance discovery)
+- PR #133 (symmetry + cross-model)
+- PR #134 (time-domain identities)
+- PR #135 (cross-BC scaling)
+- PR #136 (property-based invariants)

--- a/src/models/quantum/KitaevHoneycomb/KitaevHoneycomb_thermal.jl
+++ b/src/models/quantum/KitaevHoneycomb/KitaevHoneycomb_thermal.jl
@@ -82,8 +82,8 @@ end
 Adaptive nested Gauss-Kronrod quadrature of `integrand(θ₁, θ₂)` over the
 2D Brillouin zone `(θ₁, θ₂) ∈ [0, 2π)²`.  Mirrors the inner / outer
 tolerance choice already used by the T = 0 `Energy` integration in
-[`KitaevHoneycomb.jl`](@ref).  Returns the integral value (the
-contribution of the prefactor `1/((2π)²)` is left to the caller).
+`KitaevHoneycomb.jl`.  Returns the integral value (the contribution
+of the prefactor `1/((2π)²)` is left to the caller).
 """
 function _kitaev_bz_integral(integrand, model::KitaevHoneycomb; rtol::Float64=1e-8)
     inner(θ₁) = first(


### PR DESCRIPTION
## Summary

Documentation を v0.17 (Tier 1) + v0.18 (Tier 2 + identity harness) の状態に追従。**Documentation CI が失敗していた原因の \`@ref\` バグも同時に fix**。各セクションに \`!!! warning \"Status: Unstable (v0.18.x)\"\` で API サーフェス未確定であることを明示。

\`@autodocs\` の \`Modules = [QAtlas]\` 構造はユーザー要望どおり**維持**。

## Build-breaker

\`src/models/quantum/KitaevHoneycomb/KitaevHoneycomb_thermal.jl\` 内の \`[\`KitaevHoneycomb.jl\`](@ref)\` (Documenter が file 名を Julia binding として解決しようとして fail) をバッククォート prose に修正。

## ドキュメント変更内容

| 範囲 | ファイル | 内容 |
|---|---|---|
| TFIM 全 surface | \`docs/src/models/quantum/tfim.md\` | Coverage matrix + PBC + Z-axis Infinite + Pfaffian XX + CC entanglement + 動的 SF helpers (23 typed \`@ref\`) |
| XXZ1D | \`docs/src/models/quantum/xxz.md\` | dense-ED full suite + Δ=1 SU(2) identity hookup |
| Heisenberg1D | \`docs/src/models/quantum/heisenberg.md\` | XXZ1D(Δ=1) delegator surface + Hulthén e₀ |
| **NEW** S1Heisenberg1D | \`docs/src/models/quantum/s1heisenberg.md\` | spin-1 dense-ED + White-Huse 文献値 |
| **NEW** KitaevHoneycomb | \`docs/src/models/quantum/kitaev-honeycomb.md\` | T=0 全 BC + matter-Majorana finite-T (v0.17) |
| **NEW** Identity Harness | \`docs/src/verification/identity-harness.md\` | 6 軸 test 多様化 (A〜F) + \`ThermoIdentity\` API + Kubo vs variance convention |
| Nav | \`docs/make.jl\` | 上記 2 新規ページを navigation に追加 + \`size_threshold = 600 KiB\` (autodocs index.md が default 200 KiB を超えたため) |

## Local build

\`\`\`
julia --project=docs docs/make.jl
\`\`\`

→ warnings のみ (search index size 警告 + 数式 \$...\$ の false-positive interpolation 警告)、**致命エラー無し**。CI でも通る見込み。

\`Project.toml 0.18.5 → 0.18.6\` (patch: documentation only, no API change)

## Test plan

- [ ] CI Documentation workflow が green
- [ ] 既存ページに regression なし