### PR TITLE
ci: aggregate coverage into single Codecov upload via lcov merge

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,11 +46,63 @@ jobs:
         with:
           julia-args: "--threads=auto"
       - uses: julia-actions/julia-processcoverage@v1
+      - name: Compute artifact name
+        id: art
+        run: |
+          name="coverage-${{ matrix.group }}"
+          name="${name//[\/,]/_}"
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.art.outputs.name }}
+          path: lcov.info
+          retention-days: 1
+          if-no-files-found: error
+
+  coverage:
+    name: Coverage (aggregated)
+    runs-on: ubuntu-latest
+    needs: test
+    if: always() && needs.test.result != 'cancelled'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v4
+        with:
+          path: coverage-parts
+          pattern: coverage-*
+      - name: Install lcov
+        run: sudo apt-get update && sudo apt-get install -y lcov
+      - name: Merge per-group lcov reports
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(find coverage-parts -name 'lcov.info' | sort)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::No coverage artifacts found"
+            exit 1
+          fi
+          echo "Merging ${#files[@]} lcov reports:"
+          printf '  %s\n' "${files[@]}"
+          args=()
+          for f in "${files[@]}"; do
+            args+=(-a "$f")
+          done
+          lcov "${args[@]}" -o lcov.info
+          summary=$(lcov --summary lcov.info)
+          echo ""
+          echo "=== Merged coverage summary ==="
+          echo "$summary"
+          {
+            echo "## Merged coverage summary"
+            echo "(merged from ${#files[@]} matrix-job artifacts)"
+            echo ""
+            echo '```'
+            echo "$summary"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
       - uses: codecov/codecov-action@v6
         with:
           file: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: ${{ matrix.group }}
           fail_ci_if_error: false
 
   all-tests:


### PR DESCRIPTION
## Problem

Each of the 9 matrix jobs runs `julia-processcoverage` and uploads the *same* `lcov.info` to Codecov — every `src/` file is present, but only one group exercises function bodies (`using QAtlas` loads everything, but only the matrix group's tests actually call functions).

Each upload was tagged with `flags: ${{ matrix.group }}` — and matrix group names contain `/` (e.g., `models/quantum/TFIM`), which is **not a valid Codecov flag character** ([docs](https://docs.codecov.com/docs/flags) restrict flag names to alphanumeric / `_` / `-` / `.`). Flag-level merging is unreliable, and the 9-way project-level union of 9 reports-of-the-same-file with wildly different hit profiles produces underestimated per-file coverage.

Concrete symptom (from `f7452a42` on main): `src/models/quantum/XXZ/XXZ.jl` is reported at **67.27%** despite having a dedicated test group that exercises it well.

## Fix

Replace the 9 flagged uploads with **one deterministic merged upload**:

1. Matrix `test` jobs upload their per-group `lcov.info` as a **workflow artifact** (name sanitised: `/` → `_`, `,` → `+`) instead of calling Codecov.
2. New **`coverage` job** runs after the matrix, downloads every `coverage-*` artifact, installs the `lcov` CLI, and merges them with `lcov -a … -o lcov.info` (hit-count sum → per-line union for the coverage %).
3. Prints `lcov --summary` to the job log as a Codecov-independent ground truth (lets us verify the merge result without trusting Codecov's flag merging).
4. Uploads the **single** merged `lcov.info` to Codecov, **with no flag** — eliminating both the 9-way merge ambiguity and the invalid-flag-name issue.
5. `all-tests` continues to gate only on the matrix; coverage upload flakiness does not block merges.

## Expected result

`XXZ.jl` and similar should jump from artificially-low percentages to whatever the lcov-merged union actually computes. The job log's `lcov --summary` provides a ground-truth number to validate against the Codecov display.