### PR TITLE
feat(classical): ZnClock — 2D Z_n clock model (Phase 1: n=2,3 minimal-model delegates, refs #231)

### DIFF
--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -32,6 +32,7 @@ export TTbar                                                # universal TT-bar d
 export TASEP                                                # totally asymmetric simple exclusion process (#241)
 export YangLee                                              # non-unitary CFT M(5,2), c=-22/5 (#234)
 export ConformalBootstrap                                   # 3D Ising bootstrap exponents (#236)
+export ZnClock                                              # 2D Z_n clock model (#231)
 
 # --- Quantum Models ---
 export TFIM                                             # v0.13 concrete struct
@@ -178,6 +179,8 @@ include("models/classical/YangLee/YangLee.jl")
 include("models/classical/YangLee/YangLee_registry.jl")        # populates REGISTRY for YangLee (#234)
 include("models/classical/ConformalBootstrap/ConformalBootstrap.jl")
 include("models/classical/ConformalBootstrap/ConformalBootstrap_registry.jl")  # populates REGISTRY for ConformalBootstrap (#236)
+include("models/classical/ZnClock/ZnClock.jl")
+include("models/classical/ZnClock/ZnClock_registry.jl")  # populates REGISTRY for ZnClock (#231)
 include("models/quantum/SchwingerModel/SchwingerModel.jl")
 include("models/quantum/SchwingerModel/SchwingerModel_registry.jl")      # populates REGISTRY for SchwingerModel (#246)
 include("models/quantum/ChernSimons3D/ChernSimons3D.jl")

--- a/src/models/classical/ZnClock/ZnClock.jl
+++ b/src/models/classical/ZnClock/ZnClock.jl
@@ -1,0 +1,111 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# ZnClock — 2-D Z_n clock model (n-state generalisation of the Ising,
+# 3-state Potts, and XY universality classes).
+#
+#     H = -J Σ_{<i,j>} cos(2π (σ_i − σ_j) / n),    σ_i ∈ {0, …, n − 1},  J > 0.
+#
+# Phase diagram (José-Kadanoff-Kirkpatrick-Nelson 1977;
+# Elitzur-Pearson-Shigemitsu 1979):
+#
+#   - n = 2:       identical to the 2-D Ising model (c = 1/2).
+#   - n = 3:       identical to the 2-D 3-state Potts model (c = 4/5).
+#   - n = 4:       Ashkin-Teller line — continuous family of c = 1 CFTs
+#                  parameterised by a marginal coupling.
+#   - n ≥ 5:       an intermediate massless XY-like BKT phase appears between
+#                  the low-T ordered and high-T disordered phases, bounded by
+#                  two BKT transitions (José et al. 1977); the critical line
+#                  carries a continuous family of c = 1 CFTs.
+#   - n → ∞:       reduces to the classical XY model (BKT transition, c = 1).
+#
+# Phase-1 scope: closed-form `CentralCharge` for n = 2 and n = 3 via
+# delegation to the already-implemented Virasoro minimal models
+# `MinimalModel(4, 3)` (Ising) and `MinimalModel(6, 5)` (3-state Potts).
+# n = 4 (Ashkin-Teller line) and n ≥ 5 (BKT line) require a coupling
+# specification to pick a CFT out of the c = 1 family and are deferred to
+# Phase 2; the corresponding branches throw a descriptive `DomainError`.
+#
+# References:
+#   - J. V. José, L. P. Kadanoff, S. Kirkpatrick, D. R. Nelson,
+#     Phys. Rev. B 16, 1217 (1977).
+#   - S. Elitzur, R. B. Pearson, J. Shigemitsu, Phys. Rev. D 19, 3698 (1979).
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    ZnClock(n::Integer) <: AbstractQAtlasModel
+    ZnClock(; n::Integer=2)
+
+2-D Z_n clock model with `n` clock states.
+
+Phase-1 quantities:
+
+| Quantity                | BC         | Method                                 |
+| ----------------------- | ---------- | -------------------------------------- |
+| [`CentralCharge`](@ref) | `Infinite` | delegated to `MinimalModel` (n = 2, 3) |
+
+For n ≥ 4 the critical theory is a continuous family of c = 1 CFTs
+(Ashkin-Teller for n = 4; intermediate BKT phase for n ≥ 5) whose
+selection requires a coupling parameter; these branches throw a
+`DomainError` and are deferred to Phase 2.
+
+# References
+
+- J. V. José, L. P. Kadanoff, S. Kirkpatrick, D. R. Nelson,
+  *Phys. Rev. B* **16**, 1217 (1977).
+- S. Elitzur, R. B. Pearson, J. Shigemitsu,
+  *Phys. Rev. D* **19**, 3698 (1979).
+"""
+struct ZnClock <: AbstractQAtlasModel
+    n::Int
+    function ZnClock(n::Integer)
+        n ≥ 2 || throw(DomainError(n, "ZnClock requires n ≥ 2; got n = $n."))
+        return new(Int(n))
+    end
+end
+ZnClock(; n::Integer=2) = ZnClock(n)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Central charge via MinimalModel delegation (n = 2, 3 only)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    fetch(m::ZnClock, ::CentralCharge, ::Infinite; n::Integer=m.n, kwargs...)
+        -> Rational{Int}
+
+Central charge of the 2-D Z_n clock model, currently supported for
+n = 2 and n = 3 via delegation:
+
+  - n = 2: `MinimalModel(4, 3)` → c = 1/2 (Ising universality).
+  - n = 3: `MinimalModel(6, 5)` → c = 4/5 (3-state Potts universality).
+
+For n = 4 (Ashkin-Teller line) and n ≥ 5 (intermediate BKT phase) the
+critical theory is a *continuous family* of c = 1 CFTs and selecting a
+particular member requires a coupling; those branches throw a
+`DomainError` and are deferred to Phase 2.
+
+# References
+
+- J. V. José, L. P. Kadanoff, S. Kirkpatrick, D. R. Nelson,
+  *Phys. Rev. B* **16**, 1217 (1977).
+- S. Elitzur, R. B. Pearson, J. Shigemitsu,
+  *Phys. Rev. D* **19**, 3698 (1979).
+"""
+function fetch(m::ZnClock, ::CentralCharge, ::Infinite; n::Integer=m.n, kwargs...)
+    n ≥ 2 || throw(DomainError(n, "ZnClock CentralCharge requires n ≥ 2; got n = $n."))
+    if n == 2
+        # Z_2 = Ising universality.
+        return QAtlas.fetch(QAtlas.MinimalModel(4, 3), CentralCharge())
+    elseif n == 3
+        # Z_3 = 3-state Potts universality.
+        return QAtlas.fetch(QAtlas.MinimalModel(6, 5), CentralCharge())
+    elseif n == 4
+        throw(DomainError(n,
+            "ZnClock CentralCharge: n = 4 (Ashkin-Teller line, continuous family of " *
+            "c = 1 CFTs) requires coupling specification (Kadanoff-Brown 1979). " *
+            "Deferred to Phase 2."))
+    else  # n ≥ 5
+        throw(DomainError(n,
+            "ZnClock CentralCharge: n ≥ 5 (intermediate BKT phase, José-Kadanoff-" *
+            "Kirkpatrick-Nelson 1977) has a critical line of c = 1 CFTs between " *
+            "the low-T ordered and high-T disordered phases. Deferred to Phase 2."))
+    end
+end

--- a/src/models/classical/ZnClock/ZnClock.jl
+++ b/src/models/classical/ZnClock/ZnClock.jl
@@ -98,14 +98,22 @@ function fetch(m::ZnClock, ::CentralCharge, ::Infinite; n::Integer=m.n, kwargs..
         # Z_3 = 3-state Potts universality.
         return QAtlas.fetch(QAtlas.MinimalModel(6, 5), CentralCharge())
     elseif n == 4
-        throw(DomainError(n,
-            "ZnClock CentralCharge: n = 4 (Ashkin-Teller line, continuous family of " *
-            "c = 1 CFTs) requires coupling specification (Kadanoff-Brown 1979). " *
-            "Deferred to Phase 2."))
+        throw(
+            DomainError(
+                n,
+                "ZnClock CentralCharge: n = 4 (Ashkin-Teller line, continuous family of " *
+                "c = 1 CFTs) requires coupling specification (Kadanoff-Brown 1979). " *
+                "Deferred to Phase 2.",
+            ),
+        )
     else  # n ≥ 5
-        throw(DomainError(n,
-            "ZnClock CentralCharge: n ≥ 5 (intermediate BKT phase, José-Kadanoff-" *
-            "Kirkpatrick-Nelson 1977) has a critical line of c = 1 CFTs between " *
-            "the low-T ordered and high-T disordered phases. Deferred to Phase 2."))
+        throw(
+            DomainError(
+                n,
+                "ZnClock CentralCharge: n ≥ 5 (intermediate BKT phase, José-Kadanoff-" *
+                "Kirkpatrick-Nelson 1977) has a critical line of c = 1 CFTs between " *
+                "the low-T ordered and high-T disordered phases. Deferred to Phase 2.",
+            ),
+        )
     end
 end

--- a/src/models/classical/ZnClock/ZnClock_registry.jl
+++ b/src/models/classical/ZnClock/ZnClock_registry.jl
@@ -1,0 +1,15 @@
+# models/classical/ZnClock/ZnClock_registry.jl
+#
+# Declarative implementation map for the 2-D Z_n clock model.
+# Schema in src/core/registry.jl.
+
+@register(
+    ZnClock,
+    CentralCharge,
+    Infinite,
+    method=:delegation,
+    reliability=:high,
+    tested_in="test/universalities/test_zn_clock.jl",
+    references=["José-Kadanoff-Kirkpatrick-Nelson 1977", "Elitzur-Pearson-Shigemitsu 1979"],
+    notes="n=2 (Ising c=1/2) and n=3 (Potts c=4/5) delegate to MinimalModel; n≥4 (Ashkin-Teller/BKT line) Phase 2.",
+)

--- a/test/universalities/test_zn_clock.jl
+++ b/test/universalities/test_zn_clock.jl
@@ -1,0 +1,29 @@
+using QAtlas, Test
+
+@testset "ZnClock — n=2 Ising universality (Phase 1)" begin
+    @test QAtlas.fetch(ZnClock(; n=2), CentralCharge(), Infinite()) == 1 // 2
+    # Default constructor
+    @test QAtlas.fetch(ZnClock(), CentralCharge(), Infinite()) == 1 // 2
+    # Delegation invariant
+    @test QAtlas.fetch(ZnClock(; n=2), CentralCharge(), Infinite()) ==
+          QAtlas.fetch(QAtlas.MinimalModel(4, 3), CentralCharge())
+end
+
+@testset "ZnClock — n=3 Potts universality (Phase 1)" begin
+    @test QAtlas.fetch(ZnClock(; n=3), CentralCharge(), Infinite()) == 4 // 5
+    @test QAtlas.fetch(ZnClock(; n=3), CentralCharge(), Infinite()) ==
+          QAtlas.fetch(QAtlas.MinimalModel(6, 5), CentralCharge())
+end
+
+@testset "ZnClock — n ≥ 4 throws DomainError (Phase 2 deferral)" begin
+    @test_throws DomainError QAtlas.fetch(ZnClock(; n=4), CentralCharge(), Infinite())
+    @test_throws DomainError QAtlas.fetch(ZnClock(; n=5), CentralCharge(), Infinite())
+    @test_throws DomainError QAtlas.fetch(ZnClock(; n=6), CentralCharge(), Infinite())
+    @test_throws DomainError QAtlas.fetch(ZnClock(; n=100), CentralCharge(), Infinite())
+end
+
+@testset "ZnClock — rejects n < 2 (Phase 1)" begin
+    @test_throws DomainError ZnClock(; n=1)
+    @test_throws DomainError ZnClock(; n=0)
+    @test_throws DomainError ZnClock(; n=-1)
+end

--- a/test/universalities/test_zn_clock.jl
+++ b/test/universalities/test_zn_clock.jl
@@ -6,13 +6,13 @@ using QAtlas, Test
     @test QAtlas.fetch(ZnClock(), CentralCharge(), Infinite()) == 1 // 2
     # Delegation invariant
     @test QAtlas.fetch(ZnClock(; n=2), CentralCharge(), Infinite()) ==
-          QAtlas.fetch(QAtlas.MinimalModel(4, 3), CentralCharge())
+        QAtlas.fetch(QAtlas.MinimalModel(4, 3), CentralCharge())
 end
 
 @testset "ZnClock — n=3 Potts universality (Phase 1)" begin
     @test QAtlas.fetch(ZnClock(; n=3), CentralCharge(), Infinite()) == 4 // 5
     @test QAtlas.fetch(ZnClock(; n=3), CentralCharge(), Infinite()) ==
-          QAtlas.fetch(QAtlas.MinimalModel(6, 5), CentralCharge())
+        QAtlas.fetch(QAtlas.MinimalModel(6, 5), CentralCharge())
 end
 
 @testset "ZnClock — n ≥ 4 throws DomainError (Phase 2 deferral)" begin


### PR DESCRIPTION
## Summary

New classical model: **ZnClock** — the 2-D Z_n clock model
(n-state generalisation of Ising / 3-state Potts / XY universality):

```
H = -J Σ_{<i,j>} cos(2π (σ_i − σ_j) / n),    σ_i ∈ {0, …, n − 1},  J > 0.
```

Phase 1 wires closed-form `CentralCharge` for the two values of `n` whose
critical theory is an isolated rational CFT, by delegation to the
already-implemented Virasoro minimal models:

| n | universality      | delegate             | c   |
|---|-------------------|----------------------|-----|
| 2 | 2-D Ising         | `MinimalModel(4, 3)` | 1/2 |
| 3 | 2-D 3-state Potts | `MinimalModel(6, 5)` | 4/5 |

Branches for n = 4 (Ashkin-Teller line) and n ≥ 5 (intermediate BKT
phase between low-T ordered and high-T disordered phases,
José-Kadanoff-Kirkpatrick-Nelson 1977) throw a descriptive
`DomainError` and are deferred to Phase 2 — the critical theory there
is a continuous family of c = 1 CFTs and requires coupling input.

Construction-time guard rejects `n < 2`.

## Files

- `src/models/classical/ZnClock/ZnClock.jl`
- `src/models/classical/ZnClock/ZnClock_registry.jl`
- `test/universalities/test_zn_clock.jl`
- `src/QAtlas.jl` (export + 2 include lines)

`src/core/quantities.jl` is untouched (`CentralCharge` already exported).

## Test plan

- [x] `julia --project=test test/universalities/test_zn_clock.jl` — 12/12 pass on Panza
  - `ZnClock — n=2 Ising universality (Phase 1)` (3/3)
  - `ZnClock — n=3 Potts universality (Phase 1)` (2/2)
  - `ZnClock — n ≥ 4 throws DomainError (Phase 2 deferral)` (4/4)
  - `ZnClock — rejects n < 2 (Phase 1)` (3/3)
- [ ] Full CI green (Aqua + downstream)

## References

- J. V. José, L. P. Kadanoff, S. Kirkpatrick, D. R. Nelson, *Phys. Rev. B* **16**, 1217 (1977).
- S. Elitzur, R. B. Pearson, J. Shigemitsu, *Phys. Rev. D* **19**, 3698 (1979).

Refs #231.
