### PR TITLE
fix(ci): include-hidden-files for .ci-out uploads (real root cause)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -91,23 +91,6 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         with:
           julia-args: "--threads=auto"
-      - name: Collect emitted ci-out into the workspace (push:main only)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          set -uo pipefail
-          dest="$GITHUB_WORKSPACE/test/.ci-out"
-          mkdir -p "$dest"
-          echo "QATLAS_CIOUT_DIR=$QATLAS_CIOUT_DIR  GITHUB_WORKSPACE=$GITHUB_WORKSPACE"
-          found=$(find "$GITHUB_WORKSPACE" "$HOME/.julia" "$RUNNER_TEMP" /tmp \
-                    -maxdepth 9 \( -name 'timings-*.tsv' -o -name 'evidence-*.jsonl' \) \
-                    2>/dev/null | sort -u || true)
-          echo "--- located emitted files ---"; printf '%s\n' "$found"
-          if [ -n "$found" ]; then
-            printf '%s\n' "$found" | while IFS= read -r f; do
-              [ -n "$f" ] && [ -f "$f" ] && cp -fv "$f" "$dest/" || true
-            done
-          fi
-          echo "--- workspace test/.ci-out ---"; ls -la "$dest" 2>&1 || true
       - uses: julia-actions/julia-processcoverage@v1
       - uses: actions/upload-artifact@v7
         with:
@@ -125,6 +108,7 @@ jobs:
           retention-days: 1
           if-no-files-found: warn
           overwrite: true
+          include-hidden-files: true
       - name: Upload shard evidence cards (push:main only)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v7
@@ -134,6 +118,7 @@ jobs:
           retention-days: 1
           if-no-files-found: warn
           overwrite: true
+          include-hidden-files: true
 
   record-timings:
     name: Record timing history


### PR DESCRIPTION
## Root cause (found definitively from logs)

It was never a sandbox/path problem. #367's Collect step `ls -la` proved the emitted files sit in `/home/runner/work/QAtlas.jl/QAtlas.jl/test/.ci-out/` (evidence 986 B, timings 412 B) right after the test. Yet:

- `coverage-s16` upload (`path: lcov.info`) → **1 file uploaded** ✓
- `timing-s16` upload (`path: test/.ci-out/timings-*.tsv`) → **"No files were found"** ✗

The decisive detail: `actions/upload-artifact@v4+` defaults to `include-hidden-files: false`, and **`.ci-out` is a dot-prefixed (hidden) directory**, so every file under it is silently excluded from the upload. `lcov.info` uploads because it is not hidden. This explains every failure since the WHY plane landed — `QATLAS_CIOUT_DIR`, the Collect step, the sandbox theory were all chasing the wrong cause.

## Fix

- `Upload shard timing` / `Upload shard evidence`: add **`include-hidden-files: true`** — the actual one-line fix.
- Remove the now-pointless `Collect emitted ci-out` step (it was predicated on the disproven sandbox theory; the files were always in the workspace).

Kept (already on main, and exactly what let us pinpoint this): the #366 loud-fail guard (record jobs `exit 1` on 0 rows) and the abspath emit logging.

## Validation

Emit is push:main-only (`QATLAS_EMIT=0` on PRs), so this PR's CI only confirms no regression. Post-merge push:main: `timing-*`/`evidence-*` artifacts should finally upload, the record jobs merge rows ≥ 1, and `ci-timings` / `ci-evidence` orphan branches get seeded for the first time. If still empty, the loud-fail guard keeps it red (never silent green).
