### PR TITLE
feat(Heisenberg1D): spinon dispersion + des Cloizeaux–Pearson + Müller S^{zz} (closes #154 phase 1)

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -97,6 +97,7 @@ makedocs(;
             "Yang Magnetization" => "calc/yang-magnetization-toeplitz.md",
             "Heisenberg Dimer" => "calc/heisenberg-dimer-singlet-triplet.md",
             "Bethe Ansatz e₀" => "calc/bethe-ansatz-heisenberg-e0.md",
+            "Heisenberg Spinons" => "calc/heisenberg-spinons.md",
             "XXZ Luttinger Parameters" => "calc/xxz-luttinger-parameters.md",
             "Honeycomb Bloch" => "calc/bloch-honeycomb-dispersion.md",
             "Kagome Flat Band" => "calc/bloch-kagome-flat-band.md",

--- a/docs/src/calc/heisenberg-spinons.md
+++ b/docs/src/calc/heisenberg-spinons.md
@@ -1,0 +1,220 @@
+# Heisenberg Spinons: Dispersion, des Cloizeaux–Pearson Continuum, Müller Ansatz
+
+This page collects the closed-form excitation kinematics of the spin-$\tfrac{1}{2}$
+isotropic antiferromagnetic Heisenberg chain in the thermodynamic limit
+that are exposed as Phase-1 helpers and `fetch` methods on
+[`Heisenberg1D`](@ref).
+
+## Main results
+
+For
+
+$$H = J\sum_{i}\mathbf{S}_i\cdot\mathbf{S}_{i+1},\qquad J>0,$$
+
+the elementary excitations are massless spinons (half-odd-integer spin)
+which always come in pairs in any physical observable. The single-spinon
+dispersion (Faddeev–Takhtajan 1981) is
+
+$$\boxed{\;\varepsilon(k) \;=\; \frac{\pi J}{2}\,|\sin k|,\qquad k\in[0,\pi].\;}$$
+
+The two-spinon continuum, parameterised by the total momentum $q$, is
+bounded by the des Cloizeaux–Pearson (1962) edges
+
+$$\boxed{\;
+  \varepsilon_L(q) \;=\; \frac{\pi J}{2}\,|\sin q|,\qquad
+  \varepsilon_U(q) \;=\; \pi J\,\bigl|\sin(q/2)\bigr|.
+\;}$$
+
+The lower edge coincides with the single-spinon dispersion and the
+continuum is gapless at $q=0$ and $q=\pi$ (Umklapp).
+
+The longitudinal dynamic structure factor inside the continuum is
+approximated by the Müller ansatz (Müller–Thomas–Beck–Bonner 1981):
+
+$$\boxed{\;
+  S^{zz}_{\rm Müller}(q,\omega)
+  \;=\; \frac{\Theta\!\bigl[\omega-\varepsilon_L(q)\bigr]\,
+              \Theta\!\bigl[\varepsilon_U(q)-\omega\bigr]}
+             {2\,\sqrt{\omega^2 - \varepsilon_L(q)^2}},
+\;}$$
+
+with $S^{zz}=0$ outside $[\varepsilon_L,\varepsilon_U]$.
+
+---
+
+## Derivation sketch
+
+### Spinon dispersion (Faddeev–Takhtajan 1981)
+
+The Bethe-ansatz solution of the spin-$\tfrac{1}{2}$ XXX antiferromagnet
+admits a thermodynamic state — the antiferromagnetic Dirac sea — built
+from a continuous distribution of real rapidities $\lambda\in\mathbb{R}$
+with density $\rho_0(\lambda)=1/(2\cosh(\pi\lambda))$. Holes in this
+distribution carry spin $\tfrac{1}{2}$ — these are the spinons.
+
+The dispersion of a single spinon is obtained by adding one hole of
+rapidity $\lambda$ on top of the sea. The resulting energy and momentum,
+relative to the ground state, are
+
+$$
+\varepsilon(\lambda) \;=\; \frac{\pi J}{2}\,
+                          \frac{1}{\cosh(\pi\lambda)},\qquad
+p(\lambda) \;=\; \frac{\pi}{2} \;-\; \arctan\bigl(\sinh(\pi\lambda)\bigr).
+$$
+
+Eliminating $\lambda$ via $\cosh(\pi\lambda) = 1/\sin p$ — itself a
+direct consequence of the second relation — yields the closed-form
+dispersion stated above:
+
+$$\varepsilon(p) \;=\; \frac{\pi J}{2}\,\sin p,\qquad p\in[0,\pi].$$
+
+The absolute value $|\sin p|$ in the boxed formula extends the result by
+the periodicity of the Brillouin zone.
+
+### Two-spinon continuum and des Cloizeaux–Pearson edges (1962)
+
+A pair of spinons with momenta $k_1, k_2 \in [0,\pi]$ carries total
+momentum $q = k_1 + k_2$ (mod $2\pi$) and total energy
+$E = \varepsilon(k_1) + \varepsilon(k_2)$. At fixed $q$ the
+spinon-pair energy ranges over an interval whose endpoints are
+extracted by Lagrange-multiplying $\varepsilon(k_1)+\varepsilon(k_2)$
+with the constraint $k_1 + k_2 = q$:
+
+$$
+\partial_{k_1}\varepsilon(k_1) \;=\; \partial_{k_2}\varepsilon(k_2)
+  \quad\Longleftrightarrow\quad
+  \cos k_1 \;=\; \cos k_2.
+$$
+
+Two solutions emerge.
+
+* $k_1 = k_2 = q/2$ — both spinons share the momentum, giving the
+  **upper edge**
+
+  $$\varepsilon_U(q) \;=\; 2\,\varepsilon(q/2)
+                       \;=\; \pi J\,\bigl|\sin(q/2)\bigr|.$$
+
+* $k_1 = 0,\ k_2 = q$ (one spinon at the gapless point) —
+  giving the **lower edge**
+
+  $$\varepsilon_L(q) \;=\; \varepsilon(0) + \varepsilon(q)
+                       \;=\; \frac{\pi J}{2}\,|\sin q|.$$
+
+Hence $\varepsilon_L(q) \equiv \varepsilon(q)$, and the continuum
+collapses ($\varepsilon_U = \varepsilon_L = 0$) at the gapless points
+$q = 0, \pi$.
+
+Numerically, at $q = \pi$ one has $\varepsilon_L = 0$ and
+$\varepsilon_U = \pi J$, which is the value carried by
+[`heisenberg_two_spinon_upper_edge`](@ref) at the AFM ordering wave
+vector.
+
+### Müller ansatz for $S^{zz}(q,\omega)$ (1981)
+
+Müller, Thomas, Beck, and Bonner proposed an explicit closed form for
+the longitudinal dynamic structure factor that
+
+* has the correct support on the two-spinon continuum,
+* reproduces the integrable square-root singularity at the lower edge
+  $\omega \to \varepsilon_L^+$ (which dominates the spectral weight),
+* is normalised to give the correct equal-time longitudinal structure
+  factor in leading order.
+
+The ansatz is
+
+$$
+S^{zz}_{\rm Müller}(q,\omega) \;=\;
+  \frac{\Theta(\omega-\varepsilon_L)\,\Theta(\varepsilon_U-\omega)}
+       {2\,\sqrt{\omega^2 - \varepsilon_L^2}},
+$$
+
+returning $0$ outside the closed continuum
+$[\varepsilon_L(q),\varepsilon_U(q)]$. The ansatz is **approximate**:
+it captures the lower-edge behaviour and the support exactly but
+misestimates the spectral weight near the upper edge, where four-spinon
+contributions become important.
+
+The ansatz value diverges as $\omega \to \varepsilon_L^+$ but remains
+integrable: $\int_{\varepsilon_L}^{\varepsilon_U}
+S^{zz}\,d\omega < \infty$. QAtlas returns the raw analytical value
+without a regulator; downstream callers integrating in $\omega$ should
+either use a quadrature aware of the square-root singularity (e.g.
+Gauss–Chebyshev, or the change of variables $\omega^2 = \varepsilon_L^2 + s$)
+or regulate via $\sqrt{\omega^2 - \varepsilon_L^2 + \eta^2}$ at their
+own choice of $\eta$.
+
+---
+
+## API
+
+```julia
+heisenberg_spinon_dispersion(model::Heisenberg1D, k::Real; J::Real = 1.0)::Float64
+heisenberg_two_spinon_lower_edge(model::Heisenberg1D, q::Real; J::Real = 1.0)::Float64
+heisenberg_two_spinon_upper_edge(model::Heisenberg1D, q::Real; J::Real = 1.0)::Float64
+
+fetch(::Heisenberg1D, ::ZZStructureFactor, ::Infinite;
+      q::Real, ω::Real, method::Symbol = :muller, J::Real = 1.0)::Float64
+```
+
+Special values, all at $J = 1$:
+
+| quantity                              | $q = 0$ | $q = \pi/2$ | $q = \pi$ |
+| ------------------------------------- | ------- | ----------- | --------- |
+| `heisenberg_spinon_dispersion`        | $0$     | $\pi/2$     | $0$       |
+| `heisenberg_two_spinon_lower_edge`    | $0$     | $\pi/2$     | $0$       |
+| `heisenberg_two_spinon_upper_edge`    | $0$     | $\pi/\sqrt{2}$ | $\pi$  |
+
+For the Quantity-based dispatch the routing is:
+
+```julia
+fetch(Heisenberg1D(), ZZStructureFactor(), Infinite();
+      q = π/2, ω = 1.0)                        # → Müller ansatz
+fetch(Heisenberg1D(), ZZStructureFactor(), Infinite();
+      q = π/2, ω = 1.0, method = :caux_hagemans)
+# → Phase-2 placeholder; raises an informative error
+```
+
+Quasiparticle dispersion stays a top-level helper (no `QuasiparticleDispersion`
+quantity type is introduced in Phase 1) — this matches the existing TFIM
+style with [`tfim_quasiparticle_dispersion`](@ref) and
+[`tfim_two_spinon_dos`](@ref). A unified `QuasiparticleDispersion`
+quantity is a candidate refactor target if/when more models grow
+analogous helpers.
+
+---
+
+## Phase 2 (TODO): exact dynamic structure factor
+
+The Müller ansatz is the standard 1981-vintage approximation. The
+**exact** result for the dynamic longitudinal structure factor of the
+infinite Heisenberg chain is given by the algebraic-Bethe-ansatz form
+factor sum due to
+
+> J.-S. Caux, R. Hagemans,
+> *The four-spinon dynamical structure factor of the Heisenberg chain*,
+> J. Stat. Mech. P12013 (2006).
+
+Implementing the Caux–Hagemans formula is **Phase 2 of issue #154** and
+is not yet shipped. The current `fetch(::Heisenberg1D,
+::ZZStructureFactor, ::Infinite; method = :caux_hagemans, …)` branch
+raises an informative `ErrorException` so downstream code can probe for
+availability. The Müller branch (`method = :muller`, default) remains
+the only Phase-1 implementation.
+
+---
+
+## References
+
+* J. des Cloizeaux, J. J. Pearson,
+  "Spin-wave spectrum of the antiferromagnetic linear chain",
+  Phys. Rev. **128**, 2131 (1962).
+* L. D. Faddeev, L. A. Takhtajan,
+  "What is the spin of a spin wave?",
+  Phys. Lett. A **85**, 375 (1981).
+* G. Müller, H. Thomas, H. Beck, J. C. Bonner,
+  "Quantum spin dynamics of the antiferromagnetic linear chain in zero
+  and nonzero magnetic field",
+  Phys. Rev. B **24**, 1429 (1981).
+* J.-S. Caux, R. Hagemans,
+  "The four-spinon dynamical structure factor of the Heisenberg chain",
+  J. Stat. Mech. P12013 (2006). (Phase 2 reference.)

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -49,6 +49,10 @@ export E8Spectrum
 # --- TFIM Infinite dynamic helpers ---
 export tfim_quasiparticle_dispersion, tfim_two_spinon_dos
 
+# --- Heisenberg1D Infinite spinon kinematics (issue #154 phase 1) ---
+export heisenberg_spinon_dispersion,
+    heisenberg_two_spinon_lower_edge, heisenberg_two_spinon_upper_edge
+
 # --- Universality Classes ---
 export Universality, CriticalExponents, GrowthExponents
 export Ising2D, KPZ1D, MeanField  # backward-compatible aliases
@@ -87,6 +91,7 @@ include("models/quantum/TFIM/TFIM_cft_entanglement.jl")
 include("models/quantum/TFIM/TFIM_infinite_dynamics.jl")
 include("models/quantum/TFIM/TFIM_registry.jl")  # populates REGISTRY for TFIM
 include("models/quantum/Heisenberg/Heisenberg.jl")
+include("models/quantum/Heisenberg/Heisenberg_spinon.jl")
 include("models/quantum/Heisenberg/HeisenbergS1.jl")
 include("models/quantum/Heisenberg/HeisenbergS1_observables.jl")
 include("models/quantum/Heisenberg/HeisenbergS1_registry.jl")

--- a/src/models/quantum/Heisenberg/Heisenberg_registry.jl
+++ b/src/models/quantum/Heisenberg/Heisenberg_registry.jl
@@ -202,7 +202,7 @@ end
     ZZStructureFactor,
     Infinite,
     method=:muller_ansatz,
-    reliability=:approximate,
+    reliability=:medium,
     tested_in="test/standalone/test_heisenberg_spinon.jl",
     references=["des Cloizeaux–Pearson 1962", "Müller-Thomas-Beck-Bonner 1981"],
     notes="Phase 1 closed-form Müller ansatz for S^{zz}(q,ω); exact Caux–Hagemans 2006 result reserved for Phase 2.",

--- a/src/models/quantum/Heisenberg/Heisenberg_registry.jl
+++ b/src/models/quantum/Heisenberg/Heisenberg_registry.jl
@@ -190,3 +190,20 @@ end
     reliability=:high,
     tested_in="test/models/test_Heisenberg1D_thermal.jl"
 )
+
+# ── Spinon kinematics (issue #154 phase 1, Infinite) ──────────────────
+# Single-spinon dispersion + des Cloizeaux–Pearson 2-spinon continuum
+# edges are exposed as top-level helpers
+# (heisenberg_spinon_dispersion, heisenberg_two_spinon_lower_edge,
+#  heisenberg_two_spinon_upper_edge); only the dynamic structure factor
+# is registered as a Quantity here.
+@register(
+    Heisenberg1D,
+    ZZStructureFactor,
+    Infinite,
+    method=:muller_ansatz,
+    reliability=:approximate,
+    tested_in="test/standalone/test_heisenberg_spinon.jl",
+    references=["des Cloizeaux–Pearson 1962", "Müller-Thomas-Beck-Bonner 1981"],
+    notes="Phase 1 closed-form Müller ansatz for S^{zz}(q,ω); exact Caux–Hagemans 2006 result reserved for Phase 2.",
+)

--- a/src/models/quantum/Heisenberg/Heisenberg_spinon.jl
+++ b/src/models/quantum/Heisenberg/Heisenberg_spinon.jl
@@ -157,6 +157,18 @@ weight near the upper edge.  The *Phase 2* exact result is given by
 the Caux–Hagemans (2006) algebraic Bethe ansatz form factor sum;
 implementing it is tracked as a TODO in
 `docs/src/calc/heisenberg-spinons.md`.
+
+!!! warning "Longitudinal only — S^{xx}, S^{yy} are NOT equal to S^{zz} at q ≠ 0"
+    Despite the SU(2) symmetry of the spin-½ XXX AFM chain, the
+    individual transverse and longitudinal dynamic structure factors
+    `S^{xx}(q, ω) = S^{yy}(q, ω)` and `S^{zz}(q, ω)` differ at any
+    `q ≠ 0` — only their sum (the rotation-invariant trace
+    `Σ_α S^{αα}`) is equal across spin axes.  The transverse Müller-
+    style ansatz (Schulz 1986; Bougourzi-Karbach-Müller 1998) shares
+    the two-spinon support `[ε_L(q), ε_U(q)]` but has a different
+    singularity structure at the lower edge.  This method returns
+    only the **longitudinal** `S^{zz}`; do not use it as a drop-in
+    for `S^{xx}` at finite `q`.
 """
 function _heisenberg_szz_muller(J::Real, q::Real, ω::Real)
     Jf = float(J)

--- a/src/models/quantum/Heisenberg/Heisenberg_spinon.jl
+++ b/src/models/quantum/Heisenberg/Heisenberg_spinon.jl
@@ -1,0 +1,238 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Heisenberg1D — Infinite-volume spinon kinematics (Phase 1: closed-form)
+#
+# This module exposes three closed-form helpers and one Quantity-based
+# `fetch` that complete the Tier-2 dynamic coverage of `Heisenberg1D` on
+# `Infinite()`:
+#
+#   1. `heisenberg_spinon_dispersion(model, k)` — single-spinon dispersion
+#      ε(k) = (π J / 2) |sin k|  (Faddeev–Takhtajan 1981).  Spinons are
+#      half-odd-integer-spin excitations of the spin-½ XXX antiferromagnet
+#      and are not generated singly; they always come in pairs in any
+#      physical observable.  Public helper, exported from `QAtlas`.
+#
+#   2. `heisenberg_two_spinon_lower_edge(model, q)` — lower edge of the
+#      two-spinon continuum at total momentum q ∈ [0, 2π],
+#      ε_L(q) = (π J / 2) |sin q|  (des Cloizeaux–Pearson 1962).  By
+#      construction this coincides with the single-spinon dispersion.
+#      Public helper, exported from `QAtlas`.
+#
+#   3. `heisenberg_two_spinon_upper_edge(model, q)` — upper edge of the
+#      two-spinon continuum,  ε_U(q) = π J |sin(q/2)|  (des
+#      Cloizeaux–Pearson 1962).  Public helper, exported from `QAtlas`.
+#
+#   4. `fetch(model, ZZStructureFactor(), Infinite(); q, ω,
+#       method = :muller, …)` — longitudinal dynamic structure factor
+#      S^{zz}(q, ω) inside the two-spinon continuum, evaluated by the
+#      Müller ansatz (Müller–Thomas–Beck–Bonner 1981):
+#
+#          S^{zz}(q, ω) ≈  Θ[ω − ε_L(q)] · Θ[ε_U(q) − ω]
+#                          ----------------------------------
+#                              2 √(ω² − ε_L(q)²)
+#
+#      and 0 outside the continuum.  This is an analytical approximation
+#      with the correct support and the correct integrable square-root
+#      singularity at the lower edge; it is *not* the exact
+#      Caux–Hagemans (2006) result, which is reserved for Phase 2 (TODO,
+#      see `docs/src/calc/heisenberg-spinons.md`).  `method` selects the
+#      ansatz; `:muller` is the only currently-supported value.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Single-spinon dispersion
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    heisenberg_spinon_dispersion(model::Heisenberg1D, k::Real; J::Real = 1.0)
+        -> Float64
+
+Single-spinon dispersion of the spin-½ antiferromagnetic Heisenberg
+chain in the thermodynamic limit (Faddeev–Takhtajan 1981):
+
+    ε(k) = (π J / 2) |sin k|,   k ∈ [0, π].
+
+Spinons are massless half-odd-integer-spin excitations and the lower
+edge of the two-spinon continuum coincides with this dispersion, see
+[`heisenberg_two_spinon_lower_edge`](@ref).
+
+Special values:
+* `ε(0) = 0`             — gapless point.
+* `ε(π/2) = π J / 2`     — band centre maximum.
+* `ε(π) = 0`             — gapless Umklapp point.
+
+`J` is passed by keyword because `Heisenberg1D` is parameterless in
+this codebase (every other quantity threads `J` through kwargs the
+same way).
+
+# References
+    L. D. Faddeev, L. A. Takhtajan, "What is the spin of a spin wave?",
+      Phys. Lett. A 85, 375 (1981).
+"""
+function heisenberg_spinon_dispersion(model::Heisenberg1D, k::Real; J::Real=1.0)
+    return (π * float(J) / 2) * abs(sin(float(k)))
+end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 2-spinon continuum edges (des Cloizeaux–Pearson 1962)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    heisenberg_two_spinon_lower_edge(model::Heisenberg1D, q::Real;
+                                     J::Real = 1.0) -> Float64
+
+Lower edge of the two-spinon continuum at total momentum `q` for the
+spin-½ XXX AFM chain (des Cloizeaux–Pearson 1962):
+
+    ε_L(q) = (π J / 2) |sin q|.
+
+By construction `ε_L(q) ≡ ε(q)` where `ε` is the single-spinon
+dispersion ([`heisenberg_spinon_dispersion`](@ref)) — this reflects
+the kinematic configuration in which one of the two spinons sits at
+zero energy, so the total energy equals the energy of the other.
+
+Special values:
+* `ε_L(0) = ε_L(π) = 0`  — gapless points (Umklapp included).
+* `ε_L(π/2) = π J / 2`   — maximum of the lower edge.
+
+# References
+    J. des Cloizeaux, J. J. Pearson, "Spin-wave spectrum of the
+      antiferromagnetic linear chain", Phys. Rev. 128, 2131 (1962).
+"""
+function heisenberg_two_spinon_lower_edge(model::Heisenberg1D, q::Real; J::Real=1.0)
+    return (π * float(J) / 2) * abs(sin(float(q)))
+end
+
+"""
+    heisenberg_two_spinon_upper_edge(model::Heisenberg1D, q::Real;
+                                     J::Real = 1.0) -> Float64
+
+Upper edge of the two-spinon continuum at total momentum `q` for the
+spin-½ XXX AFM chain (des Cloizeaux–Pearson 1962):
+
+    ε_U(q) = π J |sin(q/2)|.
+
+Special values:
+* `ε_U(0) = 0`           — Goldstone-like vanishing of the support
+                            window at q = 0.
+* `ε_U(π) = π J`         — top of the continuum at the Umklapp point.
+
+For `q ∈ (0, π]` one has `ε_U(q) ≥ ε_L(q)` strictly except at the
+gapless points where the continuum collapses to a line.
+
+# References
+    J. des Cloizeaux, J. J. Pearson, "Spin-wave spectrum of the
+      antiferromagnetic linear chain", Phys. Rev. 128, 2131 (1962).
+"""
+function heisenberg_two_spinon_upper_edge(model::Heisenberg1D, q::Real; J::Real=1.0)
+    return π * float(J) * abs(sin(float(q) / 2))
+end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Müller-ansatz longitudinal dynamic structure factor
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    _heisenberg_szz_muller(J, q, ω) -> Float64
+
+Müller-ansatz approximation to the longitudinal dynamic structure
+factor S^{zz}(q, ω) of the spin-½ XXX AFM chain.  The closed-form
+expression, valid inside the two-spinon continuum, is
+
+    S^{zz}(q, ω) ≈  Θ[ω - ε_L(q)] · Θ[ε_U(q) - ω]
+                    ----------------------------------
+                        2 √(ω² - ε_L(q)²)
+
+with `ε_L(q) = (π J / 2) |sin q|` and
+`ε_U(q) = π J |sin(q/2)|`.  Outside the closed continuum (i.e.
+`ω ≤ ε_L` or `ω ≥ ε_U`) the expression returns exactly `0.0`.
+
+The square-root singularity at the lower edge is integrable, so we
+return the raw analytical value (no regulator); callers performing
+ω-integrals are expected to use a routine that handles the integrable
+singularity (e.g. Gauss–Chebyshev or substitution `ω² = ε_L² + s`).
+
+This is *Phase 1* — the Müller ansatz captures the lower-edge
+behaviour and the support correctly but mis-estimates the spectral
+weight near the upper edge.  The *Phase 2* exact result is given by
+the Caux–Hagemans (2006) algebraic Bethe ansatz form factor sum;
+implementing it is tracked as a TODO in
+`docs/src/calc/heisenberg-spinons.md`.
+"""
+function _heisenberg_szz_muller(J::Real, q::Real, ω::Real)
+    Jf = float(J)
+    qf = float(q)
+    ωf = float(ω)
+    εL = (π * Jf / 2) * abs(sin(qf))
+    εU = π * Jf * abs(sin(qf / 2))
+    if ωf <= εL || ωf >= εU
+        return 0.0
+    end
+    return 1 / (2 * sqrt(ωf^2 - εL^2))
+end
+
+"""
+    fetch(model::Heisenberg1D, ::ZZStructureFactor, ::Infinite;
+          q::Real, ω::Real, method::Symbol = :muller, J::Real = 1.0,
+          kwargs...) -> Float64
+
+Longitudinal dynamic structure factor `S^{zz}(q, ω)` of the
+infinite-volume spin-½ XXX antiferromagnetic Heisenberg chain in the
+thermodynamic limit.
+
+The default `method = :muller` evaluates the Müller-ansatz closed
+form inside the two-spinon continuum (see
+`_heisenberg_szz_muller`):
+
+    S^{zz}(q, ω) ≈  Θ[ω − ε_L(q)] · Θ[ε_U(q) − ω]
+                    ----------------------------------
+                        2 √(ω² − ε_L(q)²)
+
+with edges defined by [`heisenberg_two_spinon_lower_edge`](@ref) and
+[`heisenberg_two_spinon_upper_edge`](@ref).  Outside the continuum
+the routine returns `0.0`.  No regulator is added at the lower edge:
+the singularity is integrable (∝ 1/√(ω − ε_L) for ω → ε_L⁺), and any
+quadrature scheme used downstream should treat it analytically rather
+than relying on a numerical cap.
+
+# Arguments
+- `q::Real`: total momentum (radians).
+- `ω::Real`: frequency (energy units consistent with `J`).
+- `method::Symbol = :muller`: ansatz selector; only `:muller` is
+  implemented in Phase 1.  Reserved future values:
+  `:caux_hagemans` for the exact form-factor sum (Phase 2).
+- `J::Real = 1.0`: Heisenberg coupling.
+
+# References
+    G. Müller, H. Thomas, H. Beck, J. C. Bonner, "Quantum spin
+      dynamics of the antiferromagnetic linear chain in zero and
+      nonzero magnetic field", Phys. Rev. B 24, 1429 (1981).
+    J.-S. Caux, R. Hagemans, "The four-spinon dynamical structure
+      factor of the Heisenberg chain", J. Stat. Mech. P12013 (2006)
+      (Phase 2 reference, not yet implemented).
+"""
+function fetch(
+    ::Heisenberg1D,
+    ::ZZStructureFactor,
+    ::Infinite;
+    q::Real,
+    ω::Real,
+    method::Symbol=:muller,
+    J::Real=1.0,
+    kwargs...,
+)
+    if method === :muller
+        return _heisenberg_szz_muller(J, q, ω)
+    elseif method === :caux_hagemans
+        return error(
+            "Heisenberg1D ZZStructureFactor Infinite: method=:caux_hagemans " *
+            "(exact 2-spinon form-factor sum, Caux–Hagemans 2006) is reserved " *
+            "for Phase 2 and not yet implemented.  Use method=:muller for the " *
+            "Phase-1 ansatz.",
+        )
+    else
+        return error(
+            "Heisenberg1D ZZStructureFactor Infinite: unknown method=:$(method); " *
+            "supported: :muller (Phase 1).  :caux_hagemans is Phase 2 (TODO).",
+        )
+    end
+end

--- a/test/standalone/test_heisenberg_spinon.jl
+++ b/test/standalone/test_heisenberg_spinon.jl
@@ -1,0 +1,175 @@
+# =============================================================================
+# Standalone tests for Heisenberg1D infinite-volume spinon kinematics defined
+# in `src/models/quantum/Heisenberg/Heisenberg_spinon.jl` (issue #154 phase 1).
+#
+# Coverage:
+#   * Single-spinon dispersion ε(k) = (π J / 2) |sin k| at k = 0, π/2, π
+#   * 2-spinon lower edge ε_L(q) coincides with the single-spinon dispersion
+#   * 2-spinon upper edge ε_U(q) = π J |sin(q/2)|
+#   * Boundary values at the gapless point q = π (lower = 0, upper = π J)
+#   * Müller-ansatz S^{zz}(q, ω) is 0 outside [ε_L, ε_U] and finite inside
+#   * S^{zz}(q, ω) → ∞ as ω → ε_L⁺ (integrable square-root singularity)
+#   * Linear J-scaling of all three energy quantities
+# =============================================================================
+
+using QAtlas, Test
+
+@testset "Heisenberg1D spinon kinematics (Phase 1, closed-form)" begin
+    model = Heisenberg1D()
+
+    # ─────────────────────────────────────────────────────────────────────
+    # Single-spinon dispersion
+    # ─────────────────────────────────────────────────────────────────────
+    @testset "single-spinon dispersion ε(k) = (π J / 2) |sin k|" begin
+        @test heisenberg_spinon_dispersion(model, 0.0) ≈ 0.0 atol = 1e-14
+        @test heisenberg_spinon_dispersion(model, π / 2) ≈ π / 2 atol = 1e-14
+        @test heisenberg_spinon_dispersion(model, π) ≈ 0.0 atol = 1e-13
+
+        # |sin| symmetry: ε(π − k) = ε(k)
+        for k in (0.1, 0.7, 1.3)
+            @test heisenberg_spinon_dispersion(model, k) ≈
+                heisenberg_spinon_dispersion(model, π - k) atol = 1e-14
+        end
+    end
+
+    # ─────────────────────────────────────────────────────────────────────
+    # 2-spinon continuum edges (des Cloizeaux–Pearson 1962)
+    # ─────────────────────────────────────────────────────────────────────
+    @testset "2-spinon lower edge ε_L(q) ≡ ε(q)" begin
+        for q in range(0.0, π; length=17)
+            @test heisenberg_two_spinon_lower_edge(model, q) ≈
+                heisenberg_spinon_dispersion(model, q) atol = 1e-14
+        end
+    end
+
+    @testset "2-spinon upper edge ε_U(q) = π J |sin(q/2)|" begin
+        @test heisenberg_two_spinon_upper_edge(model, 0.0) ≈ 0.0 atol = 1e-14
+        @test heisenberg_two_spinon_upper_edge(model, π / 2) ≈ π * sin(π / 4) atol = 1e-14
+        @test heisenberg_two_spinon_upper_edge(model, π) ≈ π atol = 1e-13   # gapless top
+    end
+
+    @testset "boundary at q = π: lower = 0, upper = π J" begin
+        @test heisenberg_two_spinon_lower_edge(model, π) ≈ 0.0 atol = 1e-13
+        @test heisenberg_two_spinon_upper_edge(model, π) ≈ π atol = 1e-13
+    end
+
+    @testset "ε_U(q) ≥ ε_L(q) on (0, π)" begin
+        # Strictly above except at gapless points 0, π where both vanish.
+        for q in range(0.05, π - 0.05; length=20)
+            @test heisenberg_two_spinon_upper_edge(model, q) >
+                heisenberg_two_spinon_lower_edge(model, q) - 1e-14
+        end
+    end
+
+    # ─────────────────────────────────────────────────────────────────────
+    # Müller-ansatz S^{zz}(q, ω): support, finiteness, edge singularity
+    # ─────────────────────────────────────────────────────────────────────
+    @testset "Müller S^{zz}: zero outside [ε_L, ε_U]" begin
+        q = 2π / 3
+        εL = heisenberg_two_spinon_lower_edge(model, q)
+        εU = heisenberg_two_spinon_upper_edge(model, q)
+        # Below lower edge
+        for ω in (0.0, 0.5 * εL, εL)
+            @test QAtlas.fetch(Heisenberg1D(), ZZStructureFactor(), Infinite(); q=q, ω=ω) ==
+                0.0
+        end
+        # Above upper edge
+        for ω in (εU, εU + 0.1, 10 * εU)
+            @test QAtlas.fetch(Heisenberg1D(), ZZStructureFactor(), Infinite(); q=q, ω=ω) ==
+                0.0
+        end
+    end
+
+    @testset "Müller S^{zz}: finite & positive inside" begin
+        q = π / 2
+        εL = heisenberg_two_spinon_lower_edge(model, q)
+        εU = heisenberg_two_spinon_upper_edge(model, q)
+        # mid-band sample
+        ωmid = (εL + εU) / 2
+        S = QAtlas.fetch(Heisenberg1D(), ZZStructureFactor(), Infinite(); q=q, ω=ωmid)
+        @test isfinite(S)
+        @test S > 0
+        # closed-form check: 1 / (2 √(ω² − ε_L²))
+        @test S ≈ 1 / (2 * sqrt(ωmid^2 - εL^2)) atol = 1e-14
+    end
+
+    @testset "Müller S^{zz}: integrable singularity ω → ε_L⁺" begin
+        q = π / 2
+        εL = heisenberg_two_spinon_lower_edge(model, q)
+        # Sequence of points approaching ε_L from above; S should grow like
+        # 1 / √(ω − ε_L) and exceed any finite constant for ω close enough.
+        S_values = Float64[]
+        for δ in (1e-2, 1e-4, 1e-6)
+            push!(
+                S_values,
+                QAtlas.fetch(
+                    Heisenberg1D(), ZZStructureFactor(), Infinite(); q=q, ω=εL + δ
+                ),
+            )
+        end
+        # Strictly monotone divergence
+        @test S_values[1] < S_values[2] < S_values[3]
+        # Exceeds 1e2 well before machine precision
+        @test S_values[3] > 1e2
+    end
+
+    @testset "Müller S^{zz}: explicit Müller method symbol works" begin
+        q = π / 2
+        ω = 1.0
+        S_default = QAtlas.fetch(Heisenberg1D(), ZZStructureFactor(), Infinite(); q=q, ω=ω)
+        S_muller = QAtlas.fetch(
+            Heisenberg1D(), ZZStructureFactor(), Infinite(); q=q, ω=ω, method=:muller
+        )
+        @test S_default == S_muller
+    end
+
+    @testset "Müller S^{zz}: Phase-2 :caux_hagemans raises informative error" begin
+        @test_throws ErrorException QAtlas.fetch(
+            Heisenberg1D(),
+            ZZStructureFactor(),
+            Infinite();
+            q=π / 2,
+            ω=1.0,
+            method=:caux_hagemans,
+        )
+        @test_throws ErrorException QAtlas.fetch(
+            Heisenberg1D(),
+            ZZStructureFactor(),
+            Infinite();
+            q=π / 2,
+            ω=1.0,
+            method=:bogus_method,
+        )
+    end
+
+    # ─────────────────────────────────────────────────────────────────────
+    # J-scaling
+    # ─────────────────────────────────────────────────────────────────────
+    @testset "linear J-scaling of dispersion + edges" begin
+        for J in (0.5, 2.0, 3.7)
+            for q in (0.3, π / 2, 2.1)
+                @test heisenberg_spinon_dispersion(model, q; J=J) ≈
+                    J * heisenberg_spinon_dispersion(model, q) atol = 1e-14
+                @test heisenberg_two_spinon_lower_edge(model, q; J=J) ≈
+                    J * heisenberg_two_spinon_lower_edge(model, q) atol = 1e-14
+                @test heisenberg_two_spinon_upper_edge(model, q; J=J) ≈
+                    J * heisenberg_two_spinon_upper_edge(model, q) atol = 1e-14
+            end
+        end
+    end
+
+    @testset "S^{zz} dimensional scaling under (J, ω) → (λ J, λ ω)" begin
+        # ε_L, ε_U scale linearly with J, and inside the continuum
+        # S^{zz}(q, ω; J) = 1 / (2 √(ω² − ε_L²)) carries one inverse power
+        # of energy.  Therefore S^{zz}(q, λ ω; λ J) = (1/λ) S^{zz}(q, ω; J).
+        q = π / 2
+        ω = 1.0
+        S1 = QAtlas.fetch(Heisenberg1D(), ZZStructureFactor(), Infinite(); q=q, ω=ω, J=1.0)
+        for λ in (0.5, 2.0, 3.0)
+            S_scaled = QAtlas.fetch(
+                Heisenberg1D(), ZZStructureFactor(), Infinite(); q=q, ω=λ * ω, J=λ * 1.0
+            )
+            @test S_scaled ≈ S1 / λ atol = 1e-14
+        end
+    end
+end


### PR DESCRIPTION
**Re-opened from #170 after PR #184 reverted it for citation / copyright audit.**

All work is preserved on `feat/issue-154-heisenberg-spinon`; this PR re-runs CI against the reverted main.

---

## Original PR #170 body

## Summary

Closes #154 (phase 1; Caux–Hagemans exact is phase 2).

Adds the closed-form Tier-2 dynamic kinematics of the spin-1/2 isotropic antiferromagnetic Heisenberg chain in the thermodynamic limit. API mirrors the existing TFIM `tfim_quasiparticle_dispersion` / `tfim_two_spinon_dos` style.

| symbol | formula | reference |
|---|---|---|
| `heisenberg_spinon_dispersion(model, k; J)` | ε(k) = (π J / 2) \|sin k\| | Faddeev–Takhtajan 1981 |
| `heisenberg_two_spinon_lower_edge(model, q; J)` | ε_L(q) = (π J / 2) \|sin q\| | des Cloizeaux–Pearson 1962 |
| `heisenberg_two_spinon_upper_edge(model, q; J)` | ε_U(q) = π J \|sin(q/2)\| | des Cloizeaux–Pearson 1962 |
| `fetch(::Heisenberg1D, ::ZZStructureFactor, ::Infinite; q, ω, method=:muller, J)` | S^{zz}(q,ω) ≈ Θ[ω−ε_L]·Θ[ε_U−ω] / (2√(ω²−ε_L²)) | Müller-Thomas-Beck-Bonner 1981 |

Special values (J = 1):
- `ε(π/2) = π/2`, `ε(0) = ε(π) = 0`
- `ε_L(q) ≡ ε(q)` for all q (the lower edge is the single-spinon dispersion)
- `ε_U(π) = π`, `ε_L(π) = 0` (gapless Umklapp point)

## Changes

- **New** `src/models/quantum/Heisenberg/Heisenberg_spinon.jl`: closed-form helpers + Müller-ansatz `fetch(::ZZStructureFactor, ::Infinite)`. Lower-edge integrable singularity returned raw (no regulator) — quadrature aware of √ω−ε_L singularities (Gauss–Chebyshev or ω² substitution) is the caller's responsibility.
- **New** `test/standalone/test_heisenberg_spinon.jl`: 92 tests in 9 testsets (dispersion endpoints, lower-edge ↔ dispersion identity, Müller support {below, inside, above}, integrable singularity ω → ε_L⁺, default ↔ explicit `:muller`, Phase-2 `:caux_hagemans` informative error, and J-scaling of all four quantities). Targeted run:

  ```
  julia --project=test test/standalone/test_heisenberg_spinon.jl
  ```
  passes **92/92** in 0.3 s on Panza.

- **Modified** `src/QAtlas.jl`: include the new file (after `Heisenberg.jl`) and export the three top-level helpers.
- **Modified** `src/models/quantum/Heisenberg/Heisenberg_registry.jl`: `@register(Heisenberg1D, ZZStructureFactor, Infinite, method=:muller_ansatz, reliability=:approximate, …)`.
- **New** `docs/src/calc/heisenberg-spinons.md`: derivation page (Bethe-ansatz hole interpretation, Lagrange-multiplier extraction of the edges, Müller-ansatz statement + limitations, Phase-2 Caux–Hagemans TODO).
- **Modified** `docs/make.jl`: registers the new derivation page in "Derivation Notes".

## Design notes

- **Top-level helpers, not a new Quantity type.** Per the user's stated preference, `heisenberg_spinon_dispersion` etc. are plain exported functions matching `tfim_quasiparticle_dispersion` style. A unified `QuasiparticleDispersion <: AbstractQuantity` is left for a future refactor once more models grow analogous helpers.
- **`J` as kwarg.** `Heisenberg1D` is parameterless in this codebase (every other quantity threads `J` via kwargs); we follow that convention.
- **No regulator at the lower edge.** The Müller singularity at ω = ε_L is integrable; capping it numerically would change the spectral weight. Returning the raw analytical value lets downstream callers integrate with the appropriate quadrature.
- **`method=:caux_hagemans` raises early.** The dispatch validates the symbol so future code paths can probe for Phase-2 availability; only `:muller` is implemented.

## Test plan

- [x] Smoke load: `using QAtlas` precompiles cleanly with the new file.
- [x] Smoke values: `heisenberg_spinon_dispersion(Heisenberg1D(), π/2) == π/2`; `ε_U(π) == π`; `ε_L(π) ≈ 0`.
- [x] Targeted standalone test: 92/92 pass in 0.3 s.
- [x] Registry resolution: `which(QAtlas.fetch, (Heisenberg1D, ZZStructureFactor, Infinite))` resolves to the new method.
- [ ] CI green on the PR.

## Phase 2 (TODO, out of scope for this PR)

Implement the exact `method=:caux_hagemans` branch via the algebraic-Bethe-ansatz form-factor sum of:

> J.-S. Caux, R. Hagemans, *The four-spinon dynamical structure factor of the Heisenberg chain*, J. Stat. Mech. P12013 (2006).

Tracked as the Phase-2 of #154; the docs page already carries a TODO section pointing at the reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

