### PR TITLE
feat(quantum): AKLT1D exact VBS spin correlations + static structure factor (closed form)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.20.0"
+version = "0.20.1"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/models/quantum/AKLT/AKLT1D.jl
+++ b/src/models/quantum/AKLT/AKLT1D.jl
@@ -140,7 +140,7 @@ Closed-form bulk correlation length of the AKLT chain,
 
     ξ = 1 / log 3 ≈ 0.91024
 
-(AKLT 1988).  Connected `⟨S^z_0 S^z_r⟩` decays as `(−1)^r 4/9 · 3^{−r}`
+(AKLT 1988).  Connected `⟨S^z_0 S^z_r⟩` decays as `(−1)^r (4/3) · 3^{−|r|}`
 in the VBS state, giving `ξ = 1/log 3` independent of `J`.
 """
 function fetch(model::AKLT1D, ::CorrelationLength, ::Infinite; kwargs...)
@@ -203,4 +203,69 @@ function fetch(model::AKLT1D, ::ExactSpectrum, bc::OBC; N::Int=bc.N, kwargs...)
     N > 0 || throw(ArgumentError("AKLT1D ExactSpectrum: N must be positive (got $N)"))
     H = _aklt_hamiltonian_matrix(model, N, OBC(N))
     return sort(real.(eigvals(Hermitian(H))))
+end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# VBS ground-state spin correlations — exact closed form (AKLT 1988)
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# The AKLT valence-bond-solid ground state has an exactly known,
+# J-independent (the GS wavefunction is the same for every J > 0)
+# equal-time two-point function:
+#
+#     ⟨Sᶻ₀ Sᶻ_r⟩ = (−1)^r · (4/3) · 3^{−|r|}     (r ≠ 0),
+#     ⟨(Sᶻ)²⟩    = 2/3                            (r = 0, S = 1 on-site),
+#
+# equivalently ⟨S⃗₀·S⃗_r⟩ = (−1)^r · 4 · 3^{−|r|} by isotropy.  The decay
+# ratio 3^{−1} per step is exactly the origin of ξ = 1/log 3.  ⟨Sᶻ⟩ = 0
+# in the VBS, so this equal-time correlator is already the *connected*
+# one.  Its lattice Fourier transform is the static structure factor
+#
+#     S_zz(q) = Σ_r e^{iqr} ⟨Sᶻ₀ Sᶻ_r⟩ = 2(1 − cos q) / (5 + 3 cos q)
+#
+# (Arovas–Auerbach–Haldane 1988): S_zz(0) = 0 (total-Sᶻ conservation),
+# antiferromagnetic peak S_zz(π) = 2.
+#
+# References:
+#   I. Affleck, T. Kennedy, E. H. Lieb, H. Tasaki, Commun. Math. Phys.
+#     115, 477 (1988) — exact VBS two-point function.
+#   D. P. Arovas, A. Auerbach, F. D. M. Haldane, Phys. Rev. Lett. 60,
+#     531 (1988) — static structure factor of the AKLT chain.
+
+"""
+    fetch(model::AKLT1D, ::ZZCorrelation{:static}, ::Infinite; r::Integer) -> Float64
+
+Exact equal-time spin-z two-point function of the AKLT VBS ground
+state at separation `r`:
+
+    ⟨Sᶻ₀ Sᶻ_r⟩ = (−1)^r · (4/3) · 3^{−|r|}   (r ≠ 0),
+    ⟨(Sᶻ)²⟩    = 2/3                          (r = 0).
+
+Closed form (AKLT 1988); `J`-independent (the VBS ground state does not
+depend on `J > 0`).  Exponential decay with rate `log 3`, consistent
+with [`fetch(::AKLT1D, ::CorrelationLength, ::Infinite)`](@ref)
+`ξ = 1/log 3`.  Since `⟨Sᶻ⟩ = 0` in the VBS this equal-time value is
+already the connected correlation.
+"""
+function fetch(::AKLT1D, ::ZZCorrelation{:static}, ::Infinite; r::Integer, kwargs...)
+    r == 0 && return 2.0 / 3.0
+    a = abs(r)
+    return (iseven(a) ? 1.0 : -1.0) * (4.0 / 3.0) * 3.0^(-a)
+end
+
+"""
+    fetch(model::AKLT1D, ::ZZStructureFactor, ::Infinite; q::Real) -> Float64
+
+Exact static (equal-time) spin-z structure factor of the AKLT chain,
+
+    S_zz(q) = Σ_r e^{iqr} ⟨Sᶻ₀ Sᶻ_r⟩ = 2 (1 − cos q) / (5 + 3 cos q)
+
+(Arovas–Auerbach–Haldane 1988).  `S_zz(0) = 0` by total-`Sᶻ`
+conservation; antiferromagnetic peak `S_zz(π) = 2`.  `J`-independent.
+This is the lattice-Fourier sum of the closed-form
+[`ZZCorrelation`](@ref) `(−1)^r (4/3) 3^{−|r|}`.
+"""
+function fetch(::AKLT1D, ::ZZStructureFactor, ::Infinite; q::Real, kwargs...)
+    c = cos(q)
+    return 2.0 * (1.0 - c) / (5.0 + 3.0 * c)
 end

--- a/src/models/quantum/AKLT/AKLT1D_registry.jl
+++ b/src/models/quantum/AKLT/AKLT1D_registry.jl
@@ -71,3 +71,25 @@
     tested_in="test/standalone/test_aklt.jl",
     notes="Full sorted spectrum from 3^N dense ED; N ≤ 8 (3^8 = 6561).",
 )
+
+# ── VBS ground-state correlations (Infinite, closed form) ────────────
+@register(
+    AKLT1D,
+    ZZCorrelation{:static},
+    Infinite,
+    method=:analytic,
+    reliability=:high,
+    tested_in="test/models/quantum/misc/test_aklt.jl",
+    references=["Affleck-Kennedy-Lieb-Tasaki 1988"],
+    notes="Exact VBS ⟨Sᶻ₀Sᶻ_r⟩ = (-1)^r (4/3) 3^{-|r|} (r≠0), 2/3 (r=0); J-independent. ED in tests verifies finite-N convergence.",
+)
+@register(
+    AKLT1D,
+    ZZStructureFactor,
+    Infinite,
+    method=:analytic,
+    reliability=:high,
+    tested_in="test/models/quantum/misc/test_aklt.jl",
+    references=["Arovas-Auerbach-Haldane 1988"],
+    notes="Exact static structure factor S_zz(q) = 2(1-cos q)/(5+3 cos q); S(0)=0, S(π)=2; J-independent.",
+)

--- a/test/models/quantum/misc/test_aklt.jl
+++ b/test/models/quantum/misc/test_aklt.jl
@@ -104,3 +104,100 @@ end
         end
     end
 end
+
+@testset "AKLT1D — exact VBS spin correlations (closed form, AKLT 1988)" begin
+    m = AKLT1D(; J=1.0)
+
+    @testset "ZZCorrelation{:static} closed form ⟨Sᶻ₀Sᶻ_r⟩" begin
+        # r = 0 : on-site ⟨(Sᶻ)²⟩ = 2/3 for S = 1 in the VBS
+        @test QAtlas.fetch(m, ZZCorrelation(; mode=:static), Infinite(); r=0) ≈ 2 / 3 atol =
+            1e-14
+        # r ≠ 0 : (-1)^r (4/3) 3^{-|r|}
+        for r in 1:6
+            v = QAtlas.fetch(m, ZZCorrelation(; mode=:static), Infinite(); r=r)
+            closed = (-1)^r * (4 / 3) * 3.0^(-r)
+            @test v ≈ closed atol = 1e-14
+        end
+        # even in r (depends only on |r|)
+        for r in 1:5
+            @test QAtlas.fetch(m, ZZCorrelation(; mode=:static), Infinite(); r=(-r)) ≈
+                QAtlas.fetch(m, ZZCorrelation(; mode=:static), Infinite(); r=r) atol = 1e-14
+        end
+        # alternating sign + exponential decay ratio is exactly 1/3
+        c1 = QAtlas.fetch(m, ZZCorrelation(; mode=:static), Infinite(); r=1)
+        c2 = QAtlas.fetch(m, ZZCorrelation(; mode=:static), Infinite(); r=2)
+        c3 = QAtlas.fetch(m, ZZCorrelation(; mode=:static), Infinite(); r=3)
+        @test c1 < 0 && c2 > 0 && c3 < 0
+        @test abs(c2 / c1) ≈ 1 / 3 atol = 1e-14
+        @test abs(c3 / c2) ≈ 1 / 3 atol = 1e-14
+        # J-independent (VBS ground state is the same for every J > 0)
+        for J in (0.3, 1.0, 4.2)
+            @test QAtlas.fetch(
+                AKLT1D(; J=J), ZZCorrelation(; mode=:static), Infinite(); r=2
+            ) ≈ QAtlas.fetch(m, ZZCorrelation(; mode=:static), Infinite(); r=2) atol = 1e-14
+        end
+    end
+
+    @testset "ZZStructureFactor closed form S_zz(q) = 2(1-cos q)/(5+3cos q)" begin
+        @test QAtlas.fetch(m, ZZStructureFactor(), Infinite(); q=0.0) ≈ 0.0 atol = 1e-14
+        @test QAtlas.fetch(m, ZZStructureFactor(), Infinite(); q=π / 2) ≈ 2 / 5 atol = 1e-14
+        @test QAtlas.fetch(m, ZZStructureFactor(), Infinite(); q=π) ≈ 2.0 atol = 1e-14
+        # S(0) = 0 is the total-Sᶻ conservation sum rule; peak at q = π
+        for q in range(0.1, π - 0.1; length=12)
+            S = QAtlas.fetch(m, ZZStructureFactor(), Infinite(); q=q)
+            @test 0.0 < S < 2.0
+            @test S < QAtlas.fetch(m, ZZStructureFactor(), Infinite(); q=π)
+        end
+        # 2π-periodic and even
+        @test QAtlas.fetch(m, ZZStructureFactor(), Infinite(); q=0.7) ≈
+            QAtlas.fetch(m, ZZStructureFactor(), Infinite(); q=0.7 + 2π) atol = 1e-12
+        @test QAtlas.fetch(m, ZZStructureFactor(), Infinite(); q=-0.7) ≈
+            QAtlas.fetch(m, ZZStructureFactor(), Infinite(); q=0.7) atol = 1e-14
+        # J-independent
+        @test QAtlas.fetch(AKLT1D(; J=2.6), ZZStructureFactor(), Infinite(); q=π) ≈ 2.0 atol =
+            1e-14
+    end
+
+    @testset "structure factor is the Fourier transform of the correlation" begin
+        # S_zz(q) = Σ_r e^{iqr} ⟨Sᶻ₀Sᶻ_r⟩; the closed form must equal the
+        # truncated lattice sum (geometric tail < 1e-12 by r = 40).
+        for q in (0.3, 1.0, 2.0, π)
+            Ssum = QAtlas.fetch(m, ZZCorrelation(; mode=:static), Infinite(); r=0)
+            for r in 1:40
+                Ssum +=
+                    2 *
+                    cos(q * r) *
+                    QAtlas.fetch(m, ZZCorrelation(; mode=:static), Infinite(); r=r)
+            end
+            @test Ssum ≈ QAtlas.fetch(m, ZZStructureFactor(), Infinite(); q=q) atol = 1e-9
+        end
+    end
+
+    @testset "ED (test-only) converges to the closed-form correlation" begin
+        # The src value is the analytical AKLT-1988 closed form; dense ED
+        # is used HERE (tests only) purely to confirm a finite-N chain
+        # reproduces it.  The OBC ground manifold is 4-fold (edge spin-½);
+        # the bulk connected ⟨Sᶻ_i Sᶻ_{i+r}⟩ on a central site still
+        # tracks the infinite-chain closed form, the residual shrinking
+        # as the reference site moves away from the boundary.
+        using LinearAlgebra: Hermitian, eigen, I, kron
+        Sz = QAtlas._S1_z
+        idn(k) = Matrix{ComplexF64}(I, 3^k, 3^k)
+        for N in (6, 8)
+            H = QAtlas._aklt_hamiltonian_matrix(m, N, OBC(N))
+            ψ = eigen(Hermitian(H)).vectors[:, 1]   # a state in the GS manifold
+            i0 = cld(N, 2)                            # central reference site
+            szop(s) = kron(idn(s - 1), Sz, idn(N - s))
+            for r in (1, 2)
+                ed = real(ψ' * (szop(i0) * szop(i0 + r) * ψ))
+                closed = (-1)^r * (4 / 3) * 3.0^(-r)
+                # loose at N = 6, tighter at N = 8 — demonstrates convergence
+                tol = N == 6 ? 5e-2 : 1e-2
+                @test isapprox(ed, closed; atol=tol)
+            end
+            # on-site ⟨(Sᶻ)²⟩ → 2/3 only in the infinite VBS; finite-N + 4-fold OBC degeneracy leaves a few-e-3 residual (ED is a finite-N approximant of the analytic src value)
+            ed0 = real(ψ' * (szop(i0) * szop(i0) * ψ))
+            @test ed0 ≈ 2 / 3 atol = 5e-3
+        end
+    end
+end


### PR DESCRIPTION
Adds the two famous **closed-form** AKLT ground-state observables. Supersedes the closed #359 (which put dense-ED finite-T in src — AKLT is not Bethe-ansatz integrable, so finite-T has no closed form; per design review, src must hold analytical closed-form values and ED is a test-only cross-check).

## src (analytical, J-independent)

The VBS ground state is identical for every `J > 0`, so both are J-independent closed forms:

| quantity | bc | closed form | source |
|---|---|---|---|
| `ZZCorrelation{:static}` | `Infinite; r` | `2/3` (r=0); `(-1)^r (4/3) 3^{-|r|}` (r≠0) | AKLT 1988 |
| `ZZStructureFactor` | `Infinite; q` | `2(1-cos q)/(5+3 cos q)` | Arovas-Auerbach-Haldane 1988 |

`S(0)=0` (total-Sᶻ conservation), antiferromagnetic peak `S(π)=2`. The structure factor is the exact lattice-Fourier transform of the correlation (verified by sum rule in tests).

## Bonus correctness fix

The existing `AKLT1D` `CorrelationLength` docstring stated the connected correlation decays as `(−1)^r 4/9 · 3^{−r}` — that gives `4/27 ≈ 0.148` at r=1, but ED gives `-0.444 = -4/9`. Corrected to `(−1)^r (4/3) 3^{−|r|}` (`-4/9` at r=1, matches ED). The `ξ = 1/log 3` value itself was already correct and is unchanged.

## Tests (`test/models/quantum/misc/test_aklt.jl`)

- Closed-form spot values C(r) r=0..6, evenness in r, alternating sign, exact 1/3 decay ratio, J-independence
- S(q) at 0, π/2, π; `0<S<2` on (0,π); 2π-periodic + even; peak at π
- **Fourier sum rule**: `Σ_r e^{iqr} C(r) == ` closed `S(q)` to 1e-9 — proves the structure factor is the FT of the correlation
- **ED cross-check (ED in tests ONLY)**: dense-ED OBC ground state on N=6,8; central-site bulk `⟨Sᶻ_i Sᶻ_{i+r}⟩` converges to the closed form, with the tolerance deliberately loosened at smaller N — explicitly demonstrating ED is a finite-N approximant of the analytic src value (not the src implementation itself).

## Result

Targeted `models/quantum/misc` on Panza: **548/548 pass**. 3 files format-clean (JuliaFormatter v2). `src/core`, `src/QAtlas.jl`, `quantities.jl` untouched; no new dependencies; no change to existing closed-form Infinite rows.