### PR TITLE
fix(ci): collect ci-out from Pkg.test sandbox into workspace + log abs path

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -91,6 +91,23 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         with:
           julia-args: "--threads=auto"
+      - name: Collect emitted ci-out into the workspace (push:main only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          set -uo pipefail
+          dest="$GITHUB_WORKSPACE/test/.ci-out"
+          mkdir -p "$dest"
+          echo "QATLAS_CIOUT_DIR=$QATLAS_CIOUT_DIR  GITHUB_WORKSPACE=$GITHUB_WORKSPACE"
+          found=$(find "$GITHUB_WORKSPACE" "$HOME/.julia" "$RUNNER_TEMP" /tmp \
+                    -maxdepth 9 \( -name 'timings-*.tsv' -o -name 'evidence-*.jsonl' \) \
+                    2>/dev/null | sort -u || true)
+          echo "--- located emitted files ---"; printf '%s\n' "$found"
+          if [ -n "$found" ]; then
+            printf '%s\n' "$found" | while IFS= read -r f; do
+              [ -n "$f" ] && [ -f "$f" ] && cp -fv "$f" "$dest/" || true
+            done
+          fi
+          echo "--- workspace test/.ci-out ---"; ls -la "$dest" 2>&1 || true
       - uses: julia-actions/julia-processcoverage@v1
       - uses: actions/upload-artifact@v7
         with:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -154,5 +154,6 @@ if get(ENV, "QATLAS_EMIT", "0") == "1"
             println(io, k, '\t', round(v; digits=4))
         end
     end
-    println("Emitted .ci-out/timings-$(sid).tsv ($(length(_TIMINGS)) entries)")
+    _tf = joinpath(outdir, "timings-$(sid).tsv")
+    println("Emitted timing TSV -> ", abspath(_tf), " (", length(_TIMINGS), " entries; exists=", isfile(_tf), ")")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -155,5 +155,13 @@ if get(ENV, "QATLAS_EMIT", "0") == "1"
         end
     end
     _tf = joinpath(outdir, "timings-$(sid).tsv")
-    println("Emitted timing TSV -> ", abspath(_tf), " (", length(_TIMINGS), " entries; exists=", isfile(_tf), ")")
+    println(
+        "Emitted timing TSV -> ",
+        abspath(_tf),
+        " (",
+        length(_TIMINGS),
+        " entries; exists=",
+        isfile(_tf),
+        ")",
+    )
 end

--- a/test/util/verify.jl
+++ b/test/util/verify.jl
@@ -143,9 +143,11 @@ function verify(
             _json_str(string(Dates.today())),
             "}",
         )
-        open(joinpath(outdir, "evidence-$(sid).jsonl"), "a") do io
+        _ef = joinpath(outdir, "evidence-$(sid).jsonl")
+        open(_ef, "a") do io
             println(io, card)
         end
+        @info "verify: emitted card" path = abspath(_ef) exists = isfile(_ef)
     end
     return subject
 end


### PR DESCRIPTION
## Why

#366 fixed the silent-success (record jobs now fail loud red), and confirmed `QATLAS_CIOUT_DIR` resolves to the correct absolute workspace path — yet `upload-artifact` still finds **no** `timings-*.tsv` / `evidence-*.jsonl` in the workspace. So `julia-actions/julia-runtest`'s `Pkg.test` sandbox writes the files somewhere the workspace upload can't see, even with an absolute target path. The old emit `println` hardcoded a relative string, hiding the real location.

## What

- **Robust fix:** new shard step *after* `julia-runtest` (push:main only) — `find`s the emitted `timings-*.tsv` / `evidence-*.jsonl` under `$GITHUB_WORKSPACE`, `$HOME/.julia`, `$RUNNER_TEMP`, `/tmp`, and copies them into `$GITHUB_WORKSPACE/test/.ci-out` so the existing upload steps (which scan the workspace) find them — independent of wherever the sandbox actually wrote them.
- **Observability:** `runtests.jl` / `verify.jl` now print/`@info` the **absolute** emit path + `exists=` so the real location is always in the log (no more guessing).

## Validation note

Emit is push:main-only (`QATLAS_EMIT=0` on PRs), so this PR's CI only confirms no regression. Post-merge push:main: the collect step's `--- located emitted files ---` log pinpoints the sandbox path, and `ci-timings`/`ci-evidence` should finally be seeded. If still empty, the #366 loud-fail guard keeps it red (never silent green).
