### PR TITLE
ci: robust file-level shard parallelism + completeness guard

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,53 +12,55 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.group }}
+  # ───────────────────────────────────────────────────────────────────────────
+  # Single source of truth for CI parallelism.  The test universe itself
+  # lives only in test/runtests.jl `ALL_DIRS` (+ its completeness guard);
+  # this job just decides HOW MANY balanced file-level shards to fan out
+  # into.  Change `N` here and nowhere else.
+  # ───────────────────────────────────────────────────────────────────────────
+  plan:
+    name: Plan shards
     runs-on: ubuntu-latest
+    outputs:
+      shards: ${{ steps.gen.outputs.shards }}
+    steps:
+      - id: gen
+        run: |
+          N=16
+          shards=$(jq -cn --argjson n "$N" '[range(1; $n + 1) | "\(.)/\($n)"]')
+          echo "shards=$shards" >> "$GITHUB_OUTPUT"
+          echo "Fan-out: $N file-level shards -> $shards"
+
+  test:
+    name: Julia 1 - shard ${{ matrix.shard }}
+    runs-on: ubuntu-latest
+    needs: plan
     strategy:
       fail-fast: false
       matrix:
-        version:
-          - '1'
-        group:
-          - core
-          - universalities
-          - models/classical
-          - models/quantum/TFIM
-          - models/quantum/XXZ
-          - models/quantum/Heisenberg
-          - models/quantum/KitaevHoneycomb
-          - models/quantum/misc
-          - identities
-          - verification/tightbinding
-          - verification/tfim_ising
-          - verification/heisenberg_xxz
-          - verification/universality
+        shard: ${{ fromJSON(needs.plan.outputs.shards) }}
     env:
-      QATLAS_TEST_GROUP: ${{ matrix.group }}
+      # runtests.jl partitions the canonical ALL_DIRS file universe by
+      # round-robin "k/N"; the union of every shard is exactly the full
+      # suite (proven by construction + the completeness guard).
+      QATLAS_TEST_SHARD: ${{ matrix.shard }}
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v3
         with:
-          version: ${{ matrix.version }}
+          version: '1'
           arch: x64
       - uses: julia-actions/cache@v3
         with:
-          cache-name: ${{ matrix.group }}
+          cache-name: shard-${{ strategy.job-index }}
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:
           julia-args: "--threads=auto"
       - uses: julia-actions/julia-processcoverage@v1
-      - name: Compute artifact name
-        id: art
-        run: |
-          name="coverage-${{ matrix.group }}"
-          name="${name//[\/,]/_}"
-          echo "name=$name" >> "$GITHUB_OUTPUT"
       - uses: actions/upload-artifact@v7
         with:
-          name: ${{ steps.art.outputs.name }}
+          name: coverage-shard-${{ strategy.job-index }}
           path: lcov.info
           retention-days: 1
           if-no-files-found: error
@@ -76,7 +78,7 @@ jobs:
           pattern: coverage-*
       - name: Install lcov
         run: sudo apt-get update && sudo apt-get install -y lcov
-      - name: Merge per-group lcov reports
+      - name: Merge per-shard lcov reports
         run: |
           set -euo pipefail
           mapfile -t files < <(find coverage-parts -name 'lcov.info' | sort)
@@ -97,7 +99,7 @@ jobs:
           echo "$summary"
           {
             echo "## Merged coverage summary"
-            echo "(merged from ${#files[@]} matrix-job artifacts)"
+            echo "(merged from ${#files[@]} shard artifacts)"
             echo ""
             echo '```'
             echo "$summary"
@@ -112,12 +114,17 @@ jobs:
   all-tests:
     name: All tests passed
     runs-on: ubuntu-latest
-    needs: test
+    needs: [plan, test]
     if: always()
     steps:
-      - name: Check all matrix jobs passed
+      - name: Check plan + every shard passed
         run: |
-          if [ "${{ needs.test.result }}" != "success" ]; then
-            echo "One or more test groups failed: ${{ needs.test.result }}"
+          if [ "${{ needs.plan.result }}" != "success" ]; then
+            echo "Shard planning failed: ${{ needs.plan.result }}"
             exit 1
           fi
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "One or more test shards failed: ${{ needs.test.result }}"
+            exit 1
+          fi
+          echo "All shards green."

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,10 +26,16 @@ jobs:
     steps:
       - id: gen
         run: |
+          set -euo pipefail
           N=16
           shards=$(jq -cn --argjson n "$N" '[range(1; $n + 1) | "\(.)/\($n)"]')
+          count=$(jq 'length' <<<"$shards")
+          if [ "$count" -lt 1 ]; then
+            echo "::error::shard plan produced an empty list (count=$count)"
+            exit 1
+          fi
           echo "shards=$shards" >> "$GITHUB_OUTPUT"
-          echo "Fan-out: $N file-level shards -> $shards"
+          echo "Fan-out: $count file-level shards -> $shards"
 
   test:
     name: Julia 1 - shard ${{ matrix.shard }}
@@ -46,13 +52,16 @@ jobs:
       QATLAS_TEST_SHARD: ${{ matrix.shard }}
     steps:
       - uses: actions/checkout@v6
+      - name: Stable shard id (slash-free; survives partial re-runs)
+        id: sid
+        run: echo "id=$(echo '${{ matrix.shard }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
       - uses: julia-actions/setup-julia@v3
         with:
           version: '1'
           arch: x64
       - uses: julia-actions/cache@v3
         with:
-          cache-name: shard-${{ strategy.job-index }}
+          cache-name: shard-${{ steps.sid.outputs.id }}
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:
@@ -60,10 +69,11 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
       - uses: actions/upload-artifact@v7
         with:
-          name: coverage-shard-${{ strategy.job-index }}
+          name: coverage-shard-${{ steps.sid.outputs.id }}
           path: lcov.info
           retention-days: 1
           if-no-files-found: error
+          overwrite: true
 
   coverage:
     name: Coverage (aggregated)
@@ -121,6 +131,11 @@ jobs:
         run: |
           if [ "${{ needs.plan.result }}" != "success" ]; then
             echo "Shard planning failed: ${{ needs.plan.result }}"
+            exit 1
+          fi
+          shards='${{ needs.plan.outputs.shards }}'
+          if [ -z "$shards" ] || [ "$shards" = "[]" ]; then
+            echo "Plan produced no shards ('$shards') — the test matrix would be empty"
             exit 1
           fi
           if [ "${{ needs.test.result }}" != "success" ]; then

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,16 @@ println("BLAS threads: $(BLAS.get_num_threads()) / $(Sys.CPU_THREADS) cores")
 const QATLAS_TEST_FULL = get(ENV, "QATLAS_TEST_FULL", "0") != "0"
 println("QATLAS_TEST_FULL = $(QATLAS_TEST_FULL)")
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Canonical test-directory enumeration.
+#
+# `ALL_DIRS` is the *single source of truth* for which directories hold
+# the suite.  CI parallelism is file-level sharding over the union of
+# these dirs (see `QATLAS_TEST_SHARD` below), so the CI workflow no
+# longer duplicates this list — it only passes a shard index.  The
+# completeness guard (just below) makes it impossible to add a test
+# directory that silently never runs.
+# ─────────────────────────────────────────────────────────────────────────────
 const ALL_DIRS = [
     "core/",
     "universalities/",
@@ -32,16 +42,83 @@ const ALL_DIRS = [
     "verification/universality/",
 ]
 
-# QATLAS_TEST_GROUP="models/quantum/TFIM" runs only that dir (CI parallelism).
-# Comma-separated for multi-dir groups. Unset or empty → run all.
-const _test_group = get(ENV, "QATLAS_TEST_GROUP", "")
-const dirs = if isempty(_test_group)
-    ALL_DIRS
-else
-    groups = split(_test_group, ",")
-    filter(d -> any(g -> startswith(d, g), groups), ALL_DIRS)
+_is_test_file(f) = startswith(f, "test_") && endswith(f, ".jl")
+
+# ── Completeness guard ───────────────────────────────────────────────
+# Walk the whole test tree; every directory that contains a `test_*.jl`
+# MUST be enumerated in `ALL_DIRS`, and every `ALL_DIRS` entry must
+# exist and be non-empty.  Runs in every shard (cheap) and fails
+# loudly — a test directory can never be added without being wired in.
+# `test_aqua.jl` at the test/ root is the only sanctioned exception.
+let
+    root = @__DIR__
+    enumerated = Set(ALL_DIRS)
+    discovered = Set{String}()
+    for (d, _, files) in walkdir(root)
+        any(_is_test_file, files) || continue
+        rel = replace(relpath(d, root), '\\' => '/')
+        rel == "." && continue  # test/ root: only test_aqua.jl, run specially
+        push!(discovered, rel * "/")
+    end
+    leaked = sort(collect(setdiff(discovered, enumerated)))
+    isempty(leaked) || error(
+        "runtests.jl completeness guard: these on-disk test directories hold " *
+        "test_*.jl files but are NOT in ALL_DIRS and would never run — add " *
+        "them to ALL_DIRS: $(leaked)",
+    )
+    for d in ALL_DIRS
+        p = joinpath(root, d)
+        (isdir(p) && any(_is_test_file, readdir(p))) || error(
+            "runtests.jl completeness guard: ALL_DIRS entry $(repr(d)) is " *
+            "missing on disk or contains no test_*.jl files.",
+        )
+    end
 end
-println("QATLAS_TEST_GROUP = $(repr(_test_group))  →  dirs = $(dirs)")
+
+# ── Canonical, deterministic global test-file universe ───────────────
+# ALL_DIRS order × lexically-sorted files.  Sharding partitions THIS
+# list, so the union of every shard is exactly this set — no file can
+# be missed or double-run.
+const ALL_TEST_FILES = let acc = Tuple{String,String}[]
+    for d in ALL_DIRS
+        for f in sort(filter(_is_test_file, readdir(joinpath(@__DIR__, d))))
+            push!(acc, (d, f))
+        end
+    end
+    acc
+end
+
+# ── Test selection: SHARD (CI) > GROUP (local targeted) > ALL ────────
+#
+#   QATLAS_TEST_SHARD="k/N"  — round-robin shard k of N over the global
+#                              file list (CI parallelism; balanced).
+#   QATLAS_TEST_GROUP="a,b"  — dir-prefix filter (local targeted runs).
+#   neither                  — run everything.
+#
+const _shard_spec = get(ENV, "QATLAS_TEST_SHARD", "")
+const _test_group = get(ENV, "QATLAS_TEST_GROUP", "")
+
+const _selected, _mode_desc, _run_aqua = if !isempty(_shard_spec)
+    parts = split(_shard_spec, "/")
+    length(parts) == 2 ||
+        error("QATLAS_TEST_SHARD must be \"k/N\"; got $(repr(_shard_spec))")
+    k = parse(Int, parts[1])
+    n = parse(Int, parts[2])
+    (1 <= k <= n) || error("QATLAS_TEST_SHARD k/N needs 1 ≤ k ≤ N; got $k/$n")
+    sel = [tf for (i, tf) in enumerate(ALL_TEST_FILES) if ((i - 1) % n) + 1 == k]
+    (sel, "SHARD $k/$n", k == 1)
+elseif !isempty(_test_group)
+    groups = split(_test_group, ",")
+    sel = [tf for tf in ALL_TEST_FILES if any(g -> startswith(tf[1], g), groups)]
+    (sel, "GROUP $(repr(_test_group))", any(g -> startswith("core/", g), groups))
+else
+    (ALL_TEST_FILES, "ALL", true)
+end
+
+println(
+    "Test selection: $(_mode_desc) → $(length(_selected))/$(length(ALL_TEST_FILES)) " *
+    "files; aqua=$(_run_aqua)",
+)
 
 const FIG_BASE = joinpath(pkgdir(QAtlas), "docs", "src", "assets")
 const PATHS = Dict()
@@ -59,31 +136,20 @@ include(joinpath(@__DIR__, "util", "thermodynamic_identities.jl"))
     test_args = copy(ARGS)
     println("Passed arguments ARGS = $(test_args) to tests.")
 
-    # Aqua static QA — run only in the core group (or when running all).
-    if isempty(_test_group) || any(g -> startswith("core/", g), split(_test_group, ","))
+    # Aqua static QA — a one-shot whole-package check; run in exactly
+    # one shard (shard 1), the core-covering group, or a full run.
+    if _run_aqua
         @testset "test_aqua.jl" begin
             @time include(joinpath(@__DIR__, "test_aqua.jl"))
         end
     end
 
-    @time for dir in dirs
-        dirpath = joinpath(@__DIR__, dir)
-        println("\nTest $(dirpath)")
-        files = sort(
-            filter(f -> startswith(f, "test_") && endswith(f, ".jl"), readdir(dirpath))
-        )
-        if isempty(files)
-            println("  No test files found in $(dirpath).")
-            @test false
-        else
-            for f in files
-                @testset "$f" begin
-                    filepath = joinpath(dirpath, f)
-                    @time begin
-                        println("  Including $(filepath)")
-                        include(filepath)
-                    end
-                end
+    @time for (d, f) in _selected
+        filepath = joinpath(@__DIR__, d, f)
+        @testset "$(d)$(f)" begin
+            @time begin
+                println("  Including $(filepath)")
+                include(filepath)
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -102,9 +102,16 @@ const _selected, _mode_desc, _run_aqua = if !isempty(_shard_spec)
     parts = split(_shard_spec, "/")
     length(parts) == 2 ||
         error("QATLAS_TEST_SHARD must be \"k/N\"; got $(repr(_shard_spec))")
-    k = parse(Int, parts[1])
-    n = parse(Int, parts[2])
+    k = tryparse(Int, strip(parts[1]))
+    n = tryparse(Int, strip(parts[2]))
+    (k !== nothing && n !== nothing) ||
+        error("QATLAS_TEST_SHARD must be integer \"k/N\"; got $(repr(_shard_spec))")
     (1 <= k <= n) || error("QATLAS_TEST_SHARD k/N needs 1 ≤ k ≤ N; got $k/$n")
+    n <= length(ALL_TEST_FILES) || error(
+        "QATLAS_TEST_SHARD N=$n exceeds the $(length(ALL_TEST_FILES))-file suite; " *
+        "shards $(length(ALL_TEST_FILES) + 1)..$n would run zero tests — lower " *
+        "the shard count N in .github/workflows/CI.yml.",
+    )
     sel = [tf for (i, tf) in enumerate(ALL_TEST_FILES) if ((i - 1) % n) + 1 == k]
     (sel, "SHARD $k/$n", k == 1)
 elseif !isempty(_test_group)


### PR DESCRIPTION
Makes CI **comprehensive** (impossible to silently skip tests) and **fully parallel** (compute-balanced), replacing the hardcoded 13-entry dir-group matrix.

## Problems with the old matrix

1. **Silent-leak risk** — `ALL_DIRS` (runtests.jl) and the CI.yml `group:` list were dual-maintained. Add a test dir to one but not the other → tests that never run, undetected. (We nearly hit this; current state was verified complete but the footgun was live.)
2. **Poor compute use** — dir-level split is unbalanced. Wall-clock was bound by the single slowest dir job (`verification/tfim_ising` ~7.5 min, `TFIM` ~6 min) while the other 11 finished in ~1-3 min.

## Fix: file-level sharding over one source of truth

### `test/runtests.jl`
- **`QATLAS_TEST_SHARD="k/N"`** — round-robin partition of the canonical `ALL_DIRS` file universe (133 files). The union of all shards is **exactly** the full suite by construction. Verified: 133 unique files, **0 missed, 0 double-run**, balance spread 8–9 files/shard at N=16.
- **Completeness guard** — walks the whole `test/` tree; **errors** if any on-disk directory holding `test_*.jl` is absent from `ALL_DIRS`, or any `ALL_DIRS` entry is missing/empty. Runs in every shard → a test directory can never be added without being wired in. **Silent leak is now structurally impossible.** Verified: fires on a synthetic unregistered dir; passes clean.
- `QATLAS_TEST_GROUP` still works for local targeted runs (precedence **SHARD > GROUP > ALL**). Aqua runs in exactly one shard (shard 1).

### `.github/workflows/CI.yml`
- `plan` job emits the shard list as JSON from a **single `N` (=16)**; the `test` matrix consumes `fromJSON`. The directory list is **no longer duplicated** in CI — CI only carries the shard count. Change parallelism in one place.
- Per-shard Julia cache + coverage artifact keyed by `strategy.job-index`; coverage merge + `all-tests` gate updated (also checks `plan`).

## Verification (Panza)

- 16-shard partition = exact bijective cover of all 133 files (0 miss / 0 dup; sizes 8–9).
- Shards 1, 8, 16 run green (1: +Aqua; 8: 256 pass; 16: 1171 pass).
- Completeness guard fires on a synthetic `models/quantum/_leakprobe/`; no-op on clean tree.
- `runtests.jl` JuliaFormatter-clean.

## Expected effect

Wall-clock no longer bound by one heavy dir: ~34 min serial → ≈ max(heaviest single file ~1.9 min, 34/16 ≈ 2.1 min) + precompile ≈ ~4 min, within the 20-job free-public concurrency budget (build/docs/format/version still fit). `QATLAS_TEST_FULL` nightly path unchanged.