### PR TITLE
fix(docs): resolve @ref errors and method overwriting (v0.19.1)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.19.0"
+version = "0.19.1"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/docs/src/universalities/cft_minimal_models.md
+++ b/docs/src/universalities/cft_minimal_models.md
@@ -9,7 +9,7 @@ conformal field theories as concrete dispatch tags:
   $\widehat{\mathfrak{su}}(2)_k$ symmetry.
 
 Both expose their CFT data as exact `Rational{Int}` values via
-[`fetch`](@ref) on [`CentralCharge`](@ref),
+`fetch` on [`CentralCharge`](@ref),
 [`ConformalWeights`](@ref), and (minimal models only)
 [`PrimaryFields`](@ref).
 

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -610,7 +610,6 @@ struct LoschmidtEcho{M} <: AbstractQuantity
         return new{M}()
     end
 end
-LoschmidtEcho() = LoschmidtEcho{:rate}()
 LoschmidtEcho(m::Symbol) = LoschmidtEcho{m}()
 LoschmidtEcho(; mode::Symbol=:rate) = LoschmidtEcho{mode}()
 
@@ -682,7 +681,7 @@ one, equivalent to the gap between the half-filled ground state and
 the lowest charged excitation.  Strictly positive in a Mott insulator
 and exactly zero in a metal / superconductor.
 
-Implemented analytically for [](@ref) at half filling via
+Implemented analytically for [`Hubbard1D`](@ref) at half filling via
 the Lieb–Wu (1968) closed-form integral.
 """
 struct ChargeGap <: AbstractQuantity end


### PR DESCRIPTION
## Summary

Three follow-up fixes after v0.19.0 to get the Documentation workflow green on `main`:

1. `LoschmidtEcho()` positional no-arg ctor (line 613) collides with `LoschmidtEcho(; mode=:rate)` kwarg ctor (line 615) — Documenter's strict precompile rejects this. Dropped the positional form; the kwarg form already returns `LoschmidtEcho{:rate}()` for the no-arg call.
2. Empty `[](@ref)` inside the `ChargeGap` docstring → `Cannot resolve @ref` during `@autodocs`. Filled in the intended `[`Hubbard1D`](@ref)` target.
3. `[`fetch`](@ref)` in `docs/src/universalities/cft_minimal_models.md` couldn't resolve (collides with `Base.fetch`, no anchored page). Dropped the cross-ref; kept `fetch` as inline code.

Patch bump 0.19.0 → 0.19.1 so AutoRegister releases this docs fix.

## Test plan

- [ ] `Documentation` workflow builds successfully (no `Cannot resolve @ref` / no `Method overwriting`)
- [ ] `CI` still green (6466+ pass, no regressions)
- [ ] `AutoRegister` picks up v0.19.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)