### PR TITLE
ci(A): timing-balanced LPT shard planner + fast/full profile (HOW-split plane)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,7 +5,7 @@ on:
       - main
     tags: '*'
   pull_request:
-  workflow_dispatch:
+  workflow_dispatch:        # manual re-trigger entrypoint
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,57 +11,78 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: write   # record-timings pushes the orphan ci-timings branch
+
 jobs:
   # ───────────────────────────────────────────────────────────────────────────
-  # Single source of truth for CI parallelism.  The test universe itself
-  # lives only in test/runtests.jl `ALL_DIRS` (+ its completeness guard);
-  # this job just decides HOW MANY balanced file-level shards to fan out
-  # into.  Change `N` here and nowhere else.
+  # Shard planner.  WHAT-to-run is the canonical universe (test/ci/
+  # universe.jl, single source of truth + completeness guard).  This job
+  # only decides HOW to split: it Longest-Processing-Time bin-packs the
+  # universe using the `ci-timings` orphan branch when present, else
+  # falls back to deterministic round-robin.  Change shard count N here
+  # and nowhere else.
   # ───────────────────────────────────────────────────────────────────────────
   plan:
     name: Plan shards
     runs-on: ubuntu-latest
     outputs:
-      shards: ${{ steps.gen.outputs.shards }}
+      plan: ${{ steps.gen.outputs.plan }}
     steps:
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: '1'
+          arch: x64
+      - name: Fetch timing history (best-effort)
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --heads origin ci-timings >/dev/null 2>&1; then
+            git fetch --depth=1 origin ci-timings
+            git show FETCH_HEAD:timings.tsv > timings.tsv 2>/dev/null \
+              && echo "Loaded $(wc -l < timings.tsv) timing rows" \
+              || { echo "ci-timings has no timings.tsv — round-robin"; : > timings.tsv; }
+          else
+            echo "no ci-timings branch yet — round-robin fallback"
+            : > timings.tsv
+          fi
       - id: gen
         run: |
           set -euo pipefail
           N=16
-          shards=$(jq -cn --argjson n "$N" '[range(1; $n + 1) | "\(.)/\($n)"]')
-          count=$(jq 'length' <<<"$shards")
+          plan=$(julia test/ci/plan_shards.jl "$N" timings.tsv)
+          count=$(jq 'length' <<<"$plan")
           if [ "$count" -lt 1 ]; then
-            echo "::error::shard plan produced an empty list (count=$count)"
+            echo "::error::plan_shards produced an empty plan (count=$count)"
             exit 1
           fi
-          echo "shards=$shards" >> "$GITHUB_OUTPUT"
-          echo "Fan-out: $count file-level shards -> $shards"
+          echo "plan=$plan" >> "$GITHUB_OUTPUT"
+          echo "Planned $count shards."
 
   test:
-    name: Julia 1 - shard ${{ matrix.shard }}
+    name: shard ${{ matrix.sid }}
     runs-on: ubuntu-latest
     needs: plan
     strategy:
       fail-fast: false
       matrix:
-        shard: ${{ fromJSON(needs.plan.outputs.shards) }}
+        include: ${{ fromJSON(needs.plan.outputs.plan) }}
     env:
-      # runtests.jl partitions the canonical ALL_DIRS file universe by
-      # round-robin "k/N"; the union of every shard is exactly the full
-      # suite (proven by construction + the completeness guard).
-      QATLAS_TEST_SHARD: ${{ matrix.shard }}
+      QATLAS_TEST_FILES: ${{ matrix.files }}
+      QATLAS_RUN_AQUA: ${{ matrix.aqua }}
+      # PR = fast merge gate (no emit).  push:main = full + emit timing
+      # so the persisted numbers reflect the heavier computation.
+      QATLAS_TEST_PROFILE: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'full' || 'fast' }}
+      QATLAS_EMIT: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && '1' || '0' }}
     steps:
       - uses: actions/checkout@v6
-      - name: Stable shard id (slash-free; survives partial re-runs)
-        id: sid
-        run: echo "id=$(echo '${{ matrix.shard }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
       - uses: julia-actions/setup-julia@v3
         with:
           version: '1'
           arch: x64
       - uses: julia-actions/cache@v3
         with:
-          cache-name: shard-${{ steps.sid.outputs.id }}
+          cache-name: shard-${{ matrix.sid }}
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:
@@ -69,11 +90,61 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
       - uses: actions/upload-artifact@v7
         with:
-          name: coverage-shard-${{ steps.sid.outputs.id }}
+          name: coverage-${{ matrix.sid }}
           path: lcov.info
           retention-days: 1
           if-no-files-found: error
           overwrite: true
+      - name: Upload shard timing (push:main only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v7
+        with:
+          name: timing-${{ matrix.sid }}
+          path: test/.ci-out/timings-*.tsv
+          retention-days: 1
+          if-no-files-found: warn
+          overwrite: true
+
+  record-timings:
+    name: Record timing history
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.test.result == 'success'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
+        with:
+          path: timing-parts
+          pattern: timing-*
+      - name: Merge into the ci-timings orphan branch (latest value wins)
+        run: |
+          set -euo pipefail
+          mkdir -p merged
+          if git ls-remote --exit-code --heads origin ci-timings >/dev/null 2>&1; then
+            git fetch --depth=1 origin ci-timings
+            git show FETCH_HEAD:timings.tsv > merged/timings.tsv 2>/dev/null || : > merged/timings.tsv
+          else
+            : > merged/timings.tsv
+          fi
+          find timing-parts -name 'timings-*.tsv' -exec cat {} + >> merged/timings.tsv || true
+          awk -F'\t' 'NF==2{t[$1]=$2} END{for (k in t) print k"\t"t[k]}' \
+            merged/timings.tsv | sort > merged/final.tsv
+          rows=$(wc -l < merged/final.tsv)
+          if [ "$rows" -lt 1 ]; then
+            echo "No timing rows merged — skipping push"
+            exit 0
+          fi
+          echo "Merged timing rows: $rows"
+          tmp=$(mktemp -d)
+          cp merged/final.tsv "$tmp/timings.tsv"
+          cd "$tmp"
+          git init -q
+          git config user.email "ci@qatlas"
+          git config user.name "qatlas-ci"
+          git checkout -q -b ci-timings
+          git add timings.tsv
+          git commit -q -m "ci: refresh test timings ($rows rows) [skip ci]"
+          git push -q --force "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" ci-timings
 
   coverage:
     name: Coverage (aggregated)
@@ -133,9 +204,9 @@ jobs:
             echo "Shard planning failed: ${{ needs.plan.result }}"
             exit 1
           fi
-          shards='${{ needs.plan.outputs.shards }}'
-          if [ -z "$shards" ] || [ "$shards" = "[]" ]; then
-            echo "Plan produced no shards ('$shards') — the test matrix would be empty"
+          plan='${{ needs.plan.outputs.plan }}'
+          if [ -z "$plan" ] || [ "$plan" = "[]" ]; then
+            echo "Plan produced no shards ('$plan') — the test matrix would be empty"
             exit 1
           fi
           if [ "${{ needs.test.result }}" != "success" ]; then

--- a/test/ci/plan_shards.jl
+++ b/test/ci/plan_shards.jl
@@ -1,0 +1,108 @@
+# test/ci/plan_shards.jl — emit a balanced GitHub-matrix shard plan.
+#
+#   julia test/ci/plan_shards.jl <N> [timings.tsv]
+#
+# Prints (stdout, last line) a JSON array for `matrix: include:` —
+#   [{"sid":"s01","files":"d/a.jl,d/b.jl","aqua":"1"}, …]
+#
+# WHAT to run is the canonical universe (universe.jl, the single source
+# of truth + completeness guard).  Timings only decide HOW to split:
+#   * timings.tsv present  → Longest-Processing-Time bin-packing so all
+#                            shards finish at ≈ the same wall-clock.
+#   * absent / unreadable  → deterministic round-robin (identical to the
+#                            QATLAS_TEST_SHARD k/N fallback) — never a
+#                            leak, just not yet time-optimal.
+# New / unknown files get a pessimistic estimate (P90 of known, or a
+# fixed default if no history) so a surprise-heavy new test is isolated
+# rather than piled onto an already-heavy shard.
+
+include(joinpath(@__DIR__, "universe.jl"))   # ALL_TEST_FILES, test_file_key
+
+const N = let a = get(ARGS, 1, "")
+    n = tryparse(Int, a)
+    (n !== nothing && n >= 1) ||
+        error("plan_shards.jl: arg 1 must be N>=1; got $(repr(a))")
+    n
+end
+const TIMINGS_PATH = get(ARGS, 2, "")
+
+# universe → ordered "d/f" keys
+const KEYS = [test_file_key(d, f) for (d, f) in ALL_TEST_FILES]
+
+# Load timings TSV ("key\tseconds"); silently ignore missing/garbage
+# rows — the plane is advisory and must degrade, never abort planning.
+function load_timings(path)
+    t = Dict{String,Float64}()
+    (isempty(path) || !isfile(path)) && return t
+    for ln in eachline(path)
+        parts = split(strip(ln), '\t')
+        length(parts) == 2 || continue
+        v = tryparse(Float64, parts[2])
+        v === nothing && continue
+        t[String(parts[1])] = v
+    end
+    return t
+end
+const TIMES = load_timings(TIMINGS_PATH)
+
+# Pessimistic default for files with no recorded time.
+const DEFAULT_T = if isempty(TIMES)
+    1.0
+else
+    s = sort(collect(values(TIMES)))
+    s[clamp(ceil(Int, 0.9 * length(s)), 1, length(s))]   # P90 of known
+end
+
+est(k) = get(TIMES, k, DEFAULT_T)
+
+# Assignment: LPT when we have history, else round-robin.
+bins = [String[] for _ in 1:N]
+loads = zeros(Float64, N)
+
+if isempty(TIMES)
+    for (i, k) in enumerate(KEYS)
+        b = ((i - 1) % N) + 1
+        push!(bins[b], k)
+        loads[b] += est(k)
+    end
+    mode = "round-robin (no timing history)"
+else
+    for k in sort(KEYS; by=est, rev=true)         # longest first
+        b = argmin(loads)                          # least-loaded bin
+        push!(bins[b], k)
+        loads[b] += est(k)
+    end
+    mode = "LPT bin-packing"
+end
+
+# Aqua → the finishing-earliest (least-loaded) shard, so it does not
+# pile onto the critical-path shard.
+const AQUA_BIN = argmin(loads)
+
+# Emit JSON (ASCII test paths only ⇒ no escaping needed).
+io = IOBuffer()
+print(io, "[")
+for b in 1:N
+    b == 1 || print(io, ",")
+    sid = "s" * lpad(string(b), 2, '0')
+    print(io, "{\"sid\":\"", sid, "\",\"files\":\"", join(bins[b], ","), "\",")
+    print(io, "\"aqua\":\"", b == AQUA_BIN ? "1" : "0", "\"}")
+end
+print(io, "]")
+plan_json = String(take!(io))
+
+# Human-readable summary → stderr (does not pollute the JSON stdout).
+println(
+    stderr,
+    "plan_shards: N=$N  mode=$mode  files=$(length(KEYS))  " *
+    "default_t=$(round(DEFAULT_T; digits=3))s  aqua→s$(lpad(string(AQUA_BIN), 2, '0'))",
+)
+for b in 1:N
+    println(
+        stderr,
+        "  s$(lpad(string(b),2,'0')): $(length(bins[b])) files  " *
+        "est=$(round(loads[b]; digits=1))s$(b == AQUA_BIN ? "  +aqua" : "")",
+    )
+end
+
+println(plan_json)

--- a/test/ci/universe.jl
+++ b/test/ci/universe.jl
@@ -1,0 +1,71 @@
+# test/ci/universe.jl — canonical test-file universe (single source of truth).
+#
+# Included by BOTH test/runtests.jl and test/ci/plan_shards.jl.  Pure
+# stdlib, NO `using QAtlas`, so the shard planner stays fast (no package
+# precompile).  This file alone decides WHAT the suite is; the timing
+# and evidence planes never override it.
+
+const TEST_ROOT = dirname(@__DIR__)   # test/ci/ → test/
+
+const ALL_DIRS = [
+    "core/",
+    "universalities/",
+    "models/classical/",
+    "models/quantum/TFIM/",
+    "models/quantum/XXZ/",
+    "models/quantum/Heisenberg/",
+    "models/quantum/KitaevHoneycomb/",
+    "models/quantum/misc/",
+    "identities/",
+    "verification/tightbinding/",
+    "verification/tfim_ising/",
+    "verification/heisenberg_xxz/",
+    "verification/universality/",
+]
+
+_is_test_file(f) = startswith(f, "test_") && endswith(f, ".jl")
+
+# ── Completeness guard ───────────────────────────────────────────────
+# Every on-disk directory holding a `test_*.jl` MUST be enumerated in
+# ALL_DIRS, and every ALL_DIRS entry must exist and be non-empty.  Runs
+# wherever this file is included (every shard + the planner) and fails
+# loudly — a test directory can never be added without being wired in.
+# `test_aqua.jl` at the test/ root is the only sanctioned exception.
+let
+    enumerated = Set(ALL_DIRS)
+    discovered = Set{String}()
+    for (d, _, files) in walkdir(TEST_ROOT)
+        any(_is_test_file, files) || continue
+        rel = replace(relpath(d, TEST_ROOT), '\\' => '/')
+        rel == "." && continue  # test/ root: only test_aqua.jl, run specially
+        push!(discovered, rel * "/")
+    end
+    leaked = sort(collect(setdiff(discovered, enumerated)))
+    isempty(leaked) || error(
+        "universe.jl completeness guard: these on-disk test directories hold " *
+        "test_*.jl files but are NOT in ALL_DIRS and would never run — add " *
+        "them to ALL_DIRS: $(leaked)",
+    )
+    for d in ALL_DIRS
+        p = joinpath(TEST_ROOT, d)
+        (isdir(p) && any(_is_test_file, readdir(p))) || error(
+            "universe.jl completeness guard: ALL_DIRS entry $(repr(d)) is " *
+            "missing on disk or contains no test_*.jl files.",
+        )
+    end
+end
+
+# ── Canonical, deterministic global test-file universe ───────────────
+# ALL_DIRS order × lexically-sorted files.  Every selection mode picks a
+# subset of THIS list, so the union of all shards is exactly this set.
+const ALL_TEST_FILES = let acc = Tuple{String,String}[]
+    for d in ALL_DIRS
+        for f in sort(filter(_is_test_file, readdir(joinpath(TEST_ROOT, d))))
+            push!(acc, (d, f))
+        end
+    end
+    acc
+end
+
+# Stable "d/f" key form used by the timing plane and QATLAS_TEST_FILES.
+test_file_key(d, f) = d * f

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,97 +8,66 @@ const N_BLAS = min(Sys.CPU_THREADS, 64)
 BLAS.set_num_threads(N_BLAS)
 println("BLAS threads: $(BLAS.get_num_threads()) / $(Sys.CPU_THREADS) cores")
 
-# Default "fast" test profile keeps every ED at N ≤ 12 (fits in a few
-# GB of RAM) so PR CI runs in < 2 minutes on a 4-core GitHub runner.
-# Set `QATLAS_TEST_FULL=1` to also run N ∈ {14, 16} sweeps (sparse +
-# KrylovKit Lanczos, ~30 min on 128 GB / 36-core hardware).  Nightly
-# cron only.
+# Back-compat: legacy nightly switch.  Superseded by QATLAS_TEST_PROFILE
+# (QATLAS_TEST_FULL=1 ⇒ profile=nightly when profile is unset).
 const QATLAS_TEST_FULL = get(ENV, "QATLAS_TEST_FULL", "0") != "0"
 println("QATLAS_TEST_FULL = $(QATLAS_TEST_FULL)")
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Canonical test-directory enumeration.
-#
-# `ALL_DIRS` is the *single source of truth* for which directories hold
-# the suite.  CI parallelism is file-level sharding over the union of
-# these dirs (see `QATLAS_TEST_SHARD` below), so the CI workflow no
-# longer duplicates this list — it only passes a shard index.  The
-# completeness guard (just below) makes it impossible to add a test
-# directory that silently never runs.
-# ─────────────────────────────────────────────────────────────────────────────
-const ALL_DIRS = [
-    "core/",
-    "universalities/",
-    "models/classical/",
-    "models/quantum/TFIM/",
-    "models/quantum/XXZ/",
-    "models/quantum/Heisenberg/",
-    "models/quantum/KitaevHoneycomb/",
-    "models/quantum/misc/",
-    "identities/",
-    "verification/tightbinding/",
-    "verification/tfim_ising/",
-    "verification/heisenberg_xxz/",
-    "verification/universality/",
-]
-
-_is_test_file(f) = startswith(f, "test_") && endswith(f, ".jl")
-
-# ── Completeness guard ───────────────────────────────────────────────
-# Walk the whole test tree; every directory that contains a `test_*.jl`
-# MUST be enumerated in `ALL_DIRS`, and every `ALL_DIRS` entry must
-# exist and be non-empty.  Runs in every shard (cheap) and fails
-# loudly — a test directory can never be added without being wired in.
-# `test_aqua.jl` at the test/ root is the only sanctioned exception.
-let
-    root = @__DIR__
-    enumerated = Set(ALL_DIRS)
-    discovered = Set{String}()
-    for (d, _, files) in walkdir(root)
-        any(_is_test_file, files) || continue
-        rel = replace(relpath(d, root), '\\' => '/')
-        rel == "." && continue  # test/ root: only test_aqua.jl, run specially
-        push!(discovered, rel * "/")
-    end
-    leaked = sort(collect(setdiff(discovered, enumerated)))
-    isempty(leaked) || error(
-        "runtests.jl completeness guard: these on-disk test directories hold " *
-        "test_*.jl files but are NOT in ALL_DIRS and would never run — add " *
-        "them to ALL_DIRS: $(leaked)",
-    )
-    for d in ALL_DIRS
-        p = joinpath(root, d)
-        (isdir(p) && any(_is_test_file, readdir(p))) || error(
-            "runtests.jl completeness guard: ALL_DIRS entry $(repr(d)) is " *
-            "missing on disk or contains no test_*.jl files.",
-        )
+# ── Test-volume profile (orthogonal to *which* files are selected) ───
+#   fast    — PR merge gate: small N, coarse grids, loose tol; NO emit.
+#   full    — push:main: larger N, finer grids, tight tol; emit timing
+#             (and, later, evidence) — the heavier computation is what
+#             gets persisted, so recorded numbers reflect the deep run.
+#   nightly — cron: largest N sweeps, densest parameter grids.
+# Individual test files read QATLAS_TEST_PROFILE to scale their work.
+const QATLAS_TEST_PROFILE = let p = lowercase(get(ENV, "QATLAS_TEST_PROFILE", ""))
+    if !isempty(p)
+        p in ("fast", "full", "nightly") ||
+            error("QATLAS_TEST_PROFILE must be fast|full|nightly; got $(repr(p))")
+        Symbol(p)
+    elseif QATLAS_TEST_FULL
+        :nightly
+    else
+        :fast
     end
 end
+println("QATLAS_TEST_PROFILE = $(QATLAS_TEST_PROFILE)")
 
-# ── Canonical, deterministic global test-file universe ───────────────
-# ALL_DIRS order × lexically-sorted files.  Sharding partitions THIS
-# list, so the union of every shard is exactly this set — no file can
-# be missed or double-run.
-const ALL_TEST_FILES = let acc = Tuple{String,String}[]
-    for d in ALL_DIRS
-        for f in sort(filter(_is_test_file, readdir(joinpath(@__DIR__, d))))
-            push!(acc, (d, f))
-        end
-    end
-    acc
-end
+# Canonical universe + completeness guard (single source of truth,
+# shared verbatim with the shard planner).
+include(joinpath(@__DIR__, "ci", "universe.jl"))
 
-# ── Test selection: SHARD (CI) > GROUP (local targeted) > ALL ────────
+# ── Test selection: FILES > SHARD > GROUP > ALL ──────────────────────
 #
-#   QATLAS_TEST_SHARD="k/N"  — round-robin shard k of N over the global
-#                              file list (CI parallelism; balanced).
+#   QATLAS_TEST_FILES="d/f.jl,d/g.jl" — explicit list emitted by the LPT
+#       shard planner.  MUST be a subset of the canonical universe
+#       (planner cannot smuggle in non-globbed files).
+#   QATLAS_TEST_SHARD="k/N"  — round-robin shard (timing-agnostic; the
+#       planner's fallback and a manual knob).
 #   QATLAS_TEST_GROUP="a,b"  — dir-prefix filter (local targeted runs).
 #   neither                  — run everything.
 #
+# Aqua (one-shot whole-package QA) runs in exactly one selection:
+#   FILES → QATLAS_RUN_AQUA=1 ;  SHARD → shard 1 ;
+#   GROUP → a core-covering group ;  ALL → yes.
+const _test_files = get(ENV, "QATLAS_TEST_FILES", "")
 const _shard_spec = get(ENV, "QATLAS_TEST_SHARD", "")
 const _test_group = get(ENV, "QATLAS_TEST_GROUP", "")
 
-const _selected, _mode_desc, _run_aqua = if !isempty(_shard_spec)
+const _selected, _mode_desc, _run_aqua = if !isempty(_test_files)
+    want = [strip(x) for x in split(_test_files, ",") if !isempty(strip(x))]
+    idx = Dict(test_file_key(d, f) => (d, f) for (d, f) in ALL_TEST_FILES)
+    sel = Tuple{String,String}[]
+    unknown = String[]
+    for w in want
+        haskey(idx, w) ? push!(sel, idx[w]) : push!(unknown, String(w))
+    end
+    isempty(unknown) || error(
+        "QATLAS_TEST_FILES lists files outside the canonical universe " *
+        "(the planner must only emit globbed files): $(unknown)",
+    )
+    (sel, "FILES (n=$(length(sel)))", get(ENV, "QATLAS_RUN_AQUA", "0") == "1")
+elseif !isempty(_shard_spec)
     parts = split(_shard_spec, "/")
     length(parts) == 2 ||
         error("QATLAS_TEST_SHARD must be \"k/N\"; got $(repr(_shard_spec))")
@@ -124,7 +93,7 @@ end
 
 println(
     "Test selection: $(_mode_desc) → $(length(_selected))/$(length(ALL_TEST_FILES)) " *
-    "files; aqua=$(_run_aqua)",
+    "files; profile=$(QATLAS_TEST_PROFILE); aqua=$(_run_aqua)",
 )
 
 const FIG_BASE = joinpath(pkgdir(QAtlas), "docs", "src", "assets")
@@ -139,25 +108,49 @@ include(joinpath(@__DIR__, "util", "bloch.jl"))
 include(joinpath(@__DIR__, "util", "tfim_dense_ed.jl"))
 include(joinpath(@__DIR__, "util", "thermodynamic_identities.jl"))
 
+# Per-file wall-time, captured for the timing plane (HOW-to-split).
+const _TIMINGS = Dict{String,Float64}()
+
 @testset "tests" begin
     test_args = copy(ARGS)
     println("Passed arguments ARGS = $(test_args) to tests.")
 
-    # Aqua static QA — a one-shot whole-package check; run in exactly
-    # one shard (shard 1), the core-covering group, or a full run.
     if _run_aqua
         @testset "test_aqua.jl" begin
-            @time include(joinpath(@__DIR__, "test_aqua.jl"))
+            _TIMINGS["__aqua__"] = @elapsed include(joinpath(@__DIR__, "test_aqua.jl"))
+            println("  test_aqua.jl: $(round(_TIMINGS["__aqua__"]; digits=2)) s")
         end
     end
 
     @time for (d, f) in _selected
         filepath = joinpath(@__DIR__, d, f)
-        @testset "$(d)$(f)" begin
-            @time begin
-                println("  Including $(filepath)")
-                include(filepath)
-            end
+        key = test_file_key(d, f)
+        @testset "$(key)" begin
+            println("  Including $(filepath)")
+            _TIMINGS[key] = @elapsed include(filepath)
+            println("  $(key): $(round(_TIMINGS[key]; digits=2)) s")
         end
     end
+end
+
+# Emit per-shard timing as TSV (key<TAB>seconds).  Gated by QATLAS_EMIT
+# so only push:main CI writes; PR/local runs never persist.  The
+# consolidate job merges these into the `ci-timings` orphan branch; the
+# planner LPT-bin-packs the next run from it (round-robin until then).
+if get(ENV, "QATLAS_EMIT", "0") == "1"
+    outdir = joinpath(@__DIR__, ".ci-out")
+    mkpath(outdir)
+    sid = if !isempty(_shard_spec)
+        replace(_shard_spec, '/' => '-')
+    elseif !isempty(_test_files)
+        string(hash(_test_files); base=16)
+    else
+        "all"
+    end
+    open(joinpath(outdir, "timings-$(sid).tsv"), "w") do io
+        for (k, v) in sort!(collect(_TIMINGS); by=first)
+            println(io, k, '\t', round(v; digits=4))
+        end
+    end
+    println("Emitted .ci-out/timings-$(sid).tsv ($(length(_TIMINGS)) entries)")
 end


### PR DESCRIPTION
Replaces #362 (auto-closed when its base `feat/ci-shard-robust` was deleted on #361 merge — the gh --delete-branch stacked-PR pitfall). Branch rebased `--onto main` so this is exactly the single PR-A commit on current main; #361 already merged. Content unchanged from #362; CI fully validated via the integration tip #364 (all 16 shards + All tests passed green). Implements the HOW-split plane: timing-balanced LPT sharding over the universe.jl single source, fast/full profiles, ci-timings orphan branch. Supersedes #362.