### PR TITLE
feat(quantum): Compass1D — 1D alternating XX/YY (Kugel-Khomskii limit, refs #295)

### DIFF
--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -48,6 +48,7 @@ export ShastrySutherland                                 # SrCu₂(BO₃)₂ 2D 
 export S1Heisenberg1D                                    # spin-1 (Haldane chain)
 export AKLT1D                                            # spin-1 BLBQ at AKLT point
 export KitaevHeisenberg                                  # K-J-Γ honeycomb (α-RuCl₃, Rau-Lee-Kee 2014)
+export Compass1D                                       # 1D alternating XX/YY compass chain (#295)
 
 # --- Core Implementation ---
 include("core/alias.jl")
@@ -202,6 +203,8 @@ include("models/quantum/HeisenbergXYZ/HeisenbergXYZ.jl")
 include("models/quantum/HeisenbergXYZ/HeisenbergXYZ_registry.jl")          # populates REGISTRY for HeisenbergXYZ (#253)
 include("models/quantum/KitaevHeisenberg/KitaevHeisenberg.jl")
 include("models/quantum/KitaevHeisenberg/KitaevHeisenberg_registry.jl")    # populates REGISTRY for KitaevHeisenberg (#256)
+include("models/quantum/Compass1D/Compass1D.jl")
+include("models/quantum/Compass1D/Compass1D_registry.jl")  # populates REGISTRY for Compass1D (#295)
 
 include("models/quantum/TFIM/TFIM_fidelity.jl")            # FidelitySusceptibility (#147)
 include("models/quantum/TFIM/TFIM_quench_entanglement.jl") # VonNeumannEntropy{:quench} (#144)

--- a/src/models/quantum/Compass1D/Compass1D.jl
+++ b/src/models/quantum/Compass1D/Compass1D.jl
@@ -1,0 +1,93 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Compass1D — 1D alternating-bond compass chain.
+#
+# The 1D limit of the 2D Kugel–Khomskii / orbital compass model:
+#
+#   H = -J_x Σ_{i odd}  σ^x_i σ^x_{i+1}
+#       -J_y Σ_{i even} σ^y_i σ^y_{i+1},        J_x, J_y > 0.
+#
+# Via Jordan–Wigner this maps to a dimerised Kitaev / p-wave wire with
+# alternating couplings; the ground-state problem is exactly solvable.
+# The bulk mass gap is
+#
+#       Δ = 2 |J_x − J_y|,
+#
+# which collapses to Δ = 0 at the symmetric point J_x = J_y — a
+# first-order quantum phase transition between the X-bond-dominated and
+# Y-bond-dominated dimerised ground states (Brzezicki–Dziarmaga–Oleś
+# 2007).
+#
+# Phase 1 (this file) exposes a single closed-form fetch:
+#
+#   • `MassGap`, `Infinite`  →  2 · |J_x − J_y|.
+#
+# References:
+#   • W. Brzezicki, J. Dziarmaga, A. M. Oleś, "Quantum phase transition
+#     in the one-dimensional compass model", PRB 75, 134415 (2007).
+#   • K. I. Kugel, D. I. Khomskii, "The Jahn–Teller effect and
+#     magnetism: transition metal compounds", Sov. Phys. Usp. 25, 231
+#     (1982) — original orbital compass / Kugel–Khomskii model.
+#   • A. Kitaev, "Anyons in an exactly solved model and beyond", Annals
+#     of Physics 321, 2 (2006) — JW-dual dimerised Kitaev chain.
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    Compass1D(; J_x::Real = 1.0, J_y::Real = 1.0) <: AbstractQAtlasModel
+
+1D alternating-bond compass chain
+
+    H = -J_x Σ_{i odd}  σ^x_i σ^x_{i+1}
+        -J_y Σ_{i even} σ^y_i σ^y_{i+1},
+
+with `J_x, J_y > 0`.  Dual to a dimerised Kitaev / p-wave wire via
+Jordan–Wigner; exactly solvable.
+
+# Phase 1 scope (this release)
+
+Phase 1 exposes the closed-form bulk gap only:
+
+- [`MassGap`](@ref) at `Infinite()` → `Δ = 2 |J_x − J_y|`.
+
+The gap closes at the symmetric point `J_x = J_y`, which is a
+**first-order** quantum phase transition between the X-bond-dimerised
+and Y-bond-dimerised ground states (Brzezicki–Dziarmaga–Oleś 2007).
+
+# References
+
+- Brzezicki–Dziarmaga–Oleś, *PRB* **75**, 134415 (2007).
+- Kugel–Khomskii, *Sov. Phys. Usp.* **25**, 231 (1982).
+- Kitaev, *Annals of Physics* **321**, 2 (2006).
+"""
+struct Compass1D <: AbstractQAtlasModel
+    J_x::Float64
+    J_y::Float64
+    function Compass1D(J_x::Real, J_y::Real)
+        J_x > 0 || throw(DomainError(J_x, "Compass1D requires J_x > 0; got J_x = $J_x."))
+        J_y > 0 || throw(DomainError(J_y, "Compass1D requires J_y > 0; got J_y = $J_y."))
+        return new(Float64(J_x), Float64(J_y))
+    end
+end
+Compass1D(; J_x::Real=1.0, J_y::Real=1.0) = Compass1D(J_x, J_y)
+
+# ─── fetch methods ────────────────────────────────────────────────────
+
+"""
+    fetch(model::Compass1D, ::MassGap, ::Infinite) -> Float64
+
+Bulk mass gap of the 1D alternating-bond compass chain:
+
+    Δ = 2 |J_x − J_y|.
+
+Closed-form result obtained from the Jordan–Wigner dual dimerised
+Kitaev / p-wave wire (Brzezicki–Dziarmaga–Oleś 2007).  Δ vanishes at
+the symmetric point `J_x = J_y`, which is a first-order quantum phase
+transition between the X-bond-dimerised and Y-bond-dimerised ground
+states.
+
+# References
+
+- Brzezicki–Dziarmaga–Oleś, *PRB* **75**, 134415 (2007).
+"""
+function fetch(model::Compass1D, ::MassGap, ::Infinite; kwargs...)
+    return 2.0 * abs(model.J_x - model.J_y)
+end

--- a/src/models/quantum/Compass1D/Compass1D_registry.jl
+++ b/src/models/quantum/Compass1D/Compass1D_registry.jl
@@ -1,0 +1,21 @@
+# models/quantum/Compass1D/Compass1D_registry.jl — declarative implementation map.
+#
+# Compass1D Phase 1 exposes the closed-form bulk gap of the 1D
+# alternating-bond compass chain (dual to a dimerised Kitaev wire):
+#
+#   `MassGap` at `Infinite()`  →  Δ = 2 |J_x − J_y|.
+
+@register(
+    Compass1D,
+    MassGap,
+    Infinite,
+    method=:analytic,
+    reliability=:high,
+    tested_in="test/models/quantum/misc/test_compass1d.jl",
+    references=[
+        "Brzezicki-Dziarmaga-Oles PRB 75, 134415 (2007)",
+        "Kugel-Khomskii Sov. Phys. Usp. 25, 231 (1982)",
+        "Kitaev Annals of Physics 321, 2 (2006)",
+    ],
+    notes="Δ = 2|J_x − J_y| from JW-dual dimerised Kitaev chain; Δ=0 at J_x=J_y is a first-order QPT.",
+)

--- a/test/models/quantum/misc/test_compass1d.jl
+++ b/test/models/quantum/misc/test_compass1d.jl
@@ -25,3 +25,14 @@ end
     @test_throws DomainError Compass1D(; J_x=-1.0)
     @test_throws DomainError Compass1D(; J_y=0.0)
 end
+
+@testset "Compass1D — swap symmetry: Δ(J_x, J_y) == Δ(J_y, J_x)" begin
+    # True cross-check that the gap is |J_x − J_y| (symmetric in the
+    # exchange of the two bond types), not an asymmetric subtraction.
+    for (a, b) in ((1.0, 0.3), (0.7, 2.4), (1.5, 1.5), (0.01, 100.0))
+        Δ_ab = QAtlas.fetch(Compass1D(; J_x=a, J_y=b), MassGap(), Infinite())
+        Δ_ba = QAtlas.fetch(Compass1D(; J_x=b, J_y=a), MassGap(), Infinite())
+        @test Δ_ab == Δ_ba
+        @test Δ_ab == 2.0 * abs(a - b)
+    end
+end

--- a/test/models/quantum/misc/test_compass1d.jl
+++ b/test/models/quantum/misc/test_compass1d.jl
@@ -1,0 +1,27 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Tests for Compass1D — 1D alternating-bond compass chain (Phase 1).
+#
+# Coverage:
+#   • Closed-form MassGap, Δ = 2 |J_x − J_y|, at several points.
+#   • Symmetric point J_x = J_y: Δ = 0 (first-order QPT).
+#   • DomainError on J_x ≤ 0 or J_y ≤ 0.
+#
+# References:
+#   • Brzezicki–Dziarmaga–Oleś, PRB 75, 134415 (2007).
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Test
+
+@testset "Compass1D — MassGap = 2|J_x − J_y| (Phase 1)" begin
+    @test QAtlas.fetch(Compass1D(; J_x=1.0, J_y=0.5), MassGap(), Infinite()) == 1.0
+    @test QAtlas.fetch(Compass1D(; J_x=2.0, J_y=0.5), MassGap(), Infinite()) == 3.0
+    # Symmetric point: gap closes (first-order transition)
+    @test QAtlas.fetch(Compass1D(; J_x=1.0, J_y=1.0), MassGap(), Infinite()) == 0.0
+    @test QAtlas.fetch(Compass1D(; J_x=0.5, J_y=0.5), MassGap(), Infinite()) == 0.0
+end
+
+@testset "Compass1D — rejects J_x, J_y ≤ 0 (Phase 1)" begin
+    @test_throws DomainError Compass1D(; J_x=0.0)
+    @test_throws DomainError Compass1D(; J_x=-1.0)
+    @test_throws DomainError Compass1D(; J_y=0.0)
+end


### PR DESCRIPTION
## Summary

Adds **Compass1D**, the 1D alternating-bond compass chain (the 1D limit of the 2D Kugel–Khomskii orbital-compass family):

\[
H = -J_x \sum_{i\,\text{odd}}  \sigma^x_i \sigma^x_{i+1} - J_y \sum_{i\,\text{even}} \sigma^y_i \sigma^y_{i+1},\quad J_x, J_y > 0.
\]

Via Jordan–Wigner this maps onto a dimerised Kitaev / p-wave wire with alternating couplings, and the ground-state problem is exactly solvable. Phase 1 (this PR) exposes a single closed-form fetch:

| Quantity   | BC         | Value                  | Method     |
|------------|------------|------------------------|------------|
| \  | \ | \     | \ |

The gap vanishes at the symmetric point \, which is a **first-order quantum phase transition** between the X-bond-dimerised and Y-bond-dimerised ground states (Brzezicki–Dziarmaga–Oleś 2007). \ is thrown for \ or \.

## Files

- \ — struct + fetch.
- \ — declarative registry row.
- \ — Phase 1 tests.
- \ — 1 export + 2 include lines, inserted after \ anchor.

\ is **not** modified — only the existing \ quantity is reused.

## Test plan

- [x] Locally: \ reproduced at \ → \.
- [x] Locally: symmetric \ → \ (first-order transition).
- [x] Locally: \ throws \.
- [ ] CI: \ (picked up via existing \ group in \).

## References

- W. Brzezicki, J. Dziarmaga, A. M. Oleś, *Quantum phase transition in the one-dimensional compass model*, **PRB 75, 134415 (2007)** — exact gap and first-order transition.
- K. I. Kugel, D. I. Khomskii, *The Jahn–Teller effect and magnetism: transition metal compounds*, **Sov. Phys. Usp. 25, 231 (1982)** — original orbital-compass / Kugel–Khomskii model.
- A. Kitaev, *Anyons in an exactly solved model and beyond*, **Annals of Physics 321, 2 (2006)** — JW-dual dimerised Kitaev chain.

Refs #295.