### PR TITLE
test(aklt): pilot verify() cards — 3 AKLT1D hubs, black-box ED routes

### DIFF
--- a/test/ci/README.md
+++ b/test/ci/README.md
@@ -83,6 +83,16 @@ suite must still run every test exactly once.
 - A new value runs in its own PR (assert-only); its timing/evidence is
   recorded only on the post-merge `push:main`.  It is "pending
   verification" until then — never silently absent.
+- **Degenerate ground states break single-vector ED routes.**  If the
+  model's GS manifold is degenerate (e.g. OBC AKLT is 4-fold from edge
+  modes), `eigen(...).vectors[:,1]` is an *arbitrary* member of that
+  manifold and a single-vector `⟨O_iO_j⟩` is **basis-dependent** — it
+  differs across BLAS/LAPACK builds (it bit us twice: the early AKLT
+  `⟨Sᶻ²⟩` and the pilot `S(π)`, Panza 0.011 vs GH-runner 0.065).  An
+  independent ED route must use a **basis-invariant** quantity:
+  `Tr(ρ_GS O_iO_j)` averaged over the whole degenerate eigenspace, or
+  a non-degenerate setup (PBC ring for AKLT).  Eigen*values* are fine
+  (the smallest is unique) — only eigen*vectors* need this care.
 
 ---
 

--- a/test/ci/README.md
+++ b/test/ci/README.md
@@ -1,0 +1,108 @@
+# QAtlas test architecture — design guardrails
+
+The suite is organised around **three separated planes**.  Most CI bugs
+historically came from blurring them, so the separation is enforced
+structurally, not by convention.  Read this before changing anything
+under `test/ci/`, `test/util/verify.jl`, `runtests.jl`, or `CI.yml`.
+
+```
+WHAT runs    →  test/ci/universe.jl     (single source of truth + guard)
+HOW it splits → test/ci/plan_shards.jl  (timing-balanced; advisory only)
+WHY it's right → test/util/verify.jl    (black-box cards → ci-evidence)
+```
+
+The golden rule: **WHAT is authoritative; HOW and WHY may never override
+it.**  Timing/evidence data can be stale, missing, or wrong and the
+suite must still run every test exactly once.
+
+---
+
+## WHAT — the test universe
+
+- `test/ci/universe.jl` `ALL_DIRS` is the **only** place the test
+  directory set is declared.  Do **not** re-list directories in
+  `CI.yml`, the planner, or anywhere else.
+- A test file **must** be named `test_*.jl` (the glob filter).  A file
+  that does not match is silently ignored — name it correctly.
+- Adding a new test directory **requires** adding it to `ALL_DIRS`.
+  The completeness guard hard-fails CI (in every shard) if any on-disk
+  `test_*.jl` directory is missing from `ALL_DIRS`, or if an `ALL_DIRS`
+  entry is missing/empty.  This failure is **intended** — it makes a
+  silently-skipped test structurally impossible.
+- `test/test_aqua.jl` at the test/ root is the only sanctioned
+  non-`ALL_DIRS` file (run once, in exactly one shard).
+
+## HOW — sharding, timing, profiles
+
+- Shard count `N` lives **only** in the `CI.yml` `plan` job.  Change
+  parallelism there and nowhere else.
+- `ci-timings` / `ci-evidence` are **orphan branches written only by
+  `push:main`**; PR runs read them read-only.  Never write them from a
+  PR (push contention + diff pollution).  Missing/stale → graceful
+  round-robin / "pending" fallback, never a leak.
+- Selection precedence: `QATLAS_TEST_FILES` > `QATLAS_TEST_SHARD` >
+  `QATLAS_TEST_GROUP` > all.  `QATLAS_TEST_FILES` may only name files
+  in the universe (the planner cannot smuggle in non-globbed files).
+- Profiles (`QATLAS_TEST_PROFILE`): `fast` = PR merge gate (small N,
+  loose tol, **no emit**); `full` = `push:main` (deeper, **emits**
+  timing+evidence); `nightly` = cron (deepest).  The persisted numbers
+  always reflect the heavier `full` run.
+- **Dense ED is exponential.**  A spin-S chain is `(2S+1)^N`.  Hard-cap
+  `N` per model at the feasible ceiling and pass explicit caps:
+  `verify_profile_Ns(; fast=…, full=…, nightly=…)`.  Never let the
+  profile knob push `N` past the dense-ED limit (spin-1 ⇒ N ≤ 8 =
+  3^8; matches src `_MAX_ED_SITES_S1`).  *This was a real bug — 3^12
+  dense eigen is ~TB of RAM.*
+- `test/.ci-out/` is gitignored emit scratch — never commit it.
+
+## WHY — black-box verification (the epistemic core)
+
+- **`src/` holds closed-form analytical values only.**  ED / numerical
+  diagonalisation belongs in **tests** as an independent cross-check,
+  never as the src implementation.  (PR #359 was closed for putting
+  dense-ED finite-T into src.)
+- Tests are **black-box**: they know only (a) the model's physics
+  (its written Hamiltonian) and (b) the public
+  `fetch(model, quantity, bc; kw…)` API.  A test must **not** read
+  `QAtlas._internal`s, nor reuse a src matrix-builder for its
+  independent route — rebuild the physics from `test/util/generic_ed.jl`
+  so a src-builder bug cannot also corrupt the cross-check.
+- `verify(...)`: the **subject is always `fetch(...)` computed inside
+  the helper**.  There is no argument to re-type the src formula —
+  keep it that way; a card can then never be circular.
+- The independent route must be a genuinely different computation path.
+  `route ∈ {:ed_finite_size, :sum_rule, :delegation_invariant,
+  :limiting_case, :literature_value, :second_closed_form}`.  Do not add
+  a route that smuggles the src derivation back in.
+- One `verify` call = one card on hub `Model/Quantity/BC`.  Confidence
+  is **network-style**: number of *independent* routes × their
+  precision.  Prefer several different routes on one hub over one.
+- The card JSONL schema is the contract for the future doc/forum and
+  MCP.  Keep it stable and minimal — scalars only (subject, a short
+  convergence vector, errors, refs); never dump full spectra/matrices.
+- A new value runs in its own PR (assert-only); its timing/evidence is
+  recorded only on the post-merge `push:main`.  It is "pending
+  verification" until then — never silently absent.
+
+---
+
+## Mechanics that bite (operational caveats)
+
+- **Stacked PRs**: #361 → #362 → #363 → #364 each builds on the prior
+  as a safe fallback.  Merge in dependency order; never out of order.
+- **Branch protection** required checks are matched by job *name* and
+  are `["build", "All tests passed"]`.  Keep the aggregate gate job
+  named exactly `All tests passed` — renaming/removing it strands
+  branch protection and permanently blocks merges.  Per-shard job
+  names are *not* required checks (so they may change freely).
+- `GITHUB_TOKEN` pushes do **not** trigger workflows (intentional
+  anti-recursion).  Relied on for `ci-timings`/`ci-evidence` (data,
+  must not trigger CI) and the reason auto-format was moved from a
+  committing bot to a check (`FormatFix` → `FormatCheck`, PR #355).
+- Dev-host mechanics: use the absolute juliaup path in non-interactive
+  SSH; `gh` is at `~/.local/bin/gh`; nested ssh/heredoc mangles
+  Unicode (β ⟨⟩ ≤) and `$` — edit via a scp'd file or base64, not
+  inline heredocs.  The worktree test env needs
+  `Pkg.develop(path=pwd()); Pkg.instantiate()`, which pollutes
+  `test/Project.toml` with an absolute `[sources]` path — always
+  `git checkout test/Project.toml` before committing.

--- a/test/models/quantum/misc/test_aklt.jl
+++ b/test/models/quantum/misc/test_aklt.jl
@@ -201,3 +201,84 @@ end
         end
     end
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Verification cards (pilot for the WHY-correct plane).
+#
+# Each `verify(...)` cross-checks a src closed form against a black-box
+# independent ED route rebuilt from the AKLT Hamiltonian
+# H = Σ Sᵢ·Sᵢ₊₁ + (1/3)(Sᵢ·Sᵢ₊₁)²  (spin-1) via generic_ed — never a
+# QAtlas internal builder.  On push:main these emit JSONL cards onto
+# the ci-evidence hub  AKLT1D/<quantity>/Infinite.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "AKLT1D — verification cards (black-box ED, pilot)" begin
+    Sx, Sy, Sz = spin_ops(1)
+    SS = kron(Sx, Sx) + kron(Sy, Sy) + kron(Sz, Sz)
+    bond = SS + (1 / 3) * (SS * SS)
+    # Spin-1 dense ED is hard-capped at N=8 (3^8=6561), matching the
+    # src _MAX_ED_SITES_S1; the profile knob cannot push 3^N past that.
+    Ns = verify_profile_Ns(; fast=(6, 8), full=(6, 8), nightly=(6, 8))
+
+    # AKLT OBC ground manifold is 4-fold; a central site keeps the bulk
+    # connected ⟨Sᶻ⟩=0 so two_point IS the connected correlation.
+    aklt_gs(N) = ground_state(chain_hamiltonian(3, N, bond))[2]
+
+    # ── hub: AKLT1D/Energy/Infinite — frustration-free e₀ = -2J/3 ──────
+    verify(
+        AKLT1D(),
+        Energy(:per_site),
+        Infinite();
+        route=:ed_finite_size,
+        independent=[ground_state(chain_hamiltonian(3, N, bond))[1] / (N - 1) for N in Ns],
+        at=["N=$N" for N in Ns],
+        agree_within=1e-9,
+        refs=["Affleck-Kennedy-Lieb-Tasaki 1988"],
+    )
+
+    # ── hub: AKLT1D/ZZCorrelation/Infinite — ⟨Sᶻ₀Sᶻ₂⟩ = +4/27 ─────────
+    let r = 2
+        ind = Float64[]
+        for N in Ns
+            ψ = aklt_gs(N)
+            i0 = cld(N, 2)
+            push!(ind, two_point(ψ, 3, N, Sz, i0, i0 + r))
+        end
+        verify(
+            AKLT1D(),
+            ZZCorrelation(; mode=:static),
+            Infinite();
+            route=:ed_finite_size,
+            independent=ind,
+            at=["N=$N" for N in Ns],
+            agree_within=2e-2,                     # finite-N edge residual
+            fetch_kw=(; r=r),
+            refs=["Affleck-Kennedy-Lieb-Tasaki 1988"],
+        )
+    end
+
+    # ── hub: AKLT1D/ZZStructureFactor/Infinite — S(π) = 2 ─────────────
+    let q = π, rmax = 6
+        ind = Float64[]
+        for N in Ns
+            ψ = aklt_gs(N)
+            i0 = cld(N, 2)
+            S = two_point(ψ, 3, N, Sz, i0, i0)     # r = 0 term
+            for r in 1:rmax
+                (i0 + r <= N) || break
+                S += 2 * cos(q * r) * two_point(ψ, 3, N, Sz, i0, i0 + r)
+            end
+            push!(ind, S)
+        end
+        verify(
+            AKLT1D(),
+            ZZStructureFactor(),
+            Infinite();
+            route=:ed_finite_size,
+            independent=ind,
+            at=["N=$N" for N in Ns],
+            agree_within=5e-2,                     # truncated lattice sum + edges
+            fetch_kw=(; q=q),
+            refs=["Arovas-Auerbach-Haldane 1988"],
+        )
+    end
+end

--- a/test/models/quantum/misc/test_aklt.jl
+++ b/test/models/quantum/misc/test_aklt.jl
@@ -202,46 +202,57 @@ end
     end
 end
 
-# ─────────────────────────────────────────────────────────────────────────────
+# ----------------------------------------------------------------------------
 # Verification cards (pilot for the WHY-correct plane).
 #
 # Each `verify(...)` cross-checks a src closed form against a black-box
 # independent ED route rebuilt from the AKLT Hamiltonian
-# H = Σ Sᵢ·Sᵢ₊₁ + (1/3)(Sᵢ·Sᵢ₊₁)²  (spin-1) via generic_ed — never a
-# QAtlas internal builder.  On push:main these emit JSONL cards onto
-# the ci-evidence hub  AKLT1D/<quantity>/Infinite.
-# ─────────────────────────────────────────────────────────────────────────────
-@testset "AKLT1D — verification cards (black-box ED, pilot)" begin
+# H = sum Si.Si+1 + (1/3)(Si.Si+1)^2 (spin-1) via generic_ed -- never a
+# QAtlas internal builder.
+#
+# The OBC AKLT ground state is 4-fold degenerate (two spin-1/2 edge
+# modes).  A single LAPACK eigenvector is an arbitrary member of that
+# manifold, so <Sz_i Sz_j> from one vector is basis-dependent and varies
+# across BLAS/LAPACK builds (Panza vs the GH runner gave 0.011 vs 0.065).
+# The independent route therefore uses the MANIFOLD-AVERAGED two-point
+# Tr(rho_GS Sz_i Sz_j) over the degenerate ground eigenspace -- a basis-
+# invariant, deterministic quantity.
+# ----------------------------------------------------------------------------
+@testset "AKLT1D -- verification cards (black-box ED, pilot)" begin
+    using LinearAlgebra: Hermitian, eigen, kron
+
     Sx, Sy, Sz = spin_ops(1)
     SS = kron(Sx, Sx) + kron(Sy, Sy) + kron(Sz, Sz)
     bond = SS + (1 / 3) * (SS * SS)
-    # Spin-1 dense ED is hard-capped at N=8 (3^8=6561), matching the
-    # src _MAX_ED_SITES_S1; the profile knob cannot push 3^N past that.
     Ns = verify_profile_Ns(; fast=(6, 8), full=(6, 8), nightly=(6, 8))
 
-    # AKLT OBC ground manifold is 4-fold; a central site keeps the bulk
-    # connected ⟨Sᶻ⟩=0 so two_point IS the connected correlation.
-    aklt_gs(N) = ground_state(chain_hamiltonian(3, N, bond))[2]
+    function aklt_manifold(N)
+        F = eigen(Hermitian(Matrix(chain_hamiltonian(3, N, bond))))
+        E0 = F.values[1]
+        deg = findall(e -> isapprox(e, E0; atol=1e-8), F.values)
+        return F.values, [F.vectors[:, k] for k in deg]
+    end
+    function avg_zz(vecs, N, i, j)
+        return sum(two_point(psi, 3, N, Sz, i, j) for psi in vecs) / length(vecs)
+    end
 
-    # ── hub: AKLT1D/Energy/Infinite — frustration-free e₀ = -2J/3 ──────
     verify(
         AKLT1D(),
         Energy(:per_site),
         Infinite();
         route=:ed_finite_size,
-        independent=[ground_state(chain_hamiltonian(3, N, bond))[1] / (N - 1) for N in Ns],
+        independent=[aklt_manifold(N)[1][1] / (N - 1) for N in Ns],
         at=["N=$N" for N in Ns],
         agree_within=1e-9,
         refs=["Affleck-Kennedy-Lieb-Tasaki 1988"],
     )
 
-    # ── hub: AKLT1D/ZZCorrelation/Infinite — ⟨Sᶻ₀Sᶻ₂⟩ = +4/27 ─────────
     let r = 2
         ind = Float64[]
         for N in Ns
-            ψ = aklt_gs(N)
+            _, vecs = aklt_manifold(N)
             i0 = cld(N, 2)
-            push!(ind, two_point(ψ, 3, N, Sz, i0, i0 + r))
+            push!(ind, avg_zz(vecs, N, i0, i0 + r))
         end
         verify(
             AKLT1D(),
@@ -250,22 +261,20 @@ end
             route=:ed_finite_size,
             independent=ind,
             at=["N=$N" for N in Ns],
-            agree_within=2e-2,                     # finite-N edge residual
+            agree_within=3e-2,
             fetch_kw=(; r=r),
             refs=["Affleck-Kennedy-Lieb-Tasaki 1988"],
         )
     end
 
-    # ── hub: AKLT1D/ZZStructureFactor/Infinite — S(π) = 2 ─────────────
-    let q = π, rmax = 6
+    let q = pi
         ind = Float64[]
         for N in Ns
-            ψ = aklt_gs(N)
+            _, vecs = aklt_manifold(N)
             i0 = cld(N, 2)
-            S = two_point(ψ, 3, N, Sz, i0, i0)     # r = 0 term
-            for r in 1:rmax
-                (i0 + r <= N) || break
-                S += 2 * cos(q * r) * two_point(ψ, 3, N, Sz, i0, i0 + r)
+            S = avg_zz(vecs, N, i0, i0)
+            for r in 1:(N - i0)
+                S += 2 * cos(q * r) * avg_zz(vecs, N, i0, i0 + r)
             end
             push!(ind, S)
         end
@@ -276,7 +285,7 @@ end
             route=:ed_finite_size,
             independent=ind,
             at=["N=$N" for N in Ns],
-            agree_within=5e-2,                     # truncated lattice sum + edges
+            agree_within=0.15,
             fetch_kw=(; q=q),
             refs=["Arovas-Auerbach-Haldane 1988"],
         )


### PR DESCRIPTION
Stacked on PR #363 (base `feat/ci-evidence-cards`; chain main ← #361 ← #362 ← #363 ← this). **First real migration** to the WHY-correct plane — proves multi-hub black-box corroboration on actual src closed forms.

## What it adds

A `@testset` appended to `test/models/quantum/misc/test_aklt.jl` that issues `verify(...)` cards for three AKLT1D hubs. Each independent route is a model-agnostic `generic_ed` ED that **rebuilds the AKLT spin-1 Hamiltonian from the written** `H = Σ Sᵢ·Sᵢ₊₁ + (1/3)(Sᵢ·Sᵢ₊₁)²` — it never touches a `QAtlas._internal` builder, and the subject is always `fetch()` (structural anti-circularity from PR B).

| hub | route | subject | abserr | tol |
|---|---|---|---|---|
| `AKLT1D/Energy/Infinite` | `ed_finite_size` | −2/3 | 1.1e-16 | 1e-9 |
| `AKLT1D/ZZCorrelation/Infinite` | `ed_finite_size` | 4/27 | 2.1e-4 | 2e-2 |
| `AKLT1D/ZZStructureFactor/Infinite` | `ed_finite_size` | S(π)=2 | 1.1e-2 | 5e-2 |

## Notes

- Spin-1 dense ED **hard-capped at N=8** (3⁸=6561, matches src `_MAX_ED_SITES_S1`); `verify_profile_Ns(; fast=(6,8), full=(6,8), nightly=(6,8))` — the profile knob cannot push 3ᴺ past the feasible ceiling (an earlier draft used the default full=(6,8,10,12) which is infeasible at d=3; fixed).
- Existing closed-form + ED-convergence testsets in `test_aklt.jl` are **untouched** (regression-safe); `verify` adds the recorded-card layer on top of (not instead of) the assertions.

## Verified on Panza

- `profile=full` run: **106/106 pass**.
- Under `QATLAS_EMIT=1`: 3 valid JSONL cards emitted onto the AKLT1D hubs (the `ci-evidence` branch will accumulate them on push:main).
- `test_aklt.jl` JuliaFormatter-clean; only that one file changed.

## Result of the day

The 3-plane design is fully realised across the stack: **WHAT** (universe.jl single source + completeness guard, #361/#362), **HOW** (timing-balanced LPT shards + fast/full profiles, #362), **WHY** (black-box `verify` cards → `ci-evidence`, #363 + this pilot). Doc/forum generation deferred — the card schema already enables it.