### PR TITLE
ci: workflow_dispatch trigger for format bot + single-upload coverage aggregation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,12 @@ on:
       - main
     tags: '*'
   pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.group }}

--- a/.github/workflows/FormatFix.yml
+++ b/.github/workflows/FormatFix.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   format-fix:
@@ -20,6 +21,12 @@ jobs:
         run: |
           julia -e 'using Pkg; Pkg.add("JuliaFormatter"); using JuliaFormatter; format(".")'
       - name: Commit changes
+        id: fmt
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "🤖 Format code (Blue style)"
+      - name: Trigger CI on format commit
+        if: steps.fmt.outputs.changes_detected == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run CI.yml --ref ${{ github.head_ref }}


### PR DESCRIPTION
Two related CI fixes bundled together (both touch `.github/workflows/CI.yml`).

---

## Fix 1 — CI runs after formatter bot commits (`workflow_dispatch`)

### Problem
`FormatFix.yml` pushes auto-format commits via `stefanzweifel/git-auto-commit-action` using `GITHUB_TOKEN`. Per [GitHub Actions docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication):

> "Events triggered by the `GITHUB_TOKEN`, with the exception of `workflow_dispatch` and `repository_dispatch`, will not create a new workflow run."

So **no** event fires for the format commit — neither `pull_request: synchronize` nor `push` — and CI never validates the formatted code.

### Fix (no PAT required)
`workflow_dispatch` is **explicitly exempt** from the GITHUB_TOKEN suppression. We exploit this:

1. **`CI.yml`**: add `workflow_dispatch:` trigger. Dispatched runs report against the head SHA of the dispatched ref, so they appear as a check on the PR whose head matches.
2. **`FormatFix.yml`**: after `auto-commit`, dispatch CI on the PR head branch when `changes_detected == 'true'`. Requires `actions: write` permission so `GITHUB_TOKEN` can call the workflow-dispatch API.
3. **`CI.yml` concurrency**: use `github.head_ref || github.ref` so `push`, `pull_request`, and `workflow_dispatch` events for the same branch share a concurrency group. Cancels stale runs when the formatter supersedes the original commit.

---

## Fix 2 — Coverage underestimation (single-upload aggregation)

### Problem
Each of the 9 matrix jobs ran `julia-processcoverage` and uploaded the *same* `lcov.info` (every src/ file present, but only one group exercises function bodies). Each upload was tagged with `flags: ${{ matrix.group }}` — but matrix group names contain `/` (e.g., `models/quantum/TFIM`), which is **not a valid Codecov flag character** ([docs](https://docs.codecov.com/docs/flags)). Flag-level merging was unreliable, and the 9-way project-level union of identical-file/different-coverage reports produced underestimated per-file coverage (e.g., `src/models/quantum/XXZ/XXZ.jl` at 67% despite having a dedicated test group).

### Fix
1. Matrix `test` jobs now upload the per-group `lcov.info` as a **workflow artifact** (artifact name sanitised: `/` → `_`, `,` → `+`) instead of uploading to Codecov.
2. New **`coverage` job** runs after the matrix, downloads every `coverage-*` artifact, installs the `lcov` CLI, and merges them deterministically with `lcov -a … -o lcov.info` (hit-count sum → per-line union for coverage %).
3. Prints `lcov --summary` to the job log as a Codecov-independent ground truth.
4. Uploads the merged `lcov.info` to Codecov **once**, with no flag — eliminating both the 9-way merge ambiguity and the invalid flag-name issue.
5. `all-tests` continues to gate only on the matrix; coverage upload flakiness does not block merges.