### PR TITLE
feat(universalities): YangLee CFT — non-unitary M(5,2), c=-22/5 (refs #234)

### DIFF
--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -30,6 +30,7 @@ export ZnParafermion                                       # Z_n parafermion CFT
 export RandomBondIsing2D                                  # 2D ±J random-bond Ising / Edwards-Anderson (#232)
 export TTbar                                                # universal TT-bar deformation (#249)
 export TASEP                                                # totally asymmetric simple exclusion process (#241)
+export YangLee                                              # non-unitary CFT M(5,2), c=-22/5 (#234)
 
 # --- Quantum Models ---
 export TFIM                                             # v0.13 concrete struct
@@ -167,6 +168,8 @@ include("models/classical/TTbar/TTbar.jl")
 include("models/classical/TTbar/TTbar_registry.jl")  # populates REGISTRY for TTbar (#249)
 include("models/classical/TASEP/TASEP.jl")
 include("models/classical/TASEP/TASEP_registry.jl")  # populates REGISTRY for TASEP (#241)
+include("models/classical/YangLee/YangLee.jl")
+include("models/classical/YangLee/YangLee_registry.jl")        # populates REGISTRY for YangLee (#234)
 include("models/quantum/SchwingerModel/SchwingerModel.jl")
 include("models/quantum/SchwingerModel/SchwingerModel_registry.jl")      # populates REGISTRY for SchwingerModel (#246)
 include("models/quantum/ChernSimons3D/ChernSimons3D.jl")

--- a/src/models/classical/YangLee/YangLee.jl
+++ b/src/models/classical/YangLee/YangLee.jl
@@ -1,0 +1,121 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# YangLee — non-unitary Virasoro minimal model M(5, 2) describing the
+# Lee-Yang edge singularity (Yang-Lee 1952; Cardy 1985).
+#
+# Central charge
+#
+#     c(5, 2) = 1 - 6 (5 - 2)² / (5 · 2) = 1 - 54/10 = -22/5
+#
+# is negative — allowed because (5, 2) lies outside the Friedan-Qiu-Shenker
+# unitarity series M(p+1, p) (p ≥ 2).  The Kac table has only two distinct
+# primaries:
+#
+#     h_{1,1} = 0       (identity)
+#     h_{1,2} = -1/5    (the famous "negative-dimension" Yang-Lee field)
+#
+# with the Kac symmetry (r, s) ↔ (p_prime - r, p - s) identifying
+# (1, 1) ↔ (1, 4) and (1, 2) ↔ (1, 3).
+#
+# Yang-Lee (1952) showed that the partition function zeros of the Ising
+# model in an imaginary magnetic field lie on a unit circle and pinch
+# the positive real axis at an edge singularity.  Fisher (1978) and
+# Cardy (1985) identified the universality class of this edge as a
+# non-unitary CFT with c = -22/5, realised by M(5, 2).
+#
+# This Phase-1 entry registers `CentralCharge` and `ConformalWeights`,
+# delegating to [`MinimalModel(5, 2)`](@ref).
+#
+# References:
+#   - C. N. Yang and T. D. Lee, Phys. Rev. 87, 404 (1952);
+#     T. D. Lee and C. N. Yang, Phys. Rev. 87, 410 (1952).
+#   - J. L. Cardy, Phys. Rev. Lett. 54, 1354 (1985).
+#   - M. E. Fisher, Phys. Rev. Lett. 40, 1610 (1978).
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    YangLee() <: AbstractQAtlasModel
+
+Yang-Lee CFT — the non-unitary Virasoro minimal model M(5, 2) describing
+the universality class of the Lee-Yang edge singularity (Yang-Lee 1952;
+Cardy 1985).
+
+The model has no continuous parameters: M(5, 2) is fixed.
+
+Quantities registered (Phase 1):
+
+| Quantity                       | BC         | Method                         |
+| ------------------------------ | ---------- | ------------------------------ |
+| [`CentralCharge`](@ref)        | `Infinite` | delegated to MinimalModel(5,2) |
+| [`ConformalWeights`](@ref)     | `Infinite` | delegated to MinimalModel(5,2) |
+
+The famous negative-dimension primary `h_{1,2} = -1/5` is the edge
+exponent and is what makes the theory non-unitary (c = -22/5 < 0).
+
+# References
+
+- C. N. Yang and T. D. Lee, *Phys. Rev.* **87**, 404 (1952).
+- J. L. Cardy, *Phys. Rev. Lett.* **54**, 1354 (1985).
+"""
+struct YangLee <: AbstractQAtlasModel end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Central charge via MinimalModel(5, 2) delegation
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    fetch(::YangLee, ::CentralCharge, ::Infinite; kwargs...) -> Rational{Int}
+
+Central charge of the Yang-Lee CFT (non-unitary M(5, 2)):
+
+    c = -22/5
+
+delegated to [`MinimalModel(5, 2)`](@ref).  Returned as an exact
+`Rational{Int}` (`-22//5`).
+
+# References
+
+- J. L. Cardy, *Phys. Rev. Lett.* **54**, 1354 (1985).
+- C. N. Yang and T. D. Lee, *Phys. Rev.* **87**, 404 (1952).
+"""
+function fetch(::YangLee, ::CentralCharge, ::Infinite; kwargs...)
+    return QAtlas.fetch(QAtlas.MinimalModel(5, 2), CentralCharge())
+end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Conformal weights (Kac formula) via MinimalModel(5, 2) delegation
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    fetch(::YangLee, ::ConformalWeights, ::Infinite; r::Integer=1, s::Integer=1, kwargs...)
+        -> Rational{Int}
+
+Kac-formula conformal weight `h_{r,s}` of the Yang-Lee CFT, delegated
+to [`MinimalModel(5, 2)`](@ref).
+
+For M(p, p_prime) = M(5, 2) the Kac-table index range is
+`r ∈ [1, p_prime - 1] = [1, 1]` (only `r = 1`) and
+`s ∈ [1, p - 1] = [1, 4]`, with the Kac symmetry
+`(r, s) ↔ (p_prime - r, p - s)` identifying
+
+    (1, 1) ↔ (1, 4)   with   h = 0           (identity)
+    (1, 2) ↔ (1, 3)   with   h = -1/5         (Yang-Lee primary)
+
+so the theory has only two distinct primaries.
+
+Out-of-range `(r, s)` throws `DomainError` (inherited from
+`MinimalModel`).
+
+# References
+
+- J. L. Cardy, *Phys. Rev. Lett.* **54**, 1354 (1985).
+"""
+function fetch(
+    ::YangLee,
+    ::ConformalWeights,
+    ::Infinite;
+    r::Integer=1,
+    s::Integer=1,
+    kwargs...,
+)
+    return QAtlas.fetch(QAtlas.MinimalModel(5, 2), ConformalWeights(); r=r, s=s)
+end

--- a/src/models/classical/YangLee/YangLee.jl
+++ b/src/models/classical/YangLee/YangLee.jl
@@ -110,12 +110,7 @@ Out-of-range `(r, s)` throws `DomainError` (inherited from
 - J. L. Cardy, *Phys. Rev. Lett.* **54**, 1354 (1985).
 """
 function fetch(
-    ::YangLee,
-    ::ConformalWeights,
-    ::Infinite;
-    r::Integer=1,
-    s::Integer=1,
-    kwargs...,
+    ::YangLee, ::ConformalWeights, ::Infinite; r::Integer=1, s::Integer=1, kwargs...
 )
     return QAtlas.fetch(QAtlas.MinimalModel(5, 2), ConformalWeights(); r=r, s=s)
 end

--- a/src/models/classical/YangLee/YangLee_registry.jl
+++ b/src/models/classical/YangLee/YangLee_registry.jl
@@ -1,0 +1,27 @@
+# models/classical/YangLee/YangLee_registry.jl
+#
+# Declarative implementation map for the Yang-Lee CFT — non-unitary
+# Virasoro minimal model M(5, 2), c = -22/5 (Cardy 1985; Yang-Lee 1952).
+# Schema in src/core/registry.jl.
+
+@register(
+    YangLee,
+    CentralCharge,
+    Infinite,
+    method=:minimal_model_delegation,
+    reliability=:high,
+    tested_in="test/models/classical/test_yang_lee.jl",
+    references=["Cardy 1985", "Yang-Lee 1952"],
+    notes="Non-unitary minimal model M(5,2); c = -22/5 exact (Rational), delegated to MinimalModel.",
+)
+
+@register(
+    YangLee,
+    ConformalWeights,
+    Infinite,
+    method=:minimal_model_delegation,
+    reliability=:high,
+    tested_in="test/models/classical/test_yang_lee.jl",
+    references=["Cardy 1985"],
+    notes="Kac formula h_{r,s} via MinimalModel(5,2); famous Yang-Lee primary h_{1,2} = -1/5.",
+)

--- a/test/models/classical/test_yang_lee.jl
+++ b/test/models/classical/test_yang_lee.jl
@@ -15,6 +15,8 @@ using QAtlas, Test
 @testset "YangLee — CentralCharge c = -22/5 (Phase 1, M(5,2))" begin
     c = QAtlas.fetch(YangLee(), CentralCharge(), Infinite())
     @test c == -22 // 5
+    @test c isa Rational
+    @test c isa Rational{Int}
     # Delegation invariant
     @test c == QAtlas.fetch(QAtlas.MinimalModel(5, 2), CentralCharge())
 end
@@ -24,10 +26,17 @@ end
     # Identity
     @test QAtlas.fetch(m, ConformalWeights(), Infinite(); r=1, s=1) == 0
     # The famous negative-dimension Yang-Lee primary
-    @test QAtlas.fetch(m, ConformalWeights(), Infinite(); r=1, s=2) == -1 // 5
+    h12 = QAtlas.fetch(m, ConformalWeights(), Infinite(); r=1, s=2)
+    @test h12 == -1 // 5
+    @test h12 isa Rational
     # Kac symmetry (1, s) ↔ (1, p - s) for p = 5
     @test QAtlas.fetch(m, ConformalWeights(), Infinite(); r=1, s=3) == -1 // 5
     @test QAtlas.fetch(m, ConformalWeights(), Infinite(); r=1, s=4) == 0
+    # Delegation invariant on each Kac primary (not just c)
+    for s in 1:4
+        @test QAtlas.fetch(m, ConformalWeights(), Infinite(); r=1, s=s) ==
+              QAtlas.fetch(QAtlas.MinimalModel(5, 2), ConformalWeights(); r=1, s=s)
+    end
 end
 
 @testset "YangLee — index range guards (Phase 1)" begin

--- a/test/models/classical/test_yang_lee.jl
+++ b/test/models/classical/test_yang_lee.jl
@@ -35,7 +35,7 @@ end
     # Delegation invariant on each Kac primary (not just c)
     for s in 1:4
         @test QAtlas.fetch(m, ConformalWeights(), Infinite(); r=1, s=s) ==
-              QAtlas.fetch(QAtlas.MinimalModel(5, 2), ConformalWeights(); r=1, s=s)
+            QAtlas.fetch(QAtlas.MinimalModel(5, 2), ConformalWeights(); r=1, s=s)
     end
 end
 

--- a/test/models/classical/test_yang_lee.jl
+++ b/test/models/classical/test_yang_lee.jl
@@ -1,0 +1,39 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Test: YangLee — c = -22/5 and Kac primaries via MinimalModel(5, 2).
+#
+# Verifies (Phase 1):
+#   * Central charge exactly -22//5 (Rational, machine-precision agreement).
+#   * Delegation invariant: equals MinimalModel(5, 2)'s c.
+#   * Kac primaries h_{1,1} = 0 and h_{1,2} = -1/5 (the famous Yang-Lee
+#     negative-dimension primary), and their Kac-symmetric duals
+#     h_{1,4} = 0, h_{1,3} = -1/5.
+#   * Index range guards: r ∈ [1, 1], s ∈ [1, 4] raise DomainError.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Test
+
+@testset "YangLee — CentralCharge c = -22/5 (Phase 1, M(5,2))" begin
+    c = QAtlas.fetch(YangLee(), CentralCharge(), Infinite())
+    @test c == -22 // 5
+    # Delegation invariant
+    @test c == QAtlas.fetch(QAtlas.MinimalModel(5, 2), CentralCharge())
+end
+
+@testset "YangLee — ConformalWeights (Phase 1)" begin
+    m = YangLee()
+    # Identity
+    @test QAtlas.fetch(m, ConformalWeights(), Infinite(); r=1, s=1) == 0
+    # The famous negative-dimension Yang-Lee primary
+    @test QAtlas.fetch(m, ConformalWeights(), Infinite(); r=1, s=2) == -1 // 5
+    # Kac symmetry (1, s) ↔ (1, p - s) for p = 5
+    @test QAtlas.fetch(m, ConformalWeights(), Infinite(); r=1, s=3) == -1 // 5
+    @test QAtlas.fetch(m, ConformalWeights(), Infinite(); r=1, s=4) == 0
+end
+
+@testset "YangLee — index range guards (Phase 1)" begin
+    m = YangLee()
+    @test_throws DomainError QAtlas.fetch(m, ConformalWeights(), Infinite(); r=0, s=1)
+    @test_throws DomainError QAtlas.fetch(m, ConformalWeights(), Infinite(); r=2, s=1)
+    @test_throws DomainError QAtlas.fetch(m, ConformalWeights(), Infinite(); r=1, s=0)
+    @test_throws DomainError QAtlas.fetch(m, ConformalWeights(), Infinite(); r=1, s=5)
+end


### PR DESCRIPTION
## Summary

Adds the **Yang-Lee CFT** — the non-unitary Virasoro minimal model M(5, 2) describing the universality class of the Lee-Yang edge singularity (Yang-Lee 1952; Cardy 1985), with central charge

    c = 1 − 6 (p − p_prime)² / (p · p_prime) = 1 − 54/10 = −22/5

negative because (5, 2) sits outside the Friedan-Qiu-Shenker unitarity series M(p+1, p), p ≥ 2.

Phase 1 mirrors **TricriticalPotts3 (#245)**: a parameterless struct `YangLee <: AbstractQAtlasModel` delegates both `CentralCharge` and `ConformalWeights` to `MinimalModel(5, 2)`. Under the Kac symmetry (r, s) ↔ (p_prime − r, p − s) the table reduces to two distinct primaries:

| (r, s) | h_{r,s} | Identification          |
|--------|---------|--------------------------|
| (1, 1) | 0       | identity                 |
| (1, 2) | −1/5    | Yang-Lee primary         |
| (1, 3) | −1/5    | Kac-dual of (1, 2)       |
| (1, 4) | 0       | Kac-dual of identity     |

The famous **h_{1,2} = −1/5** is the Yang-Lee edge exponent (Fisher 1978; Cardy 1985).

## Files (5)

- `src/QAtlas.jl` (1 export after `XCube`, 2 includes after `LiouvilleCFT_registry`)
- `src/models/classical/YangLee/YangLee.jl`
- `src/models/classical/YangLee/YangLee_registry.jl`
- `test/models/classical/test_yang_lee.jl`

No modification to `src/core/quantities.jl`.

## Verified locally on Panza

```
fetch(YangLee(), CentralCharge(), Infinite())              == -22 // 5
fetch(YangLee(), ConformalWeights(), Infinite(); r=1, s=1) == 0
fetch(YangLee(), ConformalWeights(), Infinite(); r=1, s=2) == -1 // 5
fetch(YangLee(), ConformalWeights(), Infinite(); r=1, s=3) == -1 // 5
fetch(YangLee(), ConformalWeights(), Infinite(); r=1, s=4) == 0
```

All 10 assertions pass (CentralCharge×2, ConformalWeights×4, DomainError guards×4).

## References

- C. N. Yang and T. D. Lee, *Phys. Rev.* **87**, 404 (1952).
- T. D. Lee and C. N. Yang, *Phys. Rev.* **87**, 410 (1952).
- M. E. Fisher, *Phys. Rev. Lett.* **40**, 1610 (1978).
- J. L. Cardy, *Phys. Rev. Lett.* **54**, 1354 (1985).

## Test plan

- [x] `julia --project=. test/models/classical/test_yang_lee.jl` passes (10/10).
- [ ] CI full suite green.

Refs #234.