### PR TITLE
fix(ci): emit ci-out into workspace (Pkg.test sandbox) + fail-loud on empty

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,6 +74,10 @@ jobs:
       # so the persisted numbers reflect the heavier computation.
       QATLAS_TEST_PROFILE: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'full' || 'fast' }}
       QATLAS_EMIT: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && '1' || '0' }}
+      # julia-runtest sandboxes Pkg.test, so @__DIR__ points into a
+      # temp copy.  Pin the emit dir to the workspace so upload-artifact
+      # (which scans the workspace) actually finds the emitted files.
+      QATLAS_CIOUT_DIR: ${{ github.workspace }}/test/.ci-out
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v3
@@ -140,8 +144,8 @@ jobs:
             merged/timings.tsv | sort > merged/final.tsv
           rows=$(wc -l < merged/final.tsv)
           if [ "$rows" -lt 1 ]; then
-            echo "No timing rows merged — skipping push"
-            exit 0
+            echo "::error::push:main produced 0 timing rows — emit path broken (sandbox/QATLAS_CIOUT_DIR). Failing loudly instead of silent green."
+            exit 1
           fi
           echo "Merged timing rows: $rows"
           tmp=$(mktemp -d)
@@ -184,8 +188,8 @@ jobs:
             merged/all.jsonl > merged/evidence.jsonl || : > merged/evidence.jsonl
           rows=$(wc -l < merged/evidence.jsonl)
           if [ "$rows" -lt 1 ]; then
-            echo "No evidence cards merged — skipping push"
-            exit 0
+            echo "::error::push:main produced 0 verification cards — emit path broken (sandbox/QATLAS_CIOUT_DIR). Failing loudly instead of silent green."
+            exit 1
           fi
           echo "Merged evidence cards: $rows"
           tmp=$(mktemp -d)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -140,7 +140,7 @@ end
 # consolidate job merges these into the `ci-timings` orphan branch; the
 # planner LPT-bin-packs the next run from it (round-robin until then).
 if get(ENV, "QATLAS_EMIT", "0") == "1"
-    outdir = joinpath(@__DIR__, ".ci-out")
+    outdir = get(ENV, "QATLAS_CIOUT_DIR", joinpath(@__DIR__, ".ci-out"))
     mkpath(outdir)
     sid = if !isempty(_shard_spec)
         replace(_shard_spec, '/' => '-')

--- a/test/util/verify.jl
+++ b/test/util/verify.jl
@@ -102,7 +102,7 @@ function verify(
     @test isapprox(best, float(subject); atol=agree_within)
 
     if get(ENV, "QATLAS_EMIT", "0") == "1"
-        outdir = joinpath(@__DIR__, "..", ".ci-out")
+        outdir = get(ENV, "QATLAS_CIOUT_DIR", joinpath(@__DIR__, "..", ".ci-out"))
         mkpath(outdir)
         tf = get(ENV, "QATLAS_TEST_FILES", "")
         sid = isempty(tf) ? "all" : replace(string(hash(tf); base=16), '/' => '-')


### PR DESCRIPTION
## Problem

push:main CI was fully green but the `ci-evidence` / `ci-timings` orphan branches were never created.

**Root cause:** `julia-actions/julia-runtest` runs `Pkg.test()` in a sandboxed temp copy. `verify.jl` / `runtests.jl` wrote `.ci-out` relative to `@__DIR__`, which under the sandbox is **outside `$GITHUB_WORKSPACE`**. `upload-artifact` scans the workspace → 0 `timing-*`/`evidence-*` artifacts → the `record-*` jobs merged 0 rows and `exit 0` (silent green). Diagnosed from the shard log (`Emitted .ci-out/timings-<hash>.tsv`) vs the record-job log (`Total of 0 artifact(s) downloaded` → `skipping push`).

## Fix

- **(A)** `verify.jl` + `runtests.jl`: `outdir = get(ENV, "QATLAS_CIOUT_DIR", <old @__DIR__ path>)`. Local/PR runs (EMIT=0) keep old behavior.
- **(B)** `CI.yml` shard env: `QATLAS_CIOUT_DIR: ${{ github.workspace }}/test/.ci-out` so the sandboxed test process writes where `upload-artifact` looks (upload paths already point there — unchanged).
- **(C)** `record-timings` / `record-evidence`: on push:main, 0 rows now `::error::` + `exit 1` instead of silent skip — kills the silent-success class.

## Validation note

The emit path is **push:main-only** (`QATLAS_EMIT=0` on PRs by design), so this PR's CI only confirms no regression (fast profile, code parses, tests pass). Final validation is the post-merge push:main run — by design. After merge, expect `ci-timings`/`ci-evidence` branches to appear (or, if still broken, a **loud red** record job instead of silent green).
