### PR TITLE
feat(quantum): Hubbard1D — Lieb-Wu Bethe ansatz half-filling closed form (closes #153 phase 1)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
 Aqua = "0.8"
@@ -17,6 +18,7 @@ LinearAlgebra = "1.10"
 QuadGK = "2.11.2"
 Random = "1.10"
 SparseArrays = "1.10"
+SpecialFunctions = "2"
 Test = "1.10"
 julia = "1.10"
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -50,6 +50,7 @@ makedocs(;
                 "TFIM" => "models/quantum/tfim.md",
                 "Heisenberg" => "models/quantum/heisenberg.md",
                 "XXZ" => "models/quantum/xxz.md",
+                "Hubbard1D" => "models/quantum/hubbard1d.md",
                 "Kitaev Honeycomb" => "models/quantum/kitaev-honeycomb.md",
                 "Tight-Binding" => [
                     "models/quantum/tightbinding/index.md",

--- a/docs/src/models/index.md
+++ b/docs/src/models/index.md
@@ -12,4 +12,5 @@ Hamiltonian, all stored results with derivations and references, the
 - [Quantum Models](quantum/index.md)
   - [Transverse-Field Ising Model](quantum/tfim.md)
   - [Heisenberg Chain](quantum/heisenberg.md)
+  - [Hubbard1D Chain](quantum/hubbard1d.md)
   - [Tight-Binding Models](quantum/tightbinding/index.md)

--- a/docs/src/models/quantum/hubbard1d.md
+++ b/docs/src/models/quantum/hubbard1d.md
@@ -1,0 +1,101 @@
+# Hubbard1D — 1D Hubbard Chain (Lieb–Wu Bethe Ansatz)
+
+!!! warning "Status: Phase 1 (v0.18.x)"
+    Phase 1 exposes the Lieb–Wu (1968) closed-form integrals at **half
+    filling only** ($\mu = U/2$). General filling and finite-temperature
+    QTM observables are deferred to Phase 2; off-half-filling fetches
+    raise `DomainError`.
+
+## Hamiltonian
+
+```math
+H = -t \sum_{i, \sigma} \bigl(c_{i,\sigma}^\dagger c_{i+1,\sigma} + \text{h.c.}\bigr)
+    + U \sum_i n_{i,\uparrow} n_{i,\downarrow}
+    - \mu \sum_i n_i,
+\qquad t > 0,\ U > 0.
+```
+
+Half filling corresponds to $\mu = U/2$ by particle-hole symmetry; in
+this regime the chain is a **Mott insulator** for any $U > 0$ (no
+Mott transition — the celebrated Lieb–Wu result).
+
+## Phase 1 coverage
+
+| Quantity | Infinite (half filling) | Off half filling |
+|---|---|---|
+| `GroundStateEnergyDensity` | Lieb–Wu integral | `DomainError` |
+| `ChargeGap` | Lieb–Wu integral | `DomainError` |
+| `SpinGap` | $0$ exactly | `DomainError` |
+
+## Closed-form integrals (Lieb–Wu 1968)
+
+### Ground-state energy per site
+
+```math
+\frac{E_0}{N} = -4 t^2 \int_0^\infty d\omega \,
+    \frac{J_0(\omega)\, J_1(\omega)}{\omega \, \bigl[1 + \exp(\omega U / 2t)\bigr]}.
+```
+
+### Mott (charge) gap
+
+```math
+\Delta_c = \frac{16 t^2}{U} \int_1^\infty d\omega \,
+    \frac{\sqrt{\omega^2 - 1}}{\sinh(2\pi t \omega / U)}.
+```
+
+### Spin gap
+
+```math
+\Delta_s = 0 \quad \text{exactly} \quad (\text{rigorous gapless spinons}).
+```
+
+Both integrals are evaluated numerically with `QuadGK.quadgk` at
+relative tolerance $10^{-12}$, well below the test atol of $10^{-8}$.
+
+## Asymptotic limits (test anchors)
+
+| Limit | $E_0/N$ | $\Delta_c$ |
+|---|---|---|
+| $U/t \to 0$ (free fermion) | $-4t/\pi$ | $0$ (exponentially small) |
+| $U/t \to \infty$ (Heisenberg AFM) | $-4 t^2 \log 2 / U$ | $U - 4t + 8 t^2 \log 2 / U$ |
+
+The $U \to \infty$ limit reproduces the Hulthén ground-state energy of
+the [Heisenberg AFM chain](heisenberg.md) with effective coupling
+$J = 4 t^2 / U$.
+
+## Quick-look code
+
+```julia
+using QAtlas
+
+m = Hubbard1D(; t=1.0, U=4.0, μ=2.0)   # half filling
+
+QAtlas.fetch(m, GroundStateEnergyDensity(), Infinite())   # ≈ -0.5737293678984494
+QAtlas.fetch(m, ChargeGap(),               Infinite())    # ≈ 1.2867270220129354
+QAtlas.fetch(m, SpinGap(),                 Infinite())    # 0.0 exactly
+
+# Off half filling raises DomainError (Phase 2 territory)
+QAtlas.fetch(Hubbard1D(; t=1, U=6, μ=2),
+             GroundStateEnergyDensity(), Infinite())   # DomainError
+```
+
+## References
+
+- E. H. Lieb, F. Y. Wu, "Absence of Mott transition in an exact
+  solution of the short-range, one-band model in one dimension",
+  *Phys. Rev. Lett.* **20**, 1445 (1968).
+- F. H. L. Essler, H. Frahm, F. Göhmann, A. Klümper, V. E. Korepin,
+  *The One-Dimensional Hubbard Model*, Cambridge University Press
+  (2005).
+- E. H. Lieb, F. Y. Wu, "The one-dimensional Hubbard model: a
+  reminiscence", *Physica A* **321**, 1 (2003).
+
+## Related
+
+- [Heisenberg1D](heisenberg.md) — the $U/t \to \infty$ effective-spin
+  reduction of the half-filled Hubbard chain (Hulthén 1938).
+- [XXZ1D](xxz.md) — the same Bethe-ansatz machinery applied to the
+  anisotropic spin-½ chain (issue #108 — TBA/NLIE).
+- [Lieb tight-binding lattice](tightbinding/lieb.md) — Lieb's *other*
+  flat-band lattice result (1989); unrelated to the Lieb–Wu Hubbard
+  solution despite the shared surname.

--- a/docs/src/models/quantum/index.md
+++ b/docs/src/models/quantum/index.md
@@ -13,3 +13,5 @@ rigorously verifiable solutions.
 - [Tight-Binding Models](tightbinding/index.md) -- nearest-neighbor
   hopping on 8 lattice topologies, with closed-form Bloch spectra and
   a generic builder
+- [Hubbard1D Chain](hubbard1d.md) -- 1D Hubbard model, Lieb-Wu Bethe
+  ansatz half-filling closed forms (E_0/N, charge gap, spin gap)

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -21,6 +21,7 @@ export TightBindingSpectrum
 # backward-compat top-level alias for `Honeycomb` (see src/deprecate/)
 # since the name does not collide with anything in Lattice2D.
 export Heisenberg1D, ExactSpectrum, GroundStateEnergyDensity
+export Hubbard1D                                         # Lieb-Wu Bethe ansatz half-filling
 export S1Heisenberg1D                                    # spin-1 (Haldane chain)
 
 # --- Core Implementation ---
@@ -36,6 +37,7 @@ export Implementation, implementation_status, implementation_status_markdown
 
 # --- Quantity struct exports (new, axis-explicit naming) ---
 export Energy, FreeEnergy, SpecificHeat, MassGap, FidelitySusceptibility
+export ChargeGap, SpinGap                                # Hubbard / correlated-electron gaps
 export ThermalEntropy, VonNeumannEntropy, RenyiEntropy
 export MagnetizationX, MagnetizationY, MagnetizationZ
 export MagnetizationXLocal, MagnetizationYLocal, MagnetizationZLocal, EnergyLocal
@@ -97,6 +99,8 @@ include("models/quantum/XXZ/XXZ.jl")
 include("models/quantum/XXZ/XXZ_thermal.jl")
 include("models/quantum/XXZ/XXZ_registry.jl")  # populates REGISTRY for XXZ1D
 include("models/quantum/Heisenberg/Heisenberg_registry.jl")  # populates REGISTRY for Heisenberg1D
+include("models/quantum/Hubbard1D/Hubbard1D.jl")
+include("models/quantum/Hubbard1D/Hubbard1D_registry.jl")  # populates REGISTRY for Hubbard1D
 
 # --- Deprecation shims (legacy API) ---
 # Loaded last so they can route into any already-registered concrete

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -442,7 +442,6 @@ function fetch(model::AbstractQAtlasModel, ::Energy{:total}, bc::Union{OBC,PBC};
     return fetch(model, Energy{:per_site}(), bc; kwargs...) * _bc_size(bc, kwargs)
 end
 
-
 # ─── Charge / spin gaps (correlated electron systems) ──────────────────
 
 """

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -441,3 +441,37 @@ function fetch(model::AbstractQAtlasModel, ::Energy{:total}, bc::Union{OBC,PBC};
     )
     return fetch(model, Energy{:per_site}(), bc; kwargs...) * _bc_size(bc, kwargs)
 end
+
+
+# ─── Charge / spin gaps (correlated electron systems) ──────────────────
+
+"""
+    ChargeGap() <: AbstractQuantity
+
+Charge (Mott) gap of an electron system,
+
+    Δ_c = E₀(N+1) + E₀(N-1) - 2 E₀(N),
+
+i.e. the energy cost of adding a particle plus the cost of removing
+one, equivalent to the gap between the half-filled ground state and
+the lowest charged excitation.  Strictly positive in a Mott insulator
+and exactly zero in a metal / superconductor.
+
+Implemented analytically for [](@ref) at half filling via
+the Lieb–Wu (1968) closed-form integral.
+"""
+struct ChargeGap <: AbstractQuantity end
+
+"""
+    SpinGap() <: AbstractQuantity
+
+Spin gap of an electron system,
+
+    Δ_s = E₀(S^z = 1) - E₀(S^z = 0),
+
+i.e. the lowest excitation energy at fixed total particle number that
+flips one spin.  Zero whenever the spinon branch is gapless (e.g. the
+half-filled 1D Hubbard chain — rigorous Lieb–Wu result), positive in a
+spin-gapped phase (Haldane chain, BCS superconductor, …).
+"""
+struct SpinGap <: AbstractQuantity end

--- a/src/models/quantum/Hubbard1D/Hubbard1D.jl
+++ b/src/models/quantum/Hubbard1D/Hubbard1D.jl
@@ -1,0 +1,222 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Hubbard1D — 1D Hubbard model, Lieb–Wu Bethe ansatz half-filling closed form.
+#
+# Hamiltonian:
+#
+#   H = -t Σ_{i, σ} (c†_{i,σ} c_{i+1,σ} + h.c.)
+#       + U Σ_i n_{i,↑} n_{i,↓}
+#       - μ Σ_i n_i
+#
+#   (spin-½ fermions; t > 0 hopping, U > 0 on-site repulsion, μ chemical
+#   potential — half filling corresponds to μ = U/2 by particle-hole
+#   symmetry.)
+#
+# Phase 1 (this file) implements the Lieb–Wu (1968) closed-form
+# integrals at half filling only:
+#
+#   E₀/N = -4 t² ∫_0^∞ dω  J₀(ω) J₁(ω) / [ ω (1 + exp(ω U / 2t)) ]
+#
+#   Δ_c  = (16 t² / U) ∫_1^∞ dω  √(ω² - 1) / sinh(2π t ω / U)
+#
+#   Δ_s  = 0                     (gapless spinons; rigorous Lieb–Wu)
+#
+# Asymptotic limits used as test anchors:
+#
+#   U/t → 0   (free fermion):    E₀/N → -4 t / π,        Δ_c → 0
+#   U/t → ∞   (Heisenberg AFM):  E₀/N → -4 t² log 2 / U, Δ_c → U - 4t + 8 t² log 2 / U
+#
+# Phase 2 (deferred): general filling (μ ≠ U/2) and finite-T QTM —
+# both require the full Lieb–Wu coupled integral equations.
+#
+# References:
+#
+#   - E. H. Lieb, F. Y. Wu, "Absence of Mott transition in an exact
+#     solution of the short-range, one-band model in one dimension",
+#     Phys. Rev. Lett. 20, 1445 (1968).
+#   - F. H. L. Essler, H. Frahm, F. Göhmann, A. Klümper, V. E. Korepin,
+#     "The One-Dimensional Hubbard Model", Cambridge University Press
+#     (2005) — the canonical textbook.
+#   - E. H. Lieb, F. Y. Wu, "The one-dimensional Hubbard model: a
+#     reminiscence", Physica A 321, 1 (2003).
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QuadGK: quadgk
+using SpecialFunctions: besselj0, besselj1
+
+"""
+    Hubbard1D(; t::Real = 1.0, U::Real = 4.0, μ::Real = 2.0) <: AbstractQAtlasModel
+
+1D Hubbard model
+
+    H = -t Σ_{i, σ} (c†_{i,σ} c_{i+1,σ} + h.c.)
+        + U Σ_i n_{i,↑} n_{i,↓}
+        - μ Σ_i n_i
+
+Convention: `t > 0` hopping, `U > 0` on-site repulsion.  Half filling
+corresponds to `μ = U/2` (particle-hole-symmetric point).
+
+# Phase 1 scope (this release)
+
+Phase 1 implements the Lieb–Wu (1968) closed-form integrals at **half
+filling only** (`μ = U/2`).  The supported `Infinite()` quantities are
+
+- [`GroundStateEnergyDensity`](@ref) — `E₀/N` via the Lieb–Wu integral,
+- [`ChargeGap`](@ref) — Mott gap `Δ_c` via the Lieb–Wu second integral,
+- [`SpinGap`](@ref) — `0` exactly (rigorous gapless-spinon result).
+
+Off half filling raises a `DomainError` — the general-filling
+(coupled-integral-equation) and finite-temperature (QTM) surfaces are
+deferred to Phase 2.
+"""
+struct Hubbard1D <: AbstractQAtlasModel
+    t::Float64
+    U::Float64
+    μ::Float64
+end
+function Hubbard1D(; t::Real=1.0, U::Real=4.0, μ::Real=2.0)
+    return Hubbard1D(Float64(t), Float64(U), Float64(μ))
+end
+
+# ─── Half-filling guard ───────────────────────────────────────────────
+
+"""
+    _hubbard1d_check_half_filling(model::Hubbard1D)
+
+Throw a `DomainError` if `model.μ` is not the half-filling chemical
+potential `U/2`.  Phase 1 only exposes the Lieb–Wu closed forms at the
+particle-hole-symmetric point; general filling requires the coupled
+integral equations and is tracked as Phase 2 follow-up.
+"""
+function _hubbard1d_check_half_filling(model::Hubbard1D)
+    half = model.U / 2
+    if !isapprox(model.μ, half; atol=1e-12, rtol=1e-12)
+        throw(
+            DomainError(
+                model.μ,
+                "Hubbard1D Phase 1: only half-filling (μ = U/2) implemented; " *
+                "got μ=$(model.μ) vs U/2=$(half)",
+            ),
+        )
+    end
+    return nothing
+end
+
+# ─── Lieb–Wu integrals (half filling) ─────────────────────────────────
+
+"""
+    _hubbard1d_e0_integrand(ω, t, U)
+
+Integrand of the Lieb–Wu ground-state-energy integral at half filling,
+
+    f(ω) = J₀(ω) J₁(ω) / [ ω (1 + exp(ω U / 2t)) ].
+
+The integrand is regular at `ω = 0` (`J₁(ω)/ω → 1/2` as `ω → 0`); we
+evaluate the limit explicitly to avoid 0/0 at the lower endpoint that
+some `quadgk` adaptive subdivisions produce.
+"""
+function _hubbard1d_e0_integrand(ω::Float64, t::Float64, U::Float64)::Float64
+    if ω == 0.0
+        # J₀(0) = 1, J₁(ω)/ω → 1/2, denominator = 1 + 1 = 2 → integrand → 1/4.
+        return 0.25
+    end
+    return besselj0(ω) * besselj1(ω) / (ω * (1.0 + exp(ω * U / (2.0 * t))))
+end
+
+"""
+    _hubbard1d_e0(t, U) -> Float64
+
+Lieb–Wu (1968) ground-state energy per site at half filling:
+
+    E₀/N = -4 t² ∫_0^∞ dω  J₀(ω) J₁(ω) / [ ω (1 + exp(ω U / 2t)) ].
+"""
+function _hubbard1d_e0(t::Float64, U::Float64)::Float64
+    integral, _ = quadgk(
+        ω -> _hubbard1d_e0_integrand(ω, t, U), 0.0, Inf; rtol=1e-12, atol=1e-14
+    )
+    return -4.0 * t^2 * integral
+end
+
+"""
+    _hubbard1d_charge_gap(t, U) -> Float64
+
+Lieb–Wu (1968) Mott (charge) gap at half filling:
+
+    Δ_c = (16 t² / U) ∫_1^∞ dω  √(ω² - 1) / sinh(2π t ω / U).
+
+The integrand vanishes at `ω = 1` like `√(ω-1)` and decays
+exponentially at large `ω`; `quadgk` resolves both endpoints with the
+default Gauss–Kronrod adaptive subdivision.
+"""
+function _hubbard1d_charge_gap(t::Float64, U::Float64)::Float64
+    g(ω) = sqrt(ω^2 - 1.0) / sinh(2.0 * π * t * ω / U)
+    integral, _ = quadgk(g, 1.0, Inf; rtol=1e-12, atol=1e-14)
+    return (16.0 * t^2 / U) * integral
+end
+
+# ─── fetch methods ────────────────────────────────────────────────────
+
+"""
+    fetch(model::Hubbard1D, ::GroundStateEnergyDensity, ::Infinite) -> Float64
+
+Lieb–Wu ground-state energy density `E₀/N` at half filling.  Currently
+only implemented for `μ = U/2`; off-half-filling raises a
+`DomainError`.
+
+# Asymptotic limits
+
+- `U/t → 0`:  `E₀/N → -4t/π`  (free 1D fermion).
+- `U/t → ∞`: `E₀/N → -4 t² log 2 / U`  (Heisenberg AFM reduction).
+
+Both are exercised in `test/standalone/test_hubbard1d.jl`.
+
+# References
+
+- Lieb–Wu, *PRL* **20**, 1445 (1968).
+- Essler et al., *The One-Dimensional Hubbard Model* (Cambridge, 2005).
+"""
+function fetch(model::Hubbard1D, ::GroundStateEnergyDensity, ::Infinite; kwargs...)
+    _hubbard1d_check_half_filling(model)
+    return _hubbard1d_e0(model.t, model.U)
+end
+
+"""
+    fetch(model::Hubbard1D, ::ChargeGap, ::Infinite) -> Float64
+
+Lieb–Wu Mott (charge) gap at half filling:
+
+    Δ_c = (16 t² / U) ∫_1^∞ dω  √(ω² - 1) / sinh(2π t ω / U).
+
+Strictly positive for any `U > 0` (no Mott transition in 1D — the
+chain is insulating at half filling for arbitrarily small `U`, the
+celebrated Lieb–Wu result).
+
+# Asymptotic limits
+
+- `U → 0`: `Δ_c → 0` (exponentially small, ∝ exp(-2π t / U)).
+- `U → ∞`: `Δ_c → U - 4t + 8 t² log 2 / U`.
+
+# References
+
+- Lieb–Wu, *PRL* **20**, 1445 (1968).
+"""
+function fetch(model::Hubbard1D, ::ChargeGap, ::Infinite; kwargs...)
+    _hubbard1d_check_half_filling(model)
+    return _hubbard1d_charge_gap(model.t, model.U)
+end
+
+"""
+    fetch(model::Hubbard1D, ::SpinGap, ::Infinite) -> Float64
+
+Spin gap of the half-filled 1D Hubbard chain.  Returns `0.0` exactly:
+the spinon branch is gapless for any `U > 0` (rigorous Lieb–Wu
+result; spin-charge separation in the low-energy effective theory).
+
+# References
+
+- Lieb–Wu, *PRL* **20**, 1445 (1968).
+- Essler et al., *The One-Dimensional Hubbard Model* (Cambridge, 2005).
+"""
+function fetch(model::Hubbard1D, ::SpinGap, ::Infinite; kwargs...)
+    _hubbard1d_check_half_filling(model)
+    return 0.0
+end

--- a/src/models/quantum/Hubbard1D/Hubbard1D_registry.jl
+++ b/src/models/quantum/Hubbard1D/Hubbard1D_registry.jl
@@ -1,0 +1,39 @@
+# models/quantum/Hubbard1D/Hubbard1D_registry.jl — declarative implementation map.
+#
+# Hubbard1D Phase 1 implements Lieb–Wu (1968) closed-form integrals at
+# half filling only: `GroundStateEnergyDensity`, `ChargeGap`, `SpinGap`
+# at `Infinite()`.  Each row below mirrors a `fetch` method in
+# `Hubbard1D.jl`.
+
+@register(
+    Hubbard1D,
+    GroundStateEnergyDensity,
+    Infinite,
+    method=:bethe_ansatz,
+    reliability=:high,
+    tested_in="test/standalone/test_hubbard1d.jl",
+    references=["Lieb-Wu PRL 20, 1445 (1968)", "Essler et al. (2005)"],
+    notes="Lieb-Wu integral E₀/N = -4t² ∫₀^∞ J₀(ω) J₁(ω) / [ω (1+exp(ωU/2t))] dω at half filling (μ=U/2).",
+)
+
+@register(
+    Hubbard1D,
+    ChargeGap,
+    Infinite,
+    method=:bethe_ansatz,
+    reliability=:high,
+    tested_in="test/standalone/test_hubbard1d.jl",
+    references=["Lieb-Wu PRL 20, 1445 (1968)", "Essler et al. (2005)"],
+    notes="Lieb-Wu integral Δ_c = (16t²/U) ∫₁^∞ √(ω²-1)/sinh(2πtω/U) dω at half filling.",
+)
+
+@register(
+    Hubbard1D,
+    SpinGap,
+    Infinite,
+    method=:analytic,
+    reliability=:high,
+    tested_in="test/standalone/test_hubbard1d.jl",
+    references=["Lieb-Wu PRL 20, 1445 (1968)"],
+    notes="Spinon branch is rigorously gapless at half filling — returns 0.0.",
+)

--- a/test/standalone/test_hubbard1d.jl
+++ b/test/standalone/test_hubbard1d.jl
@@ -1,0 +1,105 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Standalone test: Hubbard1D Lieb–Wu Bethe ansatz half-filling closed form.
+#
+# Run via:
+#
+#   julia --project=test test/standalone/test_hubbard1d.jl
+#
+# Cases (issue #153 phase 1):
+#   1. Pinned analytical E₀/N at U/t = 4   (numerical reference value).
+#   2. E₀/N → -4t/π                as U/t → 0.
+#   3. E₀/N → -4 t² log 2 / U      as U/t → ∞.
+#   4. Charge gap > 0 at any U > 0 (Mott — no transition in 1D Hubbard).
+#   5. Charge gap → 0              as U → 0.
+#   6. Charge gap → U - 4t         as U → ∞.
+#   7. Spin gap = 0                exactly.
+#   8. Off half filling (μ = U/3)  raises DomainError.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Test
+
+const _PINNED_E0_U4 = -0.5737293678984494  # quadgk rtol=1e-12 at t=1, U=4
+const _PINNED_DC_U4 = 1.2867270220129354   # quadgk rtol=1e-12 at t=1, U=4
+
+@testset "Hubbard1D — Lieb–Wu half-filling Phase 1" begin
+    @testset "Constructor + half-filling default" begin
+        m = Hubbard1D()
+        @test m.t == 1.0
+        @test m.U == 4.0
+        @test m.μ == 2.0   # half filling (U/2)
+
+        m2 = Hubbard1D(; t=2.0, U=8.0, μ=4.0)
+        @test (m2.t, m2.U, m2.μ) == (2.0, 8.0, 4.0)
+    end
+
+    @testset "Pinned E₀/N at U/t = 4" begin
+        m = Hubbard1D(; t=1.0, U=4.0, μ=2.0)
+        e0 = QAtlas.fetch(m, GroundStateEnergyDensity(), Infinite())
+        @test e0 ≈ _PINNED_E0_U4 atol = 1e-8
+    end
+
+    @testset "E₀/N → -4t/π as U/t → 0 (free 1D fermion)" begin
+        # At U/t = 0.01 the Lieb–Wu integral should be very close to
+        # the free-fermion value -4t/π.
+        m = Hubbard1D(; t=1.0, U=0.01, μ=0.005)
+        e0 = QAtlas.fetch(m, GroundStateEnergyDensity(), Infinite())
+        @test e0 ≈ -4.0 / π atol = 1e-2
+    end
+
+    @testset "E₀/N → -4 t² log(2) / U as U/t → ∞ (Heisenberg AFM)" begin
+        # At U/t = 100 the half-filled Hubbard chain reduces to the
+        # Heisenberg AFM with effective coupling J = 4 t²/U; the GS
+        # energy density is -J log 2 = -4 t² log 2 / U.
+        m = Hubbard1D(; t=1.0, U=100.0, μ=50.0)
+        e0 = QAtlas.fetch(m, GroundStateEnergyDensity(), Infinite())
+        e0_asymp = -4.0 * 1.0^2 * log(2.0) / 100.0
+        @test isapprox(e0, e0_asymp; rtol=0.05)
+    end
+
+    @testset "Charge gap pinned at U/t = 4" begin
+        m = Hubbard1D(; t=1.0, U=4.0, μ=2.0)
+        Δc = QAtlas.fetch(m, ChargeGap(), Infinite())
+        @test Δc ≈ _PINNED_DC_U4 atol = 1e-8
+        @test Δc > 0  # Mott
+    end
+
+    @testset "Charge gap > 0 for any U > 0 (Mott — no 1D transition)" begin
+        for U in (0.5, 1.0, 4.0, 16.0)
+            m = Hubbard1D(; t=1.0, U=U, μ=U / 2)
+            Δc = QAtlas.fetch(m, ChargeGap(), Infinite())
+            @test Δc > 0
+        end
+    end
+
+    @testset "Charge gap → 0 as U → 0" begin
+        # At U = 0.1 the Mott gap is exponentially small (~ exp(-2π t/U)).
+        m = Hubbard1D(; t=1.0, U=0.1, μ=0.05)
+        Δc = QAtlas.fetch(m, ChargeGap(), Infinite())
+        @test Δc < 0.05
+        @test isapprox(Δc, 0.0; atol=0.05)
+    end
+
+    @testset "Charge gap → U - 4t as U → ∞" begin
+        # At U = 100, t = 1, Δ_c → 100 - 4 + 8 log 2 / 100 ≈ 96.055.
+        # Atol 0.1 is comfortable.
+        m = Hubbard1D(; t=1.0, U=100.0, μ=50.0)
+        Δc = QAtlas.fetch(m, ChargeGap(), Infinite())
+        @test isapprox(Δc, 100.0 - 4.0; atol=0.1)
+    end
+
+    @testset "Spin gap = 0 exactly" begin
+        for (t, U) in ((1.0, 4.0), (1.0, 0.5), (2.0, 8.0), (1.0, 100.0))
+            m = Hubbard1D(; t=t, U=U, μ=U / 2)
+            Δs = QAtlas.fetch(m, SpinGap(), Infinite())
+            @test Δs == 0.0
+        end
+    end
+
+    @testset "Off half-filling raises DomainError" begin
+        # μ = U/3 (≠ U/2) — Phase 2 territory.
+        m = Hubbard1D(; t=1.0, U=6.0, μ=2.0)  # U/2 = 3.0, μ = 2.0
+        @test_throws DomainError QAtlas.fetch(m, GroundStateEnergyDensity(), Infinite())
+        @test_throws DomainError QAtlas.fetch(m, ChargeGap(), Infinite())
+        @test_throws DomainError QAtlas.fetch(m, SpinGap(), Infinite())
+    end
+end


### PR DESCRIPTION
## Summary

Adds the 1D Hubbard model (`Hubbard1D`) at half filling via the **Lieb–Wu (1968) Bethe ansatz** closed-form integrals. Phase 1 (this PR): half-filling `E₀/N`, charge gap `Δ_c`, spin gap `Δ_s = 0`. Phase 2 (general filling + finite-T QTM) deferred.

```math
E_0/N = -4 t^2 \int_0^\infty d\omega \, \frac{J_0(\omega) J_1(\omega)}{\omega \, [1 + e^{\omega U / 2t}]},
\qquad
\Delta_c = \frac{16 t^2}{U} \int_1^\infty d\omega \, \frac{\sqrt{\omega^2 - 1}}{\sinh(2\pi t \omega / U)}
```

Both integrals evaluated by `QuadGK.quadgk` at `rtol=1e-12`, well below test atol `1e-8`.

## Changes

- **New model** `src/models/quantum/Hubbard1D/Hubbard1D.jl` — `struct Hubbard1D <: AbstractQAtlasModel` with fields `t, U, μ`, plus three `fetch` methods (`GroundStateEnergyDensity`, `ChargeGap`, `SpinGap` at `Infinite`).
- **New quantities** in `src/core/quantities.jl`: `ChargeGap`, `SpinGap` (both `<: AbstractQuantity`, with full docstrings).
- **Registry** `src/models/quantum/Hubbard1D/Hubbard1D_registry.jl` — three rows, `method=:bethe_ansatz`/`:analytic`, `reliability=:high`.
- **Project.toml** — `SpecialFunctions = "2"` added (`besselj0`, `besselj1`).
- **Docs** `docs/src/models/quantum/hubbard1d.md` registered in `docs/make.jl` + index pages.

## Off-half-filling guard

```julia
QAtlas.fetch(Hubbard1D(; t=1, U=6, μ=2), GroundStateEnergyDensity(), Infinite())
# → DomainError(2.0, "Hubbard1D Phase 1: only half-filling (μ = U/2) implemented; got μ=2.0 vs U/2=3.0")
```

## Verified pinned values (t = 1, U = 4)

| Quantity | Value |
|---|---|
| `E₀/N` | `-0.5737293678984494` |
| `Δ_c`  | `1.2867270220129354` |
| `Δ_s`  | `0.0` exactly |

## Asymptotic limits verified

| Limit | Anchor | Test atol |
|---|---|---|
| `U/t → 0` | `E₀/N → -4t/π` | 0.01 (at U/t = 0.01) |
| `U/t → ∞` | `E₀/N → -4 t² log 2 / U` | rtol 0.05 (at U/t = 100) |
| `U → 0` | `Δ_c → 0` | 0.05 (at U = 0.1) |
| `U → ∞` | `Δ_c → U - 4t` | 0.1 (at U = 100) |

## Test plan

- [x] `julia --project=test test/standalone/test_hubbard1d.jl` — **23 / 23 pass**, 1.5 s.
- [x] `test/core/test_registry.jl` — drift guard + reliability vocabulary passes.
- [x] `test/standalone/test_bethe_ansatz.jl` — pre-existing Heisenberg test still passes.
- [x] `Aqua.test_all(QAtlas)` — all categories pass (unbound type params, exports, deps, stale, compat, piracy, persistent tasks).

## References

- E. H. Lieb, F. Y. Wu, *PRL* **20**, 1445 (1968) — Bethe ansatz solution.
- F. H. L. Essler, H. Frahm, F. Göhmann, A. Klümper, V. E. Korepin, *The One-Dimensional Hubbard Model*, Cambridge (2005).
- E. H. Lieb, F. Y. Wu, *Physica A* **321**, 1 (2003) — reminiscence.

Closes #153 (phase 1). Phase 2 (general filling, finite-T QTM) tracked as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
