### PR TITLE
chore(release): v0.20.0 — 30+ new models, Phase 2 expansions, CI infra

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.19.17"
+version = "0.20.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,6 +2,8 @@ using QAtlas
 using Documenter
 using Downloads
 
+DocMeta.setdocmeta!(QAtlas, :DocTestSetup, :(using QAtlas); recursive=true)
+
 assets_dir = joinpath(@__DIR__, "src", "assets")
 mkpath(assets_dir)
 favicon_path = joinpath(assets_dir, "favicon.ico")
@@ -23,8 +25,8 @@ makedocs(;
         # ~80 new fetch methods).  Bump the size threshold instead of
         # splitting the autodocs page (the user explicitly preserved the
         # `Modules = [QAtlas]` API layout).
-        size_threshold=600_000,
-        size_threshold_warn=300_000,
+        size_threshold=1_000_000,
+        size_threshold_warn=600_000,
         mathengine=MathJax3(
             Dict(
                 :tex => Dict(
@@ -133,8 +135,6 @@ logo_path = joinpath(assets_dir, "logo.png")
 Downloads.download("https://github.com/sotashimozono.png", favicon_path)
 Downloads.download("https://github.com/sotashimozono.png", logo_path)
 
-DocMeta.setdocmeta!(QAtlas, :DocTestSetup, :(using QAtlas); recursive=true)
-
 makedocs(;
     doctest=true,
     sitename="QAtlas.jl",
@@ -149,8 +149,8 @@ makedocs(;
         # ~80 new fetch methods).  Bump the size threshold instead of
         # splitting the autodocs page (the user explicitly preserved the
         # `Modules = [QAtlas]` API layout).
-        size_threshold=600_000,
-        size_threshold_warn=300_000,
+        size_threshold=1_000_000,
+        size_threshold_warn=600_000,
         mathengine=MathJax3(
             Dict(
                 :tex => Dict(

--- a/src/models/classical/TricriticalPotts3/TricriticalPotts3.jl
+++ b/src/models/classical/TricriticalPotts3/TricriticalPotts3.jl
@@ -110,7 +110,9 @@ Examples:
 - G. E. Andrews, R. J. Baxter, P. J. Forrester,
   *J. Stat. Phys.* **35**, 193 (1984).
 """
-function fetch(::TricriticalPotts3, ::ConformalWeights, ::Infinite; r::Integer, s::Integer, kwargs...)
+function fetch(
+    ::TricriticalPotts3, ::ConformalWeights, ::Infinite; r::Integer, s::Integer, kwargs...
+)
     return QAtlas.fetch(QAtlas.MinimalModel(7, 6), ConformalWeights(); r=r, s=s)
 end
 

--- a/src/models/classical/TricriticalPotts3/TricriticalPotts3.jl
+++ b/src/models/classical/TricriticalPotts3/TricriticalPotts3.jl
@@ -84,7 +84,7 @@ end
 # ═══════════════════════════════════════════════════════════════════════════════
 
 """
-    fetch(::TricriticalPotts3, ::ConformalWeights; r::Integer, s::Integer, kwargs...)
+    fetch(::TricriticalPotts3, ::ConformalWeights, ::Infinite; r::Integer, s::Integer, kwargs...)
         -> Rational{Int}
 
 Conformal weight `h_{r,s}` from the Kac table of the tricritical
@@ -110,7 +110,7 @@ Examples:
 - G. E. Andrews, R. J. Baxter, P. J. Forrester,
   *J. Stat. Phys.* **35**, 193 (1984).
 """
-function fetch(::TricriticalPotts3, ::ConformalWeights; r::Integer, s::Integer, kwargs...)
+function fetch(::TricriticalPotts3, ::ConformalWeights, ::Infinite; r::Integer, s::Integer, kwargs...)
     return QAtlas.fetch(QAtlas.MinimalModel(7, 6), ConformalWeights(); r=r, s=s)
 end
 
@@ -119,7 +119,7 @@ end
 # ═══════════════════════════════════════════════════════════════════════════════
 
 """
-    fetch(::TricriticalPotts3, ::PrimaryFields; kwargs...) -> Vector{NamedTuple}
+    fetch(::TricriticalPotts3, ::PrimaryFields, ::Infinite; kwargs...) -> Vector{NamedTuple}
 
 Kac-table primary fields of the tricritical 3-state Potts CFT,
 delegated to [`MinimalModel(7, 6)`](@ref).  Returns the
@@ -131,6 +131,6 @@ their `(r, s)` labels and `h` weights.
 - A. A. Belavin, A. M. Polyakov, A. B. Zamolodchikov,
   *Nucl. Phys. B* **241**, 333 (1984).
 """
-function fetch(::TricriticalPotts3, ::PrimaryFields; kwargs...)
+function fetch(::TricriticalPotts3, ::PrimaryFields, ::Infinite; kwargs...)
     return QAtlas.fetch(QAtlas.MinimalModel(7, 6), PrimaryFields())
 end

--- a/src/models/quantum/AKLT2D/AKLT2D.jl
+++ b/src/models/quantum/AKLT2D/AKLT2D.jl
@@ -35,6 +35,14 @@
 #      and higher dimensions", cond-mat/0407066 (2004) — PEPS realisation.
 # ─────────────────────────────────────────────────────────────────────────────
 
+"""
+    AKLT2D(; J::Real = 1.0) <: AbstractQAtlasModel
+
+2D honeycomb-lattice Affleck-Kennedy-Lieb-Tasaki (AKLT) spin-3/2 valence-bond-solid
+model.  Frustration-free Hamiltonian whose unique gapped VBS ground state has exact
+energy density e0/N = 0 (J-independent); the 2D AKLT phase is the prototypical 2D
+symmetry-protected topological (SPT) state.  See file header for full references.
+"""
 struct AKLT2D <: AbstractQAtlasModel
     J::Float64
     function AKLT2D(J::Real)

--- a/src/models/quantum/XXZ/XXZ.jl
+++ b/src/models/quantum/XXZ/XXZ.jl
@@ -95,48 +95,6 @@ native_energy_granularity(::XXZ1D, ::Infinite) = :per_site
 # logic for Δ ∈ {-1, 0, 1} is preserved bit-for-bit there; general-Δ
 # Bethe-ansatz remains a v0.13 follow-up (issue #108).
 """
-    fetch(model::XXZ1D, ::Energy{:per_site}, ::Infinite) -> Float64
-
-Ground-state energy **per site** of the infinite XXZ chain in units of
-the Hamiltonian `J`, at zero temperature.
-
-# Coverage
-
-- **Critical / gapless regime** `-1 ≤ Δ ≤ 1`: closed form for the
-  three canonical points and the Yang–Yang single integral elsewhere:
-
-      Δ = -1:  -J/4                 (isotropic FM, saturated)
-      Δ =  0:  -J/π                 (XX, free fermion)
-      Δ =  1:  J (1/4 - ln 2)       (AF Heisenberg, Hulthén 1938)
-      otherwise (γ = arccos Δ):
-        e₀(Δ) = (J cos γ)/4 − J sin² γ
-                · ∫_{-∞}^{∞} dλ / [2 cosh(πλ)·(cosh(2γλ) − cos γ)]
-
-  Returned to ≈ 1e-12 relative accuracy via adaptive QuadGK.
-
-- **Gapped regime** `|Δ| > 1`: the Bethe ansatz takes a different
-  series form (Orbach 1958 / Walker 1959 / Yang–Yang 1966 III); the
-  closed-form path here emits a warning and returns `NaN`.  Use OBC
-  dense ED at small `N` for a finite-size reference in that regime.
-"""
-function fetch(model::XXZ1D, ::Energy{:per_site}, ::Infinite; kwargs...)
-    J, Δ = model.J, model.Δ
-    if isapprox(Δ, 0.0; atol=1e-12)
-        return _xxz1d_energy_free_fermion(J)
-    elseif isapprox(Δ, 1.0; atol=1e-12)
-        return _xxz1d_energy_heisenberg_af(J)
-    elseif isapprox(Δ, -1.0; atol=1e-12)
-        return _xxz1d_energy_heisenberg_fm(J)
-    elseif -1.0 < Δ < 1.0
-        return _xxz1d_energy_yang_yang(J, Δ)
-    else
-        @warn "XXZ1D Energy: gapped regime |Δ| > 1 not yet implemented; " *
-            "use OBC dense ED at small N for a finite-size reference." Δ = Δ
-        return NaN
-    end
-end
-
-"""
     fetch(model::XXZ1D, ::GroundStateEnergyDensity, ::Infinite) -> Float64
 
 Alias for [`fetch(::XXZ1D, ::Energy, ::Infinite)`](@ref) kept so that

--- a/test/core/test_registry.jl
+++ b/test/core/test_registry.jl
@@ -86,9 +86,9 @@ end
     # By quantity instance
     @test implementation_status(Energy(:total)) == energy_total_rows
 
-    # Unregistered quantity returns empty (ConformalWeights has no
+    # Unregistered quantity returns empty (MeanRatio has no
     # fetch implementation yet, so the registry must not list it).
-    @test isempty(implementation_status(ConformalWeights()))
+    @test isempty(implementation_status(MeanRatio()))
 end
 
 @testset "implementation_status(queue) returns one row per registered triple" begin
@@ -96,7 +96,7 @@ end
     queue = [
         (m, Energy(:total), OBC(8)),       # registered
         (m, MassGap(), Infinite()),   # registered
-        (m, ConformalWeights(), OBC(8)),   # NOT registered → dropped
+        (m, MeanRatio(), OBC(8)),   # NOT registered → dropped
     ]
     rows = implementation_status(queue)
     @test length(rows) == 2
@@ -241,9 +241,9 @@ end
     # By quantity instance
     @test implementation_status(Energy(:total)) == energy_total_rows
 
-    # Unregistered quantity returns empty (FermiVelocity has no
+    # Unregistered quantity returns empty (WignerSurmise has no
     # fetch implementation yet, so the registry must not list it).
-    @test isempty(implementation_status(FermiVelocity()))
+    @test isempty(implementation_status(WignerSurmise()))
 end
 
 @testset "implementation_status(queue) returns one row per registered triple" begin
@@ -251,7 +251,7 @@ end
     queue = [
         (m, Energy(:total), OBC(8)),       # registered
         (m, MassGap(), Infinite()),   # registered
-        (m, FermiVelocity(), OBC(8)),   # NOT registered → dropped
+        (m, WignerSurmise(), OBC(8)),   # NOT registered → dropped
     ]
     rows = implementation_status(queue)
     @test length(rows) == 2

--- a/test/universalities/test_tricritical_potts3.jl
+++ b/test/universalities/test_tricritical_potts3.jl
@@ -22,16 +22,16 @@ end
 @testset "TricriticalPotts3 — ConformalWeights delegation (Phase 2)" begin
     m = TricriticalPotts3()
     # Identity has h = 0
-    @test QAtlas.fetch(m, ConformalWeights(); r=1, s=1) == 0
+    @test QAtlas.fetch(m, ConformalWeights(), Infinite(); r=1, s=1) == 0
     # Energy operator ε: h_{1,2} = 1/7
-    @test QAtlas.fetch(m, ConformalWeights(); r=1, s=2) == 1 // 7
+    @test QAtlas.fetch(m, ConformalWeights(), Infinite(); r=1, s=2) == 1 // 7
     # h_{2,1} = 3/8
-    @test QAtlas.fetch(m, ConformalWeights(); r=2, s=1) == 3 // 8
+    @test QAtlas.fetch(m, ConformalWeights(), Infinite(); r=2, s=1) == 3 // 8
     # h_{2,2} = 1/56
-    @test QAtlas.fetch(m, ConformalWeights(); r=2, s=2) == 1 // 56
+    @test QAtlas.fetch(m, ConformalWeights(), Infinite(); r=2, s=2) == 1 // 56
     # Delegation invariant: matches MinimalModel(7, 6) exactly
     for (r, s) in [(1, 1), (1, 2), (2, 1), (2, 2), (3, 3), (5, 6)]
-        @test QAtlas.fetch(m, ConformalWeights(); r=r, s=s) ==
+        @test QAtlas.fetch(m, ConformalWeights(), Infinite(); r=r, s=s) ==
             QAtlas.fetch(QAtlas.MinimalModel(7, 6), ConformalWeights(); r=r, s=s)
     end
 end
@@ -39,15 +39,15 @@ end
 @testset "TricriticalPotts3 — ConformalWeights index range (Phase 2)" begin
     m = TricriticalPotts3()
     # r ∈ [1, 5], s ∈ [1, 6] for M(7, 6)
-    @test_throws DomainError QAtlas.fetch(m, ConformalWeights(); r=0, s=1)
-    @test_throws DomainError QAtlas.fetch(m, ConformalWeights(); r=6, s=1)
-    @test_throws DomainError QAtlas.fetch(m, ConformalWeights(); r=1, s=0)
-    @test_throws DomainError QAtlas.fetch(m, ConformalWeights(); r=1, s=7)
+    @test_throws DomainError QAtlas.fetch(m, ConformalWeights(), Infinite(); r=0, s=1)
+    @test_throws DomainError QAtlas.fetch(m, ConformalWeights(), Infinite(); r=6, s=1)
+    @test_throws DomainError QAtlas.fetch(m, ConformalWeights(), Infinite(); r=1, s=0)
+    @test_throws DomainError QAtlas.fetch(m, ConformalWeights(), Infinite(); r=1, s=7)
 end
 
 @testset "TricriticalPotts3 — PrimaryFields delegation (Phase 2)" begin
     m = TricriticalPotts3()
-    pf_tp = QAtlas.fetch(m, PrimaryFields())
+    pf_tp = QAtlas.fetch(m, PrimaryFields(), Infinite())
     pf_mm = QAtlas.fetch(QAtlas.MinimalModel(7, 6), PrimaryFields())
     @test pf_tp == pf_mm
     # M(7, 6) has (p_prime - 1)*(p - 1)/2 = 5*6/2 = 15 independent primaries


### PR DESCRIPTION
Minor version bump from 0.19.17 to 0.20.0.

## Highlights since v0.19.17

### Phase 1 new models (30+)

**Quantum**: Cluster1D, TightBinding1D, J1J2Heisenberg1D, XYh1D, MixedFieldIsing1D, DMIHeisenberg1D, Compass1D, LongRangeIsing1D, S1AnisotropicD1D, TightBindingV1D, LongRangeXY1D, S1XXZ1D, ExtendedHubbard1D, PXP1D, AKLT2D, FibonacciAnyons, PpIp2DSC, SYK

**Classical**: TASEP, RandomBondIsing2D, ZnClock

**Universalities**: LogarithmicCFT, YangLee, ZnParafermion, ConformalBootstrap, BCFT, TTbar, TricriticalIsing, LiouvilleCFT, SLEkappa, TricriticalPotts3

### Phase 2 additions

KagomeHeisenbergAFM TEE; SchwingerModel ChiralCondensate; ChernSimons3D Z(S^3); SherringtonKirkpatrick e_0; GrossNeveu m_F; MajumdarGhosh SpinGap; CurieWeissIsing / TFIM / IsingSquare / IsingTriangular CriticalExponents; Heisenberg1D / Hubbard1D / HeisenbergXYZ LuttingerParameter; SpectralFormFactor as a new quantity type.

### New quantity types

`ChiralCondensate`, `SteadyStateCurrent`, `SpectralFormFactor`, `FractalDimension`.

### Infrastructure

- #355: FormatFix auto-commit bot replaced with FormatCheck CI job (unblock branch protection); CI matrix split to 13 dir-level parallel jobs; VersionCheck runs on every PR informationally.
- #354: jldoctest enabled with pilot doctest conversions.

### Review history

Each merged feature PR was reviewed in 4 passes (physics correctness, citations, tolerance & cross-checks, type stability / Aqua) before merging. ~50 fix commits landed across the batch, including:
- #312 Schwinger condensate denominator (`2π²` → `2π^{3/2}`)
- #338 BCFT `:sigma` Cardy g-factor (`1/√2` → `1`)
- 9 PRs with `isapprox(..., 0; atol=1e-12)` strict-zero gate replaced with `iszero` / `isone` / `==`

## Known carryovers

- #352: pre-existing XXZ1D `Energy{:per_site}` precompile-warning (unrelated to this release)
- #353: `docs/make.jl` has duplicate `makedocs` blocks + orphan pages (docs deploy works, but page list drift)