### PR TITLE
feat(quantum): SYK — Sachdev-Ye-Kitaev IR fermion dimension Δ_ψ = 1/q (refs #251)

### DIFF
--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -73,6 +73,7 @@ export XYh1D                                          # anisotropic XY + transve
 export ExtendedHubbard1D                              # t-U-V Hubbard chain (#294)
 export FibonacciAnyons                            # non-Abelian Fibonacci anyons (#240)
 export PpIp2DSC                                     # 2D p+ip chiral superconductor (Read-Green 2000, #238)
+export SYK                                              # Sachdev-Ye-Kitaev (#251)
 
 # --- Core Implementation ---
 include("core/alias.jl")
@@ -279,6 +280,8 @@ include("models/quantum/FibonacciAnyons/FibonacciAnyons.jl")
 include("models/quantum/FibonacciAnyons/FibonacciAnyons_registry.jl")  # populates REGISTRY for FibonacciAnyons (#240)
 include("models/quantum/PpIp2DSC/PpIp2DSC.jl")
 include("models/quantum/PpIp2DSC/PpIp2DSC_registry.jl")  # populates REGISTRY for PpIp2DSC (#238)
+include("models/quantum/SYK/SYK.jl")
+include("models/quantum/SYK/SYK_registry.jl")  # populates REGISTRY for SYK (#251)
 
 include("models/quantum/TFIM/TFIM_fidelity.jl")            # FidelitySusceptibility (#147)
 include("models/quantum/TFIM/TFIM_quench_entanglement.jl") # VonNeumannEntropy{:quench} (#144)

--- a/src/models/quantum/SYK/SYK.jl
+++ b/src/models/quantum/SYK/SYK.jl
@@ -70,9 +70,8 @@ the JT-gravity bulk dual.
 struct SYK <: AbstractQAtlasModel
     q::Int
     function SYK(q::Integer)
-        q ≥ 2 || throw(
-            DomainError(q, "SYK requires q-body coupling with q ≥ 2; got q = $q.")
-        )
+        q ≥ 2 ||
+            throw(DomainError(q, "SYK requires q-body coupling with q ≥ 2; got q = $q."))
         iseven(q) ||
             throw(DomainError(q, "SYK requires q even (Majorana indices); got q = $q."))
         return new(Int(q))
@@ -120,15 +119,9 @@ bilinear tower), are deferred to Phase 2.
 - J. Maldacena, D. Stanford, *Phys. Rev. D* **94**, 106002 (2016).
 """
 function fetch(
-    m::SYK,
-    ::ConformalWeights,
-    ::Infinite;
-    q::Integer=m.q,
-    field::Symbol=:ψ,
-    kwargs...,
+    m::SYK, ::ConformalWeights, ::Infinite; q::Integer=m.q, field::Symbol=:ψ, kwargs...
 )
-    q ≥ 2 ||
-        throw(DomainError(q, "SYK ConformalWeights requires q ≥ 2; got q = $q."))
+    q ≥ 2 || throw(DomainError(q, "SYK ConformalWeights requires q ≥ 2; got q = $q."))
     iseven(q) || throw(
         DomainError(
             q,

--- a/src/models/quantum/SYK/SYK.jl
+++ b/src/models/quantum/SYK/SYK.jl
@@ -1,0 +1,148 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SYK — Sachdev-Ye-Kitaev model (large-N maximally chaotic
+# random-fermion quantum mechanics).
+#
+# Hamiltonian (q-body Majorana coupling, Maldacena-Stanford 2016
+# convention):
+#
+#     H = (i^{q/2} / q!) Σ_{i_1<…<i_q} J_{i_1…i_q} ψ_{i_1} … ψ_{i_q},
+#         ⟨J²⟩ = J² (q-1)! / N^{q-1},
+#
+# with `N` Majorana fermions `ψ_i` and all-to-all `q`-body Gaussian
+# disorder.  In the large-`N`, low-energy (IR) limit the disorder-
+# averaged theory becomes **emergently conformal**: the Schwarzian
+# reparametrisation mode emerges as the soft sector and the Majorana
+# fermion acquires a universal IR conformal dimension
+#
+#     Δ_ψ = 1 / q                  (Kitaev 2015; Maldacena-Stanford 2016)
+#
+# i.e. `⟨ψ(τ_1) ψ(τ_2)⟩ ∝ 1 / |τ_12|^{2 Δ_ψ}` at large `|τ_12|`.
+# SYK is the prototype of holographic 1-D quantum mechanics dual to
+# AdS₂ dilaton gravity / JT gravity, and saturates the Maldacena-
+# Shenker-Stanford bound on chaos `λ_L = 2π / β`.
+#
+# Phase 1 of this file therefore exposes only the IR Majorana
+# conformal dimension `Δ_ψ = 1 / q` via `ConformalWeights` at
+# `field = :ψ`.  Composite-operator dimensions (e.g. the bilinear
+# `O_n = ψ ∂_τ^{2n+1} ψ` tower), the Schwarzian zero-temperature
+# entropy, the four-point function reproducing JT bulk
+# diagrammatics, and the maximal Lyapunov exponent are deferred
+# to Phase 2.
+#
+# References:
+#   - S. Sachdev, J. Ye, Phys. Rev. Lett. 70, 3339 (1993).
+#   - A. Kitaev, "A simple model of quantum holography",
+#     KITP talks (2015).
+#   - J. Maldacena, D. Stanford, Phys. Rev. D 94, 106002 (2016).
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    SYK(; q::Integer = 4) <: AbstractQAtlasModel
+
+Sachdev-Ye-Kitaev model: `N` Majorana fermions with all-to-all
+random `q`-body coupling.  The defining structural parameter for
+the universal large-`N` IR is `q` (which must be even — Majorana
+antisymmetry — and `≥ 2`).  The fermion number `N` and the
+coupling scale `J` set the UV / finite-`N` data but do **not**
+enter the leading large-`N` IR conformal dimension exposed here.
+
+Default `q = 4` is the most-studied case: 4-body Majorana
+coupling, exactly soluble Schwarzian-dressed two-point function,
+and a maximal Lyapunov exponent saturating the Maldacena-
+Shenker-Stanford bound.
+
+Quantities registered (Phase 1):
+
+| Quantity                        | BC         | Method                              |
+| ------------------------------- | ---------- | ----------------------------------- |
+| [`ConformalWeights`](@ref)      | `Infinite` | analytic large-N IR (`Δ_ψ = 1/q`)   |
+
+Phase 2 will add composite-operator dimensions (bilinear tower),
+the Schwarzian zero-T entropy, maximal Lyapunov saturation, and
+the JT-gravity bulk dual.
+
+# References
+
+- S. Sachdev, J. Ye, *Phys. Rev. Lett.* **70**, 3339 (1993).
+- A. Kitaev, KITP talks (2015) — "A simple model of quantum holography".
+- J. Maldacena, D. Stanford, *Phys. Rev. D* **94**, 106002 (2016).
+"""
+struct SYK <: AbstractQAtlasModel
+    q::Int
+    function SYK(q::Integer)
+        q ≥ 2 || throw(
+            DomainError(q, "SYK requires q-body coupling with q ≥ 2; got q = $q.")
+        )
+        iseven(q) ||
+            throw(DomainError(q, "SYK requires q even (Majorana indices); got q = $q."))
+        return new(Int(q))
+    end
+end
+SYK(; q::Integer=4) = SYK(q)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# IR Majorana conformal dimension — Δ_ψ = 1 / q
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    fetch(m::SYK, ::ConformalWeights, ::Infinite;
+          q::Integer = m.q, field::Symbol = :ψ, kwargs...) -> Rational{Int}
+
+Large-`N` IR (low-energy / emergent-conformal) Majorana fermion
+conformal dimension of the Sachdev-Ye-Kitaev model:
+
+    Δ_ψ = 1 / q.
+
+This is the universal scaling of the disorder-averaged two-point
+function
+
+    ⟨ψ(τ_1) ψ(τ_2)⟩ ∝ 1 / |τ_12|^{2 Δ_ψ}
+
+in the IR conformal window where the Schwarzian reparametrisation
+soft mode dominates the dynamics (Kitaev 2015; Maldacena-Stanford
+2016).  Finite-`N` and subleading-`1/(βJ)` Schwarzian corrections,
+as well as composite-operator dimensions (the `O_n = ψ ∂_τ^{2n+1} ψ`
+bilinear tower), are deferred to Phase 2.
+
+# Arguments
+
+- `q::Integer = m.q`: body-count of the Majorana coupling.  Must be
+  even and `≥ 2`.
+- `field::Symbol = :ψ`: which IR operator to query.  Phase 1
+  supports only `:ψ` (the elementary Majorana fermion); any other
+  symbol raises `DomainError`, deferring composite-operator
+  dimensions to Phase 2.
+
+# References
+
+- S. Sachdev, J. Ye, *Phys. Rev. Lett.* **70**, 3339 (1993).
+- A. Kitaev, KITP talks (2015).
+- J. Maldacena, D. Stanford, *Phys. Rev. D* **94**, 106002 (2016).
+"""
+function fetch(
+    m::SYK,
+    ::ConformalWeights,
+    ::Infinite;
+    q::Integer=m.q,
+    field::Symbol=:ψ,
+    kwargs...,
+)
+    q ≥ 2 ||
+        throw(DomainError(q, "SYK ConformalWeights requires q ≥ 2; got q = $q."))
+    iseven(q) || throw(
+        DomainError(
+            q,
+            "SYK ConformalWeights requires q even (q-body Majorana coupling); got q = $q.",
+        ),
+    )
+    if field == :ψ
+        return 1 // q
+    else
+        throw(
+            DomainError(
+                field,
+                "SYK ConformalWeights: Phase 1 supports only field=:ψ (Majorana fermion IR dimension); composite-operator dimensions Phase 2. Got field=:$field.",
+            ),
+        )
+    end
+end

--- a/src/models/quantum/SYK/SYK_registry.jl
+++ b/src/models/quantum/SYK/SYK_registry.jl
@@ -1,0 +1,15 @@
+# models/quantum/SYK/SYK_registry.jl
+#
+# Declarative implementation map for the Sachdev-Ye-Kitaev model.
+# Schema documented in src/core/registry.jl.
+
+@register(
+    SYK,
+    ConformalWeights,
+    Infinite,
+    method=:analytic,
+    reliability=:high,
+    tested_in="test/models/quantum/misc/test_syk.jl",
+    references=["Sachdev-Ye 1993", "Kitaev 2015", "Maldacena-Stanford 2016"],
+    notes="Large-N IR Majorana conformal dimension Δ_ψ = 1/q; composite-operator dimensions Phase 2.",
+)

--- a/test/models/quantum/misc/test_syk.jl
+++ b/test/models/quantum/misc/test_syk.jl
@@ -1,0 +1,29 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Standalone test: SYK — large-N IR Majorana ConformalWeight Δ_ψ = 1/q.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Test
+
+@testset "SYK — IR Majorana ConformalWeight Δ_ψ = 1/q (Phase 1)" begin
+    # Default q=4
+    @test QAtlas.fetch(SYK(), ConformalWeights(), Infinite(); field=:ψ) == 1 // 4
+    # Other even q
+    @test QAtlas.fetch(SYK(; q=2), ConformalWeights(), Infinite(); field=:ψ) == 1 // 2
+    @test QAtlas.fetch(SYK(; q=6), ConformalWeights(), Infinite(); field=:ψ) == 1 // 6
+    @test QAtlas.fetch(SYK(; q=8), ConformalWeights(), Infinite(); field=:ψ) == 1 // 8
+    # Default field = :ψ
+    @test QAtlas.fetch(SYK(), ConformalWeights(), Infinite()) == 1 // 4
+end
+
+@testset "SYK — rejects q ≤ 1 / q odd (Phase 1)" begin
+    @test_throws DomainError SYK(; q=1)
+    @test_throws DomainError SYK(; q=0)
+    @test_throws DomainError SYK(; q=3)  # odd q invalid for Majorana
+    @test_throws DomainError SYK(; q=5)
+end
+
+@testset "SYK — rejects unknown field (Phase 2 deferral)" begin
+    m = SYK()
+    @test_throws DomainError QAtlas.fetch(m, ConformalWeights(), Infinite(); field=:O)
+    @test_throws DomainError QAtlas.fetch(m, ConformalWeights(), Infinite(); field=:ε)
+end

--- a/test/models/quantum/misc/test_syk.jl
+++ b/test/models/quantum/misc/test_syk.jl
@@ -15,6 +15,21 @@ using QAtlas, Test
     @test QAtlas.fetch(SYK(), ConformalWeights(), Infinite()) == 1 // 4
 end
 
+@testset "SYK — unitarity bound and monotonicity (Phase 1 cross-check)" begin
+    # Unitarity bound: free Majorana in d=1 has Δ=1/2; q=2 saturates, q>2 strict.
+    # Equivalently 1//q ≤ 1//2 for all valid q ≥ 2.
+    for q in (2, 4, 6, 8, 10, 12)
+        Δ = QAtlas.fetch(SYK(; q=q), ConformalWeights(), Infinite(); field=:ψ)
+        @test Δ ≤ 1 // 2
+    end
+    # Monotonicity: Δ_ψ(q+2) < Δ_ψ(q) — strictly decreasing in q.
+    for q in (2, 4, 6, 8, 10)
+        Δq = QAtlas.fetch(SYK(; q=q), ConformalWeights(), Infinite(); field=:ψ)
+        Δqp = QAtlas.fetch(SYK(; q=q + 2), ConformalWeights(), Infinite(); field=:ψ)
+        @test Δqp < Δq
+    end
+end
+
 @testset "SYK — rejects q ≤ 1 / q odd (Phase 1)" begin
     @test_throws DomainError SYK(; q=1)
     @test_throws DomainError SYK(; q=0)


### PR DESCRIPTION
## Summary

Adds the **Sachdev-Ye-Kitaev model** — `N` Majorana fermions with all-to-all random `q`-body coupling — to the quantum-model catalogue. Refs #251.

The Hamiltonian (Maldacena-Stanford 2016 convention) is

```
H = (i^{q/2} / q!) Σ_{i_1<…<i_q} J_{i_1…i_q} ψ_{i_1} … ψ_{i_q},
    ⟨J²⟩ = J² (q-1)! / N^{q-1}.
```

In the large-`N` IR limit the disorder-averaged theory becomes **emergently conformal**: the Schwarzian reparametrisation mode dominates the soft sector and the Majorana fermion acquires the universal IR conformal dimension

```
Δ_ψ = 1 / q                  (Kitaev 2015; Maldacena-Stanford 2016)
```

SYK is the prototype of holographic 1-D quantum mechanics dual to **AdS₂ dilaton gravity / JT gravity**, and saturates the Maldacena-Shenker-Stanford bound on chaos λ_L = 2π / β.

## What this PR registers

| Quantity                       | BC         | Method                                |
| ------------------------------ | ---------- | ------------------------------------- |
| `ConformalWeights`             | `Infinite` | analytic (`Δ_ψ = 1 / q` at `field=:ψ`) |

## Interface

```julia
QAtlas.fetch(SYK(),         ConformalWeights(), Infinite())            # 1//4 (default q=4)
QAtlas.fetch(SYK(; q=2),    ConformalWeights(), Infinite(); field=:ψ)  # 1//2
QAtlas.fetch(SYK(; q=6),    ConformalWeights(), Infinite(); field=:ψ)  # 1//6
QAtlas.fetch(SYK(; q=8),    ConformalWeights(), Infinite(); field=:ψ)  # 1//8
```

Returns `Rational{Int}` (exact `1 // q`).

## Constraints validated

- `q ≥ 2` and `iseven(q)` (Majorana antisymmetry — odd `q` invalid).
- `field=:ψ` is the only Phase-1-supported operator.

`q ∈ {0, 1, 3, 5}` and `field ∈ {:O, :ε, …}` all raise `DomainError` with messages pointing to the Phase-2 follow-up.

## Phase 2 deferrals

- Composite-operator dimensions (the bilinear tower `O_n = ψ ∂_τ^{2n+1} ψ` with anomalous dimensions `h_n`).
- Schwarzian zero-temperature entropy `S_0`.
- **Maximal Lyapunov exponent** `λ_L = 2π / β` saturating the Maldacena-Shenker-Stanford bound.
- JT-gravity bulk dual / out-of-time-order correlator (OTOC).

## Test plan

- [x] `SYK()` at default `q=4` returns `1//4`.
- [x] `SYK(; q=2)`, `SYK(; q=6)`, `SYK(; q=8)` return `1//2`, `1//6`, `1//8` respectively.
- [x] `field` kwarg defaults to `:ψ` (`SYK()` without kwarg returns `1//4`).
- [x] Constructor rejects `q ∈ {0, 1, 3, 5}` with `DomainError`.
- [x] `fetch` rejects `field ∈ {:O, :ε}` with `DomainError`.
- [x] All 11 standalone tests pass locally on Panza.
- [ ] CI green across all groups.

## Files

- `src/models/quantum/SYK/SYK.jl` — struct + fetch + docstrings.
- `src/models/quantum/SYK/SYK_registry.jl` — `@register` entry.
- `test/models/quantum/misc/test_syk.jl` — standalone tests.
- `src/QAtlas.jl` — `export SYK` + 2 include lines.

## References

- S. Sachdev, J. Ye, *Phys. Rev. Lett.* **70**, 3339 (1993).
- A. Kitaev, KITP talks (2015) — *A simple model of quantum holography*.
- J. Maldacena, D. Stanford, *Phys. Rev. D* **94**, 106002 (2016).

Refs #251.
