### PR TITLE
ci(B): black-box verify() + ci-evidence JSONL cards (WHY-correct plane)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -104,6 +104,15 @@ jobs:
           retention-days: 1
           if-no-files-found: warn
           overwrite: true
+      - name: Upload shard evidence cards (push:main only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v7
+        with:
+          name: evidence-${{ matrix.sid }}
+          path: test/.ci-out/evidence-*.jsonl
+          retention-days: 1
+          if-no-files-found: warn
+          overwrite: true
 
   record-timings:
     name: Record timing history
@@ -145,6 +154,50 @@ jobs:
           git add timings.tsv
           git commit -q -m "ci: refresh test timings ($rows rows) [skip ci]"
           git push -q --force "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" ci-timings
+
+  record-evidence:
+    name: Record verification evidence
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.test.result == 'success'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
+        with:
+          path: evidence-parts
+          pattern: evidence-*
+      - name: Merge JSONL cards into the ci-evidence orphan branch
+        run: |
+          set -euo pipefail
+          mkdir -p merged
+          if git ls-remote --exit-code --heads origin ci-evidence >/dev/null 2>&1; then
+            git fetch --depth=1 origin ci-evidence
+            git show FETCH_HEAD:evidence.jsonl > merged/old.jsonl 2>/dev/null || : > merged/old.jsonl
+          else
+            : > merged/old.jsonl
+          fi
+          : > merged/new.jsonl
+          find evidence-parts -name 'evidence-*.jsonl' -exec cat {} + >> merged/new.jsonl || true
+          cat merged/old.jsonl merged/new.jsonl > merged/all.jsonl
+          jq -c -s 'reduce .[] as $c ({}; .[$c.hub + "|" + $c.route] = $c)
+                    | to_entries | sort_by(.key) | map(.value) | .[]' \
+            merged/all.jsonl > merged/evidence.jsonl || : > merged/evidence.jsonl
+          rows=$(wc -l < merged/evidence.jsonl)
+          if [ "$rows" -lt 1 ]; then
+            echo "No evidence cards merged — skipping push"
+            exit 0
+          fi
+          echo "Merged evidence cards: $rows"
+          tmp=$(mktemp -d)
+          cp merged/evidence.jsonl "$tmp/evidence.jsonl"
+          cd "$tmp"
+          git init -q
+          git config user.email "ci@qatlas"
+          git config user.name "qatlas-ci"
+          git checkout -q -b ci-evidence
+          git add evidence.jsonl
+          git commit -q -m "ci: refresh verification evidence ($rows cards) [skip ci]"
+          git push -q --force "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" ci-evidence
 
   coverage:
     name: Coverage (aggregated)

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 docs/build/
 Manifest.toml
+# CI scratch: per-shard timing/evidence emitted under QATLAS_EMIT
+test/.ci-out/

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,11 +1,12 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 KrylovKit = "0b1a1467-8014-51b9-945f-bf0ae24f4b77"
-Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Lattice2D = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
 LatticeCore = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 QAtlas = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/test/ci/README.md
+++ b/test/ci/README.md
@@ -1,0 +1,118 @@
+# QAtlas test architecture — design guardrails
+
+The suite is organised around **three separated planes**.  Most CI bugs
+historically came from blurring them, so the separation is enforced
+structurally, not by convention.  Read this before changing anything
+under `test/ci/`, `test/util/verify.jl`, `runtests.jl`, or `CI.yml`.
+
+```
+WHAT runs    →  test/ci/universe.jl     (single source of truth + guard)
+HOW it splits → test/ci/plan_shards.jl  (timing-balanced; advisory only)
+WHY it's right → test/util/verify.jl    (black-box cards → ci-evidence)
+```
+
+The golden rule: **WHAT is authoritative; HOW and WHY may never override
+it.**  Timing/evidence data can be stale, missing, or wrong and the
+suite must still run every test exactly once.
+
+---
+
+## WHAT — the test universe
+
+- `test/ci/universe.jl` `ALL_DIRS` is the **only** place the test
+  directory set is declared.  Do **not** re-list directories in
+  `CI.yml`, the planner, or anywhere else.
+- A test file **must** be named `test_*.jl` (the glob filter).  A file
+  that does not match is silently ignored — name it correctly.
+- Adding a new test directory **requires** adding it to `ALL_DIRS`.
+  The completeness guard hard-fails CI (in every shard) if any on-disk
+  `test_*.jl` directory is missing from `ALL_DIRS`, or if an `ALL_DIRS`
+  entry is missing/empty.  This failure is **intended** — it makes a
+  silently-skipped test structurally impossible.
+- `test/test_aqua.jl` at the test/ root is the only sanctioned
+  non-`ALL_DIRS` file (run once, in exactly one shard).
+
+## HOW — sharding, timing, profiles
+
+- Shard count `N` lives **only** in the `CI.yml` `plan` job.  Change
+  parallelism there and nowhere else.
+- `ci-timings` / `ci-evidence` are **orphan branches written only by
+  `push:main`**; PR runs read them read-only.  Never write them from a
+  PR (push contention + diff pollution).  Missing/stale → graceful
+  round-robin / "pending" fallback, never a leak.
+- Selection precedence: `QATLAS_TEST_FILES` > `QATLAS_TEST_SHARD` >
+  `QATLAS_TEST_GROUP` > all.  `QATLAS_TEST_FILES` may only name files
+  in the universe (the planner cannot smuggle in non-globbed files).
+- Profiles (`QATLAS_TEST_PROFILE`): `fast` = PR merge gate (small N,
+  loose tol, **no emit**); `full` = `push:main` (deeper, **emits**
+  timing+evidence); `nightly` = cron (deepest).  The persisted numbers
+  always reflect the heavier `full` run.
+- **Dense ED is exponential.**  A spin-S chain is `(2S+1)^N`.  Hard-cap
+  `N` per model at the feasible ceiling and pass explicit caps:
+  `verify_profile_Ns(; fast=…, full=…, nightly=…)`.  Never let the
+  profile knob push `N` past the dense-ED limit (spin-1 ⇒ N ≤ 8 =
+  3^8; matches src `_MAX_ED_SITES_S1`).  *This was a real bug — 3^12
+  dense eigen is ~TB of RAM.*
+- `test/.ci-out/` is gitignored emit scratch — never commit it.
+
+## WHY — black-box verification (the epistemic core)
+
+- **`src/` holds closed-form analytical values only.**  ED / numerical
+  diagonalisation belongs in **tests** as an independent cross-check,
+  never as the src implementation.  (PR #359 was closed for putting
+  dense-ED finite-T into src.)
+- Tests are **black-box**: they know only (a) the model's physics
+  (its written Hamiltonian) and (b) the public
+  `fetch(model, quantity, bc; kw…)` API.  A test must **not** read
+  `QAtlas._internal`s, nor reuse a src matrix-builder for its
+  independent route — rebuild the physics from `test/util/generic_ed.jl`
+  so a src-builder bug cannot also corrupt the cross-check.
+- `verify(...)`: the **subject is always `fetch(...)` computed inside
+  the helper**.  There is no argument to re-type the src formula —
+  keep it that way; a card can then never be circular.
+- The independent route must be a genuinely different computation path.
+  `route ∈ {:ed_finite_size, :sum_rule, :delegation_invariant,
+  :limiting_case, :literature_value, :second_closed_form}`.  Do not add
+  a route that smuggles the src derivation back in.
+- One `verify` call = one card on hub `Model/Quantity/BC`.  Confidence
+  is **network-style**: number of *independent* routes × their
+  precision.  Prefer several different routes on one hub over one.
+- The card JSONL schema is the contract for the future doc/forum and
+  MCP.  Keep it stable and minimal — scalars only (subject, a short
+  convergence vector, errors, refs); never dump full spectra/matrices.
+- A new value runs in its own PR (assert-only); its timing/evidence is
+  recorded only on the post-merge `push:main`.  It is "pending
+  verification" until then — never silently absent.
+- **Degenerate ground states break single-vector ED routes.**  If the
+  model's GS manifold is degenerate (e.g. OBC AKLT is 4-fold from edge
+  modes), `eigen(...).vectors[:,1]` is an *arbitrary* member of that
+  manifold and a single-vector `⟨O_iO_j⟩` is **basis-dependent** — it
+  differs across BLAS/LAPACK builds (it bit us twice: the early AKLT
+  `⟨Sᶻ²⟩` and the pilot `S(π)`, Panza 0.011 vs GH-runner 0.065).  An
+  independent ED route must use a **basis-invariant** quantity:
+  `Tr(ρ_GS O_iO_j)` averaged over the whole degenerate eigenspace, or
+  a non-degenerate setup (PBC ring for AKLT).  Eigen*values* are fine
+  (the smallest is unique) — only eigen*vectors* need this care.
+
+---
+
+## Mechanics that bite (operational caveats)
+
+- **Stacked PRs**: #361 → #362 → #363 → #364 each builds on the prior
+  as a safe fallback.  Merge in dependency order; never out of order.
+- **Branch protection** required checks are matched by job *name* and
+  are `["build", "All tests passed"]`.  Keep the aggregate gate job
+  named exactly `All tests passed` — renaming/removing it strands
+  branch protection and permanently blocks merges.  Per-shard job
+  names are *not* required checks (so they may change freely).
+- `GITHUB_TOKEN` pushes do **not** trigger workflows (intentional
+  anti-recursion).  Relied on for `ci-timings`/`ci-evidence` (data,
+  must not trigger CI) and the reason auto-format was moved from a
+  committing bot to a check (`FormatFix` → `FormatCheck`, PR #355).
+- Dev-host mechanics: use the absolute juliaup path in non-interactive
+  SSH; `gh` is at `~/.local/bin/gh`; nested ssh/heredoc mangles
+  Unicode (β ⟨⟩ ≤) and `$` — edit via a scp'd file or base64, not
+  inline heredocs.  The worktree test env needs
+  `Pkg.develop(path=pwd()); Pkg.instantiate()`, which pollutes
+  `test/Project.toml` with an absolute `[sources]` path — always
+  `git checkout test/Project.toml` before committing.

--- a/test/core/test_verify_harness.jl
+++ b/test/core/test_verify_harness.jl
@@ -1,0 +1,50 @@
+# Self-test for the black-box verification harness (test/util/verify.jl
+# + test/util/generic_ed.jl).  Proves: (1) the subject is fetched, not
+# re-typed; (2) a model-agnostic ED route (built from the *physics*, not
+# any QAtlas internal builder) reproduces a src closed form; (3) route
+# validation rejects anything outside the independent vocabulary.
+
+using QAtlas, Test
+using LinearAlgebra: kron
+
+@testset "verify harness — black-box independence (self-test)" begin
+    # AKLT bond from the WRITTEN Hamiltonian H = Σ S·S + 1/3 (S·S)²,
+    # spin-1, J = 1 — reconstructed purely from generic_ed primitives.
+    Sx, Sy, Sz = spin_ops(1)
+    SS = kron(Sx, Sx) + kron(Sy, Sy) + kron(Sz, Sz)
+    bond = SS + (1 / 3) * (SS * SS)
+
+    Ns = (4, 6)
+    ed_eps = Float64[]
+    for N in Ns
+        H = chain_hamiltonian(3, N, bond)          # OBC, no src builder
+        E0, _ = ground_state(H)
+        push!(ed_eps, E0 / (N - 1))                # frustration-free ⇒ -2/3
+    end
+
+    # `verify` fetches the subject itself (AKLT1D Energy{:per_site},
+    # Infinite = closed form -2J/3); we only hand it the independent ED.
+    s = verify(
+        AKLT1D(),
+        Energy(:per_site),
+        Infinite();
+        route=:ed_finite_size,
+        independent=ed_eps,
+        at=["N=$N" for N in Ns],
+        agree_within=1e-9,
+        refs=["Affleck-Kennedy-Lieb-Tasaki 1988"],
+    )
+    @test s ≈ -2 / 3 atol = 1e-12          # subject came from fetch
+    @test all(e -> isapprox(e, -2 / 3; atol=1e-10), ed_eps)  # ED reproduced it
+
+    # Route vocabulary is closed — "retype the formula" is unexpressible.
+    @test_throws ErrorException verify(
+        AKLT1D(),
+        Energy(:per_site),
+        Infinite();
+        route=:retype_formula,
+        independent=[-2 / 3],
+        agree_within=1e-9,
+        refs=["x"],
+    )
+end

--- a/test/models/quantum/misc/test_aklt.jl
+++ b/test/models/quantum/misc/test_aklt.jl
@@ -201,3 +201,93 @@ end
         end
     end
 end
+
+# ----------------------------------------------------------------------------
+# Verification cards (pilot for the WHY-correct plane).
+#
+# Each `verify(...)` cross-checks a src closed form against a black-box
+# independent ED route rebuilt from the AKLT Hamiltonian
+# H = sum Si.Si+1 + (1/3)(Si.Si+1)^2 (spin-1) via generic_ed -- never a
+# QAtlas internal builder.
+#
+# The OBC AKLT ground state is 4-fold degenerate (two spin-1/2 edge
+# modes).  A single LAPACK eigenvector is an arbitrary member of that
+# manifold, so <Sz_i Sz_j> from one vector is basis-dependent and varies
+# across BLAS/LAPACK builds (Panza vs the GH runner gave 0.011 vs 0.065).
+# The independent route therefore uses the MANIFOLD-AVERAGED two-point
+# Tr(rho_GS Sz_i Sz_j) over the degenerate ground eigenspace -- a basis-
+# invariant, deterministic quantity.
+# ----------------------------------------------------------------------------
+@testset "AKLT1D -- verification cards (black-box ED, pilot)" begin
+    using LinearAlgebra: Hermitian, eigen, kron
+
+    Sx, Sy, Sz = spin_ops(1)
+    SS = kron(Sx, Sx) + kron(Sy, Sy) + kron(Sz, Sz)
+    bond = SS + (1 / 3) * (SS * SS)
+    Ns = verify_profile_Ns(; fast=(6, 8), full=(6, 8), nightly=(6, 8))
+
+    function aklt_manifold(N)
+        F = eigen(Hermitian(Matrix(chain_hamiltonian(3, N, bond))))
+        E0 = F.values[1]
+        deg = findall(e -> isapprox(e, E0; atol=1e-8), F.values)
+        return F.values, [F.vectors[:, k] for k in deg]
+    end
+    function avg_zz(vecs, N, i, j)
+        return sum(two_point(psi, 3, N, Sz, i, j) for psi in vecs) / length(vecs)
+    end
+
+    verify(
+        AKLT1D(),
+        Energy(:per_site),
+        Infinite();
+        route=:ed_finite_size,
+        independent=[aklt_manifold(N)[1][1] / (N - 1) for N in Ns],
+        at=["N=$N" for N in Ns],
+        agree_within=1e-9,
+        refs=["Affleck-Kennedy-Lieb-Tasaki 1988"],
+    )
+
+    let r = 2
+        ind = Float64[]
+        for N in Ns
+            _, vecs = aklt_manifold(N)
+            i0 = cld(N, 2)
+            push!(ind, avg_zz(vecs, N, i0, i0 + r))
+        end
+        verify(
+            AKLT1D(),
+            ZZCorrelation(; mode=:static),
+            Infinite();
+            route=:ed_finite_size,
+            independent=ind,
+            at=["N=$N" for N in Ns],
+            agree_within=3e-2,
+            fetch_kw=(; r=r),
+            refs=["Affleck-Kennedy-Lieb-Tasaki 1988"],
+        )
+    end
+
+    let q = pi
+        ind = Float64[]
+        for N in Ns
+            _, vecs = aklt_manifold(N)
+            i0 = cld(N, 2)
+            S = avg_zz(vecs, N, i0, i0)
+            for r in 1:(N - i0)
+                S += 2 * cos(q * r) * avg_zz(vecs, N, i0, i0 + r)
+            end
+            push!(ind, S)
+        end
+        verify(
+            AKLT1D(),
+            ZZStructureFactor(),
+            Infinite();
+            route=:ed_finite_size,
+            independent=ind,
+            at=["N=$N" for N in Ns],
+            agree_within=0.15,
+            fetch_kw=(; q=q),
+            refs=["Arovas-Auerbach-Haldane 1988"],
+        )
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,6 +107,8 @@ include(joinpath(@__DIR__, "util", "sparse_ed.jl"))
 include(joinpath(@__DIR__, "util", "bloch.jl"))
 include(joinpath(@__DIR__, "util", "tfim_dense_ed.jl"))
 include(joinpath(@__DIR__, "util", "thermodynamic_identities.jl"))
+include(joinpath(@__DIR__, "util", "generic_ed.jl"))
+include(joinpath(@__DIR__, "util", "verify.jl"))
 
 # Per-file wall-time, captured for the timing plane (HOW-to-split).
 const _TIMINGS = Dict{String,Float64}()

--- a/test/util/generic_ed.jl
+++ b/test/util/generic_ed.jl
@@ -1,0 +1,120 @@
+# test/util/generic_ed.jl — model-agnostic spin-S dense ED.
+#
+# Independent-route building blocks for `verify(...)` cards.  These
+# reconstruct the physics from a *Hamiltonian spec the test supplies
+# from the model definition* — they deliberately do NOT call any
+# `QAtlas._internal` builder, so a bug in a src matrix-builder cannot
+# also corrupt the independent cross-check (true black-box independence).
+
+using LinearAlgebra: Hermitian, Diagonal, eigen, eigvals, I, kron
+
+_eyed(n) = Matrix{ComplexF64}(I, n, n)
+
+"""
+    spin_ops(S) -> (Sx, Sy, Sz)
+
+Dense `(2S+1)×(2S+1)` spin-`S` operators (ħ = 1).  S ∈ {1/2, 1, 3/2, …}.
+"""
+function spin_ops(S::Real)
+    d = Int(round(2S + 1))
+    m = [S - (k - 1) for k in 1:d]                     # S, S-1, …, -S
+    Sz = Matrix{ComplexF64}(Diagonal(m))
+    Sp = zeros(ComplexF64, d, d)
+    for k in 1:(d - 1)
+        mk = m[k + 1]                                  # lower state's m
+        Sp[k, k + 1] = sqrt(S * (S + 1) - mk * (mk + 1))
+    end
+    Sm = collect(Sp')
+    Sx = (Sp + Sm) / 2
+    Sy = (Sp - Sm) / (2im)
+    return Sx, Sy, Sz
+end
+
+"""
+    chain_hamiltonian(d, N, bond; onsite=nothing) -> Hermitian
+
+Dense `dᴺ×dᴺ` OBC Hamiltonian from a `d²×d²` nearest-neighbour `bond`
+operator (+ optional `d×d` `onsite`).  The caller supplies `bond` from
+the model's *written Hamiltonian*, not from src.
+"""
+function chain_hamiltonian(d::Int, N::Int, bond::AbstractMatrix; onsite=nothing)
+    D = d^N
+    H = zeros(ComplexF64, D, D)
+    for i in 1:(N - 1)
+        H .+= kron(_eyed(d^(i - 1)), bond, _eyed(d^(N - i - 1)))
+    end
+    if onsite !== nothing
+        for i in 1:N
+            H .+= kron(_eyed(d^(i - 1)), onsite, _eyed(d^(N - i)))
+        end
+    end
+    return Hermitian(H)
+end
+
+"""
+    chain_hamiltonian_pbc(d, N, terms) -> Hermitian
+
+PBC chain where the bond is `Σ A⊗B` over `terms::Vector{Tuple}` (e.g.
+`[(Sx,Sx),(Sy,Sy),(Sz,Sz)]` for S·S).  Adds NN bonds i=1..N-1 plus the
+wrap (site N, site 1).  Exact for sum-of-products bonds (the
+AKLT/Heisenberg family).
+"""
+function chain_hamiltonian_pbc(d::Int, N::Int, terms::Vector{<:Tuple})
+    D = d^N
+    H = zeros(ComplexF64, D, D)
+    bond = sum(kron(A, B) for (A, B) in terms)
+    for i in 1:(N - 1)
+        H .+= kron(_eyed(d^(i - 1)), bond, _eyed(d^(N - i - 1)))
+    end
+    for (A, B) in terms                                # wrap (N,1)
+        opN = kron(_eyed(d^(N - 1)), A)
+        op1 = kron(B, _eyed(d^(N - 1)))
+        H .+= opN * op1
+    end
+    return Hermitian(H)
+end
+
+dense_spectrum(H) = sort(real.(eigvals(Hermitian(Matrix(H)))))
+
+function ground_state(H)
+    F = eigen(Hermitian(Matrix(H)))
+    return F.values[1], F.vectors[:, 1]
+end
+
+"""
+    site_op(o, d, N, site) -> Matrix
+
+Embed a single-site `d×d` operator at `site` in an `N`-site chain.
+"""
+function site_op(o::AbstractMatrix, d::Int, N::Int, site::Int)
+    kron(_eyed(d^(site - 1)), o, _eyed(d^(N - site)))
+end
+
+"""
+    two_point(ψ, d, N, o, i, j) -> Float64
+
+`⟨ψ| oᵢ oⱼ |ψ⟩` (real part) for a single-site operator `o`.
+"""
+function two_point(ψ, d::Int, N::Int, o::AbstractMatrix, i::Int, j::Int)
+    Oi = site_op(o, d, N, i)
+    Oj = site_op(o, d, N, j)
+    return real(ψ' * (Oi * (Oj * ψ)))
+end
+
+"""
+    thermo_from_spectrum(evals, β) -> (E, F, S, C)  [totals]
+
+Exact canonical thermodynamics from an eigenvalue list (log-sum-exp
+shifted).  Per-site = divide by N at the call site.
+"""
+function thermo_from_spectrum(evals::AbstractVector, β::Real)
+    emin = minimum(evals)
+    w = exp.(-β .* (evals .- emin))
+    Z = sum(w)
+    E = sum(evals .* w) / Z
+    E2 = sum((evals .^ 2) .* w) / Z
+    F = -(log(Z) - β * emin) / β
+    Sent = β * (E - F)
+    Cv = β^2 * (E2 - E^2)
+    return E, F, Sent, Cv
+end

--- a/test/util/verify.jl
+++ b/test/util/verify.jl
@@ -1,0 +1,151 @@
+# test/util/verify.jl — black-box verification cards (WHY-correct plane).
+#
+# A `verify(...)` call cross-checks a src closed-form value against an
+# INDEPENDENT route and (on push:main) emits one JSONL "verification
+# card" to test/.ci-out/evidence-<sid>.jsonl.  The `ci-evidence` orphan
+# branch accumulates the cards; a future doc/forum generator renders a
+# per-(model,quantity) hub note whose confidence grows with the number
+# and precision of independent corroborating cards (Zettelkasten-style).
+#
+# Anti-circularity is STRUCTURAL, not a convention:
+#   * the value under test (`subject`) is ALWAYS obtained by the helper
+#     calling `QAtlas.fetch(model, quantity, bc; fetch_kw...)`.  There is
+#     NO argument that lets a test re-type the src formula.
+#   * the test only supplies an `independent` number/array computed by a
+#     route that does not look at src internals (ED, sum rule, …).
+#   * `route` must be one of a fixed vocabulary of *independent* routes;
+#     "retype the formula" is simply not expressible.
+#
+# Profiles: PR/local runs assert only.  push:main (QATLAS_EMIT=1, full
+# profile) is the heavier computation and the only writer of cards.
+
+using Dates: Dates
+using Test: @test
+
+const _VERIFY_ROUTES = (
+    :ed_finite_size,        # exact diagonalisation, finite-N → closed form
+    :sum_rule,              # an independent analytic identity / sum rule
+    :delegation_invariant,  # model X at p ≡ model Y (different derivation)
+    :limiting_case,         # a known independent value at a special point
+    :literature_value,      # a published numeric (DMRG/MC) cross-check
+    :second_closed_form,    # an independent closed form, different derivation
+)
+
+_verify_typename(x) = string(nameof(typeof(x)))
+
+function _verify_hub(model, quantity, bc)
+    return string(
+        _verify_typename(model), "/", _verify_typename(quantity), "/", _verify_typename(bc)
+    )
+end
+
+function _verify_commit()
+    sha = get(ENV, "GITHUB_SHA", "")
+    isempty(sha) || return sha
+    try
+        return strip(read(`git rev-parse --short HEAD`, String))
+    catch
+        return "unknown"
+    end
+end
+
+# Profile-scaled N-sweep helper for independent ED routes.
+function verify_profile_Ns(;
+    fast=(6, 8), full=(6, 8, 10, 12), nightly=(6, 8, 10, 12, 14, 16)
+)
+    p = isdefined(Main, :QATLAS_TEST_PROFILE) ? Main.QATLAS_TEST_PROFILE : :fast
+    p === :nightly && return nightly
+    p === :full && return full
+    return fast
+end
+
+_json_str(s) = '"' * replace(string(s), '\\' => "\\\\", '"' => "\\\"") * '"'
+function _json_arr(xs)
+    return "[" * join((x isa Real ? string(x) : _json_str(x) for x in xs), ",") * "]"
+end
+
+"""
+    verify(model, quantity, bc;
+           route, independent, agree_within,
+           refs, reliability=:high, fetch_kw=(;), at=nothing) -> subject
+
+Black-box-verify the src value `fetch(model, quantity, bc; fetch_kw...)`
+against an `independent` numeric (scalar or convergence vector) obtained
+by `route` (one of `$(_VERIFY_ROUTES)`).  Runs `@test` (best/last
+element within `agree_within`) and, under `QATLAS_EMIT=1`, appends one
+JSONL verification card.  The subject is fetched here — never supplied
+by the caller — so the card can never be circular.
+"""
+function verify(
+    model,
+    quantity,
+    bc;
+    route::Symbol,
+    independent,
+    agree_within::Real,
+    refs::AbstractVector{<:AbstractString},
+    reliability::Symbol=:high,
+    fetch_kw::NamedTuple=(;),
+    at=nothing,
+)
+    route in _VERIFY_ROUTES ||
+        error("verify: route must be one of $(_VERIFY_ROUTES); got $(repr(route))")
+
+    # ── the ONLY src touch-point: subject is fetched, never re-typed ──
+    subject = QAtlas.fetch(model, quantity, bc; fetch_kw...)
+
+    ind =
+        independent isa AbstractVector ? collect(float.(independent)) : [float(independent)]
+    best = last(ind)                  # convergence: largest-N / final value
+    abserr = abs(best - float(subject))
+
+    @test isapprox(best, float(subject); atol=agree_within)
+
+    if get(ENV, "QATLAS_EMIT", "0") == "1"
+        outdir = joinpath(@__DIR__, "..", ".ci-out")
+        mkpath(outdir)
+        tf = get(ENV, "QATLAS_TEST_FILES", "")
+        sid = isempty(tf) ? "all" : replace(string(hash(tf); base=16), '/' => '-')
+        atv = at === nothing ? String[] : [string(a) for a in at]
+        card = string(
+            "{",
+            "\"hub\":",
+            _json_str(_verify_hub(model, quantity, bc)),
+            ",",
+            "\"route\":",
+            _json_str(route),
+            ",",
+            "\"subject\":",
+            float(subject),
+            ",",
+            "\"independent\":",
+            _json_arr(ind),
+            ",",
+            "\"at\":",
+            _json_arr(atv),
+            ",",
+            "\"abserr\":",
+            round(abserr; sigdigits=4),
+            ",",
+            "\"atol\":",
+            float(agree_within),
+            ",",
+            "\"reliability\":",
+            _json_str(reliability),
+            ",",
+            "\"refs\":",
+            _json_arr(refs),
+            ",",
+            "\"commit\":",
+            _json_str(_verify_commit()),
+            ",",
+            "\"date\":",
+            _json_str(string(Dates.today())),
+            "}",
+        )
+        open(joinpath(outdir, "evidence-$(sid).jsonl"), "a") do io
+            println(io, card)
+        end
+    end
+    return subject
+end


### PR DESCRIPTION
Stacked on PR #362 (base `feat/ci-timing-balanced`; chain main ← #361 ← #362 ← this). Implements the **WHY-correct** plane: every src closed form gets auditable, network-style justification.

## Structural anti-circularity (the core concern)

`verify(model, quantity, bc; route, independent, agree_within, refs, …)`:
- The **subject is ALWAYS `QAtlas.fetch(model,quantity,bc; fetch_kw…)` computed inside the helper**. There is *no argument* by which a test can re-type the src formula → a card can never be `formula == same formula`.
- `route` must be one of a fixed vocabulary of **independent** routes: `:ed_finite_size :sum_rule :delegation_invariant :limiting_case :literature_value :second_closed_form`. "Retype the formula" is simply unexpressible.
- Independent routes use `test/util/generic_ed.jl` — a model-agnostic spin-S dense ED that rebuilds the physics **from the written Hamiltonian, not from any `QAtlas._internal` builder** → a src-builder bug cannot also corrupt the cross-check (true black-box independence).

## Zettelkasten / network corroboration

Each `verify` call = one JSONL **card** `{hub,route,subject,independent,at,abserr,atol,reliability,refs,commit,date}`. `hub = Model/Quantity/BC`. Multiple cards with **different routes** on one hub = independent corroboration; a future doc/forum renders the hub note and a confidence that grows with #independent routes × precision. JSONL is MCP-resource-shaped (hub → resource, card → sub-resource). **No doc generator in this PR** — only the schema, which already enables it.

## Persistence (reuses PR A pattern)

- push:main + `QATLAS_EMIT=1` + `full` profile → per-shard `evidence-*.jsonl` artifact.
- `record-evidence` job (mirrors `record-timings`): jq-merge (latest card per `hub|route` wins) → force-push orphan **`ci-evidence`** branch (`[skip ci]`). PR runs read-only → no contention, no diff pollution.
- `test/.ci-out/` gitignored (emit scratch, never committed).

## Profiles

`verify_profile_Ns()` scales the independent ED N-sweep: PR=fast (assert-only, no emit), push:main=full (deeper ED, emits), nightly=deepest. The persisted card always reflects the heavier main computation.

## Verified on Panza

- Self-test `test/core/test_verify_harness.jl`: AKLT bond rebuilt from H via `generic_ed`; ED reproduces `fetch(AKLT1D,Energy{:per_site},Infinite)=-2/3` to **abserr 3.3e-16**; 4/4 pass assert-only; invalid `route` rejected.
- Emit path writes a valid JSON card `AKLT1D/Energy/Infinite | ed_finite_size | subj=-0.6667 abserr=3.3e-16`.
- Completeness guard accepts the new `core/` test (universe 133 → 134); 3 jl files JuliaFormatter-clean; CI.yml YAML valid.

## Next

PR C: migrate AKLT1D `ZZCorrelation`/`ZZStructureFactor`/energy/gap to `verify` cards (pilot), proving multi-route corroboration on real hubs.