### PR TITLE
fix(XXZ registry): correct LoschmidtEcho sign-flip notes

### DIFF
--- a/src/models/quantum/XXZ/XXZ_registry.jl
+++ b/src/models/quantum/XXZ/XXZ_registry.jl
@@ -270,7 +270,7 @@ register!(
         "Heyl Polkovnikov Kehrein Phys. Rev. Lett. 110, 135704 (2013)",
         "Essler Fagotti J. Stat. Mech. (2016) 064002",
     ],
-    notes="XX → XX quench Loschmidt rate λ(t) at Δ = 0 only; same-sign J ⇒ λ ≡ 0 (Fermi sea preserved), sign-flip ⇒ Inf (Anderson orthogonality).  Δ ≠ 0 throws DomainError.",
+    notes="XX → XX quench Loschmidt rate λ(t) at Δ = 0 only; same-sign J ⇒ λ ≡ 0 (Fermi sea preserved), sign-flip ⇒ 0 (|GS(J₀)⟩ is a number eigenstate of H_f; Anderson orthogonality does not apply to the Loschmidt amplitude).  Δ ≠ 0 throws DomainError.",
 )
 # models/quantum/XXZ/XXZ_registry.jl — declarative implementation map.
 #


### PR DESCRIPTION
Fixes inconsistency in XXZ_registry.jl: the notes for LoschmidtEcho{:rate} said 'sign-flip ⇒ Inf (Anderson orthogonality)' but the implementation correctly returns 0.0 for sign-flip. Reason: |GS(J₀)⟩ is a number eigenstate of H_f (both are XX Hamiltonians sharing the same momentum eigenstates), so |L(t)|=1 and λ(t)≡0 for all J quenches. Anderson orthogonality applies to static GS overlaps, not to the Loschmidt amplitude.