### PR TITLE
feat(quantum): PpIp2DSC — Read-Green 2D p+ip chiral superconductor (Phase 1, refs #238)

### DIFF
--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -70,6 +70,7 @@ export MixedFieldIsing1D                            # TFIM + longitudinal field,
 export XYh1D                                          # anisotropic XY + transverse field (LSM 1961, #292)
 export ExtendedHubbard1D                              # t-U-V Hubbard chain (#294)
 export FibonacciAnyons                            # non-Abelian Fibonacci anyons (#240)
+export PpIp2DSC                                     # 2D p+ip chiral superconductor (Read-Green 2000, #238)
 
 # --- Core Implementation ---
 include("core/alias.jl")
@@ -269,6 +270,8 @@ include("models/quantum/ExtendedHubbard1D/ExtendedHubbard1D.jl")
 include("models/quantum/ExtendedHubbard1D/ExtendedHubbard1D_registry.jl")  # populates REGISTRY for ExtendedHubbard1D (#294)
 include("models/quantum/FibonacciAnyons/FibonacciAnyons.jl")
 include("models/quantum/FibonacciAnyons/FibonacciAnyons_registry.jl")  # populates REGISTRY for FibonacciAnyons (#240)
+include("models/quantum/PpIp2DSC/PpIp2DSC.jl")
+include("models/quantum/PpIp2DSC/PpIp2DSC_registry.jl")  # populates REGISTRY for PpIp2DSC (#238)
 
 include("models/quantum/TFIM/TFIM_fidelity.jl")            # FidelitySusceptibility (#147)
 include("models/quantum/TFIM/TFIM_quench_entanglement.jl") # VonNeumannEntropy{:quench} (#144)

--- a/src/models/quantum/PpIp2DSC/PpIp2DSC.jl
+++ b/src/models/quantum/PpIp2DSC/PpIp2DSC.jl
@@ -1,0 +1,127 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# PpIp2DSC — 2-D p_x + i p_y chiral superconductor (Read-Green 2000).
+#
+# Mean-field BCS Hamiltonian for spinless fermions on a 2-D continuum
+# (or lattice) with chiral p-wave pairing:
+#
+#     H = Σ_k [ ξ_k c†_k c_k + (Δ_k c†_k c†_{-k} + h.c.) ],
+#     ξ_k = ε_k − μ,           Δ_k = Δ₀ (k_x + i k_y).
+#
+# Read–Green (2000) showed that the BdG ground state of this
+# Hamiltonian is gapped in the bulk and falls into two distinct phases
+# as a function of the chemical potential `μ`:
+#
+#   * Weak-pairing phase  (μ > 0): topologically non-trivial,
+#     first Chern number `C = 1`, single chiral Majorana edge mode,
+#     `c = 1/2` Ising-like boundary CFT, non-Abelian Ising anyons
+#     bound to vortex cores.
+#   * Strong-pairing phase (μ < 0): trivial (`C = 0`), no edge modes.
+#
+# This is the prototypical 2-D fermionic topological superconductor
+# and is the candidate state for the ν = 5/2 fractional quantum Hall
+# plateau (Moore–Read Pfaffian).
+#
+# Phase 1 of this entry registers the two parameter-independent
+# bulk topological invariants of the weak-pairing phase:
+#
+#   * CentralCharge        c = 1/2   (chiral Majorana edge CFT)
+#   * TopologicalInvariant C = 1     (first Chern number)
+#
+# Vortex-core Majorana zero-mode quantities, the BdG spectrum on a
+# strip / disc, and the strong-pairing phase (`μ ≤ 0`) are tracked as
+# Phase 2 and are intentionally excluded here.
+#
+# References:
+#   - N. Read, D. Green, *Phys. Rev. B* **61**, 10267 (2000).
+#   - A. Y. Kitaev, *Ann. Phys.* **321**, 2 (2006).
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    PpIp2DSC(; Δ₀::Real = 1.0, μ::Real = 1.0) <: AbstractQAtlasModel
+
+2-D p_x + i p_y chiral superconductor (Read–Green 2000) for spinless
+fermions, with BCS pairing amplitude `Δ₀ > 0` and chemical potential
+`μ > 0` (weak-pairing topological phase).
+
+Phase 1 exposes the parameter-independent bulk topological data of
+the weak-pairing phase:
+
+| Quantity                            | BC         | Value   |
+| ----------------------------------- | ---------- | ------- |
+| [`CentralCharge`](@ref)             | `Infinite` | `1/2`   |
+| [`TopologicalInvariant`](@ref)      | `Infinite` | `1`     |
+
+The strong-pairing trivial phase (`μ ≤ 0`) is excluded by the
+constructor: only the topological branch is exposed in Phase 1.
+
+# References
+
+- N. Read, D. Green, *Phys. Rev. B* **61**, 10267 (2000).
+- A. Y. Kitaev, *Ann. Phys.* **321**, 2 (2006).
+"""
+struct PpIp2DSC <: AbstractQAtlasModel
+    Δ₀::Float64
+    μ::Float64
+    function PpIp2DSC(Δ₀::Real, μ::Real)
+        Δ₀ > 0 || throw(
+            DomainError(Δ₀, "PpIp2DSC requires Δ₀ > 0; got Δ₀ = $Δ₀."),
+        )
+        μ > 0 || throw(
+            DomainError(
+                μ,
+                "PpIp2DSC requires μ > 0 (weak-pairing topological phase); got μ = $μ.",
+            ),
+        )
+        return new(Float64(Δ₀), Float64(μ))
+    end
+end
+PpIp2DSC(; Δ₀::Real=1.0, μ::Real=1.0) = PpIp2DSC(Δ₀, μ)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Chiral Majorana edge CFT — central charge c = 1/2
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    fetch(::PpIp2DSC, ::CentralCharge, ::Infinite; kwargs...) -> Rational{Int}
+
+Central charge of the chiral Majorana edge CFT of the 2-D p+ip
+weak-pairing superconductor (Read–Green 2000):
+
+    c = 1/2
+
+(a single right-moving Majorana fermion, i.e. the chiral half of the
+2-D Ising model). Parameter-independent within the weak-pairing
+topological phase (`μ > 0`).
+
+# References
+
+- N. Read, D. Green, *Phys. Rev. B* **61**, 10267 (2000).
+- A. Y. Kitaev, *Ann. Phys.* **321**, 2 (2006).
+"""
+function fetch(::PpIp2DSC, ::CentralCharge, ::Infinite; kwargs...)
+    return 1 // 2
+end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# First Chern number of the BdG ground state — C = 1
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    fetch(::PpIp2DSC, ::TopologicalInvariant, ::Infinite; kwargs...) -> Int
+
+First Chern number of the BdG ground-state band of the 2-D p+ip
+weak-pairing superconductor (Read–Green 2000):
+
+    C = 1
+
+(in contrast to `C = 0` in the strong-pairing trivial phase at
+`μ < 0`). By the bulk–boundary correspondence this drives a single
+chiral Majorana edge mode.
+
+# References
+
+- N. Read, D. Green, *Phys. Rev. B* **61**, 10267 (2000).
+"""
+function fetch(::PpIp2DSC, ::TopologicalInvariant, ::Infinite; kwargs...)
+    return 1
+end

--- a/src/models/quantum/PpIp2DSC/PpIp2DSC.jl
+++ b/src/models/quantum/PpIp2DSC/PpIp2DSC.jl
@@ -63,9 +63,7 @@ struct PpIp2DSC <: AbstractQAtlasModel
     Δ₀::Float64
     μ::Float64
     function PpIp2DSC(Δ₀::Real, μ::Real)
-        Δ₀ > 0 || throw(
-            DomainError(Δ₀, "PpIp2DSC requires Δ₀ > 0; got Δ₀ = $Δ₀."),
-        )
+        Δ₀ > 0 || throw(DomainError(Δ₀, "PpIp2DSC requires Δ₀ > 0; got Δ₀ = $Δ₀."))
         μ > 0 || throw(
             DomainError(
                 μ,

--- a/src/models/quantum/PpIp2DSC/PpIp2DSC_registry.jl
+++ b/src/models/quantum/PpIp2DSC/PpIp2DSC_registry.jl
@@ -1,0 +1,26 @@
+# models/quantum/PpIp2DSC/PpIp2DSC_registry.jl
+#
+# Declarative implementation map for the 2-D p_x + i p_y chiral
+# superconductor (Read-Green 2000).  Schema in src/core/registry.jl.
+
+@register(
+    PpIp2DSC,
+    CentralCharge,
+    Infinite,
+    method=:analytic,
+    reliability=:high,
+    tested_in="test/models/quantum/misc/test_ppip_2dsc.jl",
+    references=["Read-Green 2000", "Kitaev 2006"],
+    notes="Chiral Majorana edge CFT c=1/2 in weak-pairing topological phase (μ>0).",
+)
+
+@register(
+    PpIp2DSC,
+    TopologicalInvariant,
+    Infinite,
+    method=:analytic,
+    reliability=:high,
+    tested_in="test/models/quantum/misc/test_ppip_2dsc.jl",
+    references=["Read-Green 2000"],
+    notes="First Chern number C=1 in weak-pairing topological phase.",
+)

--- a/test/models/quantum/misc/test_ppip_2dsc.jl
+++ b/test/models/quantum/misc/test_ppip_2dsc.jl
@@ -16,6 +16,9 @@ using QAtlas, Test
     @test c isa Rational
     # Parameter-independent within topological phase
     @test QAtlas.fetch(PpIp2DSC(; Δ₀=2.0, μ=3.0), CentralCharge(), Infinite()) == 1 // 2
+    # Cross-check: chiral Majorana edge CFT = Ising boundary CFT = MinimalModel(4, 3)
+    @test QAtlas.fetch(PpIp2DSC(), CentralCharge(), Infinite()) ==
+          QAtlas.fetch(QAtlas.MinimalModel(4, 3), CentralCharge())
 end
 
 @testset "PpIp2DSC — TopologicalInvariant C = 1 (Phase 1)" begin

--- a/test/models/quantum/misc/test_ppip_2dsc.jl
+++ b/test/models/quantum/misc/test_ppip_2dsc.jl
@@ -1,0 +1,31 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# PpIp2DSC — 2-D p+ip chiral superconductor (Read-Green 2000), Phase 1.
+#
+# Verifies the two parameter-independent topological invariants of the
+# weak-pairing phase:
+#   * CentralCharge        c = 1/2   (chiral Majorana edge CFT)
+#   * TopologicalInvariant C = 1     (first Chern number)
+# and rejects parameters outside the weak-pairing branch.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Test
+
+@testset "PpIp2DSC — edge CFT CentralCharge = 1/2 (Phase 1)" begin
+    c = QAtlas.fetch(PpIp2DSC(), CentralCharge(), Infinite())
+    @test c == 1 // 2
+    @test c isa Rational
+    # Parameter-independent within topological phase
+    @test QAtlas.fetch(PpIp2DSC(; Δ₀=2.0, μ=3.0), CentralCharge(), Infinite()) == 1 // 2
+end
+
+@testset "PpIp2DSC — TopologicalInvariant C = 1 (Phase 1)" begin
+    @test QAtlas.fetch(PpIp2DSC(), TopologicalInvariant(), Infinite()) == 1
+    @test QAtlas.fetch(PpIp2DSC(; Δ₀=5.0, μ=0.5), TopologicalInvariant(), Infinite()) == 1
+end
+
+@testset "PpIp2DSC — rejects Δ₀ ≤ 0 / μ ≤ 0 (Phase 1)" begin
+    @test_throws DomainError PpIp2DSC(; Δ₀=0.0)
+    @test_throws DomainError PpIp2DSC(; Δ₀=-1.0)
+    @test_throws DomainError PpIp2DSC(; μ=0.0)
+    @test_throws DomainError PpIp2DSC(; μ=-1.0)
+end

--- a/test/models/quantum/misc/test_ppip_2dsc.jl
+++ b/test/models/quantum/misc/test_ppip_2dsc.jl
@@ -18,7 +18,7 @@ using QAtlas, Test
     @test QAtlas.fetch(PpIp2DSC(; Δ₀=2.0, μ=3.0), CentralCharge(), Infinite()) == 1 // 2
     # Cross-check: chiral Majorana edge CFT = Ising boundary CFT = MinimalModel(4, 3)
     @test QAtlas.fetch(PpIp2DSC(), CentralCharge(), Infinite()) ==
-          QAtlas.fetch(QAtlas.MinimalModel(4, 3), CentralCharge())
+        QAtlas.fetch(QAtlas.MinimalModel(4, 3), CentralCharge())
 end
 
 @testset "PpIp2DSC — TopologicalInvariant C = 1 (Phase 1)" begin


### PR DESCRIPTION
## Summary

Adds **PpIp2DSC** — the 2-D p_x + i p_y chiral superconductor (Read–Green 2000) — as a new QAtlas model in the weak-pairing topological phase.

Mean-field BCS Hamiltonian for spinless fermions:

```
H = Σ_k [ ξ_k c†_k c_k + (Δ_k c†_k c†_{-k} + h.c.) ],   Δ_k = Δ₀ (k_x + i k_y).
```

For `μ > 0` the BdG ground state is in the **weak-pairing topological phase** with first Chern number `C = 1` and a single chiral Majorana edge mode (`c = 1/2` Ising-like boundary CFT). The strong-pairing trivial phase (`μ ≤ 0`) is excluded by the constructor (`DomainError`) and is tracked as Phase 2.

This is the prototypical 2-D fermionic topological superconductor and the candidate state for the ν = 5/2 fractional quantum Hall plateau (Moore–Read Pfaffian, non-Abelian Ising anyons in vortex cores).

## Phase 1 quantities (closed-form, parameter-independent)

| Quantity                | BC         | Value | Method       |
| ----------------------- | ---------- | ----- | ------------ |
| `CentralCharge`         | `Infinite` | `1/2` | `:analytic`  |
| `TopologicalInvariant`  | `Infinite` | `1`   | `:analytic`  |

- `c = 1/2`: single right-moving Majorana = chiral half of 2-D Ising.
- `C = 1`: first Chern number of the BdG ground-state band → single chiral Majorana edge mode by bulk–boundary correspondence.

## Files changed

- `src/models/quantum/PpIp2DSC/PpIp2DSC.jl` — struct (`Δ₀ > 0`, `μ > 0`) + two `fetch` methods
- `src/models/quantum/PpIp2DSC/PpIp2DSC_registry.jl` — `@register` for both quantities
- `test/models/quantum/misc/test_ppip_2dsc.jl` — 9 tests (3 testsets) verifying `c = 1/2`, `C = 1`, and `DomainError` on `Δ₀ ≤ 0` / `μ ≤ 0`
- `src/QAtlas.jl` — `export PpIp2DSC` (alongside `KitaevHeisenberg`) and two `include` lines

`src/core/quantities.jl` is **not** modified — `CentralCharge` and `TopologicalInvariant` were already exported (lines 73 / 80).

## Test plan

- [x] `julia --project=test test/models/quantum/misc/test_ppip_2dsc.jl` — 9/9 pass locally on Panza
- [ ] CI green on the full `Pkg.test()` suite
- [ ] Lint / formatter clean

## References

- N. Read, D. Green, *Phys. Rev. B* **61**, 10267 (2000).
- A. Y. Kitaev, *Ann. Phys.* **321**, 2 (2006).

Refs #238.