### PR TITLE
feat(Universality): CasimirEnergyCorrection — Cardy 1986 finite-size CFT correction (closes #150)

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -69,6 +69,7 @@ makedocs(;
             "XY / Heisenberg" => "universalities/on-models.md",
             "Mean-Field" => "universalities/mean-field.md",
             "E8" => "universalities/e8.md",
+            "CFT Casimir Correction" => "universalities/cft-casimir.md",
         ],
         "Verification" => [
             "verification/index.md",

--- a/docs/src/universalities/cft-casimir.md
+++ b/docs/src/universalities/cft-casimir.md
@@ -1,0 +1,125 @@
+# CFT Finite-Size Casimir Correction
+
+## Overview
+
+For a 1+1D conformal field theory at a critical point with central
+charge $c$ and CFT velocity $v$, the ground-state energy on a finite
+system of size $L$ admits a universal $1/L$ correction
+(Cardy 1986; Blöte–Cardy–Nightingale 1986; Affleck 1986):
+
+$$E_0^{\mathrm{PBC}}(L) = L\,\varepsilon_\infty - \frac{\pi c v}{6 L} + O(L^{-2})$$
+
+$$E_0^{\mathrm{OBC}}(L) = L\,\varepsilon_\infty + \varepsilon_{\mathrm{surf}} - \frac{\pi c v}{24 L} + O(L^{-2})$$
+
+The PBC term comes from quantising the CFT on a cylinder of
+circumference $L$; the OBC term comes from the corresponding strip.
+Their ratio is exactly **4**, a kinematic consequence of the conformal
+map.
+
+QAtlas exposes only the universal $1/L$ correction term — the
+[`CasimirEnergyCorrection`](@ref) quantity — via
+`Universality{C}` dispatch.  The extensive piece
+$L\,\varepsilon_\infty$ and the OBC surface term
+$\varepsilon_{\mathrm{surf}}$ are model-specific and live on the model
+side (e.g. TFIM ground-state energy at the critical field).
+
+---
+
+## API
+
+```julia
+using QAtlas
+
+# 1+1D Ising at criticality, periodic chain of size L = 16, v = 2J = 2
+QAtlas.fetch(Universality(:Ising), CasimirEnergyCorrection(), PBC(); L=16.0, v=2.0)
+# -> -π/96  ≈ -0.0327249...
+
+# Same Ising, OBC
+QAtlas.fetch(Universality(:Ising), CasimirEnergyCorrection(), OBC(); L=16.0, v=2.0)
+# -> -π/384 ≈ -0.0081812...
+
+# Heisenberg chain (SU(2)_1 WZW; v = (π/2) J at the AFM point)
+QAtlas.fetch(Universality(:Heisenberg), CasimirEnergyCorrection(), PBC(); L=16.0, v=π/2)
+```
+
+The CFT velocity `v` is **model-dependent** and supplied by the caller:
+
+| Model                       | Velocity $v$ at criticality                |
+|----------------------------|--------------------------------------------|
+| TFIM, $h = J$              | $v = 2J$                                   |
+| AFM Heisenberg chain        | $v = (\pi/2)\,J$                           |
+| XXZ Luttinger liquid        | $v = v_F = \pi J \sin(\gamma)/\gamma$ (Bethe ansatz)|
+
+QAtlas already exposes `LuttingerVelocity` / `FermiVelocity` /
+`SpinWaveVelocity` for the relevant models — read those, then pass
+the value through as the `v` kwarg.
+
+---
+
+## Supported Universality Classes
+
+| `C`            | $c$       | 1+1D CFT origin                                  |
+|----------------|-----------|--------------------------------------------------|
+| `:Ising`       | $1/2$     | Virasoro minimal model $\mathcal{M}(3,4)$        |
+| `:Potts3`      | $4/5$     | Virasoro minimal model $\mathcal{M}(5,6)$        |
+| `:Potts4`      | $1$       | Free-boson radius limit (marginal)               |
+| `:XY`          | $1$       | Compact free boson / 1+1D Luttinger liquid       |
+| `:Heisenberg`  | $1$       | $\mathrm{SU}(2)_1$ Wess–Zumino–Witten model      |
+
+Other classes (`:KPZ`, `:Percolation`, `:MeanField`, …) raise
+`ErrorException`:
+
+- **KPZ** is non-equilibrium and has no CFT central charge in the
+  Cardy sense.
+- **Percolation** has $c = 0$ but the underlying CFT is *logarithmic*
+  (non-unitary); the simple Cardy formula does not apply in the same
+  form.
+- **Mean-field** lives above the upper critical dimension, with no
+  1+1D CFT representation.
+
+---
+
+## Verification properties
+
+- **PBC : OBC ratio = 4** (kinematic, class-independent):
+
+  $$\frac{E_{0,\mathrm{Casimir}}^{\mathrm{PBC}}}{E_{0,\mathrm{Casimir}}^{\mathrm{OBC}}} = \frac{-\pi c v / (6 L)}{-\pi c v / (24 L)} = 4.$$
+
+- **$L \to \infty$** $\Rightarrow$ value $\to 0$ as $1/L$.
+
+- **Sign**: always negative (the conformal cylinder lowers the
+  ground-state energy below the bulk value).
+
+These properties are exercised in
+`test/standalone/test_universality_cft_casimir.jl`.
+
+---
+
+## Phase 2 (TODO)
+
+The conformal **tower of states** —
+
+$$E_n - E_0 = \frac{2\pi v}{L}\,(h_n + \bar h_n) + O(L^{-2})$$
+
+with primary scaling dimensions $(h, \bar h)$ — is tracked separately
+as future work (issue #150 Phase 2) and will be exposed via a
+`ConformalTower` quantity once implemented.  For 2D Ising the primary
+spectrum is
+
+$$\{(0,0),\ (1/16, 1/16),\ (1/2, 1/2)\}$$
+
+(identity, spin field $\sigma$, energy field $\varepsilon$); see
+[Ising universality](ising.md) for the corresponding scaling
+dimensions.
+
+---
+
+## References
+
+1. J. Cardy, "Operator content of two-dimensional conformally
+   invariant theories", *Nucl. Phys. B* **270**, 186 (1986).
+2. H. W. J. Blöte, J. L. Cardy, M. P. Nightingale, "Conformal
+   invariance, the central charge, and universal finite-size
+   amplitudes at criticality", *Phys. Rev. Lett.* **56**, 742 (1986).
+3. I. Affleck, "Universal term in the free energy at a critical point
+   and the conformal anomaly", *Phys. Rev. Lett.* **56**, 746 (1986).

--- a/docs/src/universalities/cft-casimir.md
+++ b/docs/src/universalities/cft-casimir.md
@@ -42,17 +42,24 @@ QAtlas.fetch(Universality(:Ising), CasimirEnergyCorrection(), OBC(); L=16.0, v=2
 QAtlas.fetch(Universality(:Heisenberg), CasimirEnergyCorrection(), PBC(); L=16.0, v=π/2)
 ```
 
-The CFT velocity `v` is **model-dependent** and supplied by the caller:
+The CFT velocity `v` is **model-dependent** and supplied by the caller.
+Each row below quotes the velocity in the **spin convention used by the
+named model in QAtlas**, so that passing `model.J` (and `model.h`)
+through this column gives the correct numerical `v`:
 
-| Model                       | Velocity $v$ at criticality                |
-|----------------------------|--------------------------------------------|
-| TFIM, $h = J$              | $v = 2J$                                   |
-| AFM Heisenberg chain        | $v = (\pi/2)\,J$                           |
-| XXZ Luttinger liquid        | $v = v_F = \pi J \sin(\gamma)/\gamma$ (Bethe ansatz)|
+| Model                       | Spin convention             | Velocity $v$ at criticality                |
+|-----------------------------|-----------------------------|----------------------------------------------|
+| [`TFIM`](@ref), $h = J$ | Pauli, $H = -J\sum\sigma^z\sigma^z - h\sum\sigma^x$ | $v = 2J$                |
+| AFM Heisenberg chain        | $\mathbf{S} = oldsymbol{\sigma}/2$, $H = J\sum \mathbf{S}\cdot\mathbf{S}$ | $v = (\pi/2)\,J$ |
+| XXZ Luttinger liquid        | $\mathbf{S} = oldsymbol{\sigma}/2$, $H = J\sum(S^xS^x+S^yS^y+\Delta S^zS^z)$ | $v = \pi J\,\sin(\gamma)/\gamma$ (Bethe ansatz, $\Delta=\cos\gamma$) |
 
-QAtlas already exposes `LuttingerVelocity` / `FermiVelocity` /
-`SpinWaveVelocity` for the relevant models — read those, then pass
-the value through as the `v` kwarg.
+If a downstream code uses Pauli normalisation ($\mathbf{S}=oldsymbol{\sigma}$
+without the $1/2$ factor) for a spin-$	frac12$ chain, all three
+velocities pick up a factor of $4$ relative to this table.
+
+QAtlas already exposes [`LuttingerVelocity`](@ref) /
+[`FermiVelocity`](@ref) / [`SpinWaveVelocity`](@ref) for the relevant
+models — read those, then pass the value through as the `v` kwarg.
 
 ---
 

--- a/docs/src/universalities/index.md
+++ b/docs/src/universalities/index.md
@@ -83,6 +83,7 @@ the test suite.
 ## Further Reading
 
 - [Ising](ising.md) --- the most thoroughly studied class
+- [CFT Casimir Correction](cft-casimir.md) --- universal 1/L finite-size correction (Cardy 1986)
 - [Mean-Field](mean-field.md) --- baseline for $d \geq d_c$
 - [Cross-Verification](../verification/cross-checks.md) --- how
   universality predictions are tested against model-specific results

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -45,6 +45,7 @@ export XXStructureFactor, YYStructureFactor, ZZStructureFactor
 export CentralCharge, LuttingerParameter, CorrelationLength
 export FermiVelocity, LuttingerVelocity, SpinWaveVelocity
 export E8Spectrum
+export CasimirEnergyCorrection
 
 # --- TFIM Infinite dynamic helpers ---
 export tfim_quasiparticle_dispersion, tfim_two_spinon_dos

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -396,7 +396,7 @@ here so `src/core/alias.jl` can reference it without circular loads.
 """
 struct E8Spectrum <: AbstractQuantity end
 
-raw"""
+"""
     CasimirEnergyCorrection() <: AbstractQuantity
 
 Universal `1/L` finite-size correction to the ground-state energy of a
@@ -406,18 +406,18 @@ For a critical 1+1D system with central charge `c` and CFT velocity
 `v` on a system of size `L`:
 
 - Periodic boundary (PBC):
-  ``E_0(L) = L\,\varepsilon_\infty - \dfrac{\pi c v}{6 L} + O(L^{-2})``
+  ``E_0(L) = L\\,\\varepsilon_\\infty - \\dfrac{\\pi c v}{6 L} + O(L^{-2})``
 - Open boundary (OBC):
-  ``E_0(L) = L\,\varepsilon_\infty + \varepsilon_{\mathrm{surf}} - \dfrac{\pi c v}{24 L} + O(L^{-2})``
+  ``E_0(L) = L\\,\\varepsilon_\\infty + \\varepsilon_{\\mathrm{surf}} - \\dfrac{\\pi c v}{24 L} + O(L^{-2})``
 
 This quantity returns *only* the universal ``1/L`` correction term
-(``-\pi c v/(6 L)`` at PBC, ``-\pi c v/(24 L)`` at OBC), not the
-extensive ``L \varepsilon_\infty`` piece nor the OBC surface term
-``\varepsilon_{\mathrm{surf}}``.  The PBC-to-OBC ratio is exactly 4,
+(``-\\pi c v/(6 L)`` at PBC, ``-\\pi c v/(24 L)`` at OBC), not the
+extensive ``L \\varepsilon_\\infty`` piece nor the OBC surface term
+``\\varepsilon_{\\mathrm{surf}}``.  The PBC-to-OBC ratio is exactly 4,
 independent of the universality class.
 
 The CFT velocity `v` is model-dependent (e.g. ``v = 2J`` for the TFIM
-at the critical point, ``v = (\pi/2) J`` for the AFM Heisenberg chain,
+at the critical point, ``v = (\\pi/2) J`` for the AFM Heisenberg chain,
 ``v = v_F`` for the XXZ Luttinger liquid) and is supplied by the caller
 as a kwarg.  The central charge `c` is read from the universality
 class via the same data the `Universality{C}` entry exposes for
@@ -431,8 +431,8 @@ class via the same data the `Universality{C}` entry exposes for
 
 !!! note "Phase 2 (TODO)"
     The conformal *tower of states* --- primary scaling dimensions
-    ``(h, \bar h)`` and the
-    ``E_n - E_0 = (2\pi v/L)(h_n + \bar h_n)`` excitation pattern ---
+    ``(h, \\bar h)`` and the
+    ``E_n - E_0 = (2\\pi v/L)(h_n + \\bar h_n)`` excitation pattern ---
     is tracked separately as future work (Phase 2 of issue #150) and
     will be exposed via a `ConformalTower` quantity once implemented.
 """

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -396,6 +396,48 @@ here so `src/core/alias.jl` can reference it without circular loads.
 """
 struct E8Spectrum <: AbstractQuantity end
 
+raw"""
+    CasimirEnergyCorrection() <: AbstractQuantity
+
+Universal `1/L` finite-size correction to the ground-state energy of a
+1+1D conformal field theory.
+
+For a critical 1+1D system with central charge `c` and CFT velocity
+`v` on a system of size `L`:
+
+- Periodic boundary (PBC):
+  ``E_0(L) = L\,\varepsilon_\infty - \dfrac{\pi c v}{6 L} + O(L^{-2})``
+- Open boundary (OBC):
+  ``E_0(L) = L\,\varepsilon_\infty + \varepsilon_{\mathrm{surf}} - \dfrac{\pi c v}{24 L} + O(L^{-2})``
+
+This quantity returns *only* the universal ``1/L`` correction term
+(``-\pi c v/(6 L)`` at PBC, ``-\pi c v/(24 L)`` at OBC), not the
+extensive ``L \varepsilon_\infty`` piece nor the OBC surface term
+``\varepsilon_{\mathrm{surf}}``.  The PBC-to-OBC ratio is exactly 4,
+independent of the universality class.
+
+The CFT velocity `v` is model-dependent (e.g. ``v = 2J`` for the TFIM
+at the critical point, ``v = (\pi/2) J`` for the AFM Heisenberg chain,
+``v = v_F`` for the XXZ Luttinger liquid) and is supplied by the caller
+as a kwarg.  The central charge `c` is read from the universality
+class via the same data the `Universality{C}` entry exposes for
+[`CriticalExponents`](@ref).
+
+# References
+- J. Cardy, *Nucl. Phys. B* **270**, 186 (1986).
+- H. W. J. Blöte, J. L. Cardy, M. P. Nightingale, *Phys. Rev. Lett.*
+  **56**, 742 (1986).
+- I. Affleck, *Phys. Rev. Lett.* **56**, 746 (1986).
+
+!!! note "Phase 2 (TODO)"
+    The conformal *tower of states* --- primary scaling dimensions
+    ``(h, \bar h)`` and the
+    ``E_n - E_0 = (2\pi v/L)(h_n + \bar h_n)`` excitation pattern ---
+    is tracked separately as future work (Phase 2 of issue #150) and
+    will be exposed via a `ConformalTower` quantity once implemented.
+"""
+struct CasimirEnergyCorrection <: AbstractQuantity end
+
 # Other spectrum / universality tag types (`TightBindingSpectrum`,
 # `ExactSpectrum`, `GroundStateEnergyDensity`, `CriticalExponents`,
 # `GrowthExponents`) are currently defined in their respective model /

--- a/src/universalities/Universality.jl
+++ b/src/universalities/Universality.jl
@@ -54,3 +54,116 @@ KPZ-type growth / roughness / dynamic exponents.  Returns
 `(β_growth, α_rough, z)` instead of the equilibrium set.
 """
 struct GrowthExponents <: AbstractQuantity end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CFT Casimir / finite-size ground-state energy correction (Cardy 1986)
+#
+# For a 1+1D conformal field theory with central charge c and CFT
+# velocity v on a system of size L the ground-state energy admits the
+# expansion
+#
+#   E_0^PBC(L) = L · ε_∞               - π c v / (6  L) + O(L^{-2})
+#   E_0^OBC(L) = L · ε_∞ + ε_surf      - π c v / (24 L) + O(L^{-2})
+#
+# Only the universal 1/L correction is exposed here.  Sign convention:
+# the correction is *negative*; the system gains energy from the
+# Casimir-like vacuum-mode shift on a finite cylinder / strip.
+#
+# Provenance: each per-class central charge below cites a primary
+# reference for the 1+1D CFT, distinct from (but consistent with) the
+# 2D classical universality data already shipped under
+# `CriticalExponents`.  The PBC-to-OBC ratio of 4 is a *kinematic*
+# consequence of the conformal map between cylinder and strip.
+#
+# Phase 2 (TODO, issue #150 follow-up): expose the primary tower
+# (h, h̄) for each minimal model via a separate `ConformalTower`
+# quantity.  Not implemented in this commit.
+#
+# References:
+#   J. Cardy, Nucl. Phys. B 270, 186 (1986).
+#   H. W. J. Blöte, J. L. Cardy, M. P. Nightingale,
+#     Phys. Rev. Lett. 56, 742 (1986).
+#   I. Affleck, Phys. Rev. Lett. 56, 746 (1986).
+# ─────────────────────────────────────────────────────────────────────────────
+
+raw"""
+    _universality_central_charge(::Universality{C}) -> Real
+
+Return the central charge `c` of the 1+1D CFT associated with
+universality class `C`.  Used internally by
+[`CasimirEnergyCorrection`](@ref) fetch.
+
+Supported classes:
+
+| `C`           | `c`     | Reference                                            |
+|---------------|---------|------------------------------------------------------|
+| `:Ising`      | `1//2`  | BPZ minimal model M(3,4); Cardy 1986                 |
+| `:Potts3`     | `4//5`  | M(5,6) minimal model; Dotsenko–Fateev 1984           |
+| `:Potts4`     | `1//1`  | Free-boson radius limit; Saleur 1987                 |
+| `:XY`         | `1//1`  | Compact free boson (1+1D Luttinger liquid)           |
+| `:Heisenberg` | `1//1`  | SU(2)_1 WZW (Affleck–Haldane); 1+1D AFM chain        |
+
+Other classes raise `ErrorException`.  The 2D classical critical
+percolation CFT is c = 0 (logarithmic, non-unitary) and is *not*
+described by the simple Cardy formula in the same form, so it is
+deliberately excluded here.  KPZ is non-equilibrium and has no CFT
+central charge.  Mean-field is above the upper critical dimension and
+has no 1+1D CFT representation.
+"""
+_universality_central_charge(::Universality{:Ising}) = 1 // 2
+_universality_central_charge(::Universality{:Potts3}) = 4 // 5
+_universality_central_charge(::Universality{:Potts4}) = 1 // 1
+_universality_central_charge(::Universality{:XY}) = 1 // 1
+_universality_central_charge(::Universality{:Heisenberg}) = 1 // 1
+
+function _universality_central_charge(::Universality{C}) where {C}
+    return error(
+        "QAtlas Universality{:$C}: no 1+1D CFT central charge is " *
+        "registered for this universality class.  CasimirEnergyCorrection " *
+        "requires `c` from a unitary 1+1D CFT; classes such as :KPZ " *
+        "(non-equilibrium), :Percolation (non-unitary, c = 0 logarithmic), " *
+        "and :MeanField (no 1+1D CFT) are not supported.  If `C` should " *
+        "have a 1+1D CFT entry, add a method to " *
+        "`QAtlas._universality_central_charge` and document the source.",
+    )
+end
+
+raw"""
+    fetch(::Universality{C}, ::CasimirEnergyCorrection, ::PBC; L, v) -> Real
+
+Return the universal Cardy 1/L correction
+``-\pi c v / (6 L)`` at periodic boundary conditions, where `c` is
+the central charge of the 1+1D CFT for class `C` (see
+[`_universality_central_charge`](@ref)) and `v` is the CFT velocity
+supplied by the caller.
+
+`L` and `v` must be positive.  The return type is `Rational` when both
+`c` is rational and `v` is rational/integer; otherwise `Float64`.
+"""
+function fetch(
+    u::Universality{C}, ::CasimirEnergyCorrection, ::PBC; L::Real, v::Real, kwargs...
+) where {C}
+    L > 0 || throw(ArgumentError("CasimirEnergyCorrection: L must be positive; got $L"))
+    v > 0 || throw(ArgumentError("CasimirEnergyCorrection: v must be positive; got $v"))
+    c = _universality_central_charge(u)
+    return -π * c * v / (6 * L)
+end
+
+raw"""
+    fetch(::Universality{C}, ::CasimirEnergyCorrection, ::OBC; L, v) -> Real
+
+Return the universal Cardy 1/L correction
+``-\pi c v / (24 L)`` at open boundary conditions.
+
+The PBC : OBC ratio of the 1/L term is exactly 4, a kinematic
+consequence of the conformal map between the cylinder (PBC) and the
+strip (OBC).
+"""
+function fetch(
+    u::Universality{C}, ::CasimirEnergyCorrection, ::OBC; L::Real, v::Real, kwargs...
+) where {C}
+    L > 0 || throw(ArgumentError("CasimirEnergyCorrection: L must be positive; got $L"))
+    v > 0 || throw(ArgumentError("CasimirEnergyCorrection: v must be positive; got $v"))
+    c = _universality_central_charge(u)
+    return -π * c * v / (24 * L)
+end

--- a/test/standalone/test_universality_cft_casimir.jl
+++ b/test/standalone/test_universality_cft_casimir.jl
@@ -1,0 +1,113 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Standalone test: CFT Casimir / finite-size ground-state energy correction
+# (Cardy 1986, Blöte–Cardy–Nightingale 1986, Affleck 1986)
+#
+# Phase 1 of issue #150 — only the universal 1/L correction is exercised.
+# The `ConformalTower` quantity is Phase 2 / out of scope here.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Test
+
+@testset "Universality: CFT Casimir correction (Cardy 1986)" begin
+    # ─── Ising c = 1/2 PBC, exact closed-form check ─────────────────────────
+    @testset "Ising c=1/2 PBC reference value" begin
+        # E_0^PBC 1/L term = -π c v / (6 L)
+        # at c = 1/2, v = 2.0, L = 16.0 → -π · (1/2) · 2 / (6 · 16) = -π/96
+        val = QAtlas.fetch(
+            Universality(:Ising), CasimirEnergyCorrection(), PBC(); L=16.0, v=2.0
+        )
+        @test val ≈ -π / 96 atol = 1e-12
+    end
+
+    # ─── Ising c = 1/2 OBC ──────────────────────────────────────────────────
+    @testset "Ising c=1/2 OBC reference value" begin
+        val = QAtlas.fetch(
+            Universality(:Ising), CasimirEnergyCorrection(), OBC(); L=16.0, v=2.0
+        )
+        # at c = 1/2, v = 2.0, L = 16.0 → -π · (1/2) · 2 / (24 · 16) = -π/384
+        @test val ≈ -π / 384 atol = 1e-12
+    end
+
+    # ─── PBC : OBC ratio = 4, class-independent (kinematic CFT result) ──────
+    @testset "PBC : OBC ratio = 4, class-independent" begin
+        for class in (:Ising, :Potts3, :Potts4, :XY, :Heisenberg)
+            pbc = QAtlas.fetch(
+                Universality(class), CasimirEnergyCorrection(), PBC(); L=20.0, v=1.7
+            )
+            obc = QAtlas.fetch(
+                Universality(class), CasimirEnergyCorrection(), OBC(); L=20.0, v=1.7
+            )
+            @test pbc ≈ 4 * obc atol = 1e-12
+        end
+    end
+
+    # ─── L → ∞ limit → 0 (1/L scaling) ──────────────────────────────────────
+    @testset "Thermodynamic limit: 1/L scaling, value -> 0" begin
+        v = 2.0
+        for L in (1e3, 1e4, 1e5, 1e6)
+            pbc = QAtlas.fetch(
+                Universality(:Ising), CasimirEnergyCorrection(), PBC(); L=L, v=v
+            )
+            # 1/L scaling: pbc * L is L-independent
+            @test pbc * L ≈ -π * (1 // 2) * v / 6 atol = 1e-12
+        end
+        # vanishes at very large L
+        huge = QAtlas.fetch(
+            Universality(:Ising), CasimirEnergyCorrection(), PBC(); L=1e10, v=2.0
+        )
+        @test abs(huge) < 1e-9
+    end
+
+    # ─── Multi-class numeric values (Potts3 c=4/5, Potts4 c=1, XY/Heis c=1) ─
+    @testset "Per-class central charge values" begin
+        # Potts3 c = 4/5
+        p3 = QAtlas.fetch(
+            Universality(:Potts3), CasimirEnergyCorrection(), PBC(); L=10.0, v=1.0
+        )
+        @test p3 ≈ -π * (4 // 5) / 60 atol = 1e-12  # -π · (4/5) · 1 / (6·10)
+        # Potts4 c = 1
+        p4 = QAtlas.fetch(
+            Universality(:Potts4), CasimirEnergyCorrection(), PBC(); L=10.0, v=1.0
+        )
+        @test p4 ≈ -π / 60 atol = 1e-12
+        # XY c = 1
+        xy = QAtlas.fetch(
+            Universality(:XY), CasimirEnergyCorrection(), PBC(); L=10.0, v=1.0
+        )
+        @test xy ≈ -π / 60 atol = 1e-12
+        # Heisenberg c = 1
+        hb = QAtlas.fetch(
+            Universality(:Heisenberg), CasimirEnergyCorrection(), PBC(); L=10.0, v=1.0
+        )
+        @test hb ≈ -π / 60 atol = 1e-12
+    end
+
+    # ─── Unsupported classes raise ErrorException ───────────────────────────
+    @testset "Unsupported classes raise ErrorException" begin
+        # KPZ: non-equilibrium, no CFT central charge
+        @test_throws ErrorException QAtlas.fetch(
+            Universality(:KPZ), CasimirEnergyCorrection(), PBC(); L=16.0, v=2.0
+        )
+        # Percolation: non-unitary logarithmic CFT, c = 0 not via Cardy
+        @test_throws ErrorException QAtlas.fetch(
+            Universality(:Percolation), CasimirEnergyCorrection(), OBC(); L=16.0, v=2.0
+        )
+        # Unknown class
+        @test_throws ErrorException QAtlas.fetch(
+            Universality(:Bogus), CasimirEnergyCorrection(), PBC(); L=16.0, v=2.0
+        )
+    end
+
+    # ─── Domain checks: L, v must be positive ───────────────────────────────
+    @testset "Argument validation" begin
+        @test_throws ArgumentError QAtlas.fetch(
+            Universality(:Ising), CasimirEnergyCorrection(), PBC(); L=-1.0, v=2.0
+        )
+        @test_throws ArgumentError QAtlas.fetch(
+            Universality(:Ising), CasimirEnergyCorrection(), PBC(); L=16.0, v=0.0
+        )
+        @test_throws ArgumentError QAtlas.fetch(
+            Universality(:Ising), CasimirEnergyCorrection(), OBC(); L=0.0, v=2.0
+        )
+    end
+end


### PR DESCRIPTION
## Summary

Closes #150 (Phase 1 only — `ConformalTower` Phase 2 is explicitly deferred).

Adds the universal `1/L` finite-size ground-state energy correction for 1+1D CFTs (Cardy 1986; Blöte–Cardy–Nightingale 1986; Affleck 1986) at the `Universality{C}` level.

$$E_0^{\mathrm{PBC}}(L) = L\,\varepsilon_\infty - \frac{\pi c v}{6 L} + O(L^{-2})$$

$$E_0^{\mathrm{OBC}}(L) = L\,\varepsilon_\infty + \varepsilon_{\mathrm{surf}} - \frac{\pi c v}{24 L} + O(L^{-2})$$

The new `CasimirEnergyCorrection <: AbstractQuantity` exposes **only** the universal `1/L` term; the extensive bulk and OBC surface pieces remain on the model side. The PBC : OBC ratio of `4` is a kinematic class-independent CFT result.

| `C`             | `c`     | 1+1D CFT origin                                  |
|-----------------|---------|--------------------------------------------------|
| `:Ising`        | `1//2`  | Virasoro minimal model $\mathcal{M}(3,4)$        |
| `:Potts3`       | `4//5`  | Virasoro minimal model $\mathcal{M}(5,6)$        |
| `:Potts4`       | `1//1`  | Free-boson radius limit (marginal)               |
| `:XY`           | `1//1`  | Compact free boson / 1+1D Luttinger liquid       |
| `:Heisenberg`   | `1//1`  | $\mathrm{SU}(2)_1$ WZW model                     |

Other classes (`:KPZ`, `:Percolation`, `:MeanField`, …) raise `ErrorException` with a clear diagnostic — KPZ has no CFT central charge, Percolation is a non-unitary logarithmic CFT (`c = 0` but the simple Cardy formula does not apply in the same form), and Mean-field has no 1+1D CFT representation.

The CFT velocity `v` is supplied by the caller (model-dependent: `2J` for TFIM at criticality, `(π/2)J` for AFM Heisenberg, $v_F$ for XXZ Luttinger liquid, etc.).

## Changes

- `src/core/quantities.jl`: new `CasimirEnergyCorrection` struct with full Cardy-formula docstring + references.
- `src/QAtlas.jl`: export `CasimirEnergyCorrection`.
- `src/universalities/Universality.jl`:
  - `_universality_central_charge(::Universality{C})` per-class table.
  - `fetch(::Universality{C}, ::CasimirEnergyCorrection, ::PBC; L, v)` → `-π c v / (6 L)`.
  - `fetch(::Universality{C}, ::CasimirEnergyCorrection, ::OBC; L, v)` → `-π c v / (24 L)`.
- `test/standalone/test_universality_cft_casimir.jl`: 22 tests (Ising PBC reference value, OBC reference, PBC:OBC = 4 across all 5 classes, 1/L scaling, per-class central charges, ErrorException for unsupported classes, argument validation).
- `docs/src/universalities/cft-casimir.md` + `docs/make.jl` + `docs/src/universalities/index.md`: new doc page registered in the Universalities section.

## Phase 2 (TODO, out of scope)

The conformal **tower of states**

$$E_n - E_0 = \frac{2\pi v}{L}\,(h_n + \bar h_n) + O(L^{-2})$$

with primary scaling dimensions `(h, h̄)` is tracked separately and will be exposed via a `ConformalTower` quantity in a follow-up. Documented as TODO in the docstring and on the doc page.

## Test plan

- [x] Targeted: `julia --project=test test/standalone/test_universality_cft_casimir.jl` → **22 / 22 pass** (0.2 s)
- [x] Smoke: `Universality(:Ising) + PBC, L=16, v=2.0` → `-π/96` exact (diff 0.0)
- [x] Aqua sanity check on QAtlas module → 10 / 10 pass (no export drift)
- [x] Regression: `test/standalone/test_universality_exponents.jl` still green
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
