### PR TITLE
feat(XXZ): XX (Δ=0) free-fermion finite-T observables at Infinite() (refs #95)

### DIFF
--- a/docs/src/models/quantum/xxz.md
+++ b/docs/src/models/quantum/xxz.md
@@ -4,7 +4,9 @@
     The XXZ1D OBC dense-ED full observable surface was introduced in
     v0.17. Method signatures and kwarg names (`beta`, `i`, `j`, `ℓ`, …)
     may change in v0.19. The infinite-system finite-temperature surface
-    is not yet implemented (TBA / NLIE work tracked in issue #108).
+    is currently restricted to the **XX point (Δ = 0)** via the
+    free-fermion (Jordan-Wigner) integrals; general-Δ TBA / NLIE is
+    tracked in issue #108.
 
 ## Hamiltonian
 
@@ -36,8 +38,8 @@ rows are analytic / Bethe-ansatz closed forms.
 | Quantity | OBC | Infinite |
 |---|---|---|
 | `Energy{:total}` (any $\Delta$) | dense-ED | — |
-| `Energy{:per_site}` | conversion via $E/N$ | $\Delta \in \{-1, 0, 1\}$ only (issue #108) |
-| `FreeEnergy` / `ThermalEntropy` / `SpecificHeat` | dense-ED | — (TBA not yet) |
+| `Energy{:per_site}` | conversion via $E/N$ | GS at $\Delta \in \{-1, 0, 1\}$; finite-T at Δ = 0 (issue #108 for general Δ) |
+| `FreeEnergy` / `ThermalEntropy` / `SpecificHeat` | dense-ED | Δ = 0 free-fermion (QuadGK); other Δ NaN+warn (issue #108) |
 | `MagnetizationX` / `Y` / `Z` (+ `…Local`) | dense-ED | — |
 | `SusceptibilityXX` / `YY` / `ZZ` | variance | — |
 | `XXCorrelation` / `YY` / `ZZ` (`:static`, `:connected`) | dense-ED | — |
@@ -49,6 +51,40 @@ rows are analytic / Bethe-ansatz closed forms.
 | `EnergyLocal` | dense-ED (symmetric bond split) | — |
 
 `SpinWaveVelocity` is a type-level alias of `LuttingerVelocity`.
+
+## XX Point (Δ = 0) — Free-Fermion Thermo at Infinite()
+
+After Jordan-Wigner the XX chain is non-interacting; the
+single-particle dispersion (in the spin convention `Sᵅ = σᵅ/2`) is
+
+```math
+\varepsilon(k) = -J \cos k, \quad k \in [-\pi, \pi].
+```
+
+QAtlas exposes per-site `FreeEnergy`, `Energy{:per_site}`,
+`ThermalEntropy`, and `SpecificHeat` at `Infinite()` for `Δ = 0` via
+adaptive Gauss-Kronrod quadrature on `[0, π]`:
+
+```math
+\begin{aligned}
+f(\beta) &= -\frac{1}{\pi\beta} \int_0^\pi \log\!\left(2\cosh\tfrac{\beta\varepsilon(k)}{2}\right) dk, \
+e(\beta) &= -\frac{1}{2\pi} \int_0^\pi \varepsilon(k)\,\tanh\tfrac{\beta\varepsilon(k)}{2}\,dk, \
+s(\beta) &= \beta\,\bigl(e(\beta) - f(\beta)\bigr), \
+C(\beta) &=  \frac{1}{\pi} \int_0^\pi \bigl(\tfrac{\beta\varepsilon}{2}\bigr)^2 \operatorname{sech}^2\!\tfrac{\beta\varepsilon}{2}\,dk.
+\end{aligned}
+```
+
+```julia
+m = XXZ1D(J=1.0, Δ=0.0)
+QAtlas.fetch(m, Energy(),         Infinite(); beta=10.0)   # → ≈ -1/π = -0.3183
+QAtlas.fetch(m, FreeEnergy(),     Infinite(); beta=1.0)
+QAtlas.fetch(m, ThermalEntropy(), Infinite(); beta=0.01)   # → ≈ log 2
+QAtlas.fetch(m, SpecificHeat(),   Infinite(); beta=1.0)    # → > 0
+```
+
+For any Δ ≠ 0 these four calls emit a `@warn` and return `NaN` —
+the general-Δ thermal Bethe ansatz / NLIE is tracked in
+[issue #108](https://github.com/sotashimozono/QAtlas.jl/issues/108).
 
 ## v0.17 Highlights — Dense-ED Full Suite
 

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -95,6 +95,7 @@ include("models/quantum/KitaevHoneycomb/KitaevHoneycomb_thermal.jl")
 include("models/quantum/KitaevHoneycomb/KitaevHoneycomb_registry.jl")
 include("models/quantum/XXZ/XXZ.jl")
 include("models/quantum/XXZ/XXZ_thermal.jl")
+include("models/quantum/XXZ/XXZ_xx_infinite.jl")
 include("models/quantum/XXZ/XXZ_registry.jl")  # populates REGISTRY for XXZ1D
 include("models/quantum/Heisenberg/Heisenberg_registry.jl")  # populates REGISTRY for Heisenberg1D
 

--- a/src/models/quantum/XXZ/XXZ.jl
+++ b/src/models/quantum/XXZ/XXZ.jl
@@ -78,33 +78,11 @@ _xxz1d_energy_heisenberg_fm(J::Float64)::Float64 = -J / 4
 native_energy_granularity(::XXZ1D, ::OBC) = :total
 native_energy_granularity(::XXZ1D, ::Infinite) = :per_site
 
-"""
-    fetch(model::XXZ1D, ::Energy{:per_site}, ::Infinite) -> Float64
-
-Ground-state energy **per site** of the infinite XXZ chain in units of
-the Hamiltonian `J`.  Currently exposes the three canonical values:
-
-- `Δ = -1`  →  `-J/4`             (isotropic FM, saturated)
-- `Δ =  0`  →  `-J/π`             (XX, free fermion)
-- `Δ =  1`  →  `J (1/4 - ln 2)`   (AF Heisenberg, Hulthén 1938)
-
-For every other `Δ` a warning is emitted and `NaN` is returned — the
-general-`Δ` Bethe-ansatz integral is tracked as a v0.13 follow-up.
-"""
-function fetch(model::XXZ1D, ::Energy{:per_site}, ::Infinite; kwargs...)
-    J, Δ = model.J, model.Δ
-    if isapprox(Δ, 0.0; atol=1e-12)
-        return _xxz1d_energy_free_fermion(J)
-    elseif isapprox(Δ, 1.0; atol=1e-12)
-        return _xxz1d_energy_heisenberg_af(J)
-    elseif isapprox(Δ, -1.0; atol=1e-12)
-        return _xxz1d_energy_heisenberg_fm(J)
-    else
-        @warn "XXZ1D Energy: general-Δ Bethe ansatz not yet implemented; " *
-            "only Δ ∈ {-1, 0, 1} are exposed in this release." Δ = Δ
-        return NaN
-    end
-end
+# fetch(::XXZ1D, ::Energy{:per_site}, ::Infinite; ...) is defined in
+# XXZ_xx_infinite.jl, which extends the ground-state branch with a
+# finite-T (β kwarg) free-fermion path at Δ = 0.  The ground-state
+# logic for Δ ∈ {-1, 0, 1} is preserved bit-for-bit there; general-Δ
+# Bethe-ansatz remains a v0.13 follow-up (issue #108).
 
 """
     fetch(model::XXZ1D, ::GroundStateEnergyDensity, ::Infinite) -> Float64

--- a/src/models/quantum/XXZ/XXZ_registry.jl
+++ b/src/models/quantum/XXZ/XXZ_registry.jl
@@ -226,3 +226,35 @@ end
     tested_in="test/models/test_XXZ1D_observables.jl",
     notes="S_α = log Tr ρ_A^α / (1 - α); pass subsystem ℓ and order α.",
 )
+
+# ── Free-fermion thermal at Infinite (Δ = 0 only; general Δ pending #108) ──
+@register(
+    XXZ1D,
+    FreeEnergy,
+    Infinite,
+    method=:free_fermion_quadgk,
+    reliability=:high,
+    tested_in="test/standalone/test_xxz_xx_infinite.jl",
+    references=["Mahan §1.3", "Coleman §2.4", "Takahashi 1999 §4"],
+    notes="XX (Δ = 0) free-fermion f(β) by QuadGK; warns + NaN at general Δ (issue #108).",
+)
+@register(
+    XXZ1D,
+    ThermalEntropy,
+    Infinite,
+    method=:free_fermion_quadgk,
+    reliability=:high,
+    tested_in="test/standalone/test_xxz_xx_infinite.jl",
+    references=["Mahan §1.3", "Coleman §2.4"],
+    notes="XX (Δ = 0) free-fermion s(β) = β(e − f); warns + NaN at general Δ.",
+)
+@register(
+    XXZ1D,
+    SpecificHeat,
+    Infinite,
+    method=:free_fermion_quadgk,
+    reliability=:high,
+    tested_in="test/standalone/test_xxz_xx_infinite.jl",
+    references=["Mahan §1.3"],
+    notes="XX (Δ = 0) free-fermion C(β) = (1/π) ∫₀^π (βε/2)² sech²(βε/2) dk.",
+)

--- a/src/models/quantum/XXZ/XXZ_xx_infinite.jl
+++ b/src/models/quantum/XXZ/XXZ_xx_infinite.jl
@@ -38,12 +38,20 @@
 # **Why does `e` carry 1/(2π) while `f, s, C` carry 1/π?**  All four
 # observables are defined as `(1/(2π)) ∫_{-π}^{π} ⋯ dk`; collapsing
 # to [0, π] by the k ↔ -k symmetry of the integrand contributes a
-# factor 2 to the overall coefficient.  For `f, s, C` the integrand is
-# even in k *and* the natural definition of e, s, C also includes
-# an extra factor of 2 (e.g. `f = -(1/β) ⟨log(1 + e^{-βε})⟩` plus its
-# particle-hole partner combine into `log(2 cosh(βε/2))`).  For `e`
-# the original definition `e = ⟨ε · n_F(ε)⟩` does not have such a
-# doubling, so the k → [0,π] reduction leaves the prefactor at 1/(2π).
+# factor 2 to the overall coefficient.  The remaining factor comes
+# from the algebraic identity
+#     log(1 + e^{-βε}) = -βε/2 + log(2 cosh(βε/2))
+# combined with ∫_{-π}^{π} ε(k) dk = 0 (true for ε(k) = -J cos k since
+# cos is odd over a full period of length 2π — equivalently ε is even
+# in k but its mean over the BZ is zero).  The linear -βε/2 piece
+# integrates to zero, so for `f` (and inherited `s, C`) the
+# integrand collapses cleanly to `log(2 cosh(βε/2))` — already
+# carrying an implicit factor of 2 from the cosh.  For `e` the
+# integrand `ε · n_F(ε)` does not benefit from this doubling: the
+# similar identity `ε · n_F(ε) = ε/2 - (ε/2) tanh(βε/2)` produces a
+# linear ε/2 piece that *also* integrates to zero, but no extra factor
+# of 2 appears in the surviving `-(ε/2) tanh` term.  Hence the k →
+# [0, π] reduction of `e` retains the prefactor at 1/(2π).
 # A direct algebraic check: at β → ∞,
 #     e(∞) = -(1/(2π)) ∫₀^π ε(k) sgn(ε(k)) dk
 #          = -(1/(2π)) ∫₀^π |ε(k)| dk

--- a/src/models/quantum/XXZ/XXZ_xx_infinite.jl
+++ b/src/models/quantum/XXZ/XXZ_xx_infinite.jl
@@ -1,0 +1,268 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# XXZ chain at Δ = 0 (XX / free fermion) — thermodynamic-limit finite-T
+# observables.
+#
+# After the Jordan-Wigner transformation, the XX chain in the *spin*
+# convention used throughout XXZ.jl
+#
+#     H = J Σᵢ (Sˣᵢ Sˣᵢ₊₁ + Sʸᵢ Sʸᵢ₊₁),    Sᵅ = σᵅ / 2
+#
+# maps (after the cancellation of nearest-neighbour JW strings) to the
+# tight-binding fermion chain
+#
+#     H_JW = (J/2) Σᵢ (c†ᵢ cᵢ₊₁ + h.c.)
+#
+# whose single-particle dispersion is
+#
+#     ε(k) = J cos(k),     k ∈ [-π, π]
+#
+# at half filling and zero chemical potential.  We work with the
+# equivalent (k → π + k) form
+#
+#     ε(k) = -J cos(k)
+#
+# so that the band minimum sits at k = 0; this is purely a relabelling
+# and leaves all thermal observables invariant since they depend on
+# ε only through the even functionals
+# `log(2 cosh(βε/2))`, `ε · tanh(βε/2)`, `(βε/2)² sech²(βε/2)`.
+#
+# Per-site free-fermion thermodynamics in the thermodynamic limit
+# (1/(2π) ∫_{-π}^{π} = 1/π ∫_0^π by k ↔ -k symmetry):
+#
+#     f(β)  = -(1/(πβ))  ∫₀^π log(2 cosh(β ε(k) / 2)) dk
+#     e(β)  = -(1/(2π))  ∫₀^π ε(k) · tanh(β ε(k) / 2) dk
+#     s(β)  =  (1/π)     ∫₀^π [ log(2 cosh(βε/2)) − (βε/2) tanh(βε/2) ] dk
+#           ≡  β (e(β) − f(β))
+#     C(β)  =  (1/π)     ∫₀^π (β ε(k) / 2)² sech²(β ε(k) / 2) dk
+#
+# **Why does `e` carry 1/(2π) while `f, s, C` carry 1/π?**  All four
+# observables are defined as `(1/(2π)) ∫_{-π}^{π} ⋯ dk`; collapsing
+# to [0, π] by the k ↔ -k symmetry of the integrand contributes a
+# factor 2 to the overall coefficient.  For `f, s, C` the integrand is
+# even in k *and* the natural definition of e, s, C also includes
+# an extra factor of 2 (e.g. `f = -(1/β) ⟨log(1 + e^{-βε})⟩` plus its
+# particle-hole partner combine into `log(2 cosh(βε/2))`).  For `e`
+# the original definition `e = ⟨ε · n_F(ε)⟩` does not have such a
+# doubling, so the k → [0,π] reduction leaves the prefactor at 1/(2π).
+# A direct algebraic check: at β → ∞,
+#     e(∞) = -(1/(2π)) ∫₀^π ε(k) sgn(ε(k)) dk
+#          = -(1/(2π)) ∫₀^π |ε(k)| dk
+#          = -(J/(2π)) · ∫₀^π |cos k| dk
+#          = -(J/(2π)) · 2  =  -J/π,
+# matching `_xxz1d_energy_free_fermion(J) = -J/π` from XXZ.jl.
+#
+# Limit checks:
+#
+#   • β → ∞:  e(∞) = -J/π          ← XX ground-state energy density
+#                                   (Hulthén / Yang-Yang, see XXZ.jl)
+#             f(∞) → e(∞)           (entropy → 0)
+#             s(∞) → 0
+#             C(∞) → 0 (frozen-out)
+#   • β → 0:  e(0) → 0             (each integrand picks up only an
+#                                    O(β) contribution from the
+#                                    high-T expansion of `tanh`)
+#             f(0) → -(log 2)/β   (free spin per site)
+#             s(0) → log 2          (per-site fermion / spin entropy)
+#             C(0) → 0
+#
+# References
+#   - G. D. Mahan, *Many-Particle Physics* (3rd ed.), §1.3.
+#   - P. Coleman, *Introduction to Many-Body Physics*, §2.4.
+#   - M. Takahashi, *Thermodynamics of One-Dimensional Solvable Models*
+#     (1999), §4 — XX point as Δ = 0 / γ = π/2 limit of XXZ.
+#
+# This file implements only the Δ = 0 special case.  General-Δ TBA
+# (issue #108) is a separate workstream that will live alongside the
+# existing OBC ED methods.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QuadGK: quadgk
+
+# ── Numerically robust log(2 cosh x) ──────────────────────────────────────────
+@inline function _xx_logcosh2(x::Real)
+    a = abs(x)
+    return a + log1p(exp(-2 * a))
+end
+
+# ── Single-particle dispersion (spin convention; band minimum at k = 0) ──────
+@inline _xx_dispersion(k::Real, J::Real) = -J * cos(k)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Internal kernel: per-site thermodynamic potential of the XX chain at finite β.
+#
+# `quantity` ∈ (:free_energy, :energy, :entropy, :specific_heat).
+#
+# Integrals are evaluated by adaptive Gauss-Kronrod quadrature on [0, π];
+# the symmetry k ↔ -k is folded into the prefactor (1/π for the symmetric
+# integrands, 1/(2π) for `e`; see header for the derivation).  Each branch
+# returns the per-site value in the spin-S convention used by XXZ.jl
+# (so the β → ∞ limit of `:energy` reproduces -J/π exactly).
+# ─────────────────────────────────────────────────────────────────────────────
+function _xx_thermo_infinite(quantity::Symbol, J::Real, β::Real)
+    if quantity === :free_energy
+        # f(β) = -(1/(πβ)) ∫₀^π log(2 cosh(βε(k)/2)) dk
+        integrand = k -> _xx_logcosh2(β * _xx_dispersion(k, J) / 2)
+        val, _ = quadgk(integrand, 0.0, π; rtol=1e-10)
+        return -val / (π * β)
+    elseif quantity === :energy
+        # e(β) = -(1/(2π)) ∫₀^π ε(k) tanh(β ε(k) / 2) dk
+        integrand = k -> begin
+            εk = _xx_dispersion(k, J)
+            εk * tanh(β * εk / 2)
+        end
+        val, _ = quadgk(integrand, 0.0, π; rtol=1e-10)
+        return -val / (2 * π)
+    elseif quantity === :entropy
+        # s(β) = (1/π) ∫₀^π [ log(2 cosh(βε/2)) - (βε/2) tanh(βε/2) ] dk
+        integrand = k -> begin
+            εk = _xx_dispersion(k, J)
+            x = β * εk / 2
+            _xx_logcosh2(x) - x * tanh(x)
+        end
+        val, _ = quadgk(integrand, 0.0, π; rtol=1e-10)
+        return val / π
+    elseif quantity === :specific_heat
+        # C(β) = (1/π) ∫₀^π (βε/2)² sech²(βε/2) dk
+        integrand = k -> begin
+            εk = _xx_dispersion(k, J)
+            x = β * εk / 2
+            x^2 * sech(x)^2
+        end
+        val, _ = quadgk(integrand, 0.0, π; rtol=1e-10)
+        return val / π
+    else
+        error("Unknown XX thermal quantity: $quantity")
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# fetch dispatch — Δ = 0 only.
+#
+# These methods are guarded by `_xx_is_free_fermion(model)`
+# (`isapprox(Δ, 0; atol=1e-12)`); for other Δ they emit a warn+NaN
+# placeholder.  Issue #108 will replace those NaNs with a TBA
+# implementation.
+# ─────────────────────────────────────────────────────────────────────────────
+
+@inline _xx_is_free_fermion(model::XXZ1D) = isapprox(model.Δ, 0.0; atol=1e-12)
+
+function _xx_warn_general_delta(quantity::Symbol, Δ::Real)
+    @warn (
+        "XXZ1D thermal observable at Infinite() for general Δ requires the " *
+        "thermal Bethe ansatz (issue #108); only Δ = 0 (XX / free fermion) " *
+        "is implemented. Returning NaN."
+    ) quantity = quantity Δ = Δ
+    return NaN
+end
+
+# ── Energy{:per_site}, Infinite — finite-T (β provided) and ground state ─────
+#
+# Replaces the `Energy{:per_site}, Infinite` method previously defined
+# in XXZ.jl by branching on whether `beta` was passed:
+#
+#   • no `beta` kwarg ⇒ closed-form ground-state value (canonical
+#                       three points; warn+NaN otherwise) — identical
+#                       to the XXZ.jl implementation it supersedes.
+#   • `beta` kwarg     ⇒ free-fermion finite-T integral at Δ = 0;
+#                        warn+NaN at other Δ (issue #108).
+
+"""
+    fetch(model::XXZ1D, ::Energy{:per_site}, ::Infinite; [beta]) -> Float64
+
+Per-site energy of the infinite XXZ chain.
+
+* Without `beta`: ground-state energy density.  Closed-form values at
+  the three canonical points `Δ ∈ {-1, 0, 1}`; warns and returns
+  `NaN` otherwise (general-Δ Bethe ansatz is a follow-up).
+* With `beta`: thermal energy density `⟨H⟩_β / N`.  At `Δ = 0`
+  evaluated by Gauss-Kronrod quadrature of the free-fermion integral
+
+      e(β) = -(1/(2π)) ∫₀^π ε(k) tanh(β ε(k) / 2) dk,   ε(k) = -J cos k.
+
+  The β → ∞ limit reproduces `-J/π` (matching XXZ.jl's
+  `_xxz1d_energy_free_fermion`).  At general Δ the thermal Bethe
+  ansatz (issue #108) is required; a warning is emitted and `NaN`
+  returned.
+"""
+function fetch(model::XXZ1D, ::Energy{:per_site}, ::Infinite; kwargs...)
+    if haskey(kwargs, :beta)
+        β = kwargs[:beta]
+        if _xx_is_free_fermion(model)
+            return _xx_thermo_infinite(:energy, model.J, β)
+        end
+        return _xx_warn_general_delta(:energy, model.Δ)
+    end
+    # Ground state — same logic as the original XXZ.jl method.
+    J, Δ = model.J, model.Δ
+    if isapprox(Δ, 0.0; atol=1e-12)
+        return _xxz1d_energy_free_fermion(J)
+    elseif isapprox(Δ, 1.0; atol=1e-12)
+        return _xxz1d_energy_heisenberg_af(J)
+    elseif isapprox(Δ, -1.0; atol=1e-12)
+        return _xxz1d_energy_heisenberg_fm(J)
+    else
+        @warn "XXZ1D Energy: general-Δ Bethe ansatz not yet implemented; " *
+            "only Δ ∈ {-1, 0, 1} are exposed in this release." Δ = Δ
+        return NaN
+    end
+end
+
+# ── FreeEnergy, ThermalEntropy, SpecificHeat at Infinite ────────────────────
+
+"""
+    fetch(model::XXZ1D, ::FreeEnergy, ::Infinite; beta::Real, kwargs...)
+
+Per-site Helmholtz free energy of the infinite XXZ chain.
+Currently only `Δ = 0` (XX / free fermion) is implemented:
+
+    f(β) = -(1/(πβ)) ∫₀^π log(2 cosh(β ε(k) / 2)) dk,   ε(k) = -J cos k.
+
+For other Δ the thermal Bethe ansatz (issue #108) is required; this
+method emits a warning and returns `NaN`.
+
+References: Mahan, *Many-Particle Physics*, §1.3; Coleman, *Introduction
+to Many-Body Physics*, §2.4; Takahashi (1999), §4.
+"""
+function fetch(model::XXZ1D, ::FreeEnergy, ::Infinite; beta::Real, kwargs...)
+    if _xx_is_free_fermion(model)
+        return _xx_thermo_infinite(:free_energy, model.J, beta)
+    end
+    return _xx_warn_general_delta(:free_energy, model.Δ)
+end
+
+"""
+    fetch(model::XXZ1D, ::ThermalEntropy, ::Infinite; beta::Real, kwargs...)
+
+Per-site Gibbs entropy of the infinite XXZ chain.  Implemented at
+Δ = 0 only via
+
+    s(β) = (1/π) ∫₀^π [ log(2 cosh(βε/2)) - (βε/2) tanh(βε/2) ] dk,
+    ε(k) = -J cos k,
+
+equivalent to `s(β) = β (e(β) - f(β))`.  In the high-T limit
+(`β → 0`) this saturates to `log 2` per site.  Returns `NaN`
+(with a warning) for general Δ pending issue #108.
+"""
+function fetch(model::XXZ1D, ::ThermalEntropy, ::Infinite; beta::Real, kwargs...)
+    if _xx_is_free_fermion(model)
+        return _xx_thermo_infinite(:entropy, model.J, beta)
+    end
+    return _xx_warn_general_delta(:entropy, model.Δ)
+end
+
+"""
+    fetch(model::XXZ1D, ::SpecificHeat, ::Infinite; beta::Real, kwargs...)
+
+Per-site heat capacity of the infinite XXZ chain.  At Δ = 0,
+
+    C(β) = (1/π) ∫₀^π (β ε / 2)² sech²(β ε / 2) dk,   ε(k) = -J cos k.
+
+Returns `NaN` (with a warning) for general Δ pending the thermal
+Bethe ansatz of issue #108.
+"""
+function fetch(model::XXZ1D, ::SpecificHeat, ::Infinite; beta::Real, kwargs...)
+    if _xx_is_free_fermion(model)
+        return _xx_thermo_infinite(:specific_heat, model.J, beta)
+    end
+    return _xx_warn_general_delta(:specific_heat, model.Δ)
+end

--- a/test/standalone/test_xxz_xx_infinite.jl
+++ b/test/standalone/test_xxz_xx_infinite.jl
@@ -1,0 +1,125 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Standalone test: free-fermion finite-T observables for XXZ1D at Δ = 0
+# (the XX point) on `Infinite()` boundary conditions.
+#
+# Validates:
+#   • T → 0 limit of Energy(β) reproduces XXZ.jl's GS value -J/π
+#   • T → ∞ limit of Energy(β) → 0 and ThermalEntropy(β) → log 2 per site
+#   • Thermodynamic identity s = β(e − f)
+#   • Energy = ∂(βf)/∂β via central differences (cross-check)
+#   • SpecificHeat is non-negative and matches β² ∂²(βf)/∂β²
+#   • J-scaling: replacing J with αJ scales (e, f) ↦ α·(e_α=1, f_α=1)
+#     at scaled β = β/α (free-fermion homogeneity)
+#   • General Δ ≠ 0 still returns NaN with a warning (preserves the
+#     #108 placeholder contract)
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Test
+
+const _XX = XXZ1D(; J=1.0, Δ=0.0)
+
+@testset "XXZ1D Δ=0 / Infinite — Energy: T = 0 and T = ∞ limits" begin
+    e0 = QAtlas.fetch(_XX, Energy(), Infinite())              # ground state
+    @test e0 ≈ -1 / π atol = 1e-14
+
+    # T = 0 limit (β = 100): converges to e0 within 1e-3
+    e_lowT = QAtlas.fetch(_XX, Energy(), Infinite(); beta=100.0)
+    @test isapprox(e_lowT, -1 / π; atol=1e-3)
+
+    # T = ∞ limit (β = 0.01): energy ≈ 0
+    e_highT = QAtlas.fetch(_XX, Energy(), Infinite(); beta=0.01)
+    @test abs(e_highT) < 5e-3
+end
+
+@testset "XXZ1D Δ=0 / Infinite — high-T entropy → log 2 per site" begin
+    s_highT = QAtlas.fetch(_XX, ThermalEntropy(), Infinite(); beta=0.01)
+    @test isapprox(s_highT, log(2); atol=2e-4)
+    # at intermediate β the entropy is between 0 and log 2
+    s_mid = QAtlas.fetch(_XX, ThermalEntropy(), Infinite(); beta=1.0)
+    @test 0 < s_mid < log(2)
+    # very low T the entropy → 0
+    s_lowT = QAtlas.fetch(_XX, ThermalEntropy(), Infinite(); beta=100.0)
+    @test 0 ≤ s_lowT < 0.05
+end
+
+@testset "XXZ1D Δ=0 / Infinite — Gibbs identity s = β(e − f)" begin
+    for β in (0.05, 0.5, 1.0, 5.0, 20.0)
+        e = QAtlas.fetch(_XX, Energy(), Infinite(); beta=β)
+        f = QAtlas.fetch(_XX, FreeEnergy(), Infinite(); beta=β)
+        s = QAtlas.fetch(_XX, ThermalEntropy(), Infinite(); beta=β)
+        @test isapprox(s, β * (e - f); atol=1e-9)
+    end
+end
+
+@testset "XXZ1D Δ=0 / Infinite — Energy ≈ ∂(βf)/∂β (central differences)" begin
+    # Finite-T thermodynamic identity: e(β) = ∂(βf)/∂β.  Symmetric step
+    # on β; QuadGK rtol 1e-10 ⇒ 5-digit agreement is comfortable.
+    for β0 in (0.5, 1.0, 3.0)
+        h = 1e-4
+        f_plus = QAtlas.fetch(_XX, FreeEnergy(), Infinite(); beta=β0 + h)
+        f_minus = QAtlas.fetch(_XX, FreeEnergy(), Infinite(); beta=β0 - h)
+        # ∂(βf)/∂β ≈ ((β+h) f(β+h) − (β−h) f(β−h)) / (2h)
+        e_finite_diff = ((β0 + h) * f_plus - (β0 - h) * f_minus) / (2h)
+        e_exact = QAtlas.fetch(_XX, Energy(), Infinite(); beta=β0)
+        @test isapprox(e_finite_diff, e_exact; atol=1e-6)
+    end
+end
+
+@testset "XXZ1D Δ=0 / Infinite — SpecificHeat sanity & ∂²(βf)/∂β² check" begin
+    # Thermodynamic identity: C = -β² ∂²(βf)/∂β².
+    #
+    # Derivation (denoting f' = df/dβ):
+    #   s = β(e − f) = β·∂(βf)/∂β − βf = β² f',
+    #   ∂s/∂T = -β² ∂s/∂β = -β²·(2β f' + β² f''),
+    #   C  = T ∂s/∂T = -(β/1)·(2β f' + β² f'')·(1/β) ?  Cleaner:
+    #     ∂²(βf)/∂β² = 2 f' + β f'', so β²·∂²(βf)/∂β² = 2β²f' + β³f''
+    #     and -β²·∂²(βf)/∂β² = C.  Sign verified empirically: at β = 1
+    #     we get c = 0.1045 and β² ∂²(βf)/∂β² = -0.1045.
+    for β0 in (0.5, 1.0, 3.0)
+        c = QAtlas.fetch(_XX, SpecificHeat(), Infinite(); beta=β0)
+        @test c ≥ 0
+        h = 1e-3
+        bf(β) = β * QAtlas.fetch(_XX, FreeEnergy(), Infinite(); beta=β)
+        d2 = (bf(β0 + h) - 2 * bf(β0) + bf(β0 - h)) / h^2
+        @test isapprox(c, -β0^2 * d2; rtol=1e-2)
+    end
+    # Low-T (β = 100): for the gapless XX chain C ∝ T (Luttinger liquid),
+    # so we only require C > 0 and C ≪ the β = 1 peak (~0.1).
+    c_lowT = QAtlas.fetch(_XX, SpecificHeat(), Infinite(); beta=100.0)
+    @test 0 < c_lowT < 5e-2
+    # High-T (β = 0.01): C ∝ β² → 0 as β → 0.
+    c_highT = QAtlas.fetch(_XX, SpecificHeat(), Infinite(); beta=0.01)
+    @test 0 ≤ c_highT < 1e-3
+end
+
+@testset "XXZ1D Δ=0 / Infinite — J-scaling (free-fermion homogeneity)" begin
+    # ε(k) = -J cos k ⇒ e(β; J) = J · e(β·J; 1), f(β; J) = J · f(β·J; 1)
+    # entropy and specific heat depend only on the dimensionless β·J.
+    β = 1.7
+    for J in (0.5, 2.0, 3.7)
+        m = XXZ1D(; J=J, Δ=0.0)
+        e_scaled = QAtlas.fetch(m, Energy(), Infinite(); beta=β)
+        f_scaled = QAtlas.fetch(m, FreeEnergy(), Infinite(); beta=β)
+        e_ref = QAtlas.fetch(_XX, Energy(), Infinite(); beta=β * J)
+        f_ref = QAtlas.fetch(_XX, FreeEnergy(), Infinite(); beta=β * J)
+        @test isapprox(e_scaled, J * e_ref; rtol=1e-9)
+        @test isapprox(f_scaled, J * f_ref; rtol=1e-9)
+        s_scaled = QAtlas.fetch(m, ThermalEntropy(), Infinite(); beta=β)
+        c_scaled = QAtlas.fetch(m, SpecificHeat(), Infinite(); beta=β)
+        s_ref = QAtlas.fetch(_XX, ThermalEntropy(), Infinite(); beta=β * J)
+        c_ref = QAtlas.fetch(_XX, SpecificHeat(), Infinite(); beta=β * J)
+        @test isapprox(s_scaled, s_ref; rtol=1e-9)
+        @test isapprox(c_scaled, c_ref; rtol=1e-9)
+    end
+end
+
+@testset "XXZ1D Δ ≠ 0 / Infinite — warn+NaN placeholder is preserved" begin
+    # Issue #108 owns the general-Δ TBA; for now we still return NaN+warn.
+    for Δ in (0.5, -0.5, 0.99)
+        m = XXZ1D(; J=1.0, Δ=Δ)
+        @test isnan(QAtlas.fetch(m, FreeEnergy(), Infinite(); beta=1.0))
+        @test isnan(QAtlas.fetch(m, ThermalEntropy(), Infinite(); beta=1.0))
+        @test isnan(QAtlas.fetch(m, SpecificHeat(), Infinite(); beta=1.0))
+        @test isnan(QAtlas.fetch(m, Energy(), Infinite(); beta=1.0))
+    end
+end


### PR DESCRIPTION
## Summary

Adds the **XX (Δ = 0) free-fermion path** of issue #95 — closed-form
per-site thermal observables for the infinite XXZ chain at the XX
point. Full closure of #95 still depends on #108 (general-Δ TBA /
NLIE, separate parallel agent).

## What's new

At `Infinite()` boundary condition for `XXZ1D` with `Δ = 0`:

| Quantity | Method |
|---|---|
| `Energy{:per_site}` (with `beta`) | adaptive Gauss-Kronrod |
| `FreeEnergy` | adaptive Gauss-Kronrod |
| `ThermalEntropy` | adaptive Gauss-Kronrod |
| `SpecificHeat` | adaptive Gauss-Kronrod |

For any other Δ these four methods continue to emit a `@warn` and
return `NaN` (the issue #108 placeholder contract is preserved).

## Implementation

`src/models/quantum/XXZ/XXZ_xx_infinite.jl` (new file) holds the
free-fermion integrals plus the Δ = 0-gated `fetch` dispatch. The
single-particle dispersion in the spin convention used by `XXZ.jl`
(`Sᵅ = σᵅ/2`) is

```
ε(k) = -J cos k,    k ∈ [-π, π]
```

and the four per-site potentials are evaluated by `QuadGK.quadgk`
on `[0, π]` (k ↔ -k symmetry folded into the prefactors):

```
f(β) = -(1/(πβ)) ∫₀^π log(2 cosh(βε/2)) dk
e(β) = -(1/(2π)) ∫₀^π ε · tanh(βε/2) dk
s(β) = β · (e − f)
C(β) =  (1/π)    ∫₀^π (βε/2)² sech²(βε/2) dk
```

The β → ∞ limit of `Energy` reproduces `_xxz1d_energy_free_fermion(J) = -J/π` bit-for-bit.

The old `fetch(::XXZ1D, ::Energy{:per_site}, ::Infinite)` ground-state
method in `XXZ.jl` was removed and absorbed into the new file (its
ground-state branch is preserved character-for-character; the new
method just adds a `if haskey(kwargs, :beta)` finite-T fork).

## Convention note

The issue brief used the Pauli-convention dispersion `ε(k) = -2J cos k`
with GS limit `-2J/π`; `XXZ.jl` uses the spin convention which
gives `ε(k) = -J cos k` and GS limit `-J/π` (matching the existing
`_xxz1d_energy_free_fermion`). The implementation follows the spin
convention so the new finite-T methods agree with the existing
ground-state value at β → ∞.

## Test plan

`test/standalone/test_xxz_xx_infinite.jl` (new file): 7 testsets,
46 tests, all passing on Julia 1.12.

- [x] T = 0 limit (β = 100): `Energy` → -1/π within 1e-3
- [x] T = ∞ limit (β = 0.01): `Energy` ≈ 0, `ThermalEntropy` ≈ log 2 per site
- [x] Gibbs identity `s = β(e − f)` over a wide β range
- [x] Energy = ∂(βf)/∂β cross-check via central differences
- [x] SpecificHeat = -β² ∂²(βf)/∂β² cross-check via central differences
- [x] J-scaling: replacing `J → αJ` is equivalent to `β → β/α` in the
  dimensionless thermo
- [x] General Δ ≠ 0 still returns NaN with a warning (preserves the
  #108 placeholder contract)

Run locally:

```
cd /path/to/QAtlas.jl
julia --project=test test/standalone/test_xxz_xx_infinite.jl
```

## Files

- `src/models/quantum/XXZ/XXZ_xx_infinite.jl` — new (268 lines)
- `test/standalone/test_xxz_xx_infinite.jl` — new (115 lines)
- `src/models/quantum/XXZ/XXZ.jl` — old `Energy{:per_site}, Infinite` method removed (replaced by the new file)
- `src/models/quantum/XXZ/XXZ_registry.jl` — three new `@register` rows
- `src/QAtlas.jl` — `include` the new file
- `docs/src/models/quantum/xxz.md` — new "XX Point" section + coverage-matrix updates

Refs #95 (full closure waits on #108).
