### PR TITLE
feat(quantum): Kitaev1D — 1D Majorana wire with Pfaffian topological invariant (closes #152)

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -52,6 +52,7 @@ makedocs(;
                 "XXZ" => "models/quantum/xxz.md",
                 "Hubbard1D" => "models/quantum/hubbard1d.md",
                 "Kitaev Honeycomb" => "models/quantum/kitaev-honeycomb.md",
+                "Kitaev1D" => "models/quantum/kitaev1d.md",
                 "Tight-Binding" => [
                     "models/quantum/tightbinding/index.md",
                     "Honeycomb" => "models/quantum/tightbinding/honeycomb.md",

--- a/docs/src/models/quantum/index.md
+++ b/docs/src/models/quantum/index.md
@@ -15,3 +15,6 @@ rigorously verifiable solutions.
   a generic builder
 - [Hubbard1D Chain](hubbard1d.md) -- 1D Hubbard model, Lieb-Wu Bethe
   ansatz half-filling closed forms (E_0/N, charge gap, spin gap)
+- [Kitaev1D Wire](kitaev1d.md) -- 1D p-wave Majorana wire (Kitaev 2001),
+  Pfaffian Z_2 topological invariant, OBC Majorana edge modes
+  (distinct from the 2D `KitaevHoneycomb` spin model)

--- a/docs/src/models/quantum/kitaev1d.md
+++ b/docs/src/models/quantum/kitaev1d.md
@@ -1,0 +1,123 @@
+# Kitaev1D — 1D p-wave Majorana Wire
+
+## Overview
+
+The 1D Kitaev (2001) chain is the canonical exactly-solvable model of a
+1D topological superconductor.  It is a free-fermion Bogoliubov-de
+Gennes problem with a `Z_2` Pfaffian invariant: the topological phase
+hosts two Majorana zero modes at the ends of an open chain.
+
+> **Distinct from `KitaevHoneycomb`.**  This model is the *one-dimensional*
+> spinless p-wave wire (Kitaev, *Phys.-Usp.* 44, 131, 2001).  The
+> [`KitaevHoneycomb`](kitaev-honeycomb.md) model is a *two-dimensional*
+> anisotropic spin model on the honeycomb lattice (Kitaev,
+> *Ann. Phys.* 321, 2, 2006).  They share a name only by historical
+> accident.
+
+## Hamiltonian
+
+```math
+H = -\mu \sum_i c_i^{\dagger} c_i
+    - t   \sum_i \bigl(c_i^{\dagger} c_{i+1} + \text{h.c.}\bigr)
+    + \Delta \sum_i \bigl(c_i c_{i+1} + \text{h.c.}\bigr)
+```
+
+with `c_i` spinless fermions, chemical potential `μ`, hopping `t`, and
+p-wave pairing `Δ`.  Defaults: `μ = 0`, `t = 1`, `Δ = 1`.
+
+**PBC dispersion (closed form):**
+
+```math
+E(k) = \sqrt{(2t \cos k + \mu)^2 + 4\Delta^2 \sin^2 k}.
+```
+
+**Phase diagram** (`Δ ≠ 0`, `t ≠ 0`):
+
+| Regime              | Phase           | Pfaffian invariant |
+| ------------------- | --------------- | ------------------ |
+| `\|μ\| < 2\|t\|`    | topological     | `ν = -1`           |
+| `\|μ\| = 2\|t\|`    | gapless         | ill-defined        |
+| `\|μ\| > 2\|t\|`    | trivial         | `ν = +1`           |
+
+**Topological invariant** (Kitaev 2001, Pfaffian sign):
+
+```math
+\nu = \operatorname{sgn}\bigl[\operatorname{Pf} A(k=0)
+                              \cdot \operatorname{Pf} A(k=\pi)\bigr]
+    = \operatorname{sgn}(\mu^2 - 4t^2),
+```
+
+evaluated on the 2 × 2 Majorana Bloch matrix `A(k)` at the two
+time-reversal-invariant momenta.
+
+**OBC edge zero modes:** in the topological phase the two Majorana ends
+hybridise into a single complex fermion with hybridisation energy
+`E_edge(N) ~ exp(-N/ξ)` where `ξ ~ 1/log(2|t|/|μ|)` for
+`|μ| ≪ 2|t|`.  At the *sweet spot* `μ = 0`, `t = Δ` the two Majoranas
+decouple exactly and `E_edge` vanishes for all `N ≥ 2`.
+
+---
+
+## TFIM correspondence
+
+The transverse-field Ising model is a special case of `Kitaev1D` under
+the identification
+
+```math
+\mu = -2h, \qquad t = J, \qquad \Delta = J.
+```
+
+The OBC BdG spectra of `Kitaev1D(μ=-2h, t=J, Δ=J)` and `TFIM(J=J, h=h)`
+agree exactly (verified by `test/standalone/test_kitaev1d.jl`).  The
+helper `_kitaev1d_bdg_spectrum` is a strict generalisation of
+`_tfim_bdg_spectrum`; choosing `Δ = J` and `μ = -2h` reproduces TFIM's
+A and B blocks element-wise.
+
+---
+
+## Coverage Matrix
+
+| Quantity                          | OBC                | Infinite                              |
+| --------------------------------- | ------------------ | ------------------------------------- |
+| [`ExactSpectrum`](@ref)           | BdG (size `N`)     | —                                     |
+| [`Energy`](@ref) `{:per_site}`    | conversion         | Gauss-Kronrod over `E(k)`             |
+| [`MassGap`](@ref)                 | BdG (smallest)     | analytic min over `k`                 |
+| [`EdgeModeEnergy`](@ref)          | BdG (smallest)     | —                                     |
+| [`CorrelationLength`](@ref)       | —                  | `1 / Δ_gap` (`Inf` on critical line)  |
+| [`TopologicalInvariant`](@ref)    | —                  | Pfaffian sign at `k = 0, π`           |
+
+---
+
+## Usage
+
+```julia
+using QAtlas
+
+# Topological phase (μ = 0, sweet spot)
+m = Kitaev1D(; μ=0.0, t=1.0, Δ=1.0)
+fetch(m, TopologicalInvariant(), Infinite())   # -1
+fetch(m, MassGap(), Infinite())                # 2.0  (bulk gap)
+fetch(m, EdgeModeEnergy(), OBC(40))            # ~1e-15 (sweet-spot zero modes)
+
+# Trivial phase
+m_triv = Kitaev1D(; μ=3.0, t=1.0, Δ=1.0)
+fetch(m_triv, TopologicalInvariant(), Infinite())   # +1
+fetch(m_triv, MassGap(), Infinite())                # 1.0
+
+# TFIM cross-check
+J, h = 1.0, 0.7
+m_tfim = Kitaev1D(; μ=-2h, t=J, Δ=J)
+fetch(m_tfim, ExactSpectrum(), OBC(20))    # matches _tfim_bdg_spectrum(20, J, h)
+```
+
+---
+
+## References
+
+- A. Yu. Kitaev, "Unpaired Majorana fermions in quantum wires",
+  *Phys.-Usp.* **44**, 131 (2001).
+- J. Alicea, "New directions for the pursuit of Majorana fermions in
+  solid state systems", *Rep. Prog. Phys.* **75**, 076501 (2012).
+- J. K. Asbóth, L. Oroszlány, A. Pályi,
+  *A Short Course on Topological Insulators*,
+  Lect. Notes Phys. **919** (2016) — Pfaffian invariant.

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -13,6 +13,7 @@ export TFIM                                             # v0.13 concrete struct
 export E8                                               # v0.13 concrete struct
 export XXZ1D                                            # v0.13 new model
 export KitaevHoneycomb                                  # spin-½ Kitaev honeycomb
+export Kitaev1D                                         # 1D p-wave Majorana wire (Kitaev 2001)
 export TightBindingSpectrum
 # NOTE: `Honeycomb`, `Kagome`, `Lieb`, `Triangular` are NOT exported —
 # they all conflict with Lattice2D's topology types of the same name.
@@ -49,6 +50,7 @@ export ConformalWeights, PrimaryFields
 export FermiVelocity, LuttingerVelocity, SpinWaveVelocity
 export E8Spectrum
 export CasimirEnergyCorrection
+export TopologicalInvariant, EdgeModeEnergy           # Kitaev1D Pfaffian invariant + edge mode
 
 # --- TFIM Infinite dynamic helpers ---
 export tfim_quasiparticle_dispersion, tfim_two_spinon_dos
@@ -107,6 +109,8 @@ include("models/quantum/Heisenberg/HeisenbergS1_registry.jl")
 include("models/quantum/KitaevHoneycomb/KitaevHoneycomb.jl")
 include("models/quantum/KitaevHoneycomb/KitaevHoneycomb_thermal.jl")
 include("models/quantum/KitaevHoneycomb/KitaevHoneycomb_registry.jl")
+include("models/quantum/Kitaev1D/Kitaev1D.jl")
+include("models/quantum/Kitaev1D/Kitaev1D_registry.jl")  # populates REGISTRY for Kitaev1D
 include("models/quantum/XXZ/XXZ.jl")
 include("models/quantum/XXZ/XXZ_thermal.jl")
 include("models/quantum/XXZ/XXZ_xx_infinite.jl")

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -493,6 +493,49 @@ class via the same data the `Universality{C}` entry exposes for
     will be exposed via a `ConformalTower` quantity once implemented.
 """
 struct CasimirEnergyCorrection <: AbstractQuantity end
+    TopologicalInvariant() <: AbstractQuantity
+
+Topological `Z_2` invariant of a 1D BdG superconductor (Kitaev 2001).
+Defined as the Pfaffian sign at the time-reversal-invariant momenta
+`k = 0` and `k = π`,
+
+```math
+\\nu = \\operatorname{sgn}\\bigl[\\operatorname{Pf}(H_{\\mathrm{BdG}}(k=0))
+                                  \\cdot \\operatorname{Pf}(H_{\\mathrm{BdG}}(k=\\pi))\\bigr]
+       \\in \\{+1, -1\\},
+```
+
+with `ν = -1` in the topological phase and `ν = +1` in the trivial
+phase.  For a gapless bulk (Pfaffian zero at `k = 0` or `k = π`) the
+invariant is ill-defined and implementations should signal an error.
+
+Currently used by [`Kitaev1D`](@ref).
+"""
+struct TopologicalInvariant <: AbstractQuantity end
+
+"""
+    EdgeModeEnergy() <: AbstractQuantity
+
+Energy of the lowest-lying boundary mode on an open chain.  In a
+topological 1D superconductor (Kitaev 2001) the OBC chain hosts two
+Majorana zero modes at the chain ends; their hybridization energy
+decays exponentially with chain length,
+
+```math
+E_\\text{edge}(N) \\sim e^{-N/\\xi},
+```
+
+where `ξ` is the bulk correlation length.  In the trivial phase the
+OBC lowest single-particle excitation is set by the bulk gap.
+
+`EdgeModeEnergy` is the smallest positive BdG eigenvalue of the OBC
+chain — the same quantity as [`MassGap`](@ref) at `OBC`, exposed under
+a name that makes the boundary-mode interpretation explicit at the
+call site.
+
+Currently used by [`Kitaev1D`](@ref).
+"""
+struct EdgeModeEnergy <: AbstractQuantity end
 
 # Other spectrum / universality tag types (`TightBindingSpectrum`,
 # `ExactSpectrum`, `GroundStateEnergyDensity`, `CriticalExponents`,

--- a/src/models/quantum/Kitaev1D/Kitaev1D.jl
+++ b/src/models/quantum/Kitaev1D/Kitaev1D.jl
@@ -255,6 +255,15 @@ boundary-mode-explicit name).  In the trivial phase it converges to the
 bulk gap as `N → ∞`.
 """
 function fetch(model::Kitaev1D, ::MassGap, bc::OBC; kwargs...)
+    if model.Δ == 0.0 && abs(model.μ) < 2 * abs(model.t)
+        return error(
+            "Kitaev1D MassGap@OBC: Δ = 0 with |μ| < 2|t| is the gapless metal " *
+            "regime — the dispersion has zeros at k_F = ±arccos(-μ/2t) and the " *
+            "BdG spectrum lowest level is a finite-size remnant of those Fermi " *
+            "points, not a physical gap.  Refusing to silently mask this with a " *
+            "misleading number; re-evaluate with Δ ≠ 0.",
+        )
+    end
     N = _bc_size(bc, kwargs)
     Λ = _kitaev1d_bdg_spectrum(N, model.μ, model.t, model.Δ)
     return Λ[1]
@@ -280,6 +289,15 @@ exist as separate names so call sites can be explicit about which
 physical interpretation they have in mind.
 """
 function fetch(model::Kitaev1D, ::EdgeModeEnergy, bc::OBC; kwargs...)
+    if model.Δ == 0.0 && abs(model.μ) < 2 * abs(model.t)
+        return error(
+            "Kitaev1D EdgeModeEnergy@OBC: Δ = 0 with |μ| < 2|t| is the gapless " *
+            "metal regime — there is no SC pairing, no topological invariant, " *
+            "and no Majorana edge modes; the BdG-spectrum lowest level is a " *
+            "finite-size Fermi-point remnant.  Refusing to mask this with a " *
+            "misleading number; re-evaluate with Δ ≠ 0.",
+        )
+    end
     N = _bc_size(bc, kwargs)
     Λ = _kitaev1d_bdg_spectrum(N, model.μ, model.t, model.Δ)
     return Λ[1]

--- a/src/models/quantum/Kitaev1D/Kitaev1D.jl
+++ b/src/models/quantum/Kitaev1D/Kitaev1D.jl
@@ -183,10 +183,7 @@ function fetch(model::Kitaev1D, ::Energy{:per_site}, ::Infinite; kwargs...)
         k -> begin
             Ek = sqrt((2t * cos(k) + μ)^2 + 4Δ^2 * sin(k)^2)
             -Ek / 2
-        end,
-        -π,
-        π;
-        rtol=1e-10,
+        end, -π, π; rtol=1e-10
     )
     return result / (2π)
 end

--- a/src/models/quantum/Kitaev1D/Kitaev1D.jl
+++ b/src/models/quantum/Kitaev1D/Kitaev1D.jl
@@ -1,0 +1,384 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Kitaev (2001) 1D p-wave superconducting wire — exact BdG solution.
+#
+# Hamiltonian (spinless fermions, real-space, lattice spacing a = 1):
+#
+#   H = -μ Σᵢ c†ᵢ cᵢ
+#       - t Σᵢ (c†ᵢ c_{i+1} + h.c.)
+#       + Δ Σᵢ (cᵢ c_{i+1} + h.c.)
+#
+# • μ — chemical potential (uniform onsite)
+# • t — nearest-neighbour hopping (real)
+# • Δ — p-wave pairing amplitude (real)
+#
+# After Jordan-Wigner / Bogoliubov-de Gennes diagonalisation the spectrum is
+# free; on a PBC ring the closed-form dispersion is
+#
+#   E(k) = √( (2t cos k + μ)² + 4 Δ² sin² k ).
+#
+# Phase diagram (for Δ ≠ 0, t ≠ 0):
+#
+#   |μ| < 2|t|  → topological phase (winding ν = -1, two Majorana zero
+#                 modes at OBC chain ends with hybridisation
+#                 energy ~ e^{-N/ξ}).
+#   |μ| > 2|t|  → trivial phase (ν = +1, gapped, no edge modes).
+#   |μ| = 2|t|  → critical line (E(0) = 0 or E(π) = 0).
+#
+# The TFIM is the special case (μ = -2h, t = J, Δ = J): the BdG spectrum
+# of `Kitaev1D(μ=-2h, t=J, Δ=J)` matches that of `TFIM(J=J, h=h)` at OBC,
+# providing a built-in cross-check (`_kitaev1d_bdg_spectrum` is a strict
+# generalisation of `_tfim_bdg_spectrum`).
+#
+# References:
+#   - A. Yu. Kitaev, "Unpaired Majorana fermions in quantum wires",
+#     Phys.-Usp. 44, 131 (2001).
+#   - J. Alicea, "New directions for the pursuit of Majorana fermions in
+#     solid state systems", Rep. Prog. Phys. 75, 076501 (2012).
+#   - J. K. Asbóth, L. Oroszlány, A. Pályi, "A Short Course on Topological
+#     Insulators", Lect. Notes Phys. 919 (2016) — Pfaffian invariant.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using LinearAlgebra: eigvals, Symmetric
+using QuadGK: quadgk
+
+"""
+    Kitaev1D(; μ = 0.0, t = 1.0, Δ = 1.0) <: AbstractQAtlasModel
+
+Kitaev (2001) one-dimensional p-wave superconducting wire,
+
+```math
+H = -\\mu \\sum_i c_i^{\\dagger} c_i
+    - t   \\sum_i (c_i^{\\dagger} c_{i+1} + \\text{h.c.})
+    + \\Delta \\sum_i (c_i c_{i+1} + \\text{h.c.}).
+```
+
+`μ` is the chemical potential, `t` the hopping, `Δ` the p-wave pairing.
+`|μ| < 2|t|` is the topological phase (Majorana edge modes);
+`|μ| > 2|t|` is the trivial phase; `|μ| = 2|t|` is the gapless critical
+line.
+
+This is the 1D Majorana wire and is **distinct** from the 2D
+[`KitaevHoneycomb`](@ref) spin model.
+
+The TFIM is a special case (`μ = -2h`, `t = J`, `Δ = J`); the BdG
+spectrum of `Kitaev1D(μ=-2h, t=J, Δ=J)` agrees exactly with that of
+`TFIM(J=J, h=h)` at OBC.
+"""
+struct Kitaev1D <: AbstractQAtlasModel
+    μ::Float64
+    t::Float64
+    Δ::Float64
+end
+function Kitaev1D(; μ::Real=0.0, t::Real=1.0, Δ::Real=1.0)
+    return Kitaev1D(Float64(μ), Float64(t), Float64(Δ))
+end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Internal: BdG quasiparticle spectrum (OBC, finite N)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    _kitaev1d_bdg_spectrum(N, μ, t, Δ) -> Vector{Float64}
+
+Return the `N` non-negative BdG quasiparticle energies of the OBC
+Kitaev1D chain with `N` sites and parameters `(μ, t, Δ)`.
+
+The BdG matrix in Nambu basis is `H_BdG = [[A, B]; [-B, -A]]` (the same
+real, antisymmetric 2N × 2N convention used by `_tfim_bdg_spectrum`),
+with
+
+    A_{ii}   = -μ
+    A_{i,i+1} = A_{i+1,i} = -t
+    B_{i,i+1} = +Δ,  B_{i+1,i} = -Δ.
+
+Eigenvalues come in ± pairs; the function returns the non-negative half,
+sorted ascending.  The BdG zero modes of the topological phase (lifted
+by exponentially small N⁻¹ corrections) appear as the smallest entry.
+
+This is a strict generalisation of `_tfim_bdg_spectrum`: at
+`(μ, t, Δ) = (-2h, J, J)` the matrix coincides with the TFIM BdG matrix
+and the returned spectrum matches `_tfim_bdg_spectrum(N, J, h)`.
+"""
+function _kitaev1d_bdg_spectrum(N::Int, μ::Float64, t::Float64, Δ::Float64)::Vector{Float64}
+    A = zeros(N, N)
+    @inbounds for i in 1:N
+        A[i, i] = -μ
+    end
+    @inbounds for i in 1:(N - 1)
+        A[i, i + 1] = -t
+        A[i + 1, i] = -t
+    end
+
+    B = zeros(N, N)
+    @inbounds for i in 1:(N - 1)
+        B[i, i + 1] = Δ
+        B[i + 1, i] = -Δ
+    end
+
+    H_bdg = [A B; -B -A]
+    vals = eigvals(Symmetric(H_bdg))
+    # Drop the negative half (eigenvalues come in ± pairs); keep the
+    # non-negative branch even if one is numerically ~0 (Majorana zero
+    # mode in the topological phase) — TFIM filters at 1e-10, but here
+    # the topological zero mode is *the* observable we need to expose.
+    pos = filter(v -> v >= -1e-12, vals)
+    sort!(pos)
+    return pos[1:N]
+end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Energy granularity convention (see src/core/quantities.jl)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+native_energy_granularity(::Kitaev1D, ::Infinite) = :per_site
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ExactSpectrum (OBC) — full BdG quasiparticle spectrum
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    fetch(model::Kitaev1D, ::ExactSpectrum, bc::OBC; N::Int) -> Vector{Float64}
+
+Return the `N` non-negative BdG quasiparticle energies of the OBC
+Kitaev1D chain, sorted ascending.
+
+`N` is read from `bc.N` (`OBC(N)` / `OBC(; N)`) or, as a legacy
+fallback, from the `N` keyword argument.
+
+In the topological phase (`|μ| < 2|t|`, `Δ ≠ 0`) the lowest entry is the
+exponentially-small Majorana edge-mode hybridisation energy
+`~ e^{-N/ξ}`.  In the trivial phase the lowest entry approaches the bulk
+gap `min(|2t + μ|, |2t - μ|)`.
+"""
+function fetch(model::Kitaev1D, ::ExactSpectrum, bc::OBC; kwargs...)
+    N = _bc_size(bc, kwargs)
+    return _kitaev1d_bdg_spectrum(N, model.μ, model.t, model.Δ)
+end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Energy: thermodynamic limit (Infinite, T = 0)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    fetch(model::Kitaev1D, ::Energy{:per_site}, ::Infinite) -> Float64
+
+Ground-state energy per site of the infinite Kitaev1D chain at `T = 0`,
+
+```math
+\\varepsilon_0 = -\\frac{1}{2\\pi} \\int_{-\\pi}^{\\pi} \\frac{E(k)}{2}\\, dk,
+\\qquad
+E(k) = \\sqrt{(2t\\cos k + \\mu)^2 + 4\\Delta^2 \\sin^2 k}.
+```
+
+(The factor `1/2` accounts for the BdG particle-hole doubling: only the
+negative-energy band is filled.)
+
+Computed by adaptive Gauss-Kronrod quadrature.
+"""
+function fetch(model::Kitaev1D, ::Energy{:per_site}, ::Infinite; kwargs...)
+    μ = model.μ
+    t = model.t
+    Δ = model.Δ
+    result, _ = quadgk(
+        k -> begin
+            Ek = sqrt((2t * cos(k) + μ)^2 + 4Δ^2 * sin(k)^2)
+            -Ek / 2
+        end,
+        -π,
+        π;
+        rtol=1e-10,
+    )
+    return result / (2π)
+end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Mass gap (lowest single-quasiparticle energy in the bulk)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    fetch(model::Kitaev1D, ::MassGap, ::Infinite) -> Float64
+
+Bulk single-quasiparticle gap of the infinite Kitaev1D chain,
+
+```math
+\\Delta_{\\mathrm{gap}}
+  = \\min_k \\sqrt{(2t\\cos k + \\mu)^2 + 4\\Delta^2 \\sin^2 k}.
+```
+
+Closed form (for `t ≠ 0`, `Δ ≠ 0`):
+
+- `|μ| ≥ 2|t|`: minimum at `k = 0` or `k = π`, giving
+  `Δ_gap = ||μ| - 2|t||`.
+- `|μ| < 2|t|`: stationary point at `cos k* = -μ t / (2(t² - Δ²))`
+  when `|t| ≠ |Δ|` and `|cos k*| ≤ 1`; otherwise the minimum is at
+  `k = 0` or `k = π`.
+
+`Δ = 0` gives the gapless metal whenever `|μ| < 2|t|`, and the routine
+returns `0.0` in that case.
+
+`MassGap` at `OBC` is provided as the smallest non-negative BdG
+eigenvalue (numerically equal to [`EdgeModeEnergy`](@ref) at `OBC`).
+"""
+function fetch(model::Kitaev1D, ::MassGap, ::Infinite; kwargs...)
+    μ = model.μ
+    t = model.t
+    Δ = model.Δ
+    # Δ = 0: gapless metal whenever |μ| < 2|t|
+    if Δ == 0.0
+        return abs(μ) >= 2 * abs(t) ? abs(μ) - 2 * abs(t) : 0.0
+    end
+    # General case: minimise (2t cos k + μ)² + 4Δ² sin² k over k ∈ [0, π].
+    # Stationarity in c = cos k:
+    #   d/dc[(2t c + μ)² + 4Δ²(1 - c²)] = 4t(2tc + μ) - 8Δ² c = 0
+    #   ⇒  c* = -μ t / (2(t² - Δ²))     (t ≠ ±Δ)
+    a = t^2 - Δ^2
+    if a == 0.0
+        # |t| = |Δ|: dispersion is monotone in cos k; minima at k = 0 or π.
+        return min(abs(2t + μ), abs(2t - μ))
+    end
+    c_star = -μ * t / (2 * a)
+    # Always include k = 0 and k = π:
+    candidates = Float64[abs(2t + μ), abs(2t - μ)]
+    if -1.0 <= c_star <= 1.0
+        s_sq = 1 - c_star^2
+        push!(candidates, sqrt((2t * c_star + μ)^2 + 4Δ^2 * s_sq))
+    end
+    return minimum(candidates)
+end
+
+"""
+    fetch(model::Kitaev1D, ::MassGap, bc::OBC; N::Int) -> Float64
+
+Single-quasiparticle gap of the `N`-site OBC Kitaev1D chain — the
+smallest non-negative BdG eigenvalue of the 2N × 2N BdG matrix.
+
+In the topological phase this is the Majorana edge-mode energy
+`~ e^{-N/ξ}` (use [`EdgeModeEnergy`](@ref) for the same value under a
+boundary-mode-explicit name).  In the trivial phase it converges to the
+bulk gap as `N → ∞`.
+"""
+function fetch(model::Kitaev1D, ::MassGap, bc::OBC; kwargs...)
+    N = _bc_size(bc, kwargs)
+    Λ = _kitaev1d_bdg_spectrum(N, model.μ, model.t, model.Δ)
+    return Λ[1]
+end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Edge-mode energy (OBC) — same value as MassGap@OBC, named for boundary modes
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    fetch(model::Kitaev1D, ::EdgeModeEnergy, bc::OBC; N::Int) -> Float64
+
+Energy of the lowest-lying boundary mode on an `N`-site OBC Kitaev1D
+chain — the smallest non-negative BdG eigenvalue.
+
+In the topological phase (`|μ| < 2|t|`, `Δ ≠ 0`) the two end-localised
+Majorana modes hybridise into a single complex fermion with
+exponentially-small splitting `~ e^{-N/ξ}` where `ξ ~ 1/log(2|t|/|μ|)`
+for `|μ| ≪ 2|t|`.
+
+Numerically equal to `fetch(model, MassGap(), OBC(N))`; the two methods
+exist as separate names so call sites can be explicit about which
+physical interpretation they have in mind.
+"""
+function fetch(model::Kitaev1D, ::EdgeModeEnergy, bc::OBC; kwargs...)
+    N = _bc_size(bc, kwargs)
+    Λ = _kitaev1d_bdg_spectrum(N, model.μ, model.t, model.Δ)
+    return Λ[1]
+end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Correlation length (Infinite, T = 0)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    fetch(model::Kitaev1D, ::CorrelationLength, ::Infinite) -> Float64
+
+`T = 0` correlation length of the infinite Kitaev1D chain, set by the
+inverse bulk gap,
+
+```math
+\\xi = \\frac{1}{\\Delta_{\\mathrm{gap}}}.
+```
+
+Returns `Inf` on the gapless line `|μ| = 2|t|` (and on the gapless metal
+`Δ = 0`, `|μ| < 2|t|`).  In QAtlas convention `ξ` is dimensionless (in
+units of the lattice spacing).
+"""
+function fetch(model::Kitaev1D, ::CorrelationLength, ::Infinite; kwargs...)
+    gap = fetch(model, MassGap(), Infinite())
+    return gap <= 0.0 ? Inf : 1 / gap
+end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Topological invariant (Pfaffian sign at k = 0 and k = π)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    _kitaev1d_majorana_bloch(μ, t, k::Symbol) -> Matrix{Float64}
+
+Return the 2 × 2 real antisymmetric Majorana Bloch matrix `A(k)` of the
+infinite Kitaev1D chain at the time-reversal-invariant momenta
+`k ∈ {:zero, :pi}`.  At those momenta the pairing amplitude `2Δ sin k`
+vanishes, so the matrix depends only on `μ` and `t`:
+
+    A(k=0)  = [ 0  μ + 2t; -(μ + 2t)  0 ]   ⇒   Pf A(k=0)  = μ + 2t
+    A(k=π)  = [ 0  μ - 2t; -(μ - 2t)  0 ]   ⇒   Pf A(k=π)  = μ - 2t
+
+(Convention: the diagonal Majorana Bloch matrix at TR-invariant momenta
+has off-diagonal entry equal to the on-site mass term `μ + 2t cos k`.)
+This is the matrix on which the Kitaev (2001) Z₂ Pfaffian invariant is
+evaluated.
+"""
+function _kitaev1d_majorana_bloch(μ::Float64, t::Float64, k::Symbol)::Matrix{Float64}
+    cosk = k === :zero ? 1.0 : (k === :pi ? -1.0 : error("k must be :zero or :pi"))
+    m = μ + 2t * cosk
+    return [0.0 m; -m 0.0]
+end
+
+"""
+    fetch(model::Kitaev1D, ::TopologicalInvariant, ::Infinite) -> Int
+
+Pfaffian Z₂ invariant of the infinite Kitaev1D chain (Kitaev 2001),
+
+```math
+\\nu = \\operatorname{sgn}\\bigl[\\operatorname{Pf} A(k=0)
+                                  \\cdot \\operatorname{Pf} A(k=\\pi)\\bigr]
+     = \\operatorname{sgn}\\bigl[(\\mu + 2t)(\\mu - 2t)\\bigr]
+     = \\operatorname{sgn}(\\mu^2 - 4t^2).
+```
+
+Returns `-1` in the topological phase (`|μ| < 2|t|`) and `+1` in the
+trivial phase (`|μ| > 2|t|`).  Throws on the gapless line `|μ| = 2|t|`
+(Pfaffian vanishes; invariant ill-defined) and on the gapless metal
+`Δ = 0` with `|μ| < 2|t|`.
+
+The two 2 × 2 Pfaffians are computed using the generic
+[`pfaffian`](@ref) routine in `src/core/pfaffian.jl`, exercising the
+same numerical machinery used elsewhere in QAtlas for free-fermion Wick
+contractions.
+"""
+function fetch(model::Kitaev1D, ::TopologicalInvariant, ::Infinite; kwargs...)
+    μ = model.μ
+    t = model.t
+    Δ = model.Δ
+    # The Z₂ invariant is well-defined only when the bulk is gapped.
+    if Δ == 0.0 && abs(μ) < 2 * abs(t)
+        error(
+            "TopologicalInvariant: bulk is gapless (Δ = 0 with |μ| < 2|t|); " *
+            "the Pfaffian invariant is ill-defined.",
+        )
+    end
+    pf0 = pfaffian(_kitaev1d_majorana_bloch(μ, t, :zero))
+    pfπ = pfaffian(_kitaev1d_majorana_bloch(μ, t, :pi))
+    prod = pf0 * pfπ
+    if prod == 0.0
+        error(
+            "TopologicalInvariant: Pfaffian vanishes at |μ| = 2|t| = $(2 * abs(t)); " *
+            "the bulk is gapless and the invariant is ill-defined " *
+            "(μ = $μ, t = $t).",
+        )
+    end
+    return prod > 0 ? 1 : -1
+end

--- a/src/models/quantum/Kitaev1D/Kitaev1D_registry.jl
+++ b/src/models/quantum/Kitaev1D/Kitaev1D_registry.jl
@@ -1,0 +1,67 @@
+# models/quantum/Kitaev1D/Kitaev1D_registry.jl — declarative implementation
+# map for the 1D Majorana wire (Kitaev 2001).  See `src/core/registry.jl`
+# for the metadata schema.
+
+# ── Energy (granularity-aware) ─────────────────────────────────────────
+@register(
+    Kitaev1D,
+    Energy{:per_site},
+    Infinite,
+    method=:bdg,
+    reliability=:high,
+    tested_in="test/standalone/test_kitaev1d.jl",
+    references=["Kitaev 2001"],
+    notes="Per-site ε₀ by Gauss-Kronrod over the PBC dispersion E(k).",
+)
+
+# ── Spectrum / criticality ────────────────────────────────────────────
+@register(
+    Kitaev1D,
+    MassGap,
+    Infinite,
+    method=:analytic,
+    reliability=:high,
+    tested_in="test/standalone/test_kitaev1d.jl",
+    references=["Kitaev 2001", "Alicea 2012"],
+    notes="Closed-form min over k of √((2t cos k + μ)² + 4Δ² sin² k).",
+)
+@register(
+    Kitaev1D,
+    MassGap,
+    OBC,
+    method=:bdg,
+    reliability=:high,
+    tested_in="test/standalone/test_kitaev1d.jl",
+    references=["Kitaev 2001"],
+    notes="Smallest non-negative BdG eigenvalue (Majorana edge mode in topological phase).",
+)
+@register(
+    Kitaev1D,
+    EdgeModeEnergy,
+    OBC,
+    method=:bdg,
+    reliability=:high,
+    tested_in="test/standalone/test_kitaev1d.jl",
+    references=["Kitaev 2001", "Alicea 2012"],
+    notes="Same value as MassGap@OBC; named for the Majorana boundary-mode interpretation.",
+)
+@register(
+    Kitaev1D,
+    CorrelationLength,
+    Infinite,
+    method=:analytic,
+    reliability=:high,
+    tested_in="test/standalone/test_kitaev1d.jl",
+    references=["Kitaev 2001"],
+    notes="ξ = 1/Δ_gap; Inf on the critical line |μ| = 2|t|.",
+)
+@register(
+    Kitaev1D,
+    TopologicalInvariant,
+    Infinite,
+    method=:pfaffian,
+    reliability=:high,
+    tested_in="test/standalone/test_kitaev1d.jl",
+    references=["Kitaev 2001", "Asboth-Oroszlany-Palyi 2016"],
+    notes="ν = sgn[Pf A(k=0)·Pf A(k=π)] = sgn(μ² - 4t²); ν=-1 topological, +1 trivial.",
+)

--- a/test/standalone/test_kitaev1d.jl
+++ b/test/standalone/test_kitaev1d.jl
@@ -204,3 +204,14 @@ using QAtlas:
         )
     end
 end
+
+@testset "Kitaev1D gapless-metal guard (OBC)" begin
+    m_metal = Kitaev1D(; μ=1.0, t=1.0, Δ=0.0)
+    @test_throws ErrorException QAtlas.fetch(m_metal, MassGap(), OBC(20))
+    @test_throws ErrorException QAtlas.fetch(m_metal, EdgeModeEnergy(), OBC(20))
+
+    m_atomic = Kitaev1D(; μ=3.0, t=1.0, Δ=0.0)
+    Δgap = QAtlas.fetch(m_atomic, MassGap(), OBC(20))
+    @test isfinite(Δgap)
+    @test Δgap > 0
+end

--- a/test/standalone/test_kitaev1d.jl
+++ b/test/standalone/test_kitaev1d.jl
@@ -1,0 +1,208 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Standalone test: Kitaev (2001) 1D p-wave wire.
+#
+# Targeted run (skips Pkg.test()):
+#   julia --project=test test/standalone/test_kitaev1d.jl
+#
+# Coverage:
+#   • PBC closed-form dispersion: E(0) = |2t + μ|, E(π) = |2t - μ|
+#   • TopologicalInvariant: ν = -1 (topological) for |μ| < 2|t|;
+#                           ν = +1 (trivial)     for |μ| > 2|t|;
+#                           Pfaffian sign flips at the critical line.
+#   • TFIM correspondence: Kitaev1D(μ=-2h, t=J, Δ=J) BdG spectrum at OBC
+#                          equals TFIM(J=J, h=h) BdG spectrum.
+#   • OBC topological N = 40 has Majorana edge mode (lowest |Λ| ≤ 1e-3).
+#   • OBC trivial      N = 40 has lowest |Λ| of order the bulk gap 2(|μ| - 2t).
+#   • CorrelationLength: finite away from |μ| = 2|t|, Inf on the critical line.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Test
+using QAtlas:
+    Kitaev1D,
+    TFIM,
+    ExactSpectrum,
+    Energy,
+    MassGap,
+    CorrelationLength,
+    TopologicalInvariant,
+    EdgeModeEnergy,
+    OBC,
+    Infinite,
+    fetch
+
+@testset "Kitaev1D" begin
+
+    # ─────────────────── PBC closed-form dispersion ───────────────────
+    @testset "PBC dispersion: E(0) = |2t+μ|, E(π) = |2t-μ|" begin
+        # E(k) = √((2t cos k + μ)² + 4Δ² sin² k)
+        # At k=0: sin = 0, E = |2t + μ|.   At k=π: sin = 0, E = |2t - μ|.
+        for (μ, t, Δ) in
+            [(0.0, 1.0, 1.0), (1.0, 1.0, 1.0), (3.0, 1.0, 1.0), (-2.5, 1.0, 0.5)]
+            E0 = sqrt((2t * 1.0 + μ)^2 + 4Δ^2 * 0.0)
+            Eπ = sqrt((2t * (-1.0) + μ)^2 + 4Δ^2 * 0.0)
+            @test E0 ≈ abs(2t + μ)
+            @test Eπ ≈ abs(2t - μ)
+        end
+    end
+
+    # ─────────────────── TopologicalInvariant ─────────────────────────
+    @testset "TopologicalInvariant: ν = -1 in topological phase" begin
+        m = Kitaev1D(; μ=0.0, t=1.0, Δ=1.0)
+        @test fetch(m, TopologicalInvariant(), Infinite()) == -1
+
+        m2 = Kitaev1D(; μ=1.5, t=1.0, Δ=1.0)        # |μ| < 2|t|
+        @test fetch(m2, TopologicalInvariant(), Infinite()) == -1
+
+        m3 = Kitaev1D(; μ=-1.5, t=1.0, Δ=0.5)
+        @test fetch(m3, TopologicalInvariant(), Infinite()) == -1
+    end
+
+    @testset "TopologicalInvariant: ν = +1 in trivial phase" begin
+        m = Kitaev1D(; μ=3.0, t=1.0, Δ=1.0)         # |μ| > 2|t|
+        @test fetch(m, TopologicalInvariant(), Infinite()) == 1
+
+        m2 = Kitaev1D(; μ=-2.5, t=1.0, Δ=1.0)
+        @test fetch(m2, TopologicalInvariant(), Infinite()) == 1
+    end
+
+    @testset "Pfaffian flips sign at |μ| = 2t" begin
+        # On the gapless critical line one Pfaffian vanishes ⇒ invariant
+        # is ill-defined, the routine throws.  We sample just inside the
+        # boundary on either side and check the sign flip.
+        ε = 1e-6
+        ν_in = fetch(
+            Kitaev1D(; μ=2.0 - ε, t=1.0, Δ=1.0), TopologicalInvariant(), Infinite()
+        )
+        ν_out = fetch(
+            Kitaev1D(; μ=2.0 + ε, t=1.0, Δ=1.0), TopologicalInvariant(), Infinite()
+        )
+        @test ν_in == -1
+        @test ν_out == 1
+
+        # And the gapless point itself errors out (ill-defined invariant).
+        @test_throws ErrorException fetch(
+            Kitaev1D(; μ=2.0, t=1.0, Δ=1.0), TopologicalInvariant(), Infinite()
+        )
+        @test_throws ErrorException fetch(
+            Kitaev1D(; μ=-2.0, t=1.0, Δ=1.0), TopologicalInvariant(), Infinite()
+        )
+    end
+
+    # ─────────────────── TFIM correspondence ──────────────────────────
+    @testset "TFIM correspondence: μ=-2h, t=J, Δ=J reproduces TFIM spectrum" begin
+        # _tfim_bdg_spectrum filters values <= 1e-10, so we must do the
+        # same to the Kitaev1D spectrum to compare apples to apples.  We
+        # do it by sorting and taking the top N entries on each side
+        # (both routines build the same 2N×2N BdG matrix when the
+        # parameters coincide, so the top-N entries match exactly).
+        N = 20
+        for (J, h) in [(1.0, 0.5), (1.0, 1.5), (1.0, 1.0), (0.7, 0.3)]
+            μ_eq = -2h
+            spec_kitaev = QAtlas._kitaev1d_bdg_spectrum(N, μ_eq, J, J)
+            spec_tfim = QAtlas._tfim_bdg_spectrum(N, J, h)
+            # spec_tfim filters near-zeros (< 1e-10); take the top-K
+            # entries of the Kitaev spectrum that match length(spec_tfim).
+            K = length(spec_tfim)
+            @test K > 0
+            top_kitaev = spec_kitaev[(end - K + 1):end]
+            @test isapprox(sort(top_kitaev), sort(spec_tfim); atol=1e-9)
+        end
+    end
+
+    # ─────────────────── OBC edge mode (topological) ──────────────────
+    @testset "OBC topological N=40 has Majorana edge mode (≤ 1e-3)" begin
+        m = Kitaev1D(; μ=0.0, t=1.0, Δ=1.0)
+        N = 40
+        Λmin = fetch(m, EdgeModeEnergy(), OBC(N))
+        @test Λmin <= 1e-3
+        # Same value via MassGap@OBC by construction
+        @test fetch(m, MassGap(), OBC(N)) == Λmin
+        # Sweet spot μ = 0, t = Δ = 1: the Kitaev sweet point — the two
+        # Majoranas decouple exactly to the chain ends, so the splitting
+        # is essentially 0 (down to floating-point noise).
+        @test Λmin <= 1e-10
+    end
+
+    @testset "OBC topological μ ≠ 0 still has small edge-mode energy" begin
+        m = Kitaev1D(; μ=0.5, t=1.0, Δ=1.0)
+        Λmin = fetch(m, EdgeModeEnergy(), OBC(40))
+        @test Λmin <= 1e-3
+    end
+
+    # ─────────────────── OBC trivial: bulk gap ────────────────────────
+    @testset "OBC trivial N=40 lowest energy is order of bulk gap" begin
+        # Trivial phase: μ = 3, t = Δ = 1 ⇒ bulk gap = ||μ| - 2|t|| = 1.
+        # The OBC lowest energy converges to the bulk gap exponentially
+        # in N, so at N=40 we just check it's of the right order.
+        m = Kitaev1D(; μ=3.0, t=1.0, Δ=1.0)
+        Λmin = fetch(m, EdgeModeEnergy(), OBC(40))
+        bulk_gap = abs(abs(3.0) - 2 * 1.0)         # = 1.0; min(|2t+μ|, |2t-μ|)
+        @test Λmin >= 0.5 * bulk_gap
+        @test Λmin <= 1.5 * bulk_gap
+        # Cross-check against the analytic infinite-chain gap
+        gap_inf = fetch(m, MassGap(), Infinite())
+        @test isapprox(Λmin, gap_inf; atol=5e-2)
+    end
+
+    # ─────────────────── ExactSpectrum returns vector ─────────────────
+    @testset "ExactSpectrum returns N sorted non-negative entries" begin
+        m = Kitaev1D(; μ=0.0, t=1.0, Δ=1.0)
+        for N in (10, 20, 30)
+            spec = fetch(m, ExactSpectrum(), OBC(N))
+            @test length(spec) == N
+            @test issorted(spec)
+            @test all(spec .>= -1e-10)
+        end
+    end
+
+    # ─────────────────── CorrelationLength ─────────────────────────────
+    @testset "CorrelationLength: gapped, finite; gapless, Inf" begin
+        ξ_top = fetch(Kitaev1D(; μ=0.0, t=1.0, Δ=1.0), CorrelationLength(), Infinite())
+        @test isfinite(ξ_top)
+        @test ξ_top > 0
+
+        ξ_triv = fetch(Kitaev1D(; μ=3.0, t=1.0, Δ=1.0), CorrelationLength(), Infinite())
+        @test isfinite(ξ_triv)
+        @test ξ_triv > 0
+        # In the trivial phase μ = 3, t = Δ = 1 the bulk gap is 1, so ξ = 1.
+        @test isapprox(ξ_triv, 1.0; atol=1e-9)
+
+        ξ_crit = fetch(Kitaev1D(; μ=2.0, t=1.0, Δ=1.0), CorrelationLength(), Infinite())
+        @test ξ_crit == Inf
+    end
+
+    # ─────────────────── Energy{:per_site} smoke ──────────────────────
+    @testset "Energy(:per_site) at Infinite is finite + negative" begin
+        for (μ, t, Δ) in [(0.0, 1.0, 1.0), (1.0, 1.0, 1.0), (3.0, 1.0, 1.0)]
+            ε = fetch(Kitaev1D(; μ=μ, t=t, Δ=Δ), Energy(:per_site), Infinite())
+            @test isfinite(ε)
+            @test ε < 0
+        end
+        # Energy() resolves through the :natural router to :per_site at
+        # Infinite() (declared by `native_energy_granularity`).
+        ε_nat = fetch(Kitaev1D(), Energy(), Infinite())
+        ε_ps = fetch(Kitaev1D(), Energy(:per_site), Infinite())
+        @test ε_nat == ε_ps
+    end
+
+    # ─────────────────── MassGap closed form spot checks ──────────────
+    @testset "MassGap closed form at corners" begin
+        # Sweet spot t = Δ, μ = 0: gap = 2|Δ| (PBC dispersion
+        # E(k) = 2√(t² cos²k + Δ² sin²k) is constant = 2|t| = 2|Δ|).
+        @test isapprox(
+            fetch(Kitaev1D(; μ=0.0, t=1.0, Δ=1.0), MassGap(), Infinite()), 2.0; atol=1e-10
+        )
+
+        # Trivial μ = 3, t = Δ = 1: gap = ||μ| - 2|t|| = 1.
+        @test isapprox(
+            fetch(Kitaev1D(; μ=3.0, t=1.0, Δ=1.0), MassGap(), Infinite()), 1.0; atol=1e-10
+        )
+
+        # Critical |μ| = 2|t|: gap = 0.
+        @test isapprox(
+            fetch(Kitaev1D(; μ=2.0, t=1.0, Δ=1.0), MassGap(), Infinite()),
+            0.0;
+            atol=1e-10,
+        )
+    end
+end

--- a/test/standalone/test_kitaev1d.jl
+++ b/test/standalone/test_kitaev1d.jl
@@ -200,9 +200,7 @@ using QAtlas:
 
         # Critical |μ| = 2|t|: gap = 0.
         @test isapprox(
-            fetch(Kitaev1D(; μ=2.0, t=1.0, Δ=1.0), MassGap(), Infinite()),
-            0.0;
-            atol=1e-10,
+            fetch(Kitaev1D(; μ=2.0, t=1.0, Δ=1.0), MassGap(), Infinite()), 0.0; atol=1e-10
         )
     end
 end


### PR DESCRIPTION
## Summary

- Add the 1D Kitaev (2001) p-wave Majorana wire `Kitaev1D <: AbstractQAtlasModel` as a free-fermion BdG model with closed-form bulk dispersion `E(k) = √((2t cos k + μ)² + 4Δ² sin²k)`.
- Add two new `AbstractQuantity` types: `TopologicalInvariant` (Pfaffian Z₂ invariant ν ∈ {-1, +1}) and `EdgeModeEnergy` (smallest non-negative OBC BdG eigenvalue — the Majorana edge-mode hybridisation).
- Register six native fetch methods (`ExactSpectrum/OBC`, `Energy{:per_site}/Infinite`, `MassGap/{Infinite,OBC}`, `EdgeModeEnergy/OBC`, `CorrelationLength/Infinite`, `TopologicalInvariant/Infinite`).
- New documentation page `docs/src/models/quantum/kitaev1d.md`, wired into `docs/make.jl` and the quantum-models index.

Note: this model is **distinct from `KitaevHoneycomb`** (which is the 2D anisotropic spin model on the honeycomb lattice, Kitaev 2006).  They share a name only by historical accident.

## Implementation notes

- `_kitaev1d_bdg_spectrum` is a strict generalisation of `_tfim_bdg_spectrum`: at parameters `(μ, t, Δ) = (-2h, J, J)` the BdG matrix coincides element-wise with TFIM's, and the produced spectra match exactly (verified by a direct spectrum-equality test at OBC N=20).
- `TopologicalInvariant` uses the existing `pfaffian()` utility (`src/core/pfaffian.jl`) on the 2×2 Majorana Bloch matrix at the time-reversal-invariant momenta `k = 0, π`, giving `ν = sgn[(μ+2t)(μ-2t)] = sgn(μ² - 4t²)` (Kitaev 2001).
- `MassGap` at `Infinite` evaluates the closed-form minimum over `k` analytically by inspecting the stationary point `cos k* = -μt/(2(t² - Δ²))` plus the band-edge candidates `k = 0, π`.
- The gapless line `|μ| = 2|t|` and the gapless metal `Δ = 0` with `|μ| < 2|t|` raise an explicit error from `TopologicalInvariant` (Pfaffian vanishes / invariant ill-defined).

## Test plan

- [x] Targeted: `julia --project=test test/standalone/test_kitaev1d.jl` — **57/57 passing** (PBC dispersion, ν=−1 topological at μ=0, ν=+1 trivial at μ=3, Pfaffian flip at |μ|=2t with explicit `@test_throws` on the gapless line, TFIM correspondence at μ=-2h/t=J/Δ=J for several (J,h), OBC edge mode ≤ 1e-3 at N=40, OBC trivial lowest energy of bulk-gap order, ExactSpectrum length/order, CorrelationLength gapped/critical, Energy(:per_site) router, MassGap closed-form spot checks).
- [x] Registry drift guard: `julia --project=test test/core/test_registry.jl` — all 158 `has_native_fetch` checks green (Kitaev1D rows registered with correct methods).
- [x] Smoke load: `using QAtlas` precompiles cleanly on Julia 1.11.

## Pinned values

| Quantity | (μ, t, Δ) | OBC N | Value |
|---|---|---|---|
| `MassGap@Infinite` | (0.5, 1.0, 1.0) | — | 1.5 |
| `CorrelationLength@Infinite` | (0.5, 1.0, 1.0) | — | 0.6667 |
| `TopologicalInvariant@Infinite` | (0.5, 1.0, 1.0) | — | -1 |
| `EdgeModeEnergy@OBC` | (0.5, 1.0, 1.0) | 20 | 1.7e-12 |
| `EdgeModeEnergy@OBC` | (0.5, 1.0, 1.0) | 40 | ~1e-16 |
| `EdgeModeEnergy@OBC` | (3.0, 1.0, 1.0) | 40 | 1.016 (≈ bulk gap 1.0) |
| `MassGap@Infinite` | (0.5, 1.0, 0.5) | — | 0.9574 = √(11/12) (closed form) |

Closes #152.

## References

- A. Yu. Kitaev, *Phys.-Usp.* **44**, 131 (2001)
- J. Alicea, *Rep. Prog. Phys.* **75**, 076501 (2012)
- J. K. Asbóth, L. Oroszlány, A. Pályi, *Lect. Notes Phys.* **919** (2016)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
