### PR TITLE
feat(quantum): ExtendedHubbard1D — t-U-V Hubbard (Phase 1: V=0 Lieb-Wu delegate, refs #294)

### DIFF
--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -66,6 +66,7 @@ export DMIHeisenberg1D                                  # spin-½ Heisenberg + D
 export J1J2Heisenberg1D                              # spin-½ J₁-J₂ chain (#297)
 export MixedFieldIsing1D                            # TFIM + longitudinal field, non-integrable (#290)
 export XYh1D                                          # anisotropic XY + transverse field (LSM 1961, #292)
+export ExtendedHubbard1D                              # t-U-V Hubbard chain (#294)
 
 # --- Core Implementation ---
 include("core/alias.jl")
@@ -256,6 +257,8 @@ include("models/quantum/MixedFieldIsing1D/MixedFieldIsing1D.jl")
 include("models/quantum/MixedFieldIsing1D/MixedFieldIsing1D_registry.jl")  # populates REGISTRY for MixedFieldIsing1D (#290)
 include("models/quantum/XYh1D/XYh1D.jl")
 include("models/quantum/XYh1D/XYh1D_registry.jl")  # populates REGISTRY for XYh1D (#292)
+include("models/quantum/ExtendedHubbard1D/ExtendedHubbard1D.jl")
+include("models/quantum/ExtendedHubbard1D/ExtendedHubbard1D_registry.jl")  # populates REGISTRY for ExtendedHubbard1D (#294)
 
 include("models/quantum/TFIM/TFIM_fidelity.jl")            # FidelitySusceptibility (#147)
 include("models/quantum/TFIM/TFIM_quench_entanglement.jl") # VonNeumannEntropy{:quench} (#144)

--- a/src/models/quantum/ExtendedHubbard1D/ExtendedHubbard1D.jl
+++ b/src/models/quantum/ExtendedHubbard1D/ExtendedHubbard1D.jl
@@ -81,7 +81,7 @@ the V = 0 limit (delegated Lieb–Wu) — the V ≠ 0 phase diagram is
 deferred to Phase 2.
 """
 function _extended_hubbard1d_check_v_zero(model::ExtendedHubbard1D)
-    if !isapprox(model.V, 0.0; atol=1e-12)
+    if !iszero(model.V)
         throw(
             DomainError(
                 model.V,

--- a/src/models/quantum/ExtendedHubbard1D/ExtendedHubbard1D.jl
+++ b/src/models/quantum/ExtendedHubbard1D/ExtendedHubbard1D.jl
@@ -1,0 +1,118 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# ExtendedHubbard1D — t-U-V Hubbard chain (nearest-neighbour-density extension).
+#
+# Hamiltonian:
+#
+#   H = -t Σ_{i, σ} (c†_{i,σ} c_{i+1,σ} + h.c.)
+#       + U Σ_i n_{i,↑} n_{i,↓}
+#       + V Σ_i n_i n_{i+1}
+#
+#   (spin-½ fermions; t > 0 hopping, U ∈ ℝ on-site, V ∈ ℝ nearest-neighbour
+#   density-density.)
+#
+# Phase 1 scope (this file):  V = 0 only.  At V = 0 the model collapses to
+# the standard 1D Hubbard chain at half filling, for which the Lieb–Wu
+# (1968) integral closed forms are already implemented in `Hubbard1D`.
+# Phase 1 therefore delegates the V = 0 charge gap to `Hubbard1D` and
+# raises `DomainError` for any V ≠ 0 — the V ≠ 0 phase diagram
+# (CDW / SDW / phase separation, Voit 1995; Nakamura 2000) is deferred
+# to Phase 2.
+#
+# References:
+#   - E. H. Lieb, F. Y. Wu, PRL 20, 1445 (1968) — V=0 Bethe ansatz.
+#   - J. Voit, Rep. Prog. Phys. 58, 977 (1995) — 1D bosonization review.
+#   - M. Nakamura, Phys. Rev. B 61, 16377 (2000) — CDW/SDW/BOW phase
+#     diagram of the U-V chain at half filling.
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    ExtendedHubbard1D(; t::Real = 1.0, U::Real = 4.0, V::Real = 0.0)
+        <: AbstractQAtlasModel
+
+1D t-U-V Hubbard chain (nearest-neighbour-density extension of the
+standard Hubbard model):
+
+    H = -t Σ_{i, σ} (c†_{i,σ} c_{i+1,σ} + h.c.)
+        + U Σ_i n_{i,↑} n_{i,↓}
+        + V Σ_i n_i n_{i+1}.
+
+Convention: `t > 0` hopping, `U` on-site, `V` nearest-neighbour
+density-density.
+
+# Phase 1 scope (this release)
+
+Phase 1 exposes only the **V = 0 limit**, at which the model reduces
+to the standard 1D Hubbard chain.  The `ChargeGap` at `Infinite()` is
+delegated to [`Hubbard1D`](@ref) at half filling (μ = U/2),
+i.e. the Lieb–Wu (1968) integral
+
+    Δ_c = (16 t² / U) ∫_1^∞ dω  √(ω² - 1) / sinh(2π t ω / U).
+
+Any `V ≠ 0` raises `DomainError`.  The V ≠ 0 phase diagram
+(CDW / SDW / BOW / phase separation, Voit 1995; Nakamura 2000) is
+deferred to Phase 2.
+
+# References
+
+- Lieb, Wu, *Phys. Rev. Lett.* **20**, 1445 (1968).
+- Voit, *Rep. Prog. Phys.* **58**, 977 (1995).
+- Nakamura, *Phys. Rev. B* **61**, 16377 (2000).
+"""
+struct ExtendedHubbard1D <: AbstractQAtlasModel
+    t::Float64
+    U::Float64
+    V::Float64
+    function ExtendedHubbard1D(t::Real, U::Real, V::Real)
+        t > 0 || throw(DomainError(t, "ExtendedHubbard1D requires t > 0; got t = $t."))
+        return new(Float64(t), Float64(U), Float64(V))
+    end
+end
+function ExtendedHubbard1D(; t::Real=1.0, U::Real=4.0, V::Real=0.0)
+    return ExtendedHubbard1D(t, U, V)
+end
+
+# ─── V = 0 guard ──────────────────────────────────────────────────────
+
+"""
+    _extended_hubbard1d_check_v_zero(model::ExtendedHubbard1D)
+
+Throw `DomainError` if `model.V` is not zero.  Phase 1 only exposes
+the V = 0 limit (delegated Lieb–Wu) — the V ≠ 0 phase diagram is
+deferred to Phase 2.
+"""
+function _extended_hubbard1d_check_v_zero(model::ExtendedHubbard1D)
+    if !isapprox(model.V, 0.0; atol=1e-12)
+        throw(
+            DomainError(
+                model.V,
+                "ExtendedHubbard1D ChargeGap: V ≠ 0 introduces nearest-neighbour " *
+                "density-density interaction (CDW / SDW / BOW / phase separation, " *
+                "Voit 1995; Nakamura 2000) and is deferred to Phase 2. " *
+                "Got V = $(model.V).",
+            ),
+        )
+    end
+    return nothing
+end
+
+# ─── fetch methods ────────────────────────────────────────────────────
+
+"""
+    fetch(model::ExtendedHubbard1D, ::ChargeGap, ::Infinite) -> Float64
+
+Charge (Mott) gap of the t-U-V Hubbard chain at half filling.  Phase 1
+only supports the V = 0 limit, where the gap reduces to the Lieb–Wu
+(1968) integral and is delegated to [`Hubbard1D`](@ref) at
+`μ = U/2`.  Any `V ≠ 0` raises `DomainError`.
+
+# References
+
+- Lieb, Wu, *Phys. Rev. Lett.* **20**, 1445 (1968).
+- Voit, *Rep. Prog. Phys.* **58**, 977 (1995).
+- Nakamura, *Phys. Rev. B* **61**, 16377 (2000).
+"""
+function fetch(model::ExtendedHubbard1D, ::ChargeGap, ::Infinite; kwargs...)
+    _extended_hubbard1d_check_v_zero(model)
+    return fetch(Hubbard1D(; t=model.t, U=model.U, μ=model.U / 2),
+                 ChargeGap(), Infinite())
+end

--- a/src/models/quantum/ExtendedHubbard1D/ExtendedHubbard1D.jl
+++ b/src/models/quantum/ExtendedHubbard1D/ExtendedHubbard1D.jl
@@ -113,6 +113,7 @@ only supports the V = 0 limit, where the gap reduces to the Lieb–Wu
 """
 function fetch(model::ExtendedHubbard1D, ::ChargeGap, ::Infinite; kwargs...)
     _extended_hubbard1d_check_v_zero(model)
-    return fetch(Hubbard1D(; t=model.t, U=model.U, μ=model.U / 2),
-                 ChargeGap(), Infinite())
+    return fetch(
+        Hubbard1D(; t=model.t, U=model.U, μ=(model.U / 2)), ChargeGap(), Infinite()
+    )
 end

--- a/src/models/quantum/ExtendedHubbard1D/ExtendedHubbard1D_registry.jl
+++ b/src/models/quantum/ExtendedHubbard1D/ExtendedHubbard1D_registry.jl
@@ -1,0 +1,20 @@
+# models/quantum/ExtendedHubbard1D/ExtendedHubbard1D_registry.jl
+#
+# Declarative implementation map for the 1D t-U-V Hubbard chain.
+#
+# Phase 1 only registers the V = 0 delegate to `Hubbard1D` (ChargeGap
+# at half filling, Lieb-Wu 1968 integral).  The V ≠ 0 phase diagram
+# (CDW / SDW / BOW / phase separation, Voit 1995; Nakamura 2000) is
+# deferred to Phase 2.
+
+@register(
+    ExtendedHubbard1D,
+    ChargeGap,
+    Infinite,
+    method=:delegation,
+    reliability=:high,
+    tested_in="test/models/quantum/misc/test_extended_hubbard1d.jl",
+    references=["Lieb-Wu PRL 20, 1445 (1968)", "Voit Rep. Prog. Phys. 58, 977 (1995)",
+                "Nakamura PRB 61, 16377 (2000)"],
+    notes="V=0 delegates to Hubbard1D at half filling (Lieb-Wu integral); V≠0 (CDW/SDW/BOW phase diagram) deferred to Phase 2.",
+)

--- a/src/models/quantum/ExtendedHubbard1D/ExtendedHubbard1D_registry.jl
+++ b/src/models/quantum/ExtendedHubbard1D/ExtendedHubbard1D_registry.jl
@@ -14,7 +14,10 @@
     method=:delegation,
     reliability=:high,
     tested_in="test/models/quantum/misc/test_extended_hubbard1d.jl",
-    references=["Lieb-Wu PRL 20, 1445 (1968)", "Voit Rep. Prog. Phys. 58, 977 (1995)",
-                "Nakamura PRB 61, 16377 (2000)"],
+    references=[
+        "Lieb-Wu PRL 20, 1445 (1968)",
+        "Voit Rep. Prog. Phys. 58, 977 (1995)",
+        "Nakamura PRB 61, 16377 (2000)",
+    ],
     notes="V=0 delegates to Hubbard1D at half filling (Lieb-Wu integral); V≠0 (CDW/SDW/BOW phase diagram) deferred to Phase 2.",
 )

--- a/test/models/quantum/misc/test_extended_hubbard1d.jl
+++ b/test/models/quantum/misc/test_extended_hubbard1d.jl
@@ -1,0 +1,37 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Test: ExtendedHubbard1D — Phase 1, V = 0 delegate to Hubbard1D.
+#
+# Cases (issue #294):
+#   1. V = 0 delegate: ChargeGap matches Hubbard1D(μ = U/2) for several
+#      (t, U) points along the Lieb–Wu curve.
+#   2. V ≠ 0 raises DomainError (Phase 2 deferred).
+#   3. t ≤ 0 in the constructor raises DomainError.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Test
+
+@testset "ExtendedHubbard1D — V=0 delegate to Hubbard1D (Phase 1)" begin
+    for (t, U) in [(1.0, 4.0), (1.0, 8.0), (0.5, 2.0)]
+        Δ_eh = QAtlas.fetch(
+            ExtendedHubbard1D(; t=t, U=U, V=0.0), ChargeGap(), Infinite()
+        )
+        Δ_h = QAtlas.fetch(
+            Hubbard1D(; t=t, U=U, μ=U / 2), ChargeGap(), Infinite()
+        )
+        @test Δ_eh ≈ Δ_h
+    end
+end
+
+@testset "ExtendedHubbard1D — V ≠ 0 throws DomainError (Phase 2)" begin
+    @test_throws DomainError QAtlas.fetch(
+        ExtendedHubbard1D(; V=0.5), ChargeGap(), Infinite()
+    )
+    @test_throws DomainError QAtlas.fetch(
+        ExtendedHubbard1D(; V=-1.0), ChargeGap(), Infinite()
+    )
+end
+
+@testset "ExtendedHubbard1D — rejects t ≤ 0" begin
+    @test_throws DomainError ExtendedHubbard1D(; t=0.0)
+    @test_throws DomainError ExtendedHubbard1D(; t=-1.0)
+end

--- a/test/models/quantum/misc/test_extended_hubbard1d.jl
+++ b/test/models/quantum/misc/test_extended_hubbard1d.jl
@@ -12,12 +12,8 @@ using QAtlas, Test
 
 @testset "ExtendedHubbard1D — V=0 delegate to Hubbard1D (Phase 1)" begin
     for (t, U) in [(1.0, 4.0), (1.0, 8.0), (0.5, 2.0)]
-        Δ_eh = QAtlas.fetch(
-            ExtendedHubbard1D(; t=t, U=U, V=0.0), ChargeGap(), Infinite()
-        )
-        Δ_h = QAtlas.fetch(
-            Hubbard1D(; t=t, U=U, μ=U / 2), ChargeGap(), Infinite()
-        )
+        Δ_eh = QAtlas.fetch(ExtendedHubbard1D(; t=t, U=U, V=0.0), ChargeGap(), Infinite())
+        Δ_h = QAtlas.fetch(Hubbard1D(; t=t, U=U, μ=U / 2), ChargeGap(), Infinite())
         @test Δ_eh ≈ Δ_h
     end
 end


### PR DESCRIPTION
## Summary

Adds **ExtendedHubbard1D** — the 1D t-U-V Hubbard chain (nearest-neighbour-density extension of the standard Hubbard model) as a thin layer over the existing \ entry. Closes Phase 1 of #294.

\\\

### Phase 1 scope

- **V = 0 only**: \ at \ delegated to \ at half filling (μ = U/2), i.e. the Lieb-Wu (1968) closed-form integral.
- **V ≠ 0**: raises \ with reference to the deferred Phase 2 phase diagram (CDW / SDW / BOW / phase separation; Voit 1995, Nakamura 2000).
- **t ≤ 0**: rejected at construction (\).

### Hubbard1D API confirmed before delegation

- Struct: \ — must pass \ to land at half filling.
- Exposes \, \, \ at \.
- \ reads only model fields (kwargs ignored), so the delegate constructs a fresh \.

### Files (5)

- \
- \
- \
- \ — \ + 2 \ lines after \ anchor. \ untouched.

### Verified locally on Panza (Julia 1.12.2)

\\\

All 7 tests pass (3 V=0 delegate × (t,U) ∈ {(1,4),(1,8),(0.5,2)} + 2 V≠0 throw + 2 t≤0 throw).

## Test plan

- [x] Local run \Revise is loaded! — 7/7 pass on Panza.
- [ ] CI \ green.
- [ ] CI full test suite green.

Refs #294.