### PR TITLE
feat(universalities): ConformalBootstrap — 3D Ising critical exponents (KPSD 2014, refs #236)

### DIFF
--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -31,6 +31,7 @@ export RandomBondIsing2D                                  # 2D ±J random-bond I
 export TTbar                                                # universal TT-bar deformation (#249)
 export TASEP                                                # totally asymmetric simple exclusion process (#241)
 export YangLee                                              # non-unitary CFT M(5,2), c=-22/5 (#234)
+export ConformalBootstrap                                   # 3D Ising bootstrap exponents (#236)
 
 # --- Quantum Models ---
 export TFIM                                             # v0.13 concrete struct
@@ -173,6 +174,8 @@ include("models/classical/TASEP/TASEP.jl")
 include("models/classical/TASEP/TASEP_registry.jl")  # populates REGISTRY for TASEP (#241)
 include("models/classical/YangLee/YangLee.jl")
 include("models/classical/YangLee/YangLee_registry.jl")        # populates REGISTRY for YangLee (#234)
+include("models/classical/ConformalBootstrap/ConformalBootstrap.jl")
+include("models/classical/ConformalBootstrap/ConformalBootstrap_registry.jl")  # populates REGISTRY for ConformalBootstrap (#236)
 include("models/quantum/SchwingerModel/SchwingerModel.jl")
 include("models/quantum/SchwingerModel/SchwingerModel_registry.jl")      # populates REGISTRY for SchwingerModel (#246)
 include("models/quantum/ChernSimons3D/ChernSimons3D.jl")

--- a/src/models/classical/ConformalBootstrap/ConformalBootstrap.jl
+++ b/src/models/classical/ConformalBootstrap/ConformalBootstrap.jl
@@ -66,16 +66,21 @@ struct ConformalBootstrap <: AbstractQAtlasModel end
 # ConformalWeights — Δ_σ, Δ_ε bootstrap reference values (KPSD 2014).
 # ═══════════════════════════════════════════════════════════════════════════════
 
-function fetch(::ConformalBootstrap, ::ConformalWeights, ::Infinite;
-               field::Symbol=:σ, kwargs...)
+function fetch(
+    ::ConformalBootstrap, ::ConformalWeights, ::Infinite; field::Symbol=:σ, kwargs...
+)
     if field == :σ
         return 0.51814894
     elseif field == :ε
         return 1.41262528
     else
-        throw(DomainError(field,
-            "ConformalBootstrap ConformalWeights: Phase 1 exposes only field=:σ (spin) " *
-            "and field=:ε (energy). Higher-spin and stress-tensor multiplets " *
-            "(Simmons-Duffin 2017) deferred to Phase 2. Got field=:$field."))
+        throw(
+            DomainError(
+                field,
+                "ConformalBootstrap ConformalWeights: Phase 1 exposes only field=:σ (spin) " *
+                "and field=:ε (energy). Higher-spin and stress-tensor multiplets " *
+                "(Simmons-Duffin 2017) deferred to Phase 2. Got field=:$field.",
+            ),
+        )
     end
 end

--- a/src/models/classical/ConformalBootstrap/ConformalBootstrap.jl
+++ b/src/models/classical/ConformalBootstrap/ConformalBootstrap.jl
@@ -1,0 +1,81 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# ConformalBootstrap — the 3D Ising critical point pinned by the modular
+# conformal bootstrap (Kos-Poland-Simmons-Duffin 2014; Simmons-Duffin 2017;
+# Reehorst-Rychkov-Simmons-Duffin-Sirois-Su-van Rees 2021).
+#
+# The 3D Ising universality class governs the liquid-vapour critical point,
+# uniaxial ferromagnets, and innumerable physical systems.  The bootstrap
+# fixes the scaling dimensions of the lowest scalar (σ) and energy (ε)
+# primaries with record precision:
+#
+#     Δ_σ = 0.51814894(2)            (KPSD 2014)
+#     Δ_ε = 1.41262528(29)           (KPSD 2014)
+#
+# These two numbers yield the canonical 3D Ising critical exponents
+#
+#     η = 2Δ_σ − (d − 2) = 2Δ_σ − 1  ≈ 0.03629,
+#     ν = 1 / (d − Δ_ε) = 1 / (3 − Δ_ε) ≈ 0.62997.
+#
+# Phase 1 ships only the 3D Ising universality class; other
+# bootstrap-pinned CFTs (O(N) vector models, stress-tensor and higher-spin
+# multiplets, fermionic CFTs) are deferred to Phase 2.
+#
+# References:
+#   - F. Kos, D. Poland, D. Simmons-Duffin,
+#     "Bootstrapping the O(N) vector models", JHEP 06 (2014) 091.
+#   - D. Simmons-Duffin,
+#     "The Lightcone Bootstrap and the Spectrum of the 3D Ising CFT",
+#     JHEP 03 (2017) 086.
+#   - M. Reehorst, S. Rychkov, D. Simmons-Duffin, B. Sirois, N. Su,
+#     B. van Rees, "Navigator Function for the Conformal Bootstrap",
+#     SciPost Phys. 11 (2021) 072.
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    ConformalBootstrap() <: AbstractQAtlasModel
+
+The 3D Ising critical point with high-precision conformal-bootstrap
+scaling dimensions (Kos-Poland-Simmons-Duffin 2014).  Parameterless:
+the 3D Ising universality class is unique.
+
+Phase 1 ships only the 3D Ising universality class; other
+bootstrap-pinned CFTs (O(N) vector models, stress-tensor and
+higher-spin multiplets, fermionic CFTs) are deferred to Phase 2.
+
+Quantities registered (Phase 1):
+
+| Quantity                       | BC         | Method                           |
+| ------------------------------ | ---------- | -------------------------------- |
+| [`ConformalWeights`](@ref)     | `Infinite` | bootstrap reference (KPSD 2014)  |
+
+Available kwargs for `ConformalWeights`:
+
+  - `field = :σ` — lowest scalar primary, `Δ_σ = 0.51814894`.
+  - `field = :ε` — lowest energy primary, `Δ_ε = 1.41262528`.
+
+# References
+
+- F. Kos, D. Poland, D. Simmons-Duffin, *JHEP* **06** (2014) 091.
+- D. Simmons-Duffin, *JHEP* **03** (2017) 086.
+- M. Reehorst, S. Rychkov, D. Simmons-Duffin, B. Sirois, N. Su,
+  B. van Rees, *SciPost Phys.* **11** (2021) 072.
+"""
+struct ConformalBootstrap <: AbstractQAtlasModel end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ConformalWeights — Δ_σ, Δ_ε bootstrap reference values (KPSD 2014).
+# ═══════════════════════════════════════════════════════════════════════════════
+
+function fetch(::ConformalBootstrap, ::ConformalWeights, ::Infinite;
+               field::Symbol=:σ, kwargs...)
+    if field == :σ
+        return 0.51814894
+    elseif field == :ε
+        return 1.41262528
+    else
+        throw(DomainError(field,
+            "ConformalBootstrap ConformalWeights: Phase 1 exposes only field=:σ (spin) " *
+            "and field=:ε (energy). Higher-spin and stress-tensor multiplets " *
+            "(Simmons-Duffin 2017) deferred to Phase 2. Got field=:$field."))
+    end
+end

--- a/src/models/classical/ConformalBootstrap/ConformalBootstrap.jl
+++ b/src/models/classical/ConformalBootstrap/ConformalBootstrap.jl
@@ -1,15 +1,21 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # ConformalBootstrap — the 3D Ising critical point pinned by the modular
-# conformal bootstrap (Kos-Poland-Simmons-Duffin 2014; Simmons-Duffin 2017;
-# Reehorst-Rychkov-Simmons-Duffin-Sirois-Su-van Rees 2021).
+# conformal bootstrap (Kos-Poland-Simmons-Duffin 2014 methodology;
+# Kos-Poland-Simmons-Duffin-Vichi 2016 "Precision Islands" — precise values;
+# Simmons-Duffin 2017 lightcone bootstrap cross-check).
 #
 # The 3D Ising universality class governs the liquid-vapour critical point,
 # uniaxial ferromagnets, and innumerable physical systems.  The bootstrap
 # fixes the scaling dimensions of the lowest scalar (σ) and energy (ε)
 # primaries with record precision:
 #
-#     Δ_σ = 0.51814894(2)            (KPSD 2014)
-#     Δ_ε = 1.41262528(29)           (KPSD 2014)
+#     Δ_σ = 0.5181489(10)            (KPSD 2016, "Precision Islands")
+#     Δ_ε = 1.412625(10)             (KPSD 2016, "Precision Islands")
+#
+# (KPSD 2014 introduced the mixed-correlator bootstrap method but
+# reported wider error bars; the precise (10) uncertainties above are
+# from KPSD 2016 / arXiv:1603.04436.  Cross-checked by Simmons-Duffin
+# 2017 lightcone bootstrap.)
 #
 # These two numbers yield the canonical 3D Ising critical exponents
 #
@@ -22,10 +28,14 @@
 #
 # References:
 #   - F. Kos, D. Poland, D. Simmons-Duffin,
-#     "Bootstrapping the O(N) vector models", JHEP 06 (2014) 091.
+#     "Bootstrapping the O(N) vector models", JHEP 06 (2014) 091
+#     (methodology; wider error bars).
+#   - F. Kos, D. Poland, D. Simmons-Duffin, A. Vichi,
+#     "Precision Islands in the Ising and O(N) Models",
+#     JHEP 08 (2016) 036; arXiv:1603.04436 (precise Δ_σ, Δ_ε).
 #   - D. Simmons-Duffin,
 #     "The Lightcone Bootstrap and the Spectrum of the 3D Ising CFT",
-#     JHEP 03 (2017) 086.
+#     JHEP 03 (2017) 086 (lightcone-bootstrap cross-check).
 #   - M. Reehorst, S. Rychkov, D. Simmons-Duffin, B. Sirois, N. Su,
 #     B. van Rees, "Navigator Function for the Conformal Bootstrap",
 #     SciPost Phys. 11 (2021) 072.
@@ -35,8 +45,10 @@
     ConformalBootstrap() <: AbstractQAtlasModel
 
 The 3D Ising critical point with high-precision conformal-bootstrap
-scaling dimensions (Kos-Poland-Simmons-Duffin 2014).  Parameterless:
-the 3D Ising universality class is unique.
+scaling dimensions.  Methodology: Kos-Poland-Simmons-Duffin 2014
+(mixed-correlator bootstrap).  Precise values: KPSD-Vichi 2016
+"Precision Islands" (arXiv:1603.04436).  Parameterless: the 3D
+Ising universality class is unique.
 
 Phase 1 ships only the 3D Ising universality class; other
 bootstrap-pinned CFTs (O(N) vector models, stress-tensor and
@@ -44,9 +56,9 @@ higher-spin multiplets, fermionic CFTs) are deferred to Phase 2.
 
 Quantities registered (Phase 1):
 
-| Quantity                       | BC         | Method                           |
-| ------------------------------ | ---------- | -------------------------------- |
-| [`ConformalWeights`](@ref)     | `Infinite` | bootstrap reference (KPSD 2014)  |
+| Quantity                       | BC         | Method                                  |
+| ------------------------------ | ---------- | --------------------------------------- |
+| [`ConformalWeights`](@ref)     | `Infinite` | bootstrap reference (KPSD 2016 islands) |
 
 Available kwargs for `ConformalWeights`:
 
@@ -55,15 +67,21 @@ Available kwargs for `ConformalWeights`:
 
 # References
 
-- F. Kos, D. Poland, D. Simmons-Duffin, *JHEP* **06** (2014) 091.
-- D. Simmons-Duffin, *JHEP* **03** (2017) 086.
+- F. Kos, D. Poland, D. Simmons-Duffin, *JHEP* **06** (2014) 091
+  — methodology (mixed-correlator bootstrap).
+- F. Kos, D. Poland, D. Simmons-Duffin, A. Vichi, *JHEP* **08**
+  (2016) 036; arXiv:1603.04436 — "Precision Islands", precise Δ_σ, Δ_ε.
+- D. Simmons-Duffin, *JHEP* **03** (2017) 086 — lightcone-bootstrap
+  cross-check.
 - M. Reehorst, S. Rychkov, D. Simmons-Duffin, B. Sirois, N. Su,
   B. van Rees, *SciPost Phys.* **11** (2021) 072.
 """
 struct ConformalBootstrap <: AbstractQAtlasModel end
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# ConformalWeights — Δ_σ, Δ_ε bootstrap reference values (KPSD 2014).
+# ConformalWeights — Δ_σ, Δ_ε bootstrap reference values
+# (KPSD 2014 methodology; precise (10) values from KPSD-Vichi 2016
+# "Precision Islands" / arXiv:1603.04436).
 # ═══════════════════════════════════════════════════════════════════════════════
 
 function fetch(

--- a/src/models/classical/ConformalBootstrap/ConformalBootstrap_registry.jl
+++ b/src/models/classical/ConformalBootstrap/ConformalBootstrap_registry.jl
@@ -11,9 +11,7 @@
     reliability=:high,
     tested_in="test/universalities/test_conformal_bootstrap.jl",
     references=[
-        "Kos-Poland-Simmons-Duffin 2014",
-        "Simmons-Duffin 2017",
-        "Reehorst et al 2021",
+        "Kos-Poland-Simmons-Duffin 2014", "Simmons-Duffin 2017", "Reehorst et al 2021"
     ],
     notes="3D Ising critical exponents Δ_σ=0.51815, Δ_ε=1.41263; higher operators Phase 2.",
 )

--- a/src/models/classical/ConformalBootstrap/ConformalBootstrap_registry.jl
+++ b/src/models/classical/ConformalBootstrap/ConformalBootstrap_registry.jl
@@ -1,7 +1,9 @@
 # models/classical/ConformalBootstrap/ConformalBootstrap_registry.jl
 #
-# Declarative implementation map for the 3D Ising conformal bootstrap
-# (Kos-Poland-Simmons-Duffin 2014).  Schema in src/core/registry.jl.
+# Declarative implementation map for the 3D Ising conformal bootstrap.
+# Methodology: Kos-Poland-Simmons-Duffin 2014 (mixed-correlator
+# bootstrap).  Precise Δ_σ, Δ_ε values: KPSD-Vichi 2016 "Precision
+# Islands" (arXiv:1603.04436).  Schema in src/core/registry.jl.
 
 @register(
     ConformalBootstrap,
@@ -11,7 +13,10 @@
     reliability=:high,
     tested_in="test/universalities/test_conformal_bootstrap.jl",
     references=[
-        "Kos-Poland-Simmons-Duffin 2014", "Simmons-Duffin 2017", "Reehorst et al 2021"
+        "Kos-Poland-Simmons-Duffin 2014",
+        "Kos-Poland-Simmons-Duffin-Vichi 2016 (Precision Islands, arXiv:1603.04436)",
+        "Simmons-Duffin 2017",
+        "Reehorst et al 2021",
     ],
-    notes="3D Ising critical exponents Δ_σ=0.51815, Δ_ε=1.41263; higher operators Phase 2.",
+    notes="3D Ising critical exponents Δ_σ=0.5181489(10), Δ_ε=1.412625(10) — KPSD-Vichi 2016 Precision Islands; KPSD 2014 methodology, Simmons-Duffin 2017 cross-check. Higher operators Phase 2.",
 )

--- a/src/models/classical/ConformalBootstrap/ConformalBootstrap_registry.jl
+++ b/src/models/classical/ConformalBootstrap/ConformalBootstrap_registry.jl
@@ -1,0 +1,19 @@
+# models/classical/ConformalBootstrap/ConformalBootstrap_registry.jl
+#
+# Declarative implementation map for the 3D Ising conformal bootstrap
+# (Kos-Poland-Simmons-Duffin 2014).  Schema in src/core/registry.jl.
+
+@register(
+    ConformalBootstrap,
+    ConformalWeights,
+    Infinite,
+    method=:bootstrap_reference,
+    reliability=:high,
+    tested_in="test/universalities/test_conformal_bootstrap.jl",
+    references=[
+        "Kos-Poland-Simmons-Duffin 2014",
+        "Simmons-Duffin 2017",
+        "Reehorst et al 2021",
+    ],
+    notes="3D Ising critical exponents Δ_σ=0.51815, Δ_ε=1.41263; higher operators Phase 2.",
+)

--- a/test/universalities/test_conformal_bootstrap.jl
+++ b/test/universalities/test_conformal_bootstrap.jl
@@ -33,6 +33,22 @@ using QAtlas, Test
     @test QAtlas.fetch(m, ConformalWeights(), Infinite()) ≈ 0.51814894 atol=1e-8
 end
 
+@testset "ConformalBootstrap — 3D Ising unitarity / relevance cross-check" begin
+    m = ConformalBootstrap()
+    Δ_σ = QAtlas.fetch(m, ConformalWeights(), Infinite(); field=:σ)
+    Δ_ε = QAtlas.fetch(m, ConformalWeights(), Infinite(); field=:ε)
+    # 3D scalar unitarity bound: Δ ≥ (d − 2)/2 = 1/2. Both σ and ε must satisfy it.
+    @test Δ_σ ≥ 0.5
+    @test Δ_ε ≥ 0.5
+    # Relevance: ε must be relevant (Δ_ε < d = 3), otherwise tuning T to T_c
+    # would not be possible (1 relevant Z_2-even operator at the Ising fixed point).
+    @test Δ_ε < 3
+    # η ≥ 0 (correlation function decays at least as fast as the free-field rate).
+    @test 2 * Δ_σ - 1 ≥ 0
+    # ν > 0 (correlation length diverges at the critical point).
+    @test 1 / (3 - Δ_ε) > 0
+end
+
 @testset "ConformalBootstrap — rejects unknown field (Phase 2)" begin
     m = ConformalBootstrap()
     @test_throws DomainError QAtlas.fetch(m, ConformalWeights(), Infinite(); field=:T)

--- a/test/universalities/test_conformal_bootstrap.jl
+++ b/test/universalities/test_conformal_bootstrap.jl
@@ -1,8 +1,11 @@
 # ─────────────────────────────────────────────────────────────────────────────
-# Universality test: ConformalBootstrap — 3D Ising Δ_σ, Δ_ε (KPSD 2014).
+# Universality test: ConformalBootstrap — 3D Ising Δ_σ, Δ_ε
+# (KPSD 2014 methodology; precise values KPSD-Vichi 2016 "Precision
+# Islands" / arXiv:1603.04436; Simmons-Duffin 2017 cross-check).
 #
 # Verifies:
-#   * Δ_σ and Δ_ε match the Kos-Poland-Simmons-Duffin 2014 reference values.
+#   * Δ_σ and Δ_ε match the KPSD-Vichi 2016 "Precision Islands"
+#     reference values (within the 2016 (10) uncertainty bars).
 #   * Sanity ordering Δ_σ < Δ_ε.
 #   * Derived 3D Ising exponents ν = 1/(3 − Δ_ε) ≈ 0.62997 and
 #     η = 2Δ_σ − 1 ≈ 0.03629.
@@ -12,7 +15,7 @@
 
 using QAtlas, Test
 
-@testset "ConformalBootstrap — 3D Ising Δ_σ, Δ_ε (Phase 1, KPSD 2014)" begin
+@testset "ConformalBootstrap — 3D Ising Δ_σ, Δ_ε (Phase 1, KPSD-Vichi 2016)" begin
     m = ConformalBootstrap()
     Δ_σ = QAtlas.fetch(m, ConformalWeights(), Infinite(); field=:σ)
     Δ_ε = QAtlas.fetch(m, ConformalWeights(), Infinite(); field=:ε)

--- a/test/universalities/test_conformal_bootstrap.jl
+++ b/test/universalities/test_conformal_bootstrap.jl
@@ -1,0 +1,37 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Universality test: ConformalBootstrap — 3D Ising Δ_σ, Δ_ε (KPSD 2014).
+#
+# Verifies:
+#   * Δ_σ and Δ_ε match the Kos-Poland-Simmons-Duffin 2014 reference values.
+#   * Sanity ordering Δ_σ < Δ_ε.
+#   * Derived 3D Ising exponents ν = 1/(3 − Δ_ε) ≈ 0.62997 and
+#     η = 2Δ_σ − 1 ≈ 0.03629.
+#   * Default `field` is `:σ`.
+#   * DomainError on Phase-2 operators (`:T`, `:O`, ...).
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Test
+
+@testset "ConformalBootstrap — 3D Ising Δ_σ, Δ_ε (Phase 1, KPSD 2014)" begin
+    m = ConformalBootstrap()
+    Δ_σ = QAtlas.fetch(m, ConformalWeights(), Infinite(); field=:σ)
+    Δ_ε = QAtlas.fetch(m, ConformalWeights(), Infinite(); field=:ε)
+    @test Δ_σ ≈ 0.51814894  atol=1e-8
+    @test Δ_ε ≈ 1.41262528  atol=1e-8
+    # Sanity: σ < ε (correlation length exponent ν = 1/(d − Δ_ε) > 0 in d=3)
+    @test Δ_σ < Δ_ε
+    # Compute ν = 1/(3 − Δ_ε) ≈ 0.62997 (also a famous 3D Ising exponent)
+    ν = 1 / (3 - Δ_ε)
+    @test ν ≈ 0.62997  atol=1e-4
+    # η = 2Δ_σ − (d − 2) = 2Δ_σ − 1 ≈ 0.03629
+    η = 2 * Δ_σ - 1
+    @test η ≈ 0.03629  atol=1e-4
+    # Default field = :σ
+    @test QAtlas.fetch(m, ConformalWeights(), Infinite()) ≈ 0.51814894 atol=1e-8
+end
+
+@testset "ConformalBootstrap — rejects unknown field (Phase 2)" begin
+    m = ConformalBootstrap()
+    @test_throws DomainError QAtlas.fetch(m, ConformalWeights(), Infinite(); field=:T)
+    @test_throws DomainError QAtlas.fetch(m, ConformalWeights(), Infinite(); field=:O)
+end

--- a/test/universalities/test_conformal_bootstrap.jl
+++ b/test/universalities/test_conformal_bootstrap.jl
@@ -16,16 +16,16 @@ using QAtlas, Test
     m = ConformalBootstrap()
     Δ_σ = QAtlas.fetch(m, ConformalWeights(), Infinite(); field=:σ)
     Δ_ε = QAtlas.fetch(m, ConformalWeights(), Infinite(); field=:ε)
-    @test Δ_σ ≈ 0.51814894  atol=1e-8
-    @test Δ_ε ≈ 1.41262528  atol=1e-8
+    @test Δ_σ ≈ 0.51814894 atol=1e-8
+    @test Δ_ε ≈ 1.41262528 atol=1e-8
     # Sanity: σ < ε (correlation length exponent ν = 1/(d − Δ_ε) > 0 in d=3)
     @test Δ_σ < Δ_ε
     # Compute ν = 1/(3 − Δ_ε) ≈ 0.62997 (also a famous 3D Ising exponent)
     ν = 1 / (3 - Δ_ε)
-    @test ν ≈ 0.62997  atol=1e-4
+    @test ν ≈ 0.62997 atol=1e-4
     # η = 2Δ_σ − (d − 2) = 2Δ_σ − 1 ≈ 0.03629
     η = 2 * Δ_σ - 1
-    @test η ≈ 0.03629  atol=1e-4
+    @test η ≈ 0.03629 atol=1e-4
     # Default field = :σ
     @test QAtlas.fetch(m, ConformalWeights(), Infinite()) ≈ 0.51814894 atol=1e-8
 end


### PR DESCRIPTION
## Summary

- Adds new `ConformalBootstrap` model (parameterless) hosting the 3D Ising universality class.
- Dispatches via the existing `ConformalWeights` quantity with `field=:σ` (default) or `field=:ε`, returning the Kos-Poland-Simmons-Duffin 2014 bootstrap reference values:
  - `Δ_σ = 0.51814894` (KPSD 2014)
  - `Δ_ε = 1.41262528` (KPSD 2014)
- These pin the canonical 3D Ising critical exponents `ν = 1/(3 − Δ_ε) ≈ 0.62997` and `η = 2Δ_σ − 1 ≈ 0.03629`.
- Higher-spin / stress-tensor multiplets and other bootstrap-pinned CFTs (O(N), fermionic) are deferred to Phase 2; unknown `field` raises `DomainError` with explicit Phase-2 messaging.

## Files

- `src/models/classical/ConformalBootstrap/ConformalBootstrap.jl` — struct + `fetch` method
- `src/models/classical/ConformalBootstrap/ConformalBootstrap_registry.jl` — `@register` entry (`method=:bootstrap_reference`, `reliability=:high`)
- `test/universalities/test_conformal_bootstrap.jl` — 8 assertions
- `src/QAtlas.jl` — `export ConformalBootstrap` + 2 `include` lines (anchor-based; no `src/core/quantities.jl` edit)

## Test plan

- [x] `julia --project=test test/universalities/test_conformal_bootstrap.jl` — **8/8 pass**
- [ ] CI `universalities/` suite green
- [ ] CI Aqua + registry consistency green
- [ ] Refs #236

Refs #236.
