### PR TITLE
feat(quantum): HeisenbergXYZ — XXZ-delegation phase 1 (refs #253, v0.19.5)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.19.4"
+version = "0.19.5"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -30,6 +30,7 @@ export TightBindingSpectrum
 export Heisenberg1D, ExactSpectrum, GroundStateEnergyDensity
 export Hubbard1D                                         # Lieb-Wu Bethe ansatz half-filling
 export MajumdarGhosh                                     # spin-1/2 J1-J2 chain at MG point
+export HeisenbergXYZ                                     # spin-½ XYZ chain (Baxter 1972, axis-aligned XXZ delegation)
 export ShastrySutherland                                 # SrCu₂(BO₃)₂ 2D dimer GS (Shastry-Sutherland 1981)
 export S1Heisenberg1D                                    # spin-1 (Haldane chain)
 export AKLT1D                                            # spin-1 BLBQ at AKLT point
@@ -155,6 +156,8 @@ include("models/quantum/MajumdarGhosh/MajumdarGhosh.jl")
 include("models/quantum/MajumdarGhosh/MajumdarGhosh_registry.jl")  # populates REGISTRY for MajumdarGhosh
 include("models/quantum/ShastrySutherland/ShastrySutherland.jl")
 include("models/quantum/ShastrySutherland/ShastrySutherland_registry.jl")  # populates REGISTRY for ShastrySutherland (#259)
+include("models/quantum/HeisenbergXYZ/HeisenbergXYZ.jl")
+include("models/quantum/HeisenbergXYZ/HeisenbergXYZ_registry.jl")          # populates REGISTRY for HeisenbergXYZ (#253)
 
 include("models/quantum/TFIM/TFIM_fidelity.jl")            # FidelitySusceptibility (#147)
 include("models/quantum/TFIM/TFIM_quench_entanglement.jl") # VonNeumannEntropy{:quench} (#144)

--- a/src/models/quantum/HeisenbergXYZ/HeisenbergXYZ.jl
+++ b/src/models/quantum/HeisenbergXYZ/HeisenbergXYZ.jl
@@ -86,7 +86,7 @@ already implemented in [`XXZ1D`](@ref).  General (Jx ≠ Jy) triples
 require the Baxter elliptic Bethe ansatz and currently raise
 `DomainError` — Phase 2.
 
-`Jx ≠ 0` is required (so `Δ = Jz/Jx` is well-defined).
+`Jx > 0` is required (so `Delta = Jz/Jx` is well-defined and the delegation routes into the XXZ1D-tested domain; FM-exchange `Jx < 0` is Phase 2).
 
 # References
 
@@ -108,10 +108,14 @@ function fetch(
             "HeisenbergXYZ Energy(:per_site) currently supports only the axis-aligned reduction Jx = Jy (delegated to XXZ1D); general XYZ via Baxter elliptic Bethe ansatz is tracked as Phase 2.  Got (Jx, Jy) = ($Jx, $Jy).",
         ),
     )
-    Jx == 0 && throw(
+    # Restrict to Jx > 0 so that Delta = Jz/Jx has unambiguous sign and the
+    # delegation lands in the XXZ1D-tested domain.  Jx < 0 (FM exchange) would
+    # flip Delta's sign into XXZ1D regions whose Yang-Yang analytic
+    # continuation is not exercised by the current XXZ1D test suite.
+    Jx > 0 || throw(
         DomainError(
             Jx,
-            "HeisenbergXYZ Energy(:per_site): Jx = 0 with Jx = Jy degenerates to an Ising-like model not in the XXZ family; pure-Ising reductions are tracked as Phase 2.",
+            "HeisenbergXYZ Energy(:per_site): Jx > 0 required (Jx == 0 is Ising-like; Jx < 0 is the FM-exchange XXZ regime whose XXZ1D delegation is not yet tested).  Got Jx = $Jx.",
         ),
     )
     Δ = Jz / Jx

--- a/src/models/quantum/HeisenbergXYZ/HeisenbergXYZ.jl
+++ b/src/models/quantum/HeisenbergXYZ/HeisenbergXYZ.jl
@@ -1,0 +1,118 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# HeisenbergXYZ — spin-½ chain with three independent exchange couplings.
+#
+# Hamiltonian:
+#
+#     H = Σ_i [ Jx Sˣᵢ Sˣᵢ₊₁ + Jy Sʸᵢ Sʸᵢ₊₁ + Jz Sᶻᵢ Sᶻᵢ₊₁ ],   S = 1/2.
+#
+# This is the most general 1D nearest-neighbour spin-½ chain still
+# admitting Bethe-ansatz integrability — Baxter (1972) showed it is
+# the row-to-row transfer matrix of the 8-vertex model whose ground
+# state is expressed in elliptic theta functions.
+#
+# The general closed form involves elliptic integrals and is deferred
+# to a later phase.  What this file *does* expose are the canonical
+# *axis-aligned reductions*, each delegated to an already-implemented
+# Atlas entry:
+#
+#   * Jx = Jy   →  XXZ1D(J = Jx, Δ = Jz / Jx) at Infinite
+#                  (covers Heisenberg AF/FM at Jz = Jx, XX at Jz = 0,
+#                  Ising-like Jz/Jx > 1 etc. — already handled by
+#                  XXZ.jl + Yang-Yang single integral and the
+#                  closed-form points)
+#
+# All other (Jx ≠ Jy) triples raise DomainError pointing to the
+# Baxter-elliptic phase 2 implementation.
+#
+# References:
+#   - R. J. Baxter, Annals Phys. 70, 193 (1972).
+#   - L. D. Faddeev, L. A. Takhtajan, J. Soviet Math. 24, 241 (1984).
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    HeisenbergXYZ(; Jx::Real = 1.0, Jy::Real = 1.0, Jz::Real = 1.0)
+        <: AbstractQAtlasModel
+
+Spin-½ XYZ chain with three independent exchange couplings
+
+    H = Σ_i [ Jx Sˣᵢ Sˣᵢ₊₁ + Jy Sʸᵢ Sʸᵢ₊₁ + Jz Sᶻᵢ Sᶻᵢ₊₁ ].
+
+Most-general 1-D nearest-neighbour spin-½ integrable model
+(Baxter 1972).  This release exposes only the *axis-aligned reductions*
+`Jx = Jy` by delegating to the existing [`XXZ1D`](@ref) machinery:
+
+    HeisenbergXYZ(Jx = J, Jy = J, Jz)   ≡   XXZ1D(J = J, Δ = Jz / J).
+
+General XYZ ground-state energy (Baxter elliptic Bethe ansatz)
+is tracked as a follow-up phase and raises `DomainError` here.
+
+Quantities registered:
+
+| Quantity                       | BC         | Method                 |
+| ------------------------------ | ---------- | ---------------------- |
+| [`Energy`](@ref) (`:per_site`) | `Infinite` | delegated to XXZ1D     |
+
+# References
+
+- R. J. Baxter, *Annals Phys.* **70**, 193 (1972).
+- L. D. Faddeev, L. A. Takhtajan, *J. Soviet Math.* **24**, 241 (1984).
+"""
+struct HeisenbergXYZ <: AbstractQAtlasModel
+    Jx::Float64
+    Jy::Float64
+    Jz::Float64
+end
+HeisenbergXYZ(; Jx::Real=1.0, Jy::Real=1.0, Jz::Real=1.0) =
+    HeisenbergXYZ(Float64(Jx), Float64(Jy), Float64(Jz))
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Ground-state energy per site — axis-aligned (Jx = Jy) reduction
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    fetch(m::HeisenbergXYZ, ::Energy{:per_site}, ::Infinite;
+          Jx=m.Jx, Jy=m.Jy, Jz=m.Jz, kwargs...) -> Float64
+
+Ground-state energy per site of the spin-½ XYZ chain in the
+thermodynamic limit, restricted to the axis-aligned reduction
+`Jx = Jy`:
+
+    HeisenbergXYZ(Jx = J, Jy = J, Jz)   ⟶   fetch(XXZ1D(J = J, Δ = Jz/J), …).
+
+This routes the call through the XXZ1D Yang-Yang single integral
+(general -1 < Δ < 1) and the three closed-form points Δ ∈ {-1, 0, 1}
+already implemented in [`XXZ1D`](@ref).  General (Jx ≠ Jy) triples
+require the Baxter elliptic Bethe ansatz and currently raise
+`DomainError` — Phase 2.
+
+`Jx ≠ 0` is required (so `Δ = Jz/Jx` is well-defined).
+
+# References
+
+- C. N. Yang, C. P. Yang, *Phys. Rev.* **150**, 327 (1966).
+- R. J. Baxter, *Annals Phys.* **70**, 193 (1972).
+"""
+function fetch(
+    m::HeisenbergXYZ,
+    ::Energy{:per_site},
+    ::Infinite;
+    Jx::Real=m.Jx,
+    Jy::Real=m.Jy,
+    Jz::Real=m.Jz,
+    kwargs...,
+)
+    Jx == Jy || throw(
+        DomainError(
+            (Jx, Jy),
+            "HeisenbergXYZ Energy(:per_site) currently supports only the axis-aligned reduction Jx = Jy (delegated to XXZ1D); general XYZ via Baxter elliptic Bethe ansatz is tracked as Phase 2.  Got (Jx, Jy) = ($Jx, $Jy).",
+        ),
+    )
+    Jx == 0 && throw(
+        DomainError(
+            Jx,
+            "HeisenbergXYZ Energy(:per_site): Jx = 0 with Jx = Jy degenerates to an Ising-like model not in the XXZ family; pure-Ising reductions are tracked as Phase 2.",
+        ),
+    )
+    Δ = Jz / Jx
+    return QAtlas.fetch(QAtlas.XXZ1D(; J=Jx, Δ=Δ), Energy{:per_site}(), Infinite())
+end

--- a/src/models/quantum/HeisenbergXYZ/HeisenbergXYZ.jl
+++ b/src/models/quantum/HeisenbergXYZ/HeisenbergXYZ.jl
@@ -62,8 +62,9 @@ struct HeisenbergXYZ <: AbstractQAtlasModel
     Jy::Float64
     Jz::Float64
 end
-HeisenbergXYZ(; Jx::Real=1.0, Jy::Real=1.0, Jz::Real=1.0) =
+function HeisenbergXYZ(; Jx::Real=1.0, Jy::Real=1.0, Jz::Real=1.0)
     HeisenbergXYZ(Float64(Jx), Float64(Jy), Float64(Jz))
+end
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Ground-state energy per site — axis-aligned (Jx = Jy) reduction

--- a/src/models/quantum/HeisenbergXYZ/HeisenbergXYZ_registry.jl
+++ b/src/models/quantum/HeisenbergXYZ/HeisenbergXYZ_registry.jl
@@ -1,0 +1,16 @@
+# models/quantum/HeisenbergXYZ/HeisenbergXYZ_registry.jl
+#
+# Declarative implementation map for the spin-½ XYZ chain
+# (most general 1-D nearest-neighbour integrable spin model).
+# Schema documented in src/core/registry.jl.
+
+@register(
+    HeisenbergXYZ,
+    Energy{:per_site},
+    Infinite,
+    method=:xxz_delegation,
+    reliability=:high,
+    tested_in="test/standalone/test_heisenberg_xyz.jl",
+    references=["Yang-Yang 1966", "Baxter 1972"],
+    notes="Delegates to XXZ1D(J=Jx, Δ=Jz/Jx) when Jx=Jy; general (Jx≠Jy) raises DomainError (Baxter elliptic deferred to Phase 2).",
+)

--- a/test/models/quantum/XXZ/test_heisenberg_xyz.jl
+++ b/test/models/quantum/XXZ/test_heisenberg_xyz.jl
@@ -1,0 +1,62 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Standalone test: HeisenbergXYZ — axis-aligned XXZ-delegation.
+#
+# Verifies:
+#   * Jx = Jy = J, Jz = J (isotropic AF Heisenberg):
+#         E0/N = J (1/4 - log 2)   (Hulthén 1938 via XXZ1D Δ = 1 path)
+#   * Jx = Jy = J, Jz = 0 (XX free fermion): E0/N = -J/π
+#   * Jx = Jy = J, Jz = -J: E0/N = -J/4 (FM saturation)
+#   * Jx = Jy = J, Jz = J/2: matches XXZ1D Yang-Yang Δ = 1/2 → -3J/8
+#   * Jx ≠ Jy: DomainError (general XYZ deferred to Phase 2)
+#   * Jx = Jy = 0: DomainError (Ising-like reduction)
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Test
+
+@testset "HeisenbergXYZ — isotropic Heisenberg AF limit (Hulthén)" begin
+    m = HeisenbergXYZ(; Jx=1.0, Jy=1.0, Jz=1.0)
+    E0 = QAtlas.fetch(m, Energy(:per_site), Infinite())
+    @test E0 ≈ 0.25 - log(2.0) atol = 1e-12
+end
+
+@testset "HeisenbergXYZ — XX free-fermion limit" begin
+    m = HeisenbergXYZ(; Jx=1.0, Jy=1.0, Jz=0.0)
+    E0 = QAtlas.fetch(m, Energy(:per_site), Infinite())
+    @test E0 ≈ -1 / π atol = 1e-12
+end
+
+@testset "HeisenbergXYZ — isotropic FM saturated limit" begin
+    m = HeisenbergXYZ(; Jx=1.0, Jy=1.0, Jz=-1.0)
+    E0 = QAtlas.fetch(m, Energy(:per_site), Infinite())
+    @test E0 ≈ -1 / 4 atol = 1e-12
+end
+
+@testset "HeisenbergXYZ — Yang-Yang single integral at Δ = 1/2" begin
+    m = HeisenbergXYZ(; Jx=1.0, Jy=1.0, Jz=0.5)
+    E0 = QAtlas.fetch(m, Energy(:per_site), Infinite())
+    @test E0 ≈ -3 / 8 atol = 1e-10
+end
+
+@testset "HeisenbergXYZ — J-scaling delegated to XXZ1D" begin
+    m1 = HeisenbergXYZ(; Jx=1.0, Jy=1.0, Jz=0.5)
+    m2 = HeisenbergXYZ(; Jx=2.5, Jy=2.5, Jz=1.25)
+    e1 = QAtlas.fetch(m1, Energy(:per_site), Infinite())
+    e2 = QAtlas.fetch(m2, Energy(:per_site), Infinite())
+    # XXZ1D returns J × (Δ-only function), so e2 = 2.5 e1.
+    @test e2 ≈ 2.5 * e1 atol = 1e-10
+end
+
+@testset "HeisenbergXYZ — Jx ≠ Jy raises DomainError" begin
+    @test_throws DomainError QAtlas.fetch(
+        HeisenbergXYZ(; Jx=1.0, Jy=0.5, Jz=0.3), Energy(:per_site), Infinite()
+    )
+    @test_throws DomainError QAtlas.fetch(
+        HeisenbergXYZ(; Jx=1.0, Jy=2.0, Jz=1.0), Energy(:per_site), Infinite()
+    )
+end
+
+@testset "HeisenbergXYZ — Jx = Jy = 0 raises DomainError" begin
+    @test_throws DomainError QAtlas.fetch(
+        HeisenbergXYZ(; Jx=0.0, Jy=0.0, Jz=1.0), Energy(:per_site), Infinite()
+    )
+end


### PR DESCRIPTION
Refs #253 (Phase 1).  **Chained on top of #271** (must be merged after #271).

## Summary

Adds the spin-½ XYZ chain (Baxter 1972, most general 1-D nearest-neighbour integrable spin model):

`H = Σ_i [ Jx Sˣᵢ Sˣᵢ₊₁ + Jy Sʸᵢ Sʸᵢ₊₁ + Jz Sᶻᵢ Sᶻᵢ₊₁ ]`.

Phase 1 exposes only the **axis-aligned reduction** `Jx = Jy` by delegating to the existing `XXZ1D` machinery (Yang-Yang single integral + the three closed-form points):

`HeisenbergXYZ(Jx=J, Jy=J, Jz)  ⟶  XXZ1D(J=J, Δ=Jz/J)`.

General (`Jx ≠ Jy`) triples raise `DomainError` — the Baxter elliptic Bethe ansatz is tracked as **Phase 2**.

## Phase 2 (deferred)

- General XYZ ground-state energy via Baxter 8-vertex elliptic Bethe ansatz
- Spectral gap (massless / massive regions)
- Pure-Ising reductions (Jx = Jy = 0)

## Verification

Local Julia 1.12:
- `XYZ(Jx=1, Jy=1, Jz=0.5)` → `-0.375` = `-3/8` (Yang-Yang Δ = 1/2 from XXZ1D)
- `XYZ(Jx=1, Jy=1, Jz=1)`   → `0.25 - log 2 = -0.4431` (Hulthén)
- `XYZ(Jx=1, Jy=1, Jz=0)`   → `-1/π` (XX free-fermion)
- `XYZ(Jx=1, Jy=1, Jz=-1)`  → `-1/4` (FM saturation)

Patch bump 0.19.4 → 0.19.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)