### PR TITLE
feat(quantum): MixedFieldIsing1D — TFIM + longitudinal field (Phase 1 h_z=0 delegate, refs #290)

### DIFF
--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -48,6 +48,7 @@ export ShastrySutherland                                 # SrCu₂(BO₃)₂ 2D 
 export S1Heisenberg1D                                    # spin-1 (Haldane chain)
 export AKLT1D                                            # spin-1 BLBQ at AKLT point
 export KitaevHeisenberg                                  # K-J-Γ honeycomb (α-RuCl₃, Rau-Lee-Kee 2014)
+export MixedFieldIsing1D                            # TFIM + longitudinal field, non-integrable (#290)
 
 # --- Core Implementation ---
 include("core/alias.jl")
@@ -202,6 +203,8 @@ include("models/quantum/HeisenbergXYZ/HeisenbergXYZ.jl")
 include("models/quantum/HeisenbergXYZ/HeisenbergXYZ_registry.jl")          # populates REGISTRY for HeisenbergXYZ (#253)
 include("models/quantum/KitaevHeisenberg/KitaevHeisenberg.jl")
 include("models/quantum/KitaevHeisenberg/KitaevHeisenberg_registry.jl")    # populates REGISTRY for KitaevHeisenberg (#256)
+include("models/quantum/MixedFieldIsing1D/MixedFieldIsing1D.jl")
+include("models/quantum/MixedFieldIsing1D/MixedFieldIsing1D_registry.jl")  # populates REGISTRY for MixedFieldIsing1D (#290)
 
 include("models/quantum/TFIM/TFIM_fidelity.jl")            # FidelitySusceptibility (#147)
 include("models/quantum/TFIM/TFIM_quench_entanglement.jl") # VonNeumannEntropy{:quench} (#144)

--- a/src/models/quantum/MixedFieldIsing1D/MixedFieldIsing1D.jl
+++ b/src/models/quantum/MixedFieldIsing1D/MixedFieldIsing1D.jl
@@ -1,0 +1,100 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Mixed-Field Ising Model — 1D chain with transverse AND longitudinal field
+#
+# Hamiltonian:
+#   H = -J Σᵢ σᶻᵢσᶻᵢ₊₁  -  h_x Σᵢ σˣᵢ  -  h_z Σᵢ σᶻᵢ,    J > 0.
+#
+# Two qualitatively different regimes:
+#
+#   * h_z = 0:  recovers the standard transverse-field Ising model (TFIM),
+#               Jordan-Wigner solvable, with closed-form mass gap
+#               Δ_∞(J, h_x) = 2|h_x - J| (Pfeuty 1970).
+#
+#   * h_z ≠ 0:  the model is NON-INTEGRABLE and is the canonical minimal
+#               non-integrable Ising chain used throughout the ETH /
+#               thermalisation / chaos literature (McCoy-Wu 1978;
+#               Banuls-Cirac-Hastings 2011).  No closed form for the gap.
+#
+# Phase 1 scope (this file):
+#   * h_z = 0   → delegate the (Δ, Infinite) fetch to TFIM (closed form).
+#   * h_z ≠ 0   → throw DomainError, deferring to Phase 2 (numerical ED /
+#                 DMRG, to be implemented in a follow-up).
+#
+# References:
+#   - Pfeuty, Ann. Phys. 57, 79 (1970)
+#   - McCoy & Wu, Phys. Rev. B 18, 4886 (1978)
+#   - Banuls, Cirac & Hastings, Phys. Rev. Lett. 106, 050405 (2011)
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    MixedFieldIsing1D(; J = 1.0, h_x = 1.0, h_z = 0.0) <: AbstractQAtlasModel
+
+The 1D mixed-field Ising chain
+
+    H = -J Σ_i σᶻ_i σᶻ_{i+1} - h_x Σ_i σˣ_i - h_z Σ_i σᶻ_i,    J > 0.
+
+The default `h_z = 0.0` sits on the Phase-1 closed-form point where the
+model coincides with the standard TFIM (`Δ_∞ = 2|h_x − J|`, gap closing
+at the quantum critical point `h_x = J`).
+
+At `h_z ≠ 0` the model is **non-integrable** — fetch methods will throw
+`DomainError` in Phase 1 and route to numerical solvers in Phase 2.
+"""
+struct MixedFieldIsing1D <: AbstractQAtlasModel
+    J::Float64
+    h_x::Float64
+    h_z::Float64
+    function MixedFieldIsing1D(J::Real, h_x::Real, h_z::Real)
+        J > 0 || throw(DomainError(J, "MixedFieldIsing1D requires J > 0; got J = $J."))
+        return new(Float64(J), Float64(h_x), Float64(h_z))
+    end
+end
+MixedFieldIsing1D(; J::Real=1.0, h_x::Real=1.0, h_z::Real=0.0) =
+    MixedFieldIsing1D(J, h_x, h_z)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# MassGap, Infinite — Phase 1: delegate at h_z = 0, DomainError otherwise.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    fetch(m::MixedFieldIsing1D, ::MassGap, ::Infinite; J, h_x, h_z) -> Float64
+
+Mass gap of the infinite mixed-field Ising chain.
+
+* At `h_z = 0` (default): delegate to `TFIM(; J=J, h=h_x)` and return the
+  closed-form `Δ = 2|h_x − J|` (Pfeuty 1970).
+* At `h_z ≠ 0`: throw `DomainError` — the model is non-integrable
+  (canonical ETH / thermalisation benchmark, McCoy-Wu 1978;
+  Banuls-Cirac-Hastings 2011) and no closed-form gap exists.  Numerical
+  routes (ED / DMRG) will land in Phase 2.
+
+`J, h_x, h_z` may be overridden via keyword to evaluate the gap at a
+point different from the struct's stored parameters without rebuilding
+the model.
+"""
+function fetch(
+    m::MixedFieldIsing1D,
+    ::MassGap,
+    ::Infinite;
+    J::Real=m.J,
+    h_x::Real=m.h_x,
+    h_z::Real=m.h_z,
+    kwargs...,
+)
+    J > 0 ||
+        throw(DomainError(J, "MixedFieldIsing1D MassGap requires J > 0; got J = $J."))
+    if !isapprox(h_z, 0.0; atol=1e-12)
+        throw(
+            DomainError(
+                h_z,
+                "MixedFieldIsing1D MassGap: the model is non-integrable at h_z ≠ 0 " *
+                "(no closed-form ground-state gap). Phase 1 supports only the " *
+                "h_z = 0 limit (transverse-field Ising, delegated to TFIM). " *
+                "Got h_z = $h_z. Numerical ED/DMRG routes will land in Phase 2.",
+            ),
+        )
+    end
+    # Phase-1 delegate: TFIM's MassGap at Infinite is read from its struct
+    # fields (no J/h fetch-kwargs), so we build a TFIM at (J, h_x) and call.
+    return fetch(TFIM(; J=J, h=h_x), MassGap(), Infinite())
+end

--- a/src/models/quantum/MixedFieldIsing1D/MixedFieldIsing1D.jl
+++ b/src/models/quantum/MixedFieldIsing1D/MixedFieldIsing1D.jl
@@ -83,7 +83,7 @@ function fetch(
     kwargs...,
 )
     J > 0 || throw(DomainError(J, "MixedFieldIsing1D MassGap requires J > 0; got J = $J."))
-    if !isapprox(h_z, 0.0; atol=1e-12)
+    if !iszero(h_z)
         throw(
             DomainError(
                 h_z,

--- a/src/models/quantum/MixedFieldIsing1D/MixedFieldIsing1D.jl
+++ b/src/models/quantum/MixedFieldIsing1D/MixedFieldIsing1D.jl
@@ -49,8 +49,9 @@ struct MixedFieldIsing1D <: AbstractQAtlasModel
         return new(Float64(J), Float64(h_x), Float64(h_z))
     end
 end
-MixedFieldIsing1D(; J::Real=1.0, h_x::Real=1.0, h_z::Real=0.0) =
+function MixedFieldIsing1D(; J::Real=1.0, h_x::Real=1.0, h_z::Real=0.0)
     MixedFieldIsing1D(J, h_x, h_z)
+end
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # MassGap, Infinite — Phase 1: delegate at h_z = 0, DomainError otherwise.
@@ -81,8 +82,7 @@ function fetch(
     h_z::Real=m.h_z,
     kwargs...,
 )
-    J > 0 ||
-        throw(DomainError(J, "MixedFieldIsing1D MassGap requires J > 0; got J = $J."))
+    J > 0 || throw(DomainError(J, "MixedFieldIsing1D MassGap requires J > 0; got J = $J."))
     if !isapprox(h_z, 0.0; atol=1e-12)
         throw(
             DomainError(

--- a/src/models/quantum/MixedFieldIsing1D/MixedFieldIsing1D_registry.jl
+++ b/src/models/quantum/MixedFieldIsing1D/MixedFieldIsing1D_registry.jl
@@ -1,0 +1,17 @@
+# models/quantum/MixedFieldIsing1D/MixedFieldIsing1D_registry.jl
+#
+# One `@register` line per natively-implemented (model, quantity, bc)
+# triple for the MixedFieldIsing1D model.  See `src/core/registry.jl`
+# for the metadata schema and `TFIM_registry.jl` for the canonical
+# pattern.
+
+@register(
+    MixedFieldIsing1D,
+    MassGap,
+    Infinite,
+    method=:delegation,
+    reliability=:high,
+    tested_in="test/models/quantum/misc/test_mixed_field_ising1d.jl",
+    references=["Pfeuty 1970", "McCoy-Wu 1978"],
+    notes="h_z = 0 delegated to TFIM (closed-form Δ = 2|h_x − J|); h_z ≠ 0 non-integrable, deferred to Phase 2 (ED/DMRG).",
+)

--- a/test/models/quantum/misc/test_mixed_field_ising1d.jl
+++ b/test/models/quantum/misc/test_mixed_field_ising1d.jl
@@ -22,9 +22,7 @@ using QAtlas, Test
     # Delegation invariant: MixedFieldIsing1D at h_z = 0 matches TFIM directly.
     # TFIM stores (J, h) in struct fields, so the call signature is
     # `fetch(TFIM(; J, h=h_x), MassGap(), Infinite())`.
-    Δ_mf = QAtlas.fetch(
-        MixedFieldIsing1D(; J=1.5, h_x=0.7, h_z=0.0), MassGap(), Infinite()
-    )
+    Δ_mf = QAtlas.fetch(MixedFieldIsing1D(; J=1.5, h_x=0.7, h_z=0.0), MassGap(), Infinite())
     Δ_tfim = QAtlas.fetch(TFIM(; J=1.5, h=0.7), MassGap(), Infinite())
     @test Δ_mf ≈ Δ_tfim
     # Default constructor sits on the Phase-1 point (J = h_x = 1, h_z = 0; QCP)

--- a/test/models/quantum/misc/test_mixed_field_ising1d.jl
+++ b/test/models/quantum/misc/test_mixed_field_ising1d.jl
@@ -1,0 +1,46 @@
+using QAtlas, Test
+
+@testset "MixedFieldIsing1D — h_z = 0 delegate to TFIM (Phase 1)" begin
+    # Paramagnetic side h_x > J: Δ = 2(h_x − J)
+    @test QAtlas.fetch(
+        MixedFieldIsing1D(; J=1.0, h_x=2.0, h_z=0.0), MassGap(), Infinite()
+    ) ≈ 2.0
+    @test QAtlas.fetch(
+        MixedFieldIsing1D(; J=1.0, h_x=3.0, h_z=0.0), MassGap(), Infinite()
+    ) ≈ 4.0
+    # Ferromagnetic side h_x < J: Δ = 2(J − h_x)
+    @test QAtlas.fetch(
+        MixedFieldIsing1D(; J=1.0, h_x=0.5, h_z=0.0), MassGap(), Infinite()
+    ) ≈ 1.0
+    @test QAtlas.fetch(
+        MixedFieldIsing1D(; J=2.0, h_x=1.0, h_z=0.0), MassGap(), Infinite()
+    ) ≈ 2.0
+    # Quantum critical point h_x = J: gap closes
+    @test QAtlas.fetch(
+        MixedFieldIsing1D(; J=1.0, h_x=1.0, h_z=0.0), MassGap(), Infinite()
+    ) ≈ 0.0 atol = 1e-12
+    # Delegation invariant: MixedFieldIsing1D at h_z = 0 matches TFIM directly.
+    # TFIM stores (J, h) in struct fields, so the call signature is
+    # `fetch(TFIM(; J, h=h_x), MassGap(), Infinite())`.
+    Δ_mf = QAtlas.fetch(
+        MixedFieldIsing1D(; J=1.5, h_x=0.7, h_z=0.0), MassGap(), Infinite()
+    )
+    Δ_tfim = QAtlas.fetch(TFIM(; J=1.5, h=0.7), MassGap(), Infinite())
+    @test Δ_mf ≈ Δ_tfim
+    # Default constructor sits on the Phase-1 point (J = h_x = 1, h_z = 0; QCP)
+    @test QAtlas.fetch(MixedFieldIsing1D(), MassGap(), Infinite()) ≈ 0.0 atol = 1e-12
+end
+
+@testset "MixedFieldIsing1D — h_z ≠ 0 throws DomainError (non-integrable)" begin
+    @test_throws DomainError QAtlas.fetch(
+        MixedFieldIsing1D(; J=1.0, h_x=1.0, h_z=0.1), MassGap(), Infinite()
+    )
+    @test_throws DomainError QAtlas.fetch(
+        MixedFieldIsing1D(; J=1.0, h_x=1.0, h_z=-0.5), MassGap(), Infinite()
+    )
+end
+
+@testset "MixedFieldIsing1D — rejects J ≤ 0 (Phase 1)" begin
+    @test_throws DomainError MixedFieldIsing1D(; J=0.0)
+    @test_throws DomainError MixedFieldIsing1D(; J=-1.0)
+end

--- a/test/models/quantum/misc/test_mixed_field_ising1d.jl
+++ b/test/models/quantum/misc/test_mixed_field_ising1d.jl
@@ -42,3 +42,12 @@ end
     @test_throws DomainError MixedFieldIsing1D(; J=0.0)
     @test_throws DomainError MixedFieldIsing1D(; J=-1.0)
 end
+
+@testset "MixedFieldIsing1D — strict h_z=0 boundary (no isapprox)" begin
+    # A subnormal h_z must NOT silently delegate to TFIM. The Phase-1
+    # delegate boundary is strict (iszero), matching the KitaevHeisenberg
+    # convention. Even h_z = 1e-13 selects the non-integrable regime.
+    @test_throws DomainError QAtlas.fetch(
+        MixedFieldIsing1D(; J=1.0, h_x=1.0, h_z=1e-13), MassGap(), Infinite()
+    )
+end


### PR DESCRIPTION
Refs #290 (Phase 1).

## Summary

New model **MixedFieldIsing1D** — Ising chain in both transverse and longitudinal fields:

    H = -J Σ σ^z σ^z - h_x Σ σ^x - h_z Σ σ^z

Phase-1 supports the closed-form h_z=0 limit (= TFIM) by delegation; at h_z=0 the gap is Δ = 2|h_x − J| (Pfeuty 1970). Generic h_z≠0 is the canonical non-integrable Ising example (McCoy-Wu 1978; Banuls-Cirac-Hastings 2011 ETH studies) — DomainError with explicit message.

## References
- Pfeuty 1970, McCoy-Wu 1978, Banuls-Cirac-Hastings 2011.