### PR TITLE
feat(Universality): Virasoro minimal models M(p,p_prime) + WZW SU(2)_k (closes #165)

### DIFF
--- a/docs/src/universalities/cft_minimal_models.md
+++ b/docs/src/universalities/cft_minimal_models.md
@@ -1,0 +1,144 @@
+# CFT: Virasoro Minimal Models and WZW SU(2)$_k$
+
+QAtlas exposes two parametric families of two-dimensional rational
+conformal field theories as concrete dispatch tags:
+
+- [`MinimalModel(p, p_prime)`](@ref) — unitary and non-unitary
+  Virasoro minimal models $\mathcal{M}(p, p^\prime)$.
+- [`WZWSU2(k)`](@ref) — Wess–Zumino–Witten models with affine
+  $\widehat{\mathfrak{su}}(2)_k$ symmetry.
+
+Both expose their CFT data as exact `Rational{Int}` values via
+[`fetch`](@ref) on [`CentralCharge`](@ref),
+[`ConformalWeights`](@ref), and (minimal models only)
+[`PrimaryFields`](@ref).
+
+---
+
+## Virasoro Minimal Models $\mathcal{M}(p, p^\prime)$
+
+Following Belavin, Polyakov, Zamolodchikov (BPZ, 1984) the central
+charge of the minimal model labelled by coprime integers
+$p > p^\prime \geq 2$ is
+
+$$c(p, p^\prime) = 1 - \frac{6 (p - p^\prime)^2}{p \, p^\prime}.$$
+
+Primary fields are labelled by $(r, s)$ with $1 \leq r \leq p^\prime - 1$,
+$1 \leq s \leq p - 1$, with conformal weight given by the **Kac formula**:
+
+$$h_{r, s}(p, p^\prime) = \frac{(p \, r - p^\prime s)^2 - (p - p^\prime)^2}{4 \, p \, p^\prime}.$$
+
+The Kac table has the symmetry $h_{r, s} = h_{p^\prime - r, p - s}$,
+so the number of distinct primaries is $(p - 1)(p^\prime - 1) / 2$.
+
+### Special cases
+
+| Model                    | $(p, p^\prime)$ | $c$       | Primary weights $h$            |
+|:-------------------------|:----------------|:----------|:--------------------------------|
+| Yang–Lee (non-unitary)   | $(5, 2)$        | $-22/5$   | $0, -1/5$                       |
+| **Ising** $\mathcal{M}(4,3)$ | $(4, 3)$    | $1/2$     | $h_{1,1}=0,\ h_{1,2}=1/16,\ h_{2,1}=1/2$ |
+| Tricritical Ising        | $(5, 4)$        | $7/10$    | $0,\ 3/80,\ 1/10,\ 7/16,\ 3/5,\ 3/2$ |
+| 3-state Potts (chiral)   | $(6, 5)$        | $4/5$     | 10 primaries                    |
+
+### Usage
+
+```julia
+using QAtlas
+
+m = MinimalModel(4, 3)
+fetch(m, CentralCharge())                  # 1//2
+fetch(m, ConformalWeights(); r=1, s=2)     # 1//16  (σ)
+fetch(m, ConformalWeights(); r=2, s=1)     # 1//2   (ε)
+fetch(m, PrimaryFields())                  # 3 NamedTuples (r, s, h)
+```
+
+### Cross-check with `Universality(:Ising)`
+
+The `c = 1//2` stored on `Universality(:Ising)`'s exponent
+NamedTuple at $d = 2$ agrees identically with
+`fetch(MinimalModel(4, 3), CentralCharge())`:
+
+```julia
+fetch(MinimalModel(4, 3), CentralCharge()) ==
+    QAtlas.fetch(Universality(:Ising), CriticalExponents(); d=2).c
+# true
+```
+
+This is a sanity check that the CFT-side parametric data and the
+universality-class table agree as `Rational{Int}` values.
+
+### Validation
+
+`MinimalModel(p, p_prime)` validates its arguments at construction
+time and throws `DomainError` for any of:
+
+- $p^\prime < 2$,
+- $p \leq p^\prime$,
+- $\gcd(p, p^\prime) \neq 1$ (non-coprime).
+
+`fetch(::MinimalModel, ConformalWeights(); r, s)` throws
+`DomainError` for $(r, s)$ outside the fundamental rectangle
+$1 \leq r \leq p^\prime - 1$, $1 \leq s \leq p - 1$.
+
+---
+
+## WZW SU(2)$_k$
+
+Following Knizhnik–Zamolodchikov (1984) the Sugawara central charge
+of the level-$k$ WZW model on the affine algebra
+$\widehat{\mathfrak{su}}(2)_k$ is
+
+$$c(k) = \frac{3 k}{k + 2}, \qquad k = 1, 2, 3, \dots$$
+
+The primary fields are labelled by SU(2) spin
+$j \in \{0, 1/2, 1, 3/2, \dots, k/2\}$ with conformal weight
+
+$$h_j = \frac{j (j + 1)}{k + 2}.$$
+
+### Special cases
+
+| Level | $c$  | Spectrum $j$         | Notes                                                |
+|:-----:|:----:|:---------------------|:-----------------------------------------------------|
+| 1     | 1    | $0, 1/2$             | Free boson at SU(2)-symmetric radius; low-energy theory of the spin-$1/2$ Heisenberg AFM (Affleck 1989) |
+| 2     | 3/2  | $0, 1/2, 1$          | Equivalent to Ising × free Majorana                  |
+| 3     | 9/5  | $0, 1/2, 1, 3/2$     |                                                      |
+
+### Usage
+
+```julia
+fetch(WZWSU2(1), CentralCharge())                    # 1//1
+fetch(WZWSU2(1), ConformalWeights(); j=1//2)         # 1//4
+fetch(WZWSU2(2), ConformalWeights(); j=1)            # 1//2
+```
+
+### Validation
+
+`WZWSU2(k)` requires $k \geq 1$ and throws `DomainError` otherwise.
+
+`fetch(::WZWSU2, ConformalWeights(); j)` requires `j` to be a
+non-negative half-integer (`Integer` or `Rational{Int}` with
+$2 j \in \mathbb{Z}_{\geq 0}$) with $0 \leq j \leq k/2$.  Floats and
+non-half-integer rationals (e.g. `1//3`) raise `DomainError`.
+
+---
+
+## References
+
+- A. A. Belavin, A. M. Polyakov, A. B. Zamolodchikov,
+  *Infinite conformal symmetry in two-dimensional quantum field theory*,
+  Nucl. Phys. **B 241**, 333 (1984).
+- D. Friedan, Z. Qiu, S. Shenker,
+  *Conformal invariance, unitarity, and critical exponents in two dimensions*,
+  Phys. Rev. Lett. **52**, 1575 (1984).
+- V. G. Knizhnik, A. B. Zamolodchikov,
+  *Current algebra and Wess–Zumino model in two dimensions*,
+  Nucl. Phys. **B 247**, 83 (1984).
+- E. Witten,
+  *Non-abelian bosonization in two dimensions*,
+  Comm. Math. Phys. **92**, 455 (1984).
+- P. Di Francesco, P. Mathieu, D. Sénéchal,
+  *Conformal Field Theory* (Springer, 1997), Ch. 7 (minimal models),
+  Ch. 15 (WZW).
+- I. Affleck,
+  *Quantum spin chains and the Haldane gap*,
+  J. Phys.: Condens. Matter **1**, 3047 (1989).

--- a/docs/src/universalities/cft_minimal_models.md
+++ b/docs/src/universalities/cft_minimal_models.md
@@ -100,7 +100,7 @@ $$h_j = \frac{j (j + 1)}{k + 2}.$$
 | Level | $c$  | Spectrum $j$         | Notes                                                |
 |:-----:|:----:|:---------------------|:-----------------------------------------------------|
 | 1     | 1    | $0, 1/2$             | Free boson at SU(2)-symmetric radius; low-energy theory of the spin-$1/2$ Heisenberg AFM (Affleck 1989) |
-| 2     | 3/2  | $0, 1/2, 1$          | Equivalent to Ising × free Majorana                  |
+| 2     | 3/2  | $0, 1/2, 1$          | 3 free Majorana fermions (smallest $\mathcal{N}{=}1$ super-Virasoro minimal model) |
 | 3     | 9/5  | $0, 1/2, 1, 3/2$     |                                                      |
 
 ### Usage

--- a/docs/src/universalities/index.md
+++ b/docs/src/universalities/index.md
@@ -32,6 +32,8 @@ family of physical models.
 | Heisenberg | `:Heisenberg` | $d = 3, \geq 4$ | Bootstrap / MF | $\mathrm{O}(3)$ symmetry | [→](on-models.md) |
 | Mean-Field | `MeanField()` | $d \geq d_c$ | Exact | Baseline reference | [→](mean-field.md) |
 | E8 | `:E8` | — | Exact mass ratios | Integrable field theory | [→](e8.md) |
+| Virasoro minimal model | `MinimalModel(p, p_prime)` | $d = 2$ | Exact (Rational) | $\mathcal{M}(p, p^\prime)$ central charge & Kac weights | [→](cft_minimal_models.md) |
+| WZW SU(2)$_k$ | `WZWSU2(k)` | $d = 2$ | Exact (Rational) | Sugawara $c$, primary $h_j$ | [→](cft_minimal_models.md) |
 
 ---
 

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -43,6 +43,7 @@ export SusceptibilityXX, SusceptibilityYY, SusceptibilityZZ
 export XXCorrelation, YYCorrelation, ZZCorrelation
 export XXStructureFactor, YYStructureFactor, ZZStructureFactor
 export CentralCharge, LuttingerParameter, CorrelationLength
+export ConformalWeights, PrimaryFields
 export FermiVelocity, LuttingerVelocity, SpinWaveVelocity
 export E8Spectrum
 
@@ -52,6 +53,7 @@ export tfim_quasiparticle_dispersion, tfim_two_spinon_dos
 # --- Universality Classes ---
 export Universality, CriticalExponents, GrowthExponents
 export Ising2D, KPZ1D, MeanField  # backward-compatible aliases
+export MinimalModel, WZWSU2       # 2D rational-CFT dispatch tags
 include("universalities/Universality.jl")
 include("universalities/E8.jl")
 include("universalities/MeanField.jl")
@@ -60,6 +62,8 @@ include("universalities/KPZ.jl")
 include("universalities/Percolation.jl")
 include("universalities/Potts.jl")
 include("universalities/ONModel.jl")
+include("universalities/MinimalModel.jl")
+include("universalities/WZW.jl")
 
 # --- Models ---
 # Layout: `<class>/<Model>/<Model>.jl` (with optional sibling axis files like

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -329,6 +329,33 @@ pages return literature values.
 struct CentralCharge <: AbstractQuantity end
 
 """
+    ConformalWeights() <: AbstractQuantity
+
+Primary scaling dimension `h` of a 2D rational CFT.  For Virasoro
+[`MinimalModel`](@ref) this is the Kac-table entry `h_{r,s}`; for
+[`WZWSU2`](@ref) it is the SU(2)-spin label `h_j = j(j+1)/(k+2)`.
+
+Concrete model fetch methods take additional keyword arguments
+identifying the primary (`r`, `s` for `MinimalModel`; `j` for
+`WZWSU2`) and return an exact `Rational{Int}`.
+"""
+struct ConformalWeights <: AbstractQuantity end
+
+"""
+    PrimaryFields() <: AbstractQuantity
+
+Full list of primary fields of a 2D rational CFT.  For
+[`MinimalModel`](@ref) the result is a `Vector{NamedTuple{(:r, :s, :h)}}`
+of length `(p - 1)(p_prime - 1) / 2`, with one entry per Kac-symmetry
+orbit.
+
+Future CFT classes may return different NamedTuple schemas (e.g.
+`(j, h)` for WZW). The return type is therefore a
+`Vector{<:NamedTuple}` whose schema depends on the model.
+"""
+struct PrimaryFields <: AbstractQuantity end
+
+"""
     CorrelationLength() <: AbstractQuantity
 
 Two-point correlation length `ξ` controlling the exponential decay of

--- a/src/universalities/MinimalModel.jl
+++ b/src/universalities/MinimalModel.jl
@@ -1,0 +1,155 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Virasoro minimal models M(p, p_prime)
+#
+# References:
+#   Belavin, Polyakov, Zamolodchikov (BPZ),
+#     "Infinite conformal symmetry in two-dimensional quantum field
+#      theory", Nucl. Phys. B 241, 333 (1984).
+#   Friedan, Qiu, Shenker, Phys. Rev. Lett. 52, 1575 (1984)
+#     — minimal-model unitarity.
+#   Di Francesco, Mathieu, Sénéchal,
+#     "Conformal Field Theory" (Springer, 1997), Ch. 7.
+#
+# For coprime integers p > p_prime ≥ 2:
+#
+#   c(p, p_prime) = 1 - 6 (p - p_prime)^2 / (p p_prime)
+#
+#   h_{r,s}(p, p_prime) = ((p r - p_prime s)^2 - (p - p_prime)^2)
+#                         / (4 p p_prime),
+#       1 ≤ r ≤ p_prime - 1,  1 ≤ s ≤ p - 1
+#
+# Kac symmetry: h_{r,s} = h_{p_prime - r, p - s}.
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    MinimalModel(p::Int, p_prime::Int) <: AbstractQAtlasModel
+
+Virasoro minimal model M(p, p_prime).  `p` and `p_prime` must be
+coprime integers with `p > p_prime ≥ 2`.  Construction validates
+those conditions and throws `DomainError` otherwise.
+
+Special cases (cross-check):
+
+| Model                     | (p, p_prime) | c     |
+|---------------------------|:------------:|:-----:|
+| Yang–Lee (non-unitary)    | (5, 2)       | -22/5 |
+| Ising                     | (4, 3)       |  1/2  |
+| Tricritical Ising         | (5, 4)       |  7/10 |
+| 3-state Potts (chiral)    | (6, 5)       |  4/5  |
+
+The Ising special case `MinimalModel(4, 3)` reproduces the central
+charge stored in `Universality(:Ising)`'s `CriticalExponents` table
+(`c = 1//2`).
+
+Use [`fetch`](@ref) with [`CentralCharge`](@ref) or
+[`ConformalWeights`](@ref):
+
+```julia
+fetch(MinimalModel(4, 3), CentralCharge())                  # 1//2
+fetch(MinimalModel(4, 3), ConformalWeights(); r=1, s=2)     # 1//16
+```
+
+See also: [`WZWSU2`](@ref), [`Universality`](@ref),
+[`CentralCharge`](@ref), [`ConformalWeights`](@ref),
+[`PrimaryFields`](@ref).
+"""
+struct MinimalModel <: AbstractQAtlasModel
+    p::Int
+    p_prime::Int
+    function MinimalModel(p::Integer, p_prime::Integer)
+        p_prime ≥ 2 || throw(
+            DomainError(
+                (p, p_prime),
+                "MinimalModel(p, p_prime): require p_prime ≥ 2; got p_prime=$p_prime.",
+            ),
+        )
+        p > p_prime || throw(
+            DomainError(
+                (p, p_prime),
+                "MinimalModel(p, p_prime): require p > p_prime; got p=$p, p_prime=$p_prime.",
+            ),
+        )
+        gcd(p, p_prime) == 1 || throw(
+            DomainError(
+                (p, p_prime),
+                "MinimalModel(p, p_prime): p and p_prime must be coprime; gcd($p, $p_prime) = $(gcd(p, p_prime)).",
+            ),
+        )
+        return new(Int(p), Int(p_prime))
+    end
+end
+
+"""
+    fetch(::MinimalModel, ::CentralCharge) -> Rational{Int}
+
+Central charge of the Virasoro minimal model M(p, p_prime):
+
+    c = 1 - 6 (p - p_prime)^2 / (p p_prime).
+
+Returned as an exact `Rational{Int}`.
+"""
+function fetch(m::MinimalModel, ::CentralCharge; kwargs...)
+    p, q = m.p, m.p_prime
+    return 1 // 1 - (6 * (p - q)^2) // (p * q)
+end
+
+"""
+    fetch(::MinimalModel, ::ConformalWeights; r::Int, s::Int) -> Rational{Int}
+
+Kac-table conformal weight of the primary `(r, s)`:
+
+    h_{r,s} = ((p r - p_prime s)^2 - (p - p_prime)^2) / (4 p p_prime),
+        1 ≤ r ≤ p_prime - 1,  1 ≤ s ≤ p - 1.
+
+Out-of-range `(r, s)` throws `DomainError`.  Use the Kac symmetry
+`h_{r,s} = h_{p_prime - r, p - s}` to map a label outside the
+fundamental rectangle into it explicitly.
+"""
+function fetch(m::MinimalModel, ::ConformalWeights; r::Integer, s::Integer, kwargs...)
+    p, q = m.p, m.p_prime
+    (1 ≤ r ≤ q - 1) || throw(
+        DomainError(
+            (r, s),
+            "MinimalModel($p, $q) ConformalWeights: r must satisfy 1 ≤ r ≤ p_prime - 1 = $(q - 1); got r=$r.",
+        ),
+    )
+    (1 ≤ s ≤ p - 1) || throw(
+        DomainError(
+            (r, s),
+            "MinimalModel($p, $q) ConformalWeights: s must satisfy 1 ≤ s ≤ p - 1 = $(p - 1); got s=$s.",
+        ),
+    )
+    num = (p * r - q * s)^2 - (p - q)^2
+    den = 4 * p * q
+    return num // den
+end
+
+"""
+    fetch(::MinimalModel, ::PrimaryFields) -> Vector{NamedTuple}
+
+All distinct primary fields of M(p, p_prime), modulo Kac symmetry
+`(r, s) ~ (p_prime - r, p - s)`.  Each entry is a NamedTuple
+`(r=Int, s=Int, h=Rational{Int})`.
+
+The list is enumerated over `1 ≤ r ≤ p_prime - 1, 1 ≤ s ≤ p - 1`
+and de-duplicated by selecting the lex-smallest `(r, s)` from each
+Kac-symmetry orbit, so its length is
+
+    (p - 1)(p_prime - 1) / 2.
+"""
+function fetch(m::MinimalModel, ::PrimaryFields; kwargs...)
+    p, q = m.p, m.p_prime
+    out = NamedTuple{(:r, :s, :h),Tuple{Int,Int,Rational{Int}}}[]
+    seen = Set{Tuple{Int,Int}}()
+    for r in 1:(q - 1), s in 1:(p - 1)
+        # Kac symmetry orbit representative = lex-smallest of {(r,s), (q-r,p-s)}.
+        r2, s2 = q - r, p - s
+        rep = (r, s) ≤ (r2, s2) ? (r, s) : (r2, s2)
+        if rep ∉ seen
+            push!(seen, rep)
+            h = fetch(m, ConformalWeights(); r=rep[1], s=rep[2])
+            push!(out, (r=rep[1], s=rep[2], h=h))
+        end
+    end
+    return out
+end

--- a/src/universalities/WZW.jl
+++ b/src/universalities/WZW.jl
@@ -32,7 +32,11 @@ Special cases:
 - `k = 1`: `c = 1` (free boson at the SU(2)-symmetric radius;
   low-energy theory of the spin-1/2 Heisenberg antiferromagnet,
   Affleck 1989).
-- `k = 2`: `c = 3/2` (equivalent to Ising × free Majorana).
+- `k = 2`: `c = 3/2` — equivalent to **3 free Majorana fermions**
+  (each contributing `c = 1/2`), or equivalently the smallest N=1
+  super-Virasoro minimal model.  Note that "Ising × free Majorana"
+  with one Majorana would only give `c = 1/2 + 1/2 = 1 ≠ 3/2`; the
+  correct decomposition needs three Majorana fermions.
 - `k = 3`: `c = 9/5`.
 
 ```julia

--- a/src/universalities/WZW.jl
+++ b/src/universalities/WZW.jl
@@ -1,0 +1,117 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Wess–Zumino–Witten WZW SU(2)_k universality classes
+#
+# References:
+#   Knizhnik, Zamolodchikov,
+#     "Current algebra and Wess-Zumino model in two dimensions",
+#     Nucl. Phys. B 247, 83 (1984).
+#   Witten, Comm. Math. Phys. 92, 455 (1984).
+#   Di Francesco, Mathieu, Sénéchal,
+#     "Conformal Field Theory" (Springer, 1997), Ch. 15.
+#   Affleck, "Quantum spin chains and the Haldane gap",
+#     J. Phys.: Condens. Matter 1, 3047 (1989) — Heisenberg = SU(2)_1 WZW.
+#
+# Level k = 1, 2, 3, ...  Sugawara central charge:
+#
+#   c(k) = 3 k / (k + 2)
+#
+# Primary fields are labelled by SU(2) spin j ∈ {0, 1/2, 1, ..., k/2}
+# with conformal weight
+#
+#   h_j = j (j + 1) / (k + 2).
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    WZWSU2(k::Int) <: AbstractQAtlasModel
+
+Wess–Zumino–Witten model with affine Lie algebra SU(2) at level
+`k ≥ 1`.  Construction throws `DomainError` for `k ≤ 0`.
+
+Special cases:
+
+- `k = 1`: `c = 1` (free boson at the SU(2)-symmetric radius;
+  low-energy theory of the spin-1/2 Heisenberg antiferromagnet,
+  Affleck 1989).
+- `k = 2`: `c = 3/2` (equivalent to Ising × free Majorana).
+- `k = 3`: `c = 9/5`.
+
+```julia
+fetch(WZWSU2(1), CentralCharge())                    # 1//1
+fetch(WZWSU2(1), ConformalWeights(); j=1//2)         # 1//4
+```
+
+See also: [`MinimalModel`](@ref), [`Universality`](@ref),
+[`CentralCharge`](@ref), [`ConformalWeights`](@ref).
+"""
+struct WZWSU2 <: AbstractQAtlasModel
+    k::Int
+    function WZWSU2(k::Integer)
+        k ≥ 1 || throw(DomainError(k, "WZWSU2(k): require k ≥ 1; got k=$k."))
+        return new(Int(k))
+    end
+end
+
+"""
+    fetch(::WZWSU2, ::CentralCharge) -> Rational{Int}
+
+Sugawara central charge `c = 3k / (k + 2)` of WZW SU(2) at level `k`.
+Returned as an exact `Rational{Int}`.
+"""
+function fetch(w::WZWSU2, ::CentralCharge; kwargs...)
+    k = w.k
+    return (3 * k) // (k + 2)
+end
+
+"""
+    fetch(::WZWSU2, ::ConformalWeights; j) -> Rational{Int}
+
+Conformal weight `h_j = j (j+1) / (k+2)` of the spin-`j` primary at
+level `k`.  `j` must be a non-negative half-integer (i.e.
+`Rational` such that `2j ∈ ℤ_{≥0}`) with `0 ≤ j ≤ k/2`.
+
+Out-of-range or non-half-integer `j` throws `DomainError`.
+
+```julia
+fetch(WZWSU2(1), ConformalWeights(); j=0)            # 0//1
+fetch(WZWSU2(1), ConformalWeights(); j=1//2)         # 1//4
+fetch(WZWSU2(2), ConformalWeights(); j=1)            # 1//2
+```
+"""
+function fetch(w::WZWSU2, ::ConformalWeights; j, kwargs...)
+    k = w.k
+    jr = _wzw_su2_normalize_spin(j, k)
+    # h_j = j (j+1) / (k+2); compute as Rational{Int} exactly.
+    return (jr * (jr + 1)) // (k + 2)
+end
+
+# Coerce the user-supplied spin into a Rational{Int} after validating
+# that it is a non-negative half-integer with 2j ∈ {0, 1, ..., k}.
+function _wzw_su2_normalize_spin(j::Rational, k::Int)
+    j ≥ 0 || throw(DomainError(j, "WZWSU2 ConformalWeights: j must be ≥ 0; got j=$j."))
+    twoj = 2 * j
+    isinteger(twoj) || throw(
+        DomainError(
+            j,
+            "WZWSU2 ConformalWeights: j must be a half-integer (2j ∈ ℤ); got j=$j (2j=$twoj).",
+        ),
+    )
+    twoj_int = Int(twoj)
+    twoj_int ≤ k || throw(
+        DomainError(
+            j,
+            "WZWSU2(k=$k) ConformalWeights: j must satisfy 0 ≤ j ≤ k/2 = $(k//2); got j=$j.",
+        ),
+    )
+    return Rational{Int}(j)
+end
+function _wzw_su2_normalize_spin(j::Integer, k::Int)
+    return _wzw_su2_normalize_spin(Rational{Int}(j), k)
+end
+function _wzw_su2_normalize_spin(j::Real, k::Int)
+    return throw(
+        DomainError(
+            j,
+            "WZWSU2 ConformalWeights: j must be an Integer or Rational half-integer; got $(typeof(j)) value $j.  Pass e.g. `j = 1//2`.",
+        ),
+    )
+end

--- a/test/standalone/test_universality_minimal_models.jl
+++ b/test/standalone/test_universality_minimal_models.jl
@@ -1,0 +1,129 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Standalone test: Virasoro minimal models M(p, p_prime)
+#
+# Verifies the BPZ central-charge formula and the Kac-table conformal
+# weights as exact `Rational{Int}` values, and the Kac symmetry
+# h_{r,s} = h_{p_prime - r, p - s}.  Cross-checks the Ising special
+# case M(4, 3) against `Universality(:Ising)`'s `c = 1//2` entry.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Test
+
+# ═══════════════════ Construction & validation ════════════════════════════════
+
+@testset "MinimalModel: construction validation" begin
+    # Coprime requirement.
+    @test_throws DomainError MinimalModel(6, 4)   # gcd 2
+    @test_throws DomainError MinimalModel(9, 6)   # gcd 3
+    @test_throws DomainError MinimalModel(10, 4)  # gcd 2
+    # Order requirement: p > p_prime.
+    @test_throws DomainError MinimalModel(3, 4)
+    @test_throws DomainError MinimalModel(4, 4)   # also equal
+    # Lower bound: p_prime >= 2.
+    @test_throws DomainError MinimalModel(3, 1)
+    @test_throws DomainError MinimalModel(2, 0)
+    # Sanity: a few valid constructions return a struct with the right fields.
+    m = MinimalModel(4, 3)
+    @test m.p == 4 && m.p_prime == 3
+end
+
+# ═══════════════════ Central charge — exact rationals ═════════════════════════
+
+@testset "MinimalModel: CentralCharge (exact)" begin
+    @test QAtlas.fetch(MinimalModel(4, 3), CentralCharge()) == 1 // 2     # Ising
+    @test QAtlas.fetch(MinimalModel(5, 4), CentralCharge()) == 7 // 10    # Tricritical Ising
+    @test QAtlas.fetch(MinimalModel(6, 5), CentralCharge()) == 4 // 5     # 3-state Potts (chiral)
+    @test QAtlas.fetch(MinimalModel(5, 2), CentralCharge()) == -22 // 5   # Yang–Lee
+    @test QAtlas.fetch(MinimalModel(7, 6), CentralCharge()) == 6 // 7     # next unitary
+    # Type stability: all of these are Rational{Int}.
+    for m in
+        (MinimalModel(4, 3), MinimalModel(5, 4), MinimalModel(6, 5), MinimalModel(5, 2))
+        @test QAtlas.fetch(m, CentralCharge()) isa Rational{Int}
+    end
+end
+
+# ═══════════════════ Cross-check: Ising = M(4, 3) ═════════════════════════════
+
+@testset "MinimalModel: Ising cross-check (M(4,3) ↔ Universality(:Ising))" begin
+    c_minimal = QAtlas.fetch(MinimalModel(4, 3), CentralCharge())
+    c_ising = QAtlas.fetch(Universality(:Ising), CriticalExponents(); d=2).c
+    @test c_minimal == c_ising
+    @test c_minimal === 1 // 2
+end
+
+# ═══════════════════ Conformal weights — Ising primaries ══════════════════════
+
+@testset "MinimalModel: Ising M(4,3) primary weights" begin
+    m = MinimalModel(4, 3)
+    # Ising primaries — identity, spin σ, energy ε.
+    @test QAtlas.fetch(m, ConformalWeights(); r=1, s=1) == 0 // 1     # 1 (identity)
+    @test QAtlas.fetch(m, ConformalWeights(); r=1, s=2) == 1 // 16    # σ
+    @test QAtlas.fetch(m, ConformalWeights(); r=2, s=1) == 1 // 2     # ε
+    # Type stability.
+    @test QAtlas.fetch(m, ConformalWeights(); r=1, s=2) isa Rational{Int}
+end
+
+# ═══════════════════ Conformal weights — Tricritical Ising ════════════════════
+
+@testset "MinimalModel: Tricritical Ising M(5,4) primary weights" begin
+    m = MinimalModel(5, 4)
+    # M(5, 4) primary weights computed from h_{r,s} = ((5r - 4s)^2 - 1) / 80
+    # (Di Francesco–Mathieu–Sénéchal, Eq. 7.62 / Table 7.2).
+    @test QAtlas.fetch(m, ConformalWeights(); r=1, s=1) == 0 // 1     # 1 (identity)
+    @test QAtlas.fetch(m, ConformalWeights(); r=1, s=2) == 1 // 10    # ε
+    @test QAtlas.fetch(m, ConformalWeights(); r=2, s=2) == 3 // 80    # σ
+    @test QAtlas.fetch(m, ConformalWeights(); r=2, s=1) == 7 // 16    # σ′
+    @test QAtlas.fetch(m, ConformalWeights(); r=1, s=3) == 3 // 5     # ε′
+    @test QAtlas.fetch(m, ConformalWeights(); r=3, s=1) == 3 // 2     # ε′′
+end
+
+# ═══════════════════ Kac symmetry h_{r,s} = h_{p'-r, p-s} ═════════════════════
+
+@testset "MinimalModel: Kac symmetry across many (p, p_prime)" begin
+    for (p, q) in (
+        (4, 3),    # Ising
+        (5, 4),    # Tricritical Ising
+        (6, 5),    # 3-state Potts (chiral)
+        (7, 6),
+        (8, 7),
+        (5, 2),    # Yang–Lee (non-unitary)
+        (7, 4),    # gcd = 1, p > p_prime
+        (9, 4),
+        (11, 6),
+    )
+        m = MinimalModel(p, q)
+        for r in 1:(q - 1), s in 1:(p - 1)
+            h_rs = QAtlas.fetch(m, ConformalWeights(); r=r, s=s)
+            h_sym = QAtlas.fetch(m, ConformalWeights(); r=q - r, s=p - s)
+            @test h_rs == h_sym
+        end
+    end
+end
+
+# ═══════════════════ Out-of-range (r, s) ══════════════════════════════════════
+
+@testset "MinimalModel: out-of-range (r, s) → DomainError" begin
+    m = MinimalModel(4, 3)
+    # r ∈ 1..2, s ∈ 1..3 for M(4, 3).
+    @test_throws DomainError QAtlas.fetch(m, ConformalWeights(); r=0, s=1)
+    @test_throws DomainError QAtlas.fetch(m, ConformalWeights(); r=3, s=1)
+    @test_throws DomainError QAtlas.fetch(m, ConformalWeights(); r=1, s=0)
+    @test_throws DomainError QAtlas.fetch(m, ConformalWeights(); r=1, s=4)
+end
+
+# ═══════════════════ PrimaryFields list ═══════════════════════════════════════
+
+@testset "MinimalModel: PrimaryFields enumeration" begin
+    # Ising M(4, 3): (p-1)(p_prime-1)/2 = 3*2/2 = 3 primaries (1, σ, ε).
+    pf = QAtlas.fetch(MinimalModel(4, 3), PrimaryFields())
+    @test length(pf) == 3
+    hs = sort([x.h for x in pf])
+    @test hs == [0 // 1, 1 // 16, 1 // 2]
+    # Tricritical Ising M(5, 4): 4*3/2 = 6 primaries.
+    pf2 = QAtlas.fetch(MinimalModel(5, 4), PrimaryFields())
+    @test length(pf2) == 6
+    @test all(x -> x.h isa Rational{Int}, pf2)
+    # 3-state Potts (chiral) M(6, 5): 5*4/2 = 10 primaries.
+    pf3 = QAtlas.fetch(MinimalModel(6, 5), PrimaryFields())
+    @test length(pf3) == 10
+end

--- a/test/standalone/test_universality_wzw.jl
+++ b/test/standalone/test_universality_wzw.jl
@@ -1,0 +1,93 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Standalone test: WZW SU(2)_k universality classes
+#
+# Verifies the Sugawara central charge c(k) = 3k / (k + 2) and the
+# primary conformal weights h_j = j(j+1) / (k+2) as exact
+# `Rational{Int}` values, plus the validation rules for the spin
+# parameter j (half-integer, 0 ≤ j ≤ k/2).
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Test
+
+# ═══════════════════ Construction & validation ════════════════════════════════
+
+@testset "WZWSU2: construction validation" begin
+    @test_throws DomainError WZWSU2(0)
+    @test_throws DomainError WZWSU2(-1)
+    @test WZWSU2(1).k == 1
+    @test WZWSU2(7).k == 7
+end
+
+# ═══════════════════ Central charge — exact rationals ═════════════════════════
+
+@testset "WZWSU2: CentralCharge (Sugawara)" begin
+    @test QAtlas.fetch(WZWSU2(1), CentralCharge()) == 1 // 1     # free boson at SU(2) radius
+    @test QAtlas.fetch(WZWSU2(2), CentralCharge()) == 3 // 2     # Ising × Majorana
+    @test QAtlas.fetch(WZWSU2(3), CentralCharge()) == 9 // 5
+    @test QAtlas.fetch(WZWSU2(4), CentralCharge()) == 2 // 1
+    @test QAtlas.fetch(WZWSU2(10), CentralCharge()) == 30 // 12  # 5 // 2
+    # Type stability.
+    for k in (1, 2, 3, 7, 25)
+        @test QAtlas.fetch(WZWSU2(k), CentralCharge()) isa Rational{Int}
+    end
+end
+
+# ═══════════════════ k = 1: Heisenberg / free-boson cross-check ═══════════════
+
+@testset "WZWSU2: k=1 primary weights (j ∈ {0, 1/2})" begin
+    w = WZWSU2(1)
+    @test QAtlas.fetch(w, ConformalWeights(); j=0) == 0 // 1
+    @test QAtlas.fetch(w, ConformalWeights(); j=1 // 2) == 1 // 4
+    # Above max spin should error.
+    @test_throws DomainError QAtlas.fetch(w, ConformalWeights(); j=1)
+end
+
+# ═══════════════════ k = 2: full primary list ═════════════════════════════════
+
+@testset "WZWSU2: k=2 primary weights (j ∈ {0, 1/2, 1})" begin
+    w = WZWSU2(2)
+    @test QAtlas.fetch(w, ConformalWeights(); j=0) == 0 // 1
+    @test QAtlas.fetch(w, ConformalWeights(); j=1 // 2) == 3 // 16
+    @test QAtlas.fetch(w, ConformalWeights(); j=1) == 1 // 2
+    @test_throws DomainError QAtlas.fetch(w, ConformalWeights(); j=3 // 2)
+end
+
+# ═══════════════════ Higher k spot-checks ═════════════════════════════════════
+
+@testset "WZWSU2: k=3 primary weights" begin
+    w = WZWSU2(3)
+    @test QAtlas.fetch(w, ConformalWeights(); j=0) == 0 // 1
+    @test QAtlas.fetch(w, ConformalWeights(); j=1 // 2) == 3 // 20    # (1/2)(3/2) / 5
+    @test QAtlas.fetch(w, ConformalWeights(); j=1) == 2 // 5          # 1·2 / 5
+    @test QAtlas.fetch(w, ConformalWeights(); j=3 // 2) == 3 // 4     # (3/2)(5/2) / 5 = 15/20
+    @test_throws DomainError QAtlas.fetch(w, ConformalWeights(); j=2)
+end
+
+@testset "WZWSU2: k=4 primary weights" begin
+    w = WZWSU2(4)
+    @test QAtlas.fetch(w, ConformalWeights(); j=2) == 1 // 1          # 2·3 / 6
+    @test QAtlas.fetch(w, ConformalWeights(); j=1) == 1 // 3          # 1·2 / 6
+    @test_throws DomainError QAtlas.fetch(w, ConformalWeights(); j=5 // 2)
+end
+
+# ═══════════════════ Validation: half-integer / non-negative ═════════════════
+
+@testset "WZWSU2: invalid j → DomainError" begin
+    w = WZWSU2(4)
+    # Negative j.
+    @test_throws DomainError QAtlas.fetch(w, ConformalWeights(); j=-1 // 2)
+    @test_throws DomainError QAtlas.fetch(w, ConformalWeights(); j=-1)
+    # Non-half-integer (e.g. 1/3 is not a half-integer).
+    @test_throws DomainError QAtlas.fetch(w, ConformalWeights(); j=1 // 3)
+    @test_throws DomainError QAtlas.fetch(w, ConformalWeights(); j=2 // 3)
+    # Float (not Integer / Rational).
+    @test_throws DomainError QAtlas.fetch(w, ConformalWeights(); j=0.5)
+end
+
+# ═══════════════════ Type stability ═══════════════════════════════════════════
+
+@testset "WZWSU2: ConformalWeights returns Rational{Int}" begin
+    @test QAtlas.fetch(WZWSU2(1), ConformalWeights(); j=0) isa Rational{Int}
+    @test QAtlas.fetch(WZWSU2(1), ConformalWeights(); j=1 // 2) isa Rational{Int}
+    @test QAtlas.fetch(WZWSU2(7), ConformalWeights(); j=3) isa Rational{Int}
+end


### PR DESCRIPTION
## Summary

Adds two parametric 2D rational-CFT families as concrete dispatch tags, exposing analytical central charges and primary conformal weights as exact `Rational{Int}` values.

- **MinimalModel(p, p_prime)** — Virasoro minimal models M(p, p′), p > p′ ≥ 2 coprime.
  `c = 1 - 6(p - p′)² / (p p′)` and Kac formula for `h_{r,s}`.
- **WZWSU2(k)** — WZW SU(2)_k via Sugawara: `c = 3k/(k+2)`, `h_j = j(j+1)/(k+2)`.

Closes #165.

## API choice

Following the **KPZ1D / Ising2D precedent**, both are concrete `AbstractQAtlasModel` structs (option 2 from the design discussion) rather than extending `Universality{C}` to a multi-parameter `Universality{C, Args}`:

```julia
fetch(MinimalModel(4, 3), CentralCharge())                  # 1//2
fetch(MinimalModel(4, 3), ConformalWeights(); r=1, s=2)     # 1//16
fetch(WZWSU2(1), CentralCharge())                           # 1//1
fetch(WZWSU2(2), ConformalWeights(); j=1)                   # 1//2
```

Constructor validation throws `DomainError` for non-coprime / out-of-order / non-positive arguments; `ConformalWeights` accessors validate `(r, s)` and `j` ranges and reject non-half-integer `j`.

## Cross-check

`fetch(MinimalModel(4, 3), CentralCharge())` equals `fetch(Universality(:Ising), CriticalExponents(); d=2).c` exactly at the `Rational{Int}` level (both `1//2`).  WZW SU(2)_1 `c = 1` matches the free-boson central charge.

## Files

**New:**
- `src/universalities/MinimalModel.jl`
- `src/universalities/WZW.jl`
- `test/standalone/test_universality_minimal_models.jl` — 244 passing assertions
- `test/standalone/test_universality_wzw.jl` — 37 passing assertions
- `docs/src/universalities/cft_minimal_models.md`

**Modified:**
- `src/core/quantities.jl` — add `ConformalWeights`, `PrimaryFields` (both `<: AbstractQuantity`)
- `src/QAtlas.jl` — include the two new files; export `MinimalModel`, `WZWSU2`, `ConformalWeights`, `PrimaryFields`
- `docs/src/universalities/index.md` — table rows for the two new classes

## Test plan

Targeted tests (281/281 pass on Panza, Julia 1.12.2):

- [x] `julia --project=test test/standalone/test_universality_minimal_models.jl` — 244 pass (8 + 9 + 2 + 4 + 6 + 206 + 4 + 5)
- [x] `julia --project=test test/standalone/test_universality_wzw.jl` — 37 pass (4 + 10 + 3 + 4 + 5 + 3 + 5 + 3)

Coverage:
- M(4,3) c = 1/2 (Ising); h_{1,1}=0, h_{1,2}=1/16, h_{2,1}=1/2 — exact rational
- M(5,4) c = 7/10 (Tricritical Ising) + 5 verified primary weights
- M(6,5) c = 4/5 (3-state Potts chiral); M(5,2) c = -22/5 (Yang–Lee); M(7,6) c = 6/7
- Kac symmetry h_{r,s} = h_{p′-r, p-s} across **9 distinct (p, p′)** pairs (206 individual checks)
- gcd(p, p′) > 1, p ≤ p′, p′ < 2 → `DomainError` (each tested)
- Out-of-range (r, s) → `DomainError`
- WZW c(k=1)=1, c(k=2)=3/2, c(k=3)=9/5; primary weights at k=1,2,3,4
- Invalid j (negative, non-half-integer, > k/2, Float) → `DomainError`
- Type stability: all returns are `Rational{Int}`

## Phase-2 deferrals

None.  `PrimaryFields` for `MinimalModel` ships as Kac-orbit-deduplicated `Vector{NamedTuple{(:r, :s, :h)}}` of length `(p-1)(p′-1)/2`.  WZW `PrimaryFields` is straightforward to add later (no current users) and was deferred only because the spec did not list it as required.

## References

- Belavin, Polyakov, Zamolodchikov, Nucl. Phys. **B 241**, 333 (1984).
- Friedan, Qiu, Shenker, Phys. Rev. Lett. **52**, 1575 (1984).
- Knizhnik, Zamolodchikov, Nucl. Phys. **B 247**, 83 (1984).
- Witten, Comm. Math. Phys. **92**, 455 (1984).
- Di Francesco, Mathieu, Sénéchal, *Conformal Field Theory* (Springer, 1997).
- Affleck, J. Phys.: Condens. Matter **1**, 3047 (1989).
