### PR TITLE
feat(quantum): FibonacciAnyons — non-Abelian TEE γ = ½ log(2+φ) (refs #240)

### DIFF
--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -69,6 +69,7 @@ export J1J2Heisenberg1D                              # spin-½ J₁-J₂ chain (
 export MixedFieldIsing1D                            # TFIM + longitudinal field, non-integrable (#290)
 export XYh1D                                          # anisotropic XY + transverse field (LSM 1961, #292)
 export ExtendedHubbard1D                              # t-U-V Hubbard chain (#294)
+export FibonacciAnyons                            # non-Abelian Fibonacci anyons (#240)
 
 # --- Core Implementation ---
 include("core/alias.jl")
@@ -266,6 +267,8 @@ include("models/quantum/XYh1D/XYh1D.jl")
 include("models/quantum/XYh1D/XYh1D_registry.jl")  # populates REGISTRY for XYh1D (#292)
 include("models/quantum/ExtendedHubbard1D/ExtendedHubbard1D.jl")
 include("models/quantum/ExtendedHubbard1D/ExtendedHubbard1D_registry.jl")  # populates REGISTRY for ExtendedHubbard1D (#294)
+include("models/quantum/FibonacciAnyons/FibonacciAnyons.jl")
+include("models/quantum/FibonacciAnyons/FibonacciAnyons_registry.jl")  # populates REGISTRY for FibonacciAnyons (#240)
 
 include("models/quantum/TFIM/TFIM_fidelity.jl")            # FidelitySusceptibility (#147)
 include("models/quantum/TFIM/TFIM_quench_entanglement.jl") # VonNeumannEntropy{:quench} (#144)

--- a/src/models/quantum/FibonacciAnyons/FibonacciAnyons.jl
+++ b/src/models/quantum/FibonacciAnyons/FibonacciAnyons.jl
@@ -1,0 +1,61 @@
+"""
+    FibonacciAnyons <: AbstractQAtlasModel
+
+Non-Abelian Fibonacci anyon model.
+
+The anyon spectrum has two charges `{1, τ}` with the fusion rule
+
+    τ × τ = 1 + τ
+
+and quantum dimensions
+
+    d_1 = 1,   d_τ = φ = (1 + √5)/2  (golden ratio).
+
+Total quantum dimension
+
+    𝒟 = √(d_1² + d_τ²) = √(1 + φ²) = √(φ + 2)
+
+(using `φ² = φ + 1`).
+
+Fibonacci anyons are universal for topological quantum computation
+(Freedman-Kitaev-Larsen-Wang 2003) and arise as edge excitations of
+the Read-Rezayi Z_3 parafermion state (Read-Rezayi 1999).
+
+This model has no continuous parameters — the spectrum and quantum
+dimensions are fixed by the fusion rules.
+
+# References
+
+- M. Freedman, A. Kitaev, M. Larsen, Z. Wang, *Bull. Amer. Math. Soc.* **40**, 31 (2003).
+- N. Read, E. Rezayi, *Phys. Rev. B* **59**, 8084 (1999).
+- A. Kitaev, J. Preskill, *Phys. Rev. Lett.* **96**, 110404 (2006).
+- M. Levin, X.-G. Wen, *Phys. Rev. Lett.* **96**, 110405 (2006).
+"""
+struct FibonacciAnyons <: AbstractQAtlasModel end
+
+"""
+    fetch(::FibonacciAnyons, ::TopologicalEntanglementEntropy, ::Infinite; kwargs...) -> Float64
+
+Topological entanglement entropy of the Fibonacci-anyon non-Abelian
+topological order:
+
+    γ = log 𝒟 = (1/2) log(2 + φ)  ≈  0.6430741393
+
+where 𝒟 = √(d_1² + d_τ²) = √(1 + φ²) = √(φ + 2) is the total quantum
+dimension and φ = (1 + √5)/2 is the golden ratio (= d_τ, the
+quantum dimension of the non-trivial τ anyon).
+
+Fibonacci anyons are universal for topological quantum computation
+(Freedman-Kitaev-Larsen-Wang 2003) and arise as edge excitations of
+the Read-Rezayi Z_3 parafermion state (Read-Rezayi 1999).
+
+# References
+
+- M. Freedman, A. Kitaev, M. Larsen, Z. Wang, *Bull. Amer. Math. Soc.* **40**, 31 (2003).
+- N. Read, E. Rezayi, *Phys. Rev. B* **59**, 8084 (1999).
+- A. Kitaev, J. Preskill, *Phys. Rev. Lett.* **96**, 110404 (2006).
+- M. Levin, X.-G. Wen, *Phys. Rev. Lett.* **96**, 110405 (2006).
+"""
+function fetch(::FibonacciAnyons, ::TopologicalEntanglementEntropy, ::Infinite; kwargs...)
+    return 0.5 * log(2 + MathConstants.golden)
+end

--- a/src/models/quantum/FibonacciAnyons/FibonacciAnyons.jl
+++ b/src/models/quantum/FibonacciAnyons/FibonacciAnyons.jl
@@ -39,7 +39,7 @@ struct FibonacciAnyons <: AbstractQAtlasModel end
 Topological entanglement entropy of the Fibonacci-anyon non-Abelian
 topological order:
 
-    γ = log 𝒟 = (1/2) log(2 + φ)  ≈  0.6430741393
+    γ = log 𝒟 = (1/2) log(2 + φ)  ≈  0.6429653906
 
 where 𝒟 = √(d_1² + d_τ²) = √(1 + φ²) = √(φ + 2) is the total quantum
 dimension and φ = (1 + √5)/2 is the golden ratio (= d_τ, the

--- a/src/models/quantum/FibonacciAnyons/FibonacciAnyons_registry.jl
+++ b/src/models/quantum/FibonacciAnyons/FibonacciAnyons_registry.jl
@@ -10,5 +10,5 @@
     references=[
         "Freedman-Kitaev-Larsen-Wang 2003", "Read-Rezayi 1999", "Kitaev-Preskill 2006"
     ],
-    notes="γ = (1/2) log(2 + φ) ≈ 0.6431; non-Abelian Fibonacci fusion, universal TQC."
+    notes="γ = (1/2) log(2 + φ) ≈ 0.6430; non-Abelian Fibonacci fusion, universal TQC."
 )

--- a/src/models/quantum/FibonacciAnyons/FibonacciAnyons_registry.jl
+++ b/src/models/quantum/FibonacciAnyons/FibonacciAnyons_registry.jl
@@ -1,0 +1,7 @@
+# Registry entries for FibonacciAnyons (refs #240)
+
+@register(FibonacciAnyons, TopologicalEntanglementEntropy, Infinite,
+    method=:analytic, reliability=:high,
+    tested_in="test/models/quantum/misc/test_fibonacci_anyons.jl",
+    references=["Freedman-Kitaev-Larsen-Wang 2003", "Read-Rezayi 1999", "Kitaev-Preskill 2006"],
+    notes="γ = (1/2) log(2 + φ) ≈ 0.6431; non-Abelian Fibonacci fusion, universal TQC.")

--- a/src/models/quantum/FibonacciAnyons/FibonacciAnyons_registry.jl
+++ b/src/models/quantum/FibonacciAnyons/FibonacciAnyons_registry.jl
@@ -1,7 +1,14 @@
 # Registry entries for FibonacciAnyons (refs #240)
 
-@register(FibonacciAnyons, TopologicalEntanglementEntropy, Infinite,
-    method=:analytic, reliability=:high,
+@register(
+    FibonacciAnyons,
+    TopologicalEntanglementEntropy,
+    Infinite,
+    method=:analytic,
+    reliability=:high,
     tested_in="test/models/quantum/misc/test_fibonacci_anyons.jl",
-    references=["Freedman-Kitaev-Larsen-Wang 2003", "Read-Rezayi 1999", "Kitaev-Preskill 2006"],
-    notes="γ = (1/2) log(2 + φ) ≈ 0.6431; non-Abelian Fibonacci fusion, universal TQC.")
+    references=[
+        "Freedman-Kitaev-Larsen-Wang 2003", "Read-Rezayi 1999", "Kitaev-Preskill 2006"
+    ],
+    notes="γ = (1/2) log(2 + φ) ≈ 0.6431; non-Abelian Fibonacci fusion, universal TQC."
+)

--- a/test/models/quantum/misc/test_fibonacci_anyons.jl
+++ b/test/models/quantum/misc/test_fibonacci_anyons.jl
@@ -5,7 +5,7 @@ using QAtlas, Test
     # Closed-form check
     @test γ ≈ 0.5 * log(2 + MathConstants.golden)
     # Numerical value (φ ≈ 1.6180, 2+φ ≈ 3.6180, log = 1.2862..., ÷ 2 ≈ 0.6431)
-    @test γ ≈ 0.6430741393  atol=1e-9
+    @test γ ≈ 0.6429653906  atol=1e-9
     # Equivalently γ = log √(1 + φ²) and log √(φ+2)
     φ = MathConstants.golden
     @test γ ≈ log(sqrt(1 + φ^2))

--- a/test/models/quantum/misc/test_fibonacci_anyons.jl
+++ b/test/models/quantum/misc/test_fibonacci_anyons.jl
@@ -6,6 +6,8 @@ using QAtlas, Test
     @test γ ≈ 0.5 * log(2 + MathConstants.golden)
     # Numerical value (φ ≈ 1.6180, 2+φ ≈ 3.6180, log = 1.2862..., ÷ 2 ≈ 0.6431)
     @test γ ≈ 0.6429653906 atol=1e-9
+    # Cross-check against direct literal-sqrt formula (independent of MathConstants.golden)
+    @test γ ≈ 0.5 * log(2 + (1 + sqrt(5)) / 2) atol=1e-15
     # Equivalently γ = log √(1 + φ²) and log √(φ+2)
     φ = MathConstants.golden
     @test γ ≈ log(sqrt(1 + φ^2))

--- a/test/models/quantum/misc/test_fibonacci_anyons.jl
+++ b/test/models/quantum/misc/test_fibonacci_anyons.jl
@@ -1,0 +1,16 @@
+using QAtlas, Test
+
+@testset "FibonacciAnyons — TopologicalEntanglementEntropy (Phase 1)" begin
+    γ = QAtlas.fetch(FibonacciAnyons(), TopologicalEntanglementEntropy(), Infinite())
+    # Closed-form check
+    @test γ ≈ 0.5 * log(2 + MathConstants.golden)
+    # Numerical value (φ ≈ 1.6180, 2+φ ≈ 3.6180, log = 1.2862..., ÷ 2 ≈ 0.6431)
+    @test γ ≈ 0.6430741393  atol=1e-9
+    # Equivalently γ = log √(1 + φ²) and log √(φ+2)
+    φ = MathConstants.golden
+    @test γ ≈ log(sqrt(1 + φ^2))
+    @test γ ≈ log(sqrt(φ + 2))
+    # Larger than Z_2 toric-code value γ = log 2 ≈ 0.6931? Actually log(2) > log√(φ+2)
+    # since 2 = √4 > √(φ+2) = √3.618.  So γ_Fib < γ_Z2.
+    @test γ < log(2)
+end

--- a/test/models/quantum/misc/test_fibonacci_anyons.jl
+++ b/test/models/quantum/misc/test_fibonacci_anyons.jl
@@ -5,7 +5,7 @@ using QAtlas, Test
     # Closed-form check
     @test γ ≈ 0.5 * log(2 + MathConstants.golden)
     # Numerical value (φ ≈ 1.6180, 2+φ ≈ 3.6180, log = 1.2862..., ÷ 2 ≈ 0.6431)
-    @test γ ≈ 0.6429653906  atol=1e-9
+    @test γ ≈ 0.6429653906 atol=1e-9
     # Equivalently γ = log √(1 + φ²) and log √(φ+2)
     φ = MathConstants.golden
     @test γ ≈ log(sqrt(1 + φ^2))


### PR DESCRIPTION
## Summary

Adds **FibonacciAnyons**, the simplest non-Abelian topological-order anyon model, to QAtlas. Phase 1 exposes `TopologicalEntanglementEntropy` at `Infinite`.

### Physics

Fibonacci anyons have a two-charge spectrum `{1, τ}` with the non-Abelian fusion rule

    τ × τ = 1 + τ

and quantum dimensions

    d_1 = 1,   d_τ = φ = (1 + √5)/2   (golden ratio)

giving total quantum dimension

    𝒟 = √(d_1² + d_τ²) = √(1 + φ²) = √(φ + 2)

(using `φ² = φ + 1`).

In the Kitaev-Preskill / Levin-Wen prescription the topological entanglement entropy is

    γ = log 𝒟 = (1/2) log(2 + φ)  ≈  0.6429653906

appearing in `S(ρ_A) = α·|∂A| − γ + O(|∂A|⁻¹)` for the entanglement entropy of a Fibonacci-topological-order ground state. Note `γ_Fib = log √(φ+2) < log 2 = γ_{Z_2}` for the toric code.

Fibonacci anyons are universal for topological quantum computation (Freedman-Kitaev-Larsen-Wang 2003) and arise as the edge-excitation degrees of freedom of the Read-Rezayi Z_3 parafermion state (Read-Rezayi 1999). The struct is parameterless — the spectrum and quantum dimensions are entirely fixed by the fusion rules.

### Implementation

- `FibonacciAnyons <: AbstractQAtlasModel` (no continuous parameters)
- `fetch(::FibonacciAnyons, ::TopologicalEntanglementEntropy, ::Infinite)` returns `0.5 * log(2 + MathConstants.golden)`
- Registry entry: `method=:analytic`, `reliability=:high`
- Phase 1 scope: only `TopologicalEntanglementEntropy` at `Infinite`

## References

- M. Freedman, A. Kitaev, M. Larsen, Z. Wang, *Bull. Amer. Math. Soc.* **40**, 31 (2003).
- N. Read, E. Rezayi, *Phys. Rev. B* **59**, 8084 (1999).
- A. Kitaev, J. Preskill, *Phys. Rev. Lett.* **96**, 110404 (2006).
- M. Levin, X.-G. Wen, *Phys. Rev. Lett.* **96**, 110405 (2006).

## Test plan

- [x] Closed-form check: `γ ≈ 0.5 * log(2 + MathConstants.golden)`
- [x] Equivalent forms: `γ ≈ log √(1+φ²)` and `γ ≈ log √(φ+2)`
- [x] Ordering vs Z_2 toric code: `γ_Fib < log 2`

Refs #240.
