### PR TITLE
feat(classical): TodaLattice — gapless phonon (refs #254, v0.19.7)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.19.6"
+version = "0.19.7"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -12,6 +12,7 @@ export IsingTriangular
 export CurieWeissIsing                                   # complete-graph mean-field Ising
 export IsingChain1D                                      # 1-D Ising chain (Ising 1925)
 export SpinIce                                           # pyrochlore Pauling 1935
+export TodaLattice                                       # 1-D Toda lattice (Toda 1967, integrable)
 
 # --- Quantum Models ---
 export TFIM                                             # v0.13 concrete struct
@@ -112,6 +113,8 @@ include("models/classical/IsingChain1D/IsingChain1D.jl")
 include("models/classical/IsingChain1D/IsingChain1D_registry.jl")        # populates REGISTRY for IsingChain1D (#262)
 include("models/classical/SpinIce/SpinIce.jl")
 include("models/classical/SpinIce/SpinIce_registry.jl")                  # populates REGISTRY for SpinIce (#257)
+include("models/classical/TodaLattice/TodaLattice.jl")
+include("models/classical/TodaLattice/TodaLattice_registry.jl")          # populates REGISTRY for TodaLattice (#254)
 include("models/quantum/tightbinding/regular/Honeycomb.jl")
 include("models/quantum/tightbinding/regular/Kagome.jl")
 include("models/quantum/tightbinding/regular/Lieb.jl")

--- a/src/models/classical/TodaLattice/TodaLattice.jl
+++ b/src/models/classical/TodaLattice/TodaLattice.jl
@@ -1,0 +1,86 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# TodaLattice — 1-D Toda lattice (classical, integrable; Toda 1967).
+#
+# Hamiltonian (standard "Toda 1967" convention):
+#
+#     H = Σ_n [ p_n² / 2 + V(q_{n+1} - q_n) ],
+#       V(r) = (a/b) e^{-b r} + a r - a/b      (a, b > 0),
+#
+# with `a = b = 1` reducing to the textbook
+#
+#     V(r) = e^{-r} + r - 1,   V(0) = 0,   V''(0) = 1.
+#
+# The model is completely integrable (Hénon 1974, Flaschka 1974) and
+# admits a Lax-pair representation L̇ = [B, L] whose spectrum is
+# conserved.  N-soliton solutions in closed form are due to Toda
+# (1967); the quantum Toda chain admits a Bethe-ansatz spectrum
+# (Gutzwiller 1981, Sklyanin 1985).
+#
+# This Phase-1 entry establishes the model type and exposes the
+# **gapless acoustic phonon** scalar: small-amplitude oscillations
+# around the trivial classical ground state q_n = const, p_n = 0
+# linearise to ω(k) = 2 √(a b) |sin(k/2)|, so the bottom of the
+# small-oscillation spectrum is `MassGap = 0`.  Soliton dispersions
+# and the Gutzwiller quantum-Toda spectrum require new quantity types
+# (position / momentum-parameter-dependent scalars) and are tracked
+# as a follow-up phase.
+#
+# References:
+#   - M. Toda, J. Phys. Soc. Jpn. 22, 431 (1967).
+#   - H. Flaschka, Phys. Rev. B 9, 1924 (1974) — Lax representation.
+#   - M. Hénon, Phys. Rev. B 9, 1921 (1974) — integrals of motion.
+#   - M. C. Gutzwiller, Annals Phys. 133, 304 (1981) — quantum Toda.
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    TodaLattice(; a::Real = 1.0, b::Real = 1.0) <: AbstractQAtlasModel
+
+Classical 1-D Toda lattice (Toda 1967) with standard nearest-neighbour
+exponential potential `V(r) = (a/b) e^{-b r} + a r - a/b`.  The
+defaults `a = b = 1` give the canonical textbook form
+`V(r) = e^{-r} + r - 1`.
+
+Quantities registered (Phase 1):
+
+| Quantity                       | BC         | Method                       |
+| ------------------------------ | ---------- | ---------------------------- |
+| [`MassGap`](@ref)              | `Infinite` | linear-phonon (gapless)      |
+
+Soliton energy-momentum relations and the Gutzwiller (1981) quantum-
+Toda Bethe-ansatz spectrum are tracked as Phase 2: they need
+momentum-parameter / quantum-number-indexed quantity types not yet
+in QAtlas core.
+
+# References
+
+- M. Toda, *J. Phys. Soc. Jpn.* **22**, 431 (1967).
+- H. Flaschka, *Phys. Rev. B* **9**, 1924 (1974).
+- M. C. Gutzwiller, *Annals Phys.* **133**, 304 (1981).
+"""
+struct TodaLattice <: AbstractQAtlasModel
+    a::Float64
+    b::Float64
+end
+TodaLattice(; a::Real=1.0, b::Real=1.0) = TodaLattice(Float64(a), Float64(b))
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Linearised phonon mass gap
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    fetch(::TodaLattice, ::MassGap, ::Infinite; kwargs...) -> Float64
+
+Small-amplitude phonon gap of the classical Toda lattice around the
+uniform-spacing ground state.  The harmonic expansion gives
+`ω(k) = 2 √(a b) |sin(k/2)|`, an acoustic branch vanishing linearly
+at `k = 0`.  The corresponding mass gap is identically zero for any
+`(a, b) > 0`.
+
+# References
+
+- M. Toda, *J. Phys. Soc. Jpn.* **22**, 431 (1967).
+- H. Flaschka, *Phys. Rev. B* **9**, 1924 (1974).
+"""
+function fetch(::TodaLattice, ::MassGap, ::Infinite; kwargs...)
+    return 0.0
+end

--- a/src/models/classical/TodaLattice/TodaLattice_registry.jl
+++ b/src/models/classical/TodaLattice/TodaLattice_registry.jl
@@ -1,0 +1,15 @@
+# models/classical/TodaLattice/TodaLattice_registry.jl
+#
+# Declarative implementation map for the 1-D Toda lattice
+# (Toda 1967, classical integrable).  Schema in src/core/registry.jl.
+
+@register(
+    TodaLattice,
+    MassGap,
+    Infinite,
+    method=:linear_phonon,
+    reliability=:high,
+    tested_in="test/standalone/test_toda_lattice.jl",
+    references=["Toda 1967", "Flaschka 1974"],
+    notes="Linearised acoustic phonon ω(k) = 2√(ab)|sin(k/2)| ⇒ MassGap = 0.  Soliton / quantum-Toda spectrum tracked as Phase 2.",
+)

--- a/test/models/classical/test_toda_lattice.jl
+++ b/test/models/classical/test_toda_lattice.jl
@@ -1,0 +1,17 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Standalone test: TodaLattice — classical Toda gapless phonon.
+#
+# Verifies:
+#   * MassGap = 0 for all (a, b) > 0  (acoustic phonon at k = 0)
+#   * (a, b) defaults yield same result as explicit construction
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Test
+
+@testset "TodaLattice — gapless acoustic phonon MassGap = 0" begin
+    @test QAtlas.fetch(TodaLattice(), MassGap(), Infinite()) == 0.0
+    @test QAtlas.fetch(TodaLattice(; a=1.0, b=1.0), MassGap(), Infinite()) == 0.0
+    for a in (0.5, 2.0, 3.7), b in (0.5, 1.0, 2.5)
+        @test QAtlas.fetch(TodaLattice(; a=a, b=b), MassGap(), Infinite()) == 0.0
+    end
+end


### PR DESCRIPTION
Refs #254 (Phase 1).  **Chained on top of #273** (must be merged after #273).

## Summary

Adds the 1-D Toda lattice (Toda 1967), the canonical classical integrable nearest-neighbour exponential-potential chain:

`H = Σ_n [ p_n² / 2 + V(q_{n+1} - q_n) ],  V(r) = (a/b) e^{-br} + a r - a/b`.

Phase 1 registers the linearised acoustic-phonon `MassGap = 0` at `Infinite` (`ω(k) = 2√(ab) |sin(k/2)|`).

> **Issue title spelling**: #254's title has a typo ("ToddaLattice").  Code uses the canonical historical spelling `TodaLattice`.

## Phase 2 (deferred — needs new quantity types)

- N-soliton energy / momentum closed forms (Toda 1967)
- Quantum-Toda Bethe-ansatz spectrum (Gutzwiller 1981, Sklyanin 1985)
- Classical ↔ quantum correspondence

These need momentum-parameter / quantum-number-indexed quantity types not yet in QAtlas core.

## Verification

Local Julia 1.12: `fetch(TodaLattice(), MassGap(), Infinite()) == 0.0`.

Patch bump 0.19.6 → 0.19.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)