### PR TITLE
infra(docs): enable jldoctest + pilot 3 doctest blocks

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -133,7 +133,10 @@ logo_path = joinpath(assets_dir, "logo.png")
 Downloads.download("https://github.com/sotashimozono.png", favicon_path)
 Downloads.download("https://github.com/sotashimozono.png", logo_path)
 
+DocMeta.setdocmeta!(QAtlas, :DocTestSetup, :(using QAtlas); recursive=true)
+
 makedocs(;
+    doctest=true,
     sitename="QAtlas.jl",
     repo=Remotes.GitHub("sotashimozono", "QAtlas.jl"),
     format=Documenter.HTML(;

--- a/src/models/quantum/MajumdarGhosh/MajumdarGhosh.jl
+++ b/src/models/quantum/MajumdarGhosh/MajumdarGhosh.jl
@@ -101,6 +101,13 @@ beyond the standard surface.
 # References
 
 - C. K. Majumdar, D. K. Ghosh, J. Math. Phys. **10**, 1388 (1969).
+
+# Example
+
+```jldoctest
+julia> QAtlas.fetch(MajumdarGhosh(), GroundStateEnergyDensity(), Infinite())
+-0.375
+```
 """
 function fetch(m::MajumdarGhosh, ::GroundStateEnergyDensity, ::Infinite; kwargs...)
     return -3 * m.J / 8

--- a/src/models/quantum/TFIM/TFIM.jl
+++ b/src/models/quantum/TFIM/TFIM.jl
@@ -230,6 +230,13 @@ Central charge of the TFIM:
 - `c = 0`   in either gapped phase (`h ≠ J`) — no low-energy CFT description
 
 Criticality is detected by `|h/J - 1| ≤ 1e-6`.
+
+# Example
+
+```jldoctest
+julia> QAtlas.fetch(TFIM(), CentralCharge(), Infinite())
+0.5
+```
 """
 function fetch(model::TFIM, ::CentralCharge, ::Infinite; kwargs...)
     return abs(model.h / model.J - 1.0) ≤ 1e-6 ? 0.5 : 0.0

--- a/src/models/quantum/ToricCode/ToricCode.jl
+++ b/src/models/quantum/ToricCode/ToricCode.jl
@@ -176,6 +176,13 @@ entanglement entropy on a simply-connected region,
     S(ρ_A) = α |∂A| − γ + O(|∂A|⁻¹).
 
 Independent of `J_e`, `J_m` (purely topological).
+
+# Example
+
+```jldoctest
+julia> QAtlas.fetch(ToricCode(), TopologicalEntanglementEntropy(), Infinite())
+0.6931471805599453
+```
 """
 function fetch(::ToricCode, ::TopologicalEntanglementEntropy, ::Infinite; kwargs...)
     return log(2.0)


### PR DESCRIPTION
## Summary

Bootstraps Documenter's doctest infrastructure for QAtlas.jl. Minimal, focused change.

### Changes

- \`docs/make.jl\`: enables \`doctest=true\` in the **second** \`makedocs(...)\` (the one that wins — see #353 about the duplicated block). Adds \`DocMeta.setdocmeta!(QAtlas, :DocTestSetup, :(using QAtlas); recursive=true)\` so doctest blocks can use bare names like \`MajumdarGhosh()\`, \`Infinite()\`, etc.
- Adds 3 pilot \`jldoctest\` blocks as a demonstration; future PRs can convert more docstrings:
  - \`MajumdarGhosh\` / \`GroundStateEnergyDensity\` / \`Infinite\` → \`-0.375\`
  - \`TFIM\` / \`CentralCharge\` / \`Infinite\` → \`0.5\` (at default critical point \`h = J = 1\`)
  - \`ToricCode\` / \`TopologicalEntanglementEntropy\` / \`Infinite\` → \`0.6931471805599453\` (= \`log(2.0)\`)

### Notes

- Doctest blocks use \`QAtlas.fetch(...)\` explicitly because bare \`fetch\` clashes with \`Base.fetch\` at the doctest REPL scope (Julia raises an ambiguity hint).
- Catches the kind of rot we saw in #333 (FibonacciAnyons docstring numeric value mismatch with implementation) — \`doctest=true\` will now fail CI when a docstring example disagrees with the function output.
- Doctests add **~28 seconds** to the docs build on Panza (\`Documenter.doctest(QAtlas)\` measured: 27.98 s).
- The duplicate \`makedocs\` block in \`docs/make.jl\` is **intentionally left alone** here — see #353 for the dedup tracking issue. We only touched the second (deployed) block.

### Verification

\`\`\`
julia --project=docs -e 'using QAtlas, Documenter; \
  DocMeta.setdocmeta!(QAtlas, :DocTestSetup, :(using QAtlas); recursive=true); \
  Documenter.doctest(QAtlas)'
# => Test Summary: Doctests: QAtlas | 1 Pass, 22.3s (excl. precompile)
\`\`\`

Refs #353.
