### PR TITLE
fix(test): scope markdown rendering test to TFIM rows

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.18.9"
+version = "0.18.10"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/test/core/test_registry.jl
+++ b/test/core/test_registry.jl
@@ -124,7 +124,9 @@ end
 
 @testset "Markdown rendering produces a non-empty GFM table" begin
     io = IOBuffer()
-    implementation_status_markdown(io, implementation_status()[1:3])
+    # Pick TFIM-only rows so this test stays stable as more models get
+    # registered ahead of TFIM in include order.
+    implementation_status_markdown(io, implementation_status(TFIM)[1:3])
     md = String(take!(io))
     # Header + alignment row + 3 data rows = 5 lines minimum
     lines = split(strip(md), '\n')


### PR DESCRIPTION
## Summary

- Filter `implementation_status(TFIM)[1:3]` instead of the registry-wide first 3 rows in the markdown rendering testset
- Stops the test from breaking whenever a non-TFIM model (e.g. IsingSquare) is included earlier in load order
- Patch version bump `0.18.9` → `0.18.10`

## Why

After PR #139 added IsingSquare's registry rows ahead of TFIM's in include order, `implementation_status()[1:3]` returns IsingSquare entries — so the assertion `any(occursin("TFIM", line) ...)` started failing on `main`.  The original intent of the testset was to spot-check the short-type rendering against the canonical TFIM rows, not the first three of any model.

## Test plan

- [ ] CI passes (`test_registry.jl` Markdown rendering subgroup green)