### PR TITLE
feat(quantum): S1AnisotropicD1D — Haldane chain + single-ion D (Phase 1, refs #302)

### DIFF
--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -48,6 +48,7 @@ export ShastrySutherland                                 # SrCu₂(BO₃)₂ 2D 
 export S1Heisenberg1D                                    # spin-1 (Haldane chain)
 export AKLT1D                                            # spin-1 BLBQ at AKLT point
 export KitaevHeisenberg                                  # K-J-Γ honeycomb (α-RuCl₃, Rau-Lee-Kee 2014)
+export S1AnisotropicD1D                               # S=1 Heisenberg + single-ion D (#302)
 
 # --- Core Implementation ---
 include("core/alias.jl")
@@ -202,6 +203,8 @@ include("models/quantum/HeisenbergXYZ/HeisenbergXYZ.jl")
 include("models/quantum/HeisenbergXYZ/HeisenbergXYZ_registry.jl")          # populates REGISTRY for HeisenbergXYZ (#253)
 include("models/quantum/KitaevHeisenberg/KitaevHeisenberg.jl")
 include("models/quantum/KitaevHeisenberg/KitaevHeisenberg_registry.jl")    # populates REGISTRY for KitaevHeisenberg (#256)
+include("models/quantum/S1AnisotropicD1D/S1AnisotropicD1D.jl")
+include("models/quantum/S1AnisotropicD1D/S1AnisotropicD1D_registry.jl")  # populates REGISTRY for S1AnisotropicD1D (#302)
 
 include("models/quantum/TFIM/TFIM_fidelity.jl")            # FidelitySusceptibility (#147)
 include("models/quantum/TFIM/TFIM_quench_entanglement.jl") # VonNeumannEntropy{:quench} (#144)

--- a/src/models/quantum/S1AnisotropicD1D/S1AnisotropicD1D.jl
+++ b/src/models/quantum/S1AnisotropicD1D/S1AnisotropicD1D.jl
@@ -151,8 +151,9 @@ function fetch(
     D::Real=m.D,
     kwargs...,
 )
-    J > 0 ||
-        throw(DomainError(J, "S1AnisotropicD1D Energy{:per_site} requires J > 0; got J = $J."))
+    J > 0 || throw(
+        DomainError(J, "S1AnisotropicD1D Energy{:per_site} requires J > 0; got J = $J.")
+    )
     iszero(D) || throw(
         DomainError(
             D,

--- a/src/models/quantum/S1AnisotropicD1D/S1AnisotropicD1D.jl
+++ b/src/models/quantum/S1AnisotropicD1D/S1AnisotropicD1D.jl
@@ -109,7 +109,7 @@ function fetch(
     m::S1AnisotropicD1D, ::MassGap, ::Infinite; J::Real=m.J, D::Real=m.D, kwargs...
 )
     J > 0 || throw(DomainError(J, "S1AnisotropicD1D MassGap requires J > 0; got J = $J."))
-    isapprox(D, 0.0; atol=1e-12) || throw(
+    iszero(D) || throw(
         DomainError(
             D,
             "S1AnisotropicD1D MassGap: closed-form Haldane-gap reference available " *

--- a/src/models/quantum/S1AnisotropicD1D/S1AnisotropicD1D.jl
+++ b/src/models/quantum/S1AnisotropicD1D/S1AnisotropicD1D.jl
@@ -122,3 +122,47 @@ function fetch(
     )
     return QAtlas.fetch(QAtlas.S1Heisenberg1D(; J=J), MassGap(), Infinite())
 end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Energy per site — D = 0 delegation to S1Heisenberg1D
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    fetch(m::S1AnisotropicD1D, ::Energy{:per_site}, ::Infinite;
+          J = m.J, D = m.D, kwargs...) -> Float64
+
+Ground-state energy per site of the spin-1 anisotropic chain at the
+**D = 0 reference point**, delegated to [`S1Heisenberg1D`](@ref):
+e₀ ≈ -1.40148403897 J (White-Huse 1993 DMRG, numerical-exact).
+
+`D ≠ 0` raises `DomainError` — same Phase 2 gate as `MassGap`.
+
+# References
+
+- S. R. White, D. A. Huse, *Phys. Rev. B* **48**, 3844 (1993).
+- Y.-C. Chen, R. Roncaglia, *J. Stat. Mech.* P10024 (2008).
+- Y.-D. Tzeng, H.-H. Hung, Y.-C. Chen, M.-F. Yang, *Phys. Rev. B* **96**, 205104 (2017).
+"""
+function fetch(
+    m::S1AnisotropicD1D,
+    ::Energy{:per_site},
+    ::Infinite;
+    J::Real=m.J,
+    D::Real=m.D,
+    kwargs...,
+)
+    J > 0 ||
+        throw(DomainError(J, "S1AnisotropicD1D Energy{:per_site} requires J > 0; got J = $J."))
+    iszero(D) || throw(
+        DomainError(
+            D,
+            "S1AnisotropicD1D Energy{:per_site}: closed-form reference available " *
+            "only at D = 0 (pure spin-1 Heisenberg, White-Huse 1993 DMRG " *
+            "e₀ ≈ -1.40148 J). Generic D introduces easy-axis (D < 0) Néel or " *
+            "large-D (D > 0) trivial phases separated from Haldane by Ising/Gaussian " *
+            "transitions; required DMRG references (Chen-Roncaglia 2008, " *
+            "Tzeng-Yang-Hsu 2017) are deferred to Phase 2. Got D = $D.",
+        ),
+    )
+    return QAtlas.fetch(QAtlas.S1Heisenberg1D(; J=J), Energy{:per_site}(), Infinite())
+end

--- a/src/models/quantum/S1AnisotropicD1D/S1AnisotropicD1D.jl
+++ b/src/models/quantum/S1AnisotropicD1D/S1AnisotropicD1D.jl
@@ -1,0 +1,129 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# S1AnisotropicD1D — Spin-1 Heisenberg chain with single-ion (uniaxial)
+# anisotropy.
+#
+# Hamiltonian:
+#
+#     H = J Σᵢ  Sᵢ · Sᵢ₊₁  +  D Σᵢ (Sᵢ^z)²,    S = 1,  J > 0,  D ∈ ℝ.
+#
+# Three distinguished regimes of the (J > 0) phase diagram:
+#
+#   * D = 0  : pure spin-1 antiferromagnetic Heisenberg chain (Haldane
+#              chain) — gapped symmetry-protected topological (SPT)
+#              Haldane phase with bulk gap Δ ≈ 0.41048 J
+#              (White-Huse 1993, DMRG).
+#   * D → +∞ : easy-plane "large-D" phase — gapped, trivial product
+#              ground state ⊗ᵢ |Sᵢ^z = 0⟩.  Separated from the Haldane
+#              phase by a Gaussian (c = 1) transition near D ≈ 0.97 J
+#              (Chen-Roncaglia 2008; Tzeng-Yang-Hsu 2017).
+#   * D → −∞ : Ising-like easy-axis Néel order — gapped, doubly
+#              degenerate symmetry-broken ground states |…+1,−1,+1…⟩
+#              and |…−1,+1,−1…⟩.  Separated from Haldane by an Ising
+#              (c = 1/2) transition near D ≈ −0.31 J.
+#
+# Phase 1 of this model exposes ONLY the closed numerical reference at
+# D = 0, by delegation to the existing [`S1Heisenberg1D`](@ref) entry.
+# Any non-zero D raises DomainError pointing to the DMRG follow-up
+# (Chen-Roncaglia 2008; Tzeng-Yang-Hsu 2017).
+#
+# References:
+#   - F. D. M. Haldane, Phys. Lett. A 93, 464 (1983); PRL 50, 1153 (1983).
+#   - S. R. White, D. A. Huse, Phys. Rev. B 48, 3844 (1993) — Δ ≈ 0.41048 J.
+#   - W. Chen, K. Hida, B. C. Sanctuary, Phys. Rev. B 67, 104401 (2003).
+#   - Y.-C. Chen, R. Roncaglia, J. Stat. Mech. P10024 (2008) — D-driven SPT
+#     ↔ trivial transition in the S=1 chain with single-ion D.
+#   - Y.-D. Tzeng, H.-H. Hung, Y.-C. Chen, M.-F. Yang, Phys. Rev. B 96,
+#     205104 (2017) — phase boundary refinement & string order parameter.
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    S1AnisotropicD1D(; J::Real = 1.0, D::Real = 0.0) <: AbstractQAtlasModel
+
+Spin-1 Heisenberg chain with uniaxial single-ion anisotropy,
+
+    H = J Σᵢ Sᵢ · Sᵢ₊₁ + D Σᵢ (Sᵢ^z)²,
+
+with `J > 0` (antiferromagnetic) and `D ∈ ℝ` arbitrary single-ion
+anisotropy strength.  Same 3-dimensional local Hilbert space as
+[`S1Heisenberg1D`](@ref) but with the on-site easy-axis (`D < 0`) or
+easy-plane (`D > 0`) term added.
+
+Quantities registered (Phase 1):
+
+| Quantity              | BC         | Method                                    |
+| --------------------- | ---------- | ----------------------------------------- |
+| [`MassGap`](@ref)     | `Infinite` | delegated to S1Heisenberg1D at D = 0      |
+
+Phase 1 exposes only the `D = 0` Haldane-chain reference point,
+delegated to the existing [`S1Heisenberg1D`](@ref).  Any `D ≠ 0`
+raises `DomainError` — finite-D crosses Gaussian (large-D) and Ising
+(Néel) transitions whose closed forms are unknown and are deferred to
+the DMRG-based Phase 2 (Chen-Roncaglia 2008; Tzeng-Yang-Hsu 2017).
+
+# References
+
+- F. D. M. Haldane, *Phys. Lett. A* **93**, 464 (1983).
+- S. R. White, D. A. Huse, *Phys. Rev. B* **48**, 3844 (1993).
+- Y.-C. Chen, R. Roncaglia, *J. Stat. Mech.* P10024 (2008).
+- Y.-D. Tzeng, H.-H. Hung, Y.-C. Chen, M.-F. Yang, *Phys. Rev. B* **96**, 205104 (2017).
+"""
+struct S1AnisotropicD1D <: AbstractQAtlasModel
+    J::Float64
+    D::Float64
+    function S1AnisotropicD1D(J::Real, D::Real)
+        J > 0 || throw(DomainError(J, "S1AnisotropicD1D requires J > 0; got J = $J."))
+        return new(Float64(J), Float64(D))
+    end
+end
+S1AnisotropicD1D(; J::Real=1.0, D::Real=0.0) = S1AnisotropicD1D(J, D)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Mass gap — D = 0 delegation to S1Heisenberg1D
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    fetch(m::S1AnisotropicD1D, ::MassGap, ::Infinite;
+          J = m.J, D = m.D, kwargs...) -> Float64
+
+Bulk gap of the spin-1 anisotropic chain at the **D = 0 reference
+point**, delegated to [`S1Heisenberg1D`](@ref): Haldane gap
+`Δ ≈ 0.41048 J` (White-Huse 1993 DMRG, numerical-exact).
+
+`D ≠ 0` raises `DomainError` — Phase 2.  At finite `D` the system
+crosses
+
+  * a Gaussian (c = 1) transition near `D ≈ 0.97 J` separating Haldane
+    from the large-D phase (Chen-Roncaglia 2008), and
+  * an Ising (c = 1/2) transition near `D ≈ −0.31 J` separating Haldane
+    from the easy-axis Néel phase (Tzeng-Yang-Hsu 2017);
+
+neither phase boundary has a closed-form expression in `D/J`.
+
+# References
+
+- S. R. White, D. A. Huse, *Phys. Rev. B* **48**, 3844 (1993).
+- Y.-C. Chen, R. Roncaglia, *J. Stat. Mech.* P10024 (2008).
+- Y.-D. Tzeng, H.-H. Hung, Y.-C. Chen, M.-F. Yang, *Phys. Rev. B* **96**, 205104 (2017).
+"""
+function fetch(
+    m::S1AnisotropicD1D,
+    ::MassGap,
+    ::Infinite;
+    J::Real=m.J,
+    D::Real=m.D,
+    kwargs...,
+)
+    J > 0 || throw(DomainError(J, "S1AnisotropicD1D MassGap requires J > 0; got J = $J."))
+    isapprox(D, 0.0; atol=1e-12) || throw(
+        DomainError(
+            D,
+            "S1AnisotropicD1D MassGap: closed-form Haldane-gap reference available " *
+            "only at D = 0 (pure spin-1 Heisenberg, White-Huse 1993 DMRG " *
+            "Δ ≈ 0.41048 J). Generic D introduces easy-axis (D < 0) Néel or " *
+            "large-D (D > 0) trivial phases separated from Haldane by Ising/Gaussian " *
+            "transitions; required DMRG references (Chen-Roncaglia 2008, " *
+            "Tzeng-Yang-Hsu 2017) are deferred to Phase 2. Got D = $D.",
+        ),
+    )
+    return QAtlas.fetch(QAtlas.S1Heisenberg1D(; J=J), MassGap(), Infinite())
+end

--- a/src/models/quantum/S1AnisotropicD1D/S1AnisotropicD1D.jl
+++ b/src/models/quantum/S1AnisotropicD1D/S1AnisotropicD1D.jl
@@ -106,12 +106,7 @@ neither phase boundary has a closed-form expression in `D/J`.
 - Y.-D. Tzeng, H.-H. Hung, Y.-C. Chen, M.-F. Yang, *Phys. Rev. B* **96**, 205104 (2017).
 """
 function fetch(
-    m::S1AnisotropicD1D,
-    ::MassGap,
-    ::Infinite;
-    J::Real=m.J,
-    D::Real=m.D,
-    kwargs...,
+    m::S1AnisotropicD1D, ::MassGap, ::Infinite; J::Real=m.J, D::Real=m.D, kwargs...
 )
     J > 0 || throw(DomainError(J, "S1AnisotropicD1D MassGap requires J > 0; got J = $J."))
     isapprox(D, 0.0; atol=1e-12) || throw(

--- a/src/models/quantum/S1AnisotropicD1D/S1AnisotropicD1D_registry.jl
+++ b/src/models/quantum/S1AnisotropicD1D/S1AnisotropicD1D_registry.jl
@@ -19,3 +19,15 @@
     references=["White-Huse 1993", "Chen-Roncaglia 2008", "Tzeng-Yang-Hsu 2017"],
     notes="Phase 1: D = 0 delegate to S1Heisenberg1D (Δ ≈ 0.41048 J, DMRG numerical-exact). D ≠ 0 throws DomainError (Phase 2).",
 )
+
+# ── Infinite — Haldane per-site energy delegate (D = 0 only) ────────
+@register(
+    S1AnisotropicD1D,
+    Energy{:per_site},
+    Infinite,
+    method=:s1_heisenberg_delegation,
+    reliability=:medium,
+    tested_in="test/models/quantum/Heisenberg/test_s1_anisotropic_d1d.jl",
+    references=["White-Huse 1993", "Chen-Roncaglia 2008", "Tzeng-Yang-Hsu 2017"],
+    notes="Phase 1: D = 0 delegate to S1Heisenberg1D (e₀ ≈ -1.40148 J, DMRG numerical-exact). D ≠ 0 throws DomainError (Phase 2).",
+)

--- a/src/models/quantum/S1AnisotropicD1D/S1AnisotropicD1D_registry.jl
+++ b/src/models/quantum/S1AnisotropicD1D/S1AnisotropicD1D_registry.jl
@@ -1,0 +1,21 @@
+# models/quantum/S1AnisotropicD1D/S1AnisotropicD1D_registry.jl —
+# declarative implementation map for S1AnisotropicD1D (S=1 Heisenberg
+# chain with single-ion anisotropy D).
+#
+# Phase 1 registers only the D = 0 Haldane-chain reference point, which
+# is delegated to the existing S1Heisenberg1D entry (White-Huse 1993
+# DMRG, Δ ≈ 0.41048 J).  Non-zero D triggers DomainError at fetch time
+# and is left to a DMRG-based Phase 2 (Chen-Roncaglia 2008;
+# Tzeng-Yang-Hsu 2017).
+
+# ── Infinite — Haldane gap delegate (D = 0 only) ────────────────────
+@register(
+    S1AnisotropicD1D,
+    MassGap,
+    Infinite,
+    method=:s1_heisenberg_delegation,
+    reliability=:medium,
+    tested_in="test/models/quantum/Heisenberg/test_s1_anisotropic_d1d.jl",
+    references=["White-Huse 1993", "Chen-Roncaglia 2008", "Tzeng-Yang-Hsu 2017"],
+    notes="Phase 1: D = 0 delegate to S1Heisenberg1D (Δ ≈ 0.41048 J, DMRG numerical-exact). D ≠ 0 throws DomainError (Phase 2).",
+)

--- a/test/models/quantum/Heisenberg/test_s1_anisotropic_d1d.jl
+++ b/test/models/quantum/Heisenberg/test_s1_anisotropic_d1d.jl
@@ -1,0 +1,37 @@
+using QAtlas, Test
+
+# Phase 1 of S1AnisotropicD1D (#302): a single-ion-anisotropy spin-1
+# chain that, at D = 0, delegates to the existing S1Heisenberg1D entry
+# for the Haldane gap (White-Huse 1993 DMRG, Δ ≈ 0.41048 J).  Non-zero
+# D throws DomainError — Phase 2 (Chen-Roncaglia 2008; Tzeng-Yang-Hsu 2017).
+
+@testset "S1AnisotropicD1D — D=0 delegate (Phase 1)" begin
+    m = S1AnisotropicD1D(; J=1.0, D=0.0)
+    Δ = QAtlas.fetch(m, MassGap(), Infinite())
+    @test Δ > 0
+    # White-Huse 1993 DMRG value as encoded by S1Heisenberg1D.
+    @test isapprox(Δ, 0.41048; atol=1e-6)
+    # Delegation invariant: identical to direct S1Heisenberg1D fetch.
+    Δ_delegate = QAtlas.fetch(S1Heisenberg1D(; J=1.0), MassGap(), Infinite())
+    @test Δ ≈ Δ_delegate
+    # J scaling propagates through the delegate.
+    Δ2 = QAtlas.fetch(S1AnisotropicD1D(; J=2.0, D=0.0), MassGap(), Infinite())
+    @test isapprox(Δ2, 2.0 * Δ; atol=1e-10)
+end
+
+@testset "S1AnisotropicD1D — D≠0 throws DomainError" begin
+    @test_throws DomainError QAtlas.fetch(
+        S1AnisotropicD1D(; J=1.0, D=0.1), MassGap(), Infinite()
+    )
+    @test_throws DomainError QAtlas.fetch(
+        S1AnisotropicD1D(; J=1.0, D=-0.5), MassGap(), Infinite()
+    )
+end
+
+@testset "S1AnisotropicD1D — constructor guards" begin
+    # J ≤ 0 rejected at construction time.
+    @test_throws DomainError S1AnisotropicD1D(; J=0.0, D=0.0)
+    @test_throws DomainError S1AnisotropicD1D(; J=-1.0, D=0.0)
+    # D may be any real, including negative.
+    @test S1AnisotropicD1D(; J=1.0, D=-1.5) isa S1AnisotropicD1D
+end

--- a/test/models/quantum/Heisenberg/test_s1_anisotropic_d1d.jl
+++ b/test/models/quantum/Heisenberg/test_s1_anisotropic_d1d.jl
@@ -46,3 +46,36 @@ end
     # D may be any real, including negative.
     @test S1AnisotropicD1D(; J=1.0, D=-1.5) isa S1AnisotropicD1D
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Energy{:per_site} — D = 0 delegate to S1Heisenberg1D (White-Huse 1993).
+# ─────────────────────────────────────────────────────────────────────────────
+
+@testset "S1AnisotropicD1D — D=0 Energy{:per_site} delegate" begin
+    for J in (0.5, 1.0, 2.0, 3.7)
+        m = S1AnisotropicD1D(; J=J, D=0.0)
+        e = QAtlas.fetch(m, Energy{:per_site}(), Infinite())
+        e_delegate = QAtlas.fetch(S1Heisenberg1D(; J=J), Energy{:per_site}(), Infinite())
+        @test e ≈ e_delegate
+        @test isapprox(e, -1.40148403897 * J; atol=1e-10)
+    end
+end
+
+@testset "S1AnisotropicD1D — Energy{:per_site} D≠0 throws DomainError" begin
+    @test_throws DomainError QAtlas.fetch(
+        S1AnisotropicD1D(; J=1.0, D=0.1), Energy{:per_site}(), Infinite()
+    )
+    @test_throws DomainError QAtlas.fetch(
+        S1AnisotropicD1D(; J=1.0, D=-0.5), Energy{:per_site}(), Infinite()
+    )
+end
+
+@testset "S1AnisotropicD1D — Energy{:per_site} tiny D (1e-13) strict iszero" begin
+    # Regression: boundary check must be exact iszero(D), not isapprox.
+    @test_throws DomainError QAtlas.fetch(
+        S1AnisotropicD1D(; J=1.0, D=1e-13), Energy{:per_site}(), Infinite()
+    )
+    @test_throws DomainError QAtlas.fetch(
+        S1AnisotropicD1D(; J=1.0, D=-1e-13), Energy{:per_site}(), Infinite()
+    )
+end

--- a/test/models/quantum/Heisenberg/test_s1_anisotropic_d1d.jl
+++ b/test/models/quantum/Heisenberg/test_s1_anisotropic_d1d.jl
@@ -28,6 +28,17 @@ end
     )
 end
 
+@testset "S1AnisotropicD1D — tiny D (1e-13) is non-zero (iszero strictness)" begin
+    # Regression: boundary check must be exact iszero(D), not isapprox(...; atol=1e-12).
+    # Tiny but non-zero D crosses Gaussian/Ising transitions and has no closed form.
+    @test_throws DomainError QAtlas.fetch(
+        S1AnisotropicD1D(; J=1.0, D=1e-13), MassGap(), Infinite()
+    )
+    @test_throws DomainError QAtlas.fetch(
+        S1AnisotropicD1D(; J=1.0, D=-1e-13), MassGap(), Infinite()
+    )
+end
+
 @testset "S1AnisotropicD1D — constructor guards" begin
     # J ≤ 0 rejected at construction time.
     @test_throws DomainError S1AnisotropicD1D(; J=0.0, D=0.0)


### PR DESCRIPTION
## Summary

Adds a new model `S1AnisotropicD1D` for the spin-1 Heisenberg chain with uniaxial single-ion anisotropy

```
H = J Σᵢ  Sᵢ · Sᵢ₊₁  +  D Σᵢ (Sᵢ^z)²,    S = 1, J > 0, D ∈ ℝ.
```

Three distinguished regimes in the (`J > 0`) phase diagram:

- **D = 0** — pure spin-1 antiferromagnetic Heisenberg chain (Haldane chain). Gapped SPT Haldane phase with bulk gap `Δ ≈ 0.41048 J` (S. R. White & D. A. Huse, PRB 48, 3844 (1993), DMRG).
- **D → +∞** — easy-plane "large-D" phase: gapped, trivial product ground state `⊗ᵢ |Sᵢ^z = 0⟩`. Separated from Haldane by a Gaussian (`c = 1`) transition near `D ≈ 0.97 J` (Chen–Roncaglia 2008).
- **D → -∞** — Ising-like easy-axis Néel order: gapped, doubly degenerate symmetry-broken ground states. Separated from Haldane by an Ising (`c = 1/2`) transition near `D ≈ -0.31 J` (Tzeng–Yang–Hsu 2017).

### Phase 1 scope (this PR)

Only the **`D = 0` reference point** is registered, delegated to the existing `S1Heisenberg1D` entry for `MassGap @ Infinite`:

```julia
fetch(S1AnisotropicD1D(; J=1, D=0), MassGap(), Infinite())
# → 0.41048   (= fetch(S1Heisenberg1D(; J=1), MassGap(), Infinite()))
```

Any `D ≠ 0` (atol `1e-12`) throws `DomainError` pointing to the deferred Phase 2 work. The constructor also enforces `J > 0`.

Mirrors the `KitaevHeisenberg → KitaevHoneycomb` delegate pattern — no modifications to `src/core/quantities.jl`.

### Phase 2 (deferred, not in this PR)

Generic `D ≠ 0` requires DMRG and exposes two SPT-to-trivial transitions:

- **Haldane → large-D Gaussian** at `D_c1 ≈ 0.97 J`: Y.-C. Chen, R. Roncaglia, *J. Stat. Mech.* P10024 (2008).
- **Haldane → Néel Ising** at `D_c2 ≈ -0.31 J`: Y.-D. Tzeng, H.-H. Hung, Y.-C. Chen, M.-F. Yang, *Phys. Rev. B* **96**, 205104 (2017) — phase-boundary refinement and string order parameter.

These have no closed-form `D/J` expressions and will land as `:dmrg_reference` / numerical-value rows.

### Files

- `src/models/quantum/S1AnisotropicD1D/S1AnisotropicD1D.jl` — struct + delegate `fetch`.
- `src/models/quantum/S1AnisotropicD1D/S1AnisotropicD1D_registry.jl` — single `@register` row, `method=:s1_heisenberg_delegation`, `reliability=:medium`.
- `test/models/quantum/Heisenberg/test_s1_anisotropic_d1d.jl` — 9 tests (delegation equality, `J` scaling, `D ≠ 0` `DomainError`, constructor guards).
- `src/QAtlas.jl` — `export S1AnisotropicD1D` + two `include` lines after the `KitaevHeisenberg` anchor.

## Test plan

- [x] `julia --project=. test/models/quantum/Heisenberg/test_s1_anisotropic_d1d.jl` → 9/9 pass locally on Panza (julia 1.12.2).
- [ ] CI green (`models/quantum/Heisenberg` group picks up the new file via existing `test_*.jl` auto-discovery in `test/runtests.jl`).
- [ ] Aqua passes (single new public export `S1AnisotropicD1D`).

## References

- F. D. M. Haldane, *Phys. Lett. A* **93**, 464 (1983); *PRL* **50**, 1153 (1983).
- S. R. White, D. A. Huse, *Phys. Rev. B* **48**, 3844 (1993) — `Δ ≈ 0.41048 J`.
- Y.-C. Chen, R. Roncaglia, *J. Stat. Mech.* P10024 (2008) — Haldane ↔ large-D Gaussian.
- Y.-D. Tzeng, H.-H. Hung, Y.-C. Chen, M.-F. Yang, *Phys. Rev. B* **96**, 205104 (2017) — Haldane ↔ Néel Ising.

Refs #302.
