### PR TITLE
docs: fix broken @ref in TFIM_yy.jl (unblocks Documentation CI)

### DIFF
--- a/src/models/quantum/TFIM/TFIM_yy.jl
+++ b/src/models/quantum/TFIM/TFIM_yy.jl
@@ -44,7 +44,8 @@ end
 
 `⟨σʸ_i(t) σʸ_j(0)⟩_β` from a precomputed thermal Majorana covariance `Σ`
 and time-evolution matrix `R = exp(h·t)`.  Same structure as
-[`_sz_sz_corr_from_cached`](@ref) — only the index lists differ.
+`_sz_sz_corr_from_cached` (in `TFIM_dynamics.jl`) — only the index lists
+differ.
 
 The overall phase is `(-i)^{i+j-2}`: each σʸ_k contributes
 `-(-i)^{k-1}`; the two minus signs cancel, leaving `(-i)^{i+j-2}`.


### PR DESCRIPTION
## Summary

PR #138 で導入された TFIM_yy.jl のdocstring に `[\`_sz_sz_corr_from_cached\`](@ref)` があるが、target は `TFIM_dynamics.jl` 内の **regular Julia comment** であり docstring 化されていないため、Documenter が binding を resolve できずに build を fail させていた。

```
Error: Cannot resolve @ref for md"[\`_sz_sz_corr_from_cached\`](@ref)" in docs/src/index.md.
- No docstring found in doc for binding `QAtlas._sz_sz_corr_from_cached`.
```

## Fix

`@ref` を外して backtick prose に変更。同じ情報量で build が通る。

ローカル `julia --project=docs docs/make.jl` 通過確認済 (warnings のみ、致命エラー無し)。

**No version bump** (docstring-only change, runtime behaviour unchanged)。

## Context

PR #138 (YY OBC) merge 後 main の Documentation CI が red になっていた。本 PR で main の docs build を unblock。