### PR TITLE
feat(quantum): KitaevHeisenberg K-only delegation (refs #256, v0.19.6)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.19.5"
+version = "0.19.6"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -34,6 +34,7 @@ export HeisenbergXYZ                                     # spin-½ XYZ chain (Ba
 export ShastrySutherland                                 # SrCu₂(BO₃)₂ 2D dimer GS (Shastry-Sutherland 1981)
 export S1Heisenberg1D                                    # spin-1 (Haldane chain)
 export AKLT1D                                            # spin-1 BLBQ at AKLT point
+export KitaevHeisenberg                                  # K-J-Γ honeycomb (α-RuCl₃, Rau-Lee-Kee 2014)
 
 # --- Core Implementation ---
 include("core/alias.jl")
@@ -158,6 +159,8 @@ include("models/quantum/ShastrySutherland/ShastrySutherland.jl")
 include("models/quantum/ShastrySutherland/ShastrySutherland_registry.jl")  # populates REGISTRY for ShastrySutherland (#259)
 include("models/quantum/HeisenbergXYZ/HeisenbergXYZ.jl")
 include("models/quantum/HeisenbergXYZ/HeisenbergXYZ_registry.jl")          # populates REGISTRY for HeisenbergXYZ (#253)
+include("models/quantum/KitaevHeisenberg/KitaevHeisenberg.jl")
+include("models/quantum/KitaevHeisenberg/KitaevHeisenberg_registry.jl")    # populates REGISTRY for KitaevHeisenberg (#256)
 
 include("models/quantum/TFIM/TFIM_fidelity.jl")            # FidelitySusceptibility (#147)
 include("models/quantum/TFIM/TFIM_quench_entanglement.jl") # VonNeumannEntropy{:quench} (#144)

--- a/src/models/quantum/KitaevHeisenberg/KitaevHeisenberg.jl
+++ b/src/models/quantum/KitaevHeisenberg/KitaevHeisenberg.jl
@@ -63,8 +63,9 @@ struct KitaevHeisenberg <: AbstractQAtlasModel
     J::Float64
     Γ::Float64
 end
-KitaevHeisenberg(; K::Real=1.0, J::Real=0.0, Γ::Real=0.0) =
+function KitaevHeisenberg(; K::Real=1.0, J::Real=0.0, Γ::Real=0.0)
     KitaevHeisenberg(Float64(K), Float64(J), Float64(Γ))
+end
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Mass gap — K-only delegation to KitaevHoneycomb
@@ -107,7 +108,5 @@ function fetch(
             "KitaevHeisenberg MassGap currently only handles the Γ = 0 limit (delegated to KitaevHoneycomb); off-diagonal Γ ≠ 0 perturbations require DMRG/ED — Phase 2.",
         ),
     )
-    return QAtlas.fetch(
-        QAtlas.KitaevHoneycomb(; Kx=K, Ky=K, Kz=K), MassGap(), Infinite()
-    )
+    return QAtlas.fetch(QAtlas.KitaevHoneycomb(; Kx=K, Ky=K, Kz=K), MassGap(), Infinite())
 end

--- a/src/models/quantum/KitaevHeisenberg/KitaevHeisenberg.jl
+++ b/src/models/quantum/KitaevHeisenberg/KitaevHeisenberg.jl
@@ -1,0 +1,113 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# KitaevHeisenberg — K-J-Γ honeycomb model (α-RuCl₃ family).
+#
+# Hamiltonian (Rau-Lee-Kee 2014 convention):
+#
+#     H = Σ_{⟨ij⟩_γ} [ K Sᵢ^γ Sⱼ^γ
+#                    + J Sᵢ · Sⱼ
+#                    + Γ (Sᵢ^α Sⱼ^β + Sᵢ^β Sⱼ^α) ],
+#
+# with γ ∈ {x, y, z} labelling the three honeycomb bond directions and
+# (α, β) the two off-diagonal axes complementary to γ.
+#
+# The K-only limit (J = Γ = 0) reduces to Kitaev's celebrated
+# exactly-solvable honeycomb model (Kitaev 2006), already exposed by
+# QAtlas as [`KitaevHoneycomb`](@ref).  Switching on J (Heisenberg)
+# or Γ (off-diagonal symmetric) immediately destroys the
+# Z₂-flux integrability and leaves the model in the realm of DMRG /
+# variational Monte Carlo / numerical ED.
+#
+# Phase 1 of this file therefore only exposes the K-only delegation:
+# any (J, Γ) ≠ (0, 0) triple raises DomainError.  Future phases will
+# add the Rau-Lee-Kee perturbative phase diagram (ferromagnetic /
+# zigzag / Néel / Kitaev spin liquid) and the half-quantized thermal
+# Hall conductance κ_xy / T = π/12 (in units of k_B²/ℏ) of the
+# field-induced gapped Kitaev spin liquid (Kasahara 2018).
+#
+# References:
+#   - A. Kitaev, "Anyons in an exactly solved model and beyond",
+#     Annals Phys. 321, 2 (2006).
+#   - G. Jackeli, G. Khaliullin, Phys. Rev. Lett. 102, 017205 (2009).
+#   - J. G. Rau, E. K.-H. Lee, H.-Y. Kee, Phys. Rev. Lett. 112,
+#     077204 (2014).
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    KitaevHeisenberg(; K::Real = 1.0, J::Real = 0.0, Γ::Real = 0.0)
+        <: AbstractQAtlasModel
+
+K-J-Γ honeycomb model (α-RuCl₃ family).  Three independent exchanges
+on the three honeycomb bond directions:
+
+    H = Σ_{⟨ij⟩_γ} [ K Sᵢ^γ Sⱼ^γ + J Sᵢ · Sⱼ + Γ (Sᵢ^α Sⱼ^β + Sᵢ^β Sⱼ^α) ].
+
+Quantities registered (Phase 1):
+
+| Quantity                       | BC         | Method                              |
+| ------------------------------ | ---------- | ----------------------------------- |
+| [`MassGap`](@ref)              | `Infinite` | delegated to KitaevHoneycomb (K=K)  |
+
+Phase 1 exposes only the **K-only limit** `J = Γ = 0`, delegated to
+the existing exactly-solvable [`KitaevHoneycomb`](@ref) entry.  Any
+non-zero `J` or `Γ` raises `DomainError` pointing to the
+DMRG / ED phase-2 follow-up.
+
+# References
+
+- A. Kitaev, *Annals Phys.* **321**, 2 (2006).
+- G. Jackeli, G. Khaliullin, *Phys. Rev. Lett.* **102**, 017205 (2009).
+- J. G. Rau, E. K.-H. Lee, H.-Y. Kee, *Phys. Rev. Lett.* **112**, 077204 (2014).
+"""
+struct KitaevHeisenberg <: AbstractQAtlasModel
+    K::Float64
+    J::Float64
+    Γ::Float64
+end
+KitaevHeisenberg(; K::Real=1.0, J::Real=0.0, Γ::Real=0.0) =
+    KitaevHeisenberg(Float64(K), Float64(J), Float64(Γ))
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Mass gap — K-only delegation to KitaevHoneycomb
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    fetch(m::KitaevHeisenberg, ::MassGap, ::Infinite;
+          K=m.K, J=m.J, Γ=m.Γ, kwargs...) -> Float64
+
+Single-particle gap of the K-J-Γ honeycomb model at the **K-only
+point** `J = Γ = 0`.  Internally constructs the isotropic
+[`KitaevHoneycomb`](@ref)`(Kx = K, Ky = K, Kz = K)` and forwards.
+The Kitaev gapless A/B/C phase therefore returns `Δ = 0` at
+isotropic |K|.
+
+`J ≠ 0` or `Γ ≠ 0` raises `DomainError` — Phase 2.
+
+# References
+
+- A. Kitaev, *Annals Phys.* **321**, 2 (2006).
+"""
+function fetch(
+    m::KitaevHeisenberg,
+    ::MassGap,
+    ::Infinite;
+    K::Real=m.K,
+    J::Real=m.J,
+    Γ::Real=m.Γ,
+    kwargs...,
+)
+    iszero(J) || throw(
+        DomainError(
+            J,
+            "KitaevHeisenberg MassGap currently only handles the K-only limit J = 0 (delegated to KitaevHoneycomb); J ≠ 0 perturbations require DMRG/ED — Phase 2.",
+        ),
+    )
+    iszero(Γ) || throw(
+        DomainError(
+            Γ,
+            "KitaevHeisenberg MassGap currently only handles the Γ = 0 limit (delegated to KitaevHoneycomb); off-diagonal Γ ≠ 0 perturbations require DMRG/ED — Phase 2.",
+        ),
+    )
+    return QAtlas.fetch(
+        QAtlas.KitaevHoneycomb(; Kx=K, Ky=K, Kz=K), MassGap(), Infinite()
+    )
+end

--- a/src/models/quantum/KitaevHeisenberg/KitaevHeisenberg_registry.jl
+++ b/src/models/quantum/KitaevHeisenberg/KitaevHeisenberg_registry.jl
@@ -1,0 +1,15 @@
+# models/quantum/KitaevHeisenberg/KitaevHeisenberg_registry.jl
+#
+# Declarative implementation map for the K-J-Γ honeycomb model
+# (α-RuCl₃ family).  Schema documented in src/core/registry.jl.
+
+@register(
+    KitaevHeisenberg,
+    MassGap,
+    Infinite,
+    method=:kitaev_delegation,
+    reliability=:high,
+    tested_in="test/standalone/test_kitaev_heisenberg.jl",
+    references=["Kitaev 2006", "Rau-Lee-Kee 2014"],
+    notes="K-only limit (J=Γ=0) delegated to KitaevHoneycomb; non-zero J or Γ raises DomainError (Phase 2: DMRG/ED).",
+)

--- a/test/models/quantum/KitaevHoneycomb/test_kitaev_heisenberg.jl
+++ b/test/models/quantum/KitaevHoneycomb/test_kitaev_heisenberg.jl
@@ -1,0 +1,43 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Standalone test: KitaevHeisenberg — K-only delegation to KitaevHoneycomb.
+#
+# Verifies:
+#   * K-only isotropic point: MassGap = 0 (gapless Kitaev B-phase)
+#   * Anisotropic Kx >> Ky+Kz reduction: delegates correctly, gap > 0
+#   * J ≠ 0 raises DomainError (Phase 2 marker)
+#   * Γ ≠ 0 raises DomainError (Phase 2 marker)
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Test
+
+@testset "KitaevHeisenberg — K-only isotropic delegates to gapless Kitaev B" begin
+    m = KitaevHeisenberg(; K=1.0, J=0.0, Γ=0.0)
+    Δ = QAtlas.fetch(m, MassGap(), Infinite())
+    @test Δ == 0.0
+end
+
+@testset "KitaevHeisenberg — K-only K-scaling" begin
+    for K in (0.5, 1.0, 2.5)
+        m = KitaevHeisenberg(; K=K, J=0.0, Γ=0.0)
+        # Isotropic K-only honeycomb is in the gapless B phase: Δ = 0.
+        @test QAtlas.fetch(m, MassGap(), Infinite()) == 0.0
+    end
+end
+
+@testset "KitaevHeisenberg — DomainError on J ≠ 0" begin
+    @test_throws DomainError QAtlas.fetch(
+        KitaevHeisenberg(; K=1.0, J=0.1, Γ=0.0), MassGap(), Infinite()
+    )
+end
+
+@testset "KitaevHeisenberg — DomainError on Γ ≠ 0" begin
+    @test_throws DomainError QAtlas.fetch(
+        KitaevHeisenberg(; K=1.0, J=0.0, Γ=0.1), MassGap(), Infinite()
+    )
+end
+
+@testset "KitaevHeisenberg — DomainError on both J and Γ" begin
+    @test_throws DomainError QAtlas.fetch(
+        KitaevHeisenberg(; K=1.0, J=0.1, Γ=0.1), MassGap(), Infinite()
+    )
+end

--- a/test/models/quantum/KitaevHoneycomb/test_kitaev_heisenberg.jl
+++ b/test/models/quantum/KitaevHoneycomb/test_kitaev_heisenberg.jl
@@ -3,7 +3,6 @@
 #
 # Verifies:
 #   * K-only isotropic point: MassGap = 0 (gapless Kitaev B-phase)
-#   * Anisotropic Kx >> Ky+Kz reduction: delegates correctly, gap > 0
 #   * J ≠ 0 raises DomainError (Phase 2 marker)
 #   * Γ ≠ 0 raises DomainError (Phase 2 marker)
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Refs #256 (Phase 1).  **Chained on top of #272** (must be merged after #272).

## Summary

Adds the K-J-Γ honeycomb model (α-RuCl₃ family; Jackeli-Khaliullin 2009; Rau-Lee-Kee 2014):

`H = Σ_{⟨ij⟩_γ} [ K Sᵢ^γ Sⱼ^γ + J Sᵢ·Sⱼ + Γ (Sᵢ^α Sⱼ^β + Sᵢ^β Sⱼ^α) ]`.

Phase 1 exposes only the **K-only limit** `J = Γ = 0` by delegating to the existing exactly-solvable `KitaevHoneycomb`:

`KitaevHeisenberg(K, J=0, Γ=0)  ⟶  KitaevHoneycomb(Kx=K, Ky=K, Kz=K)`.

Registers `MassGap` at `Infinite`.  Non-zero `J` or `Γ` raises `DomainError`.

## Phase 2 (deferred)

- Rau-Lee-Kee perturbative phase diagram (FM / zigzag / Néel / Kitaev spin liquid)
- Half-quantised thermal Hall κ_xy/T = π/12 (k_B²/ℏ) under field (Kasahara 2018)
- DMRG / ED references for finite (J, Γ)

## Verification

Local Julia 1.12: `fetch(KitaevHeisenberg(K=1), MassGap(), Infinite()) == 0.0` (gapless Kitaev B-phase).

Patch bump 0.19.5 → 0.19.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)