### PR TITLE
ci(docs): run Documentation workflow on pull_request

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
     tags: '*'
+  pull_request:
+    branches:
+      - main
 permissions:
   contents: write
   statuses: write


### PR DESCRIPTION
## Summary

Adds a `pull_request` trigger to `.github/workflows/Documentation.yml`, so docs breakage is caught at PR time instead of only being visible after merge to main.

## Why

Today's workflow fires only on `push: main` and tags. PR #265 (v0.19.0) and PR #266 (v0.19.1) are the most recent examples: the v0.19.0 batch deduplication landed `Cannot resolve @ref for md"[](@ref)"` and a method-overwriting precompile error that nobody could have seen at PR time. The follow-up v0.19.1 was needed only because the failure surfaced post-merge.

## Behaviour

`Documenter.deploydocs` detects `GITHUB_EVENT_NAME=pull_request` and falls back to build-only — no gh-pages push, no `GITHUB_TOKEN` write — so this exposes docs breakage in the PR check list without any deploy/permission churn.

## Test plan

- [ ] This PR itself triggers a `Documentation` check (will be the verification)
- [ ] `Documentation` check passes (no `@ref` regressions; v0.19.1 already fixed those)
- [ ] After merge, push to main still deploys to `gh-pages` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)