### PR TITLE
feat(quantum): AKLT1D finite-temperature OBC thermodynamics (exact dense ED, N<=8)

### DIFF
--- a/src/models/quantum/AKLT/AKLT1D.jl
+++ b/src/models/quantum/AKLT/AKLT1D.jl
@@ -204,3 +204,95 @@ function fetch(model::AKLT1D, ::ExactSpectrum, bc::OBC; N::Int=bc.N, kwargs...)
     H = _aklt_hamiltonian_matrix(model, N, OBC(N))
     return sort(real.(eigvals(Hermitian(H))))
 end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# OBC finite-temperature thermodynamics — exact from the 3^N spectrum
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# The AKLT chain is not Bethe-ansatz integrable, so there is no closed-form
+# thermodynamic-limit free energy.  For finite N ≤ _MAX_ED_SITES_S1 the full
+# 3^N spectrum is accessible by dense ED, and every thermal observable is then
+# *exact* (Boltzmann sum, no truncation).  Mirrors the S1Heisenberg1D OBC
+# finite-T API one-to-one (same local Hilbert space and dense-ED budget).
+#
+# Limiting cross-checks the test-suite pins (AKLT-specific signatures):
+#   * β → ∞ : ⟨H⟩ → E₀ = −(2J/3)(N−1)  (frustration-free OBC GS, exact)
+#   * β → ∞ : total S → log 4           (two spin-½ edge modes ⇒ singlet⊕triplet)
+#   * β → 0 : total S → N log 3         (full spin-1 Hilbert space)
+#   * C(β) = β² Var(H) ≥ 0, → 0 at both β → 0 and β → ∞ (Schottky peak between)
+
+"""
+    fetch(model::AKLT1D, ::Energy{:total}, ::OBC; beta, N) -> Float64
+
+**Total** thermal energy `⟨H⟩_β = Tr(H e^{-βH}) / Tr(e^{-βH})` of the OBC
+AKLT chain at finite `N ≤ $(_MAX_ED_SITES_S1)`, computed by dense ED.  As
+`β → ∞` this converges to the exact frustration-free ground-state energy
+`E₀ = −(2J/3)(N−1)`.
+"""
+function fetch(model::AKLT1D, ::Energy{:total}, bc::OBC; beta::Real, N::Int=bc.N, kwargs...)
+    H = _aklt_hamiltonian_matrix(model, N, OBC(N))
+    return _ed_thermal_energy(H, beta)
+end
+
+"""
+    fetch(model::AKLT1D, ::FreeEnergy, ::OBC; beta, N) -> Float64
+
+Per-site Helmholtz free energy `f(β) = −log Z / (Nβ)` of the OBC AKLT
+chain (dense ED, exact for `N ≤ $(_MAX_ED_SITES_S1)`).
+"""
+function fetch(model::AKLT1D, ::FreeEnergy, bc::OBC; beta::Real, N::Int=bc.N, kwargs...)
+    H = _aklt_hamiltonian_matrix(model, N, OBC(N))
+    return _ed_thermal_free_energy(H, beta) / N
+end
+
+"""
+    fetch(model::AKLT1D, ::ThermalEntropy, ::OBC; beta, N) -> Float64
+
+Per-site Gibbs entropy `s(β) = β·(ε − f)` of the OBC AKLT chain.  As
+`β → ∞` the **total** entropy `N·s` → `log 4` — the AKLT signature of two
+free spin-½ edge modes (singlet ⊕ triplet); as `β → 0`, `N·s` → `N log 3`.
+"""
+function fetch(model::AKLT1D, ::ThermalEntropy, bc::OBC; beta::Real, N::Int=bc.N, kwargs...)
+    H = _aklt_hamiltonian_matrix(model, N, OBC(N))
+    return _ed_thermal_entropy(H, beta) / N
+end
+
+"""
+    fetch(model::AKLT1D, ::SpecificHeat, ::OBC; beta, N) -> Float64
+
+Per-site heat capacity `c(β) = β²·Var(H)/N` of the OBC AKLT chain,
+computed exactly from the energy variance in the eigenbasis (no numerical
+differentiation).  Non-negative; vanishes at both `β → 0` and `β → ∞`
+with a Schottky peak in between.
+"""
+function fetch(model::AKLT1D, ::SpecificHeat, bc::OBC; beta::Real, N::Int=bc.N, kwargs...)
+    H = _aklt_hamiltonian_matrix(model, N, OBC(N))
+    return _ed_thermal_specific_heat(H, beta) / N
+end
+
+"""
+    fetch(::AKLT1D, ::Union{Energy{:total},FreeEnergy,ThermalEntropy,SpecificHeat}, ::Infinite; beta, ...)
+
+The thermodynamic-limit finite-temperature thermodynamics of the AKLT
+chain has no closed form: the model is not Bethe-ansatz integrable and
+requires a quantum-transfer-matrix / TBA or finite-T DMRG treatment
+(deferred to a later phase).  Raises `DomainError`.  Use `OBC(N)` for an
+exact finite-N value.
+"""
+function fetch(
+    ::AKLT1D,
+    ::Union{Energy{:total},FreeEnergy,ThermalEntropy,SpecificHeat},
+    ::Infinite;
+    beta::Real,
+    kwargs...,
+)
+    throw(
+        DomainError(
+            beta,
+            "AKLT1D finite-temperature observables at Infinite() have no closed " *
+            "form (the AKLT chain is not Bethe-ansatz integrable); use OBC(N) " *
+            "dense ED for an exact finite-N value, or a quantum-transfer-matrix / " *
+            "finite-T DMRG treatment for the thermodynamic limit (Phase 2).",
+        ),
+    )
+end

--- a/src/models/quantum/AKLT/AKLT1D_registry.jl
+++ b/src/models/quantum/AKLT/AKLT1D_registry.jl
@@ -71,3 +71,44 @@
     tested_in="test/standalone/test_aklt.jl",
     notes="Full sorted spectrum from 3^N dense ED; N ≤ 8 (3^8 = 6561).",
 )
+
+# ── Energy / FreeEnergy / Entropy / SpecificHeat (OBC, dense ED) ──────
+# Finite-N exact finite-temperature thermodynamics from the 3^N spectrum
+# (the AKLT chain is not Bethe-ansatz integrable, so no Infinite closed
+# form; Infinite()+beta raises DomainError). Mirrors S1Heisenberg1D.
+@register(
+    AKLT1D,
+    Energy{:total},
+    OBC,
+    method=:dense_ed,
+    reliability=:high,
+    tested_in="test/models/quantum/misc/test_aklt.jl",
+    notes="Total ⟨H⟩(β) by dense ED on the 3^N Hilbert space; N ≤ 8. β→∞ → exact frustration-free E₀ = -(2J/3)(N-1).",
+)
+@register(
+    AKLT1D,
+    FreeEnergy,
+    OBC,
+    method=:dense_ed,
+    reliability=:high,
+    tested_in="test/models/quantum/misc/test_aklt.jl",
+    notes="Per-site f(β) = -log Z/(Nβ); exact for N ≤ 8.",
+)
+@register(
+    AKLT1D,
+    ThermalEntropy,
+    OBC,
+    method=:dense_ed,
+    reliability=:high,
+    tested_in="test/models/quantum/misc/test_aklt.jl",
+    notes="Per-site s(β); total N·s → log 4 as β→∞ (two spin-½ edge modes ⇒ singlet⊕triplet), → N log 3 as β→0.",
+)
+@register(
+    AKLT1D,
+    SpecificHeat,
+    OBC,
+    method=:dense_ed,
+    reliability=:high,
+    tested_in="test/models/quantum/misc/test_aklt.jl",
+    notes="Per-site c(β) = β² Var(H)/N from energy variance; Schottky peak, → 0 at both β→0 and β→∞.",
+)

--- a/test/models/quantum/misc/test_aklt.jl
+++ b/test/models/quantum/misc/test_aklt.jl
@@ -104,3 +104,74 @@ end
         end
     end
 end
+
+@testset "AKLT1D — OBC finite-temperature (dense ED, exact for N ≤ 8)" begin
+    m = AKLT1D(; J=1.0)
+
+    @testset "β → ∞ reproduces the exact frustration-free ground state" begin
+        # ⟨H⟩(β→∞) must converge to the EXACT OBC AKLT ground-state
+        # energy E₀ = -(2J/3)(N-1) (the VBS annihilates every bond
+        # projector, so there is no finite-size correction beyond the
+        # missing edge bond).
+        for N in (4, 6, 8)
+            E0 = -(2 / 3) * (N - 1)
+            E_inf = QAtlas.fetch(m, Energy(:total), OBC(N); beta=1.0e3)
+            @test E_inf ≈ E0 atol = 1e-6
+            # FreeEnergy → E₀ as β → ∞ (per-site × N)
+            f_inf = QAtlas.fetch(m, FreeEnergy(), OBC(N); beta=1.0e3)
+            @test f_inf * N ≈ E0 atol = 1e-2
+        end
+    end
+
+    @testset "β → ∞ entropy → log 4 (AKLT edge-mode signature)" begin
+        # Two free spin-½ edge modes ⇒ 4-fold degenerate OBC ground
+        # manifold (singlet ⊕ triplet). The residual TOTAL entropy is
+        # exactly log 4, independent of N and J.
+        for N in (4, 6, 8)
+            S_total = N * QAtlas.fetch(m, ThermalEntropy(), OBC(N); beta=1.0e3)
+            @test S_total ≈ log(4) atol = 1e-6
+        end
+        # J-independent: same residual entropy at a different coupling
+        S_J2 = 6 * QAtlas.fetch(AKLT1D(; J=2.0), ThermalEntropy(), OBC(6); beta=1.0e3)
+        @test S_J2 ≈ log(4) atol = 1e-6
+    end
+
+    @testset "β → 0 entropy → N log 3 (full spin-1 Hilbert space)" begin
+        for N in (4, 6, 8)
+            S_total = N * QAtlas.fetch(m, ThermalEntropy(), OBC(N); beta=1.0e-6)
+            @test S_total ≈ N * log(3) atol = 1e-4
+        end
+    end
+
+    @testset "SpecificHeat: non-negative, Schottky peak, vanishes at both ends" begin
+        for N in (4, 6, 8)
+            c0 = QAtlas.fetch(m, SpecificHeat(), OBC(N); beta=1.0e-6)
+            c_inf = QAtlas.fetch(m, SpecificHeat(), OBC(N); beta=1.0e3)
+            c_pk = QAtlas.fetch(m, SpecificHeat(), OBC(N); beta=1.0)
+            # → 0 at both extremes (fp-noise tolerance)
+            @test abs(c0) < 1e-6
+            @test abs(c_inf) < 1e-6
+            # finite Schottky-like peak in between, strictly positive
+            @test c_pk > 0.1
+            # heat capacity is a variance ⇒ non-negative (within fp)
+            for β in (0.1, 0.5, 1.0, 2.0, 5.0)
+                @test QAtlas.fetch(m, SpecificHeat(), OBC(N); beta=β) > -1e-9
+            end
+        end
+    end
+
+    @testset "zero-T Energy{:total} is exactly linear in J" begin
+        # ⟨H⟩ at fixed finite β is not exactly linear in J (β couples as
+        # βJ), but the β→∞ limit is the GS energy E₀ = -(2J/3)(N-1),
+        # which IS exactly linear in J.
+        E1_inf = QAtlas.fetch(AKLT1D(; J=1.0), Energy(:total), OBC(6); beta=1.0e3)
+        E2_inf = QAtlas.fetch(AKLT1D(; J=2.0), Energy(:total), OBC(6); beta=1.0e3)
+        @test E2_inf ≈ 2 * E1_inf atol = 1e-6
+    end
+
+    @testset "Infinite() + beta has no closed form ⇒ DomainError" begin
+        for Q in (Energy(:total), FreeEnergy(), ThermalEntropy(), SpecificHeat())
+            @test_throws DomainError QAtlas.fetch(m, Q, Infinite(); beta=1.0)
+        end
+    end
+end


### PR DESCRIPTION
Adds exact finite-N finite-temperature observables for the spin-1 AKLT chain.

## Why this is exact (not an approximation)

The AKLT chain is **not** Bethe-ansatz integrable, so there is no closed-form thermodynamic-limit free energy. But for finite `N <= _MAX_ED_SITES_S1 = 8` the full `3^N` spectrum is accessible by dense ED, and every thermal observable is then the **exact** Boltzmann sum. This mirrors the existing `S1Heisenberg1D` OBC finite-T API one-to-one (identical local Hilbert space, identical `_MAX_ED_SITES_S1` budget, identical shared `src/core/dense_ed.jl` helpers `_ed_thermal_{energy,free_energy,entropy,specific_heat}`).

## New `fetch` methods (`src/models/quantum/AKLT/AKLT1D.jl`)

| quantity | bc | returns |
|---|---|---|
| `Energy{:total}` | `OBC; beta` | total `<H>_beta` |
| `FreeEnergy` | `OBC; beta` | per-site `f = -logZ/(N beta)` |
| `ThermalEntropy` | `OBC; beta` | per-site `s = beta(eps - f)` |
| `SpecificHeat` | `OBC; beta` | per-site `c = beta^2 Var(H)/N` |
| any of the 4 | `Infinite; beta` | `DomainError` (QTM/TBA / finite-T DMRG -> Phase 2) |

Registry: 4 new `OBC` `method=:dense_ed`, `reliability=:high` rows. Existing closed-form `Infinite()` rows (`e0=-2J/3`, `xi=1/log3`, `O_str=4/9`, Haldane gap) unchanged.

## ED reproduces AKLT physics (now pinned in tests)

Per the request to verify ED correctly reproduces AKLT physics, the new testset in `test/models/quantum/misc/test_aklt.jl` pins these AKLT-specific cross-checks (all verified on Panza for N=4,6,8):

- **beta -> inf**: `<H> -> E0 = -(2J/3)(N-1)` **exactly** (machine precision) — the frustration-free OBC VBS ground state has no finite-size correction beyond the missing edge bond.
- **beta -> inf**: total entropy `-> log 4` — the AKLT signature of two free spin-1/2 edge modes (singlet (+) triplet), independent of N and J.
- **beta -> 0**: total entropy `-> N log 3` (full spin-1 Hilbert space).
- `C(beta) = beta^2 Var(H) >= 0`, Schottky peak (~0.32-0.35), `-> 0` at both `beta -> 0` and `beta -> inf`.
- zero-T `<H>` exactly linear in J.
- `Infinite() + beta` raises `DomainError` for all four quantities.

## Test

`QATLAS_TEST_GROUP=models/quantum/misc` on Panza: **532/532 pass**, 0 fail. Three changed files all format-clean (JuliaFormatter v2, `overwrite=false`).

## Scope

`src/core` untouched (reuses existing helpers). `src/QAtlas.jl` / `src/core/quantities.jl` untouched (all 4 quantity types already exported). No new dependencies. CI impact: 4 new OBC registry rows + one testset in the existing misc group.