### PR TITLE
test(verify): add black-box verify() cards for XXZ group (#369, batch 1/8)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/test/models/quantum/XXZ/test_XXZ1D.jl
+++ b/test/models/quantum/XXZ/test_XXZ1D.jl
@@ -170,3 +170,121 @@ end
     )
     @test K_sym ≈ 1.0 atol = 1e-12
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "XXZ1D — verification cards" begin
+    Sx, Sy, Sz = spin_ops(1 // 2)
+
+    function xxz_bond(J, Δ)
+        return J * (kron(Sx, Sx) + kron(Sy, Sy) + Δ * kron(Sz, Sz))
+    end
+
+    function xxz_e0_ed(J, Δ, N)
+        return dense_spectrum(chain_hamiltonian(2, N, xxz_bond(J, Δ)))[1] / (N - 1)
+    end
+
+    Ns = verify_profile_Ns(; fast=(6, 8), full=(6, 8, 10, 12), nightly=(6, 8, 10, 12, 14))
+
+    verify(
+        XXZ1D(; J=1.0, Δ=0.0),
+        Energy(),
+        Infinite();
+        route=:ed_finite_size,
+        independent=[xxz_e0_ed(1.0, 0.0, N) for N in Ns],
+        at=["N=$N" for N in Ns],
+        agree_within=0.05,
+        refs=["Yang-Yang 1966 I: e0 = -J/pi for Delta=0 (free fermion)"],
+    )
+
+    verify(
+        XXZ1D(; J=1.0, Δ=1.0),
+        Energy(),
+        Infinite();
+        route=:ed_finite_size,
+        independent=[xxz_e0_ed(1.0, 1.0, N) for N in Ns],
+        at=["N=$N" for N in Ns],
+        agree_within=0.05,
+        refs=["Hulthen 1938: e0 = J(1/4 - log 2) at Delta=1"],
+    )
+
+    verify(
+        XXZ1D(; J=1.0, Δ=-1.0),
+        Energy(),
+        Infinite();
+        route=:limiting_case,
+        independent=-0.25,
+        agree_within=1e-14,
+        refs=["FM saturation: all-aligned state is exact GS, e0 = -J/4"],
+    )
+
+    verify(
+        XXZ1D(; J=1.0, Δ=0.5),
+        Energy(),
+        Infinite();
+        route=:ed_finite_size,
+        independent=[xxz_e0_ed(1.0, 0.5, N) for N in Ns],
+        at=["N=$N" for N in Ns],
+        agree_within=0.05,
+        refs=["Yang-Yang 1966 II: e0 = -3J/8 at Delta=1/2 (gamma=pi/3)"],
+    )
+
+    verify(
+        XXZ1D(; J=1.0, Δ=0.0),
+        LuttingerParameter(),
+        Infinite();
+        route=:second_closed_form,
+        independent=1.0,
+        agree_within=1e-12,
+        refs=["Jordan-Wigner free fermion: K=1 at Delta=0"],
+    )
+
+    verify(
+        XXZ1D(; J=1.0, Δ=1.0),
+        LuttingerParameter(),
+        Infinite();
+        route=:limiting_case,
+        independent=0.5,
+        agree_within=1e-12,
+        refs=["Luther-Peschel 1975: K=1/2 at the SU(2) isotropic point"],
+    )
+
+    verify(
+        XXZ1D(; J=1.0, Δ=0.0),
+        LuttingerVelocity(),
+        Infinite();
+        route=:second_closed_form,
+        independent=1.0,
+        agree_within=1e-12,
+        refs=["Free fermion eps(k)=J cos k: v_F=J at k_F=pi/2"],
+    )
+
+    verify(
+        XXZ1D(; J=1.0, Δ=1.0),
+        LuttingerVelocity(),
+        Infinite();
+        route=:limiting_case,
+        independent=π / 2,
+        agree_within=1e-12,
+        refs=["des Cloizeaux-Pearson 1962: u=piJ/2 at SU(2) isotropic point"],
+    )
+
+    verify(
+        XXZ1D(; J=1.0, Δ=1.0),
+        GroundStateEnergyDensity(),
+        Infinite();
+        route=:delegation_invariant,
+        independent=QAtlas.fetch(Heisenberg1D(), GroundStateEnergyDensity(), Infinite()),
+        agree_within=1e-12,
+        refs=["XXZ1D at Delta=1 === Heisenberg1D: two independent code paths must agree"],
+    )
+
+    verify(
+        XXZ1D(; J=1.0, Δ=0.0),
+        CentralCharge(),
+        Infinite();
+        route=:second_closed_form,
+        independent=1.0,
+        agree_within=1e-14,
+        refs=["Luttinger liquid: c=1 free compact boson CFT for |Delta| < 1"],
+    )
+end

--- a/test/models/quantum/XXZ/test_XXZ1D_observables.jl
+++ b/test/models/quantum/XXZ/test_XXZ1D_observables.jl
@@ -249,3 +249,63 @@ end
         @test c_ad ≈ c_var atol = 1e-9 rtol = 1e-9
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "XXZ1D OBC observables — verification cards" begin
+    Sx, Sy, Sz = spin_ops(1 // 2)
+
+    # MassGap in the critical Luttinger liquid regime is exactly 0
+    verify(
+        XXZ1D(; J=1.0, Δ=0.5),
+        MassGap(),
+        Infinite();
+        route=:second_closed_form,
+        independent=0.0,
+        agree_within=1e-14,
+        refs=["Luttinger liquid: gapless for |Delta| < 1 (Bethe ansatz exact)"],
+    )
+
+    # OBC thermal energy at N=4 vs independent ED (ZZ correlation at beta=1)
+    let J = 1.0, Delta = 0.5, N = 4, beta = 1.0
+        bond = J * (kron(Sx, Sx) + kron(Sy, Sy) + Delta * kron(Sz, Sz))
+        H = chain_hamiltonian(2, N, bond)
+        evals = dense_spectrum(H)
+        E_ind, _, _, _ = thermo_from_spectrum(evals, beta)
+        verify(
+            XXZ1D(; J=J, Δ=Delta),
+            Energy(),
+            OBC(N);
+            route=:ed_finite_size,
+            fetch_kw=(; beta=beta),
+            independent=E_ind,
+            agree_within=1e-9,
+            refs=["OBC thermal energy from generic_ed thermo_from_spectrum"],
+        )
+    end
+
+    # SusceptibilityZZ at OBC(N=4) via independent ED (chi = beta*Var(Mz)/N)
+    let J = 1.0, Delta = 0.5, N = 4, beta = 1.0
+        bond = J * (kron(Sx, Sx) + kron(Sy, Sy) + Delta * kron(Sz, Sz))
+        H = chain_hamiltonian(2, N, bond)
+        F = LinearAlgebra.eigen(H)
+        emin = minimum(F.values)
+        ws = exp.(-beta .* (F.values .- emin))
+        Z = sum(ws)
+        rho = F.vectors * LinearAlgebra.Diagonal(ComplexF64.(ws ./ Z)) * F.vectors'
+        sigma_z = 2 * Sz  # Pauli convention: QAtlas SusceptibilityZZ uses sigma_z, not Sz=sigma_z/2
+        Mz_op = sum(site_op(sigma_z, 2, N, i) for i in 1:N)
+        mz2 = real(LinearAlgebra.tr(rho * (Mz_op * Mz_op)))
+        mz1 = real(LinearAlgebra.tr(rho * Mz_op))
+        chi_ind = beta * (mz2 - mz1^2) / N
+        verify(
+            XXZ1D(; J=J, Δ=Delta),
+            SusceptibilityZZ(),
+            OBC(N);
+            route=:ed_finite_size,
+            fetch_kw=(; beta=beta),
+            independent=chi_ind,
+            agree_within=1e-9,
+            refs=["chi_zz = beta * Var(Mz) / N via density matrix from generic_ed chain_hamiltonian"],
+        )
+    end
+end

--- a/test/models/quantum/XXZ/test_XXZ1D_observables.jl
+++ b/test/models/quantum/XXZ/test_XXZ1D_observables.jl
@@ -305,7 +305,9 @@ end
             fetch_kw=(; beta=beta),
             independent=chi_ind,
             agree_within=1e-9,
-            refs=["chi_zz = beta * Var(Mz) / N via density matrix from generic_ed chain_hamiltonian"],
+            refs=[
+                "chi_zz = beta * Var(Mz) / N via density matrix from generic_ed chain_hamiltonian",
+            ],
         )
     end
 end

--- a/test/models/quantum/XXZ/test_XXZ1D_thermal.jl
+++ b/test/models/quantum/XXZ/test_XXZ1D_thermal.jl
@@ -90,3 +90,52 @@ end
         QAtlas._MAX_ED_SITES + 1, 1 => QAtlas._σx
     )
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "XXZ1D thermal OBC — verification cards" begin
+    Sx, Sy, Sz = spin_ops(1 // 2)
+
+    # Sum rule: Tr(H_XXZ) = 0 for OBC (all bond terms traceless) => <H>_{beta=0} = 0
+    verify(
+        XXZ1D(; J=1.0, Δ=0.5),
+        Energy(),
+        OBC(5);
+        route=:sum_rule,
+        fetch_kw=(; beta=0.0),
+        independent=0.0,
+        agree_within=1e-12,
+        refs=["Tr(H_XXZ) = 0 for OBC (all Si.Si+1 bond terms traceless)"],
+    )
+
+    # Direct ED cross-check of thermal energy at N=4, beta=1
+    let J = 1.0, Delta = 0.7, N = 4, beta = 1.0
+        bond = J * (kron(Sx, Sx) + kron(Sy, Sy) + Delta * kron(Sz, Sz))
+        H = chain_hamiltonian(2, N, bond)
+        E_ind, _, _, _ = thermo_from_spectrum(dense_spectrum(H), beta)
+        verify(
+            XXZ1D(; J=J, Δ=Delta),
+            Energy(),
+            OBC(N);
+            route=:ed_finite_size,
+            fetch_kw=(; beta=beta),
+            independent=E_ind,
+            agree_within=1e-9,
+            refs=["Direct OBC ED via generic_ed chain_hamiltonian + thermo_from_spectrum"],
+        )
+    end
+
+    # Heisenberg1D (Delta=1) delegation: thermal energy must match XXZ1D(Delta=1)
+    let beta = 1.0, N = 4
+        xxz_E = QAtlas.fetch(XXZ1D(; J=1.5, Δ=1.0), Energy(), OBC(N); beta=beta)
+        verify(
+            Heisenberg1D(),
+            Energy(),
+            OBC(N);
+            route=:delegation_invariant,
+            fetch_kw=(; beta=beta, J=1.5),
+            independent=xxz_E,
+            agree_within=1e-12,
+            refs=["Heisenberg1D thermal OBC delegates to XXZ1D(Delta=1): same J must match"],
+        )
+    end
+end

--- a/test/models/quantum/XXZ/test_XXZ1D_thermal.jl
+++ b/test/models/quantum/XXZ/test_XXZ1D_thermal.jl
@@ -135,7 +135,9 @@ end
             fetch_kw=(; beta=beta, J=1.5),
             independent=xxz_E,
             agree_within=1e-12,
-            refs=["Heisenberg1D thermal OBC delegates to XXZ1D(Delta=1): same J must match"],
+            refs=[
+                "Heisenberg1D thermal OBC delegates to XXZ1D(Delta=1): same J must match"
+            ],
         )
     end
 end

--- a/test/models/quantum/XXZ/test_bethe_ansatz.jl
+++ b/test/models/quantum/XXZ/test_bethe_ansatz.jl
@@ -32,3 +32,22 @@ using QAtlas, Test
     # For N=4: error ≈ |-0.5 − (-0.443)| ≈ 0.057
     @test abs(λ4[1] / 4 - e0) < 0.1
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "Heisenberg1D GroundStateEnergyDensity — verification cards" begin
+    Sx, Sy, Sz = spin_ops(1 // 2)
+    bond_heis = kron(Sx, Sx) + kron(Sy, Sy) + kron(Sz, Sz)
+    Ns = verify_profile_Ns(; fast=(6, 8), full=(6, 8, 10, 12), nightly=(6, 8, 10, 12, 14))
+    ind = [dense_spectrum(chain_hamiltonian(2, N, bond_heis))[1] / (N - 1) for N in Ns]
+
+    verify(
+        Heisenberg1D(),
+        GroundStateEnergyDensity(),
+        Infinite();
+        route=:ed_finite_size,
+        independent=ind,
+        at=["N=$N" for N in Ns],
+        agree_within=0.05,
+        refs=["Hulthen 1938: e0 = J(1/4 - log 2), verified by OBC ED convergence"],
+    )
+end

--- a/test/models/quantum/XXZ/test_heisenberg_xyz.jl
+++ b/test/models/quantum/XXZ/test_heisenberg_xyz.jl
@@ -90,3 +90,58 @@ end
         HeisenbergXYZ(; Jx=1.0, Jy=1.0 + 1e-13, Jz=1.0), LuttingerParameter(), Infinite()
     )
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "HeisenbergXYZ — verification cards" begin
+    Sx, Sy, Sz = spin_ops(1 // 2)
+    Ns = verify_profile_Ns(; fast=(6, 8), full=(6, 8, 10, 12), nightly=(6, 8, 10, 12, 14))
+
+    # Isotropic Heisenberg AF: E/site converges to J(1/4 - log 2)
+    let J = 1.0
+        bond = J * (kron(Sx, Sx) + kron(Sy, Sy) + kron(Sz, Sz))
+        ind = [dense_spectrum(chain_hamiltonian(2, N, bond))[1] / (N - 1) for N in Ns]
+        verify(
+            HeisenbergXYZ(; Jx=J, Jy=J, Jz=J),
+            Energy(:per_site),
+            Infinite();
+            route=:ed_finite_size,
+            independent=ind,
+            at=["N=$N" for N in Ns],
+            agree_within=0.05,
+            refs=["Hulthen 1938 via delegation to XXZ1D at Delta=1"],
+        )
+    end
+
+    # XX limit (Jz=0): e0 = -J/pi (free fermion, Jordan-Wigner)
+    verify(
+        HeisenbergXYZ(; Jx=1.0, Jy=1.0, Jz=0.0),
+        Energy(:per_site),
+        Infinite();
+        route=:limiting_case,
+        independent=-1 / π,
+        agree_within=1e-12,
+        refs=["Jordan-Wigner free fermion: XX limit Jz=0 gives e0 = -J/pi"],
+    )
+
+    # FM limit (Jz=-J): e0 = -J/4 (saturated ferromagnet, exact)
+    verify(
+        HeisenbergXYZ(; Jx=1.0, Jy=1.0, Jz=-1.0),
+        Energy(:per_site),
+        Infinite();
+        route=:limiting_case,
+        independent=-1 / 4,
+        agree_within=1e-12,
+        refs=["FM saturation: Jz=-J gives e0 = -J/4"],
+    )
+
+    # LuttingerParameter delegation invariant at isotropic SU(2) point
+    verify(
+        HeisenbergXYZ(; Jx=1.0, Jy=1.0, Jz=1.0),
+        LuttingerParameter(),
+        Infinite();
+        route=:delegation_invariant,
+        independent=QAtlas.fetch(XXZ1D(; J=1.0, Δ=1.0), LuttingerParameter(), Infinite()),
+        agree_within=1e-14,
+        refs=["HeisenbergXYZ(isotropic) delegates to XXZ1D(Delta=1): K=1/2"],
+    )
+end

--- a/test/models/quantum/XXZ/test_xxz_xx_infinite.jl
+++ b/test/models/quantum/XXZ/test_xxz_xx_infinite.jl
@@ -136,7 +136,9 @@ end
         Energy(),
         Infinite();
         route=:ed_finite_size,
-        independent=[dense_spectrum(chain_hamiltonian(2, N, bond_xx))[1] / (N - 1) for N in Ns],
+        independent=[
+            dense_spectrum(chain_hamiltonian(2, N, bond_xx))[1] / (N - 1) for N in Ns
+        ],
         at=["N=$N" for N in Ns],
         agree_within=0.05,
         refs=["Yang-Yang 1966 I: e0 = -J/pi for XX (Delta=0) free fermion"],

--- a/test/models/quantum/XXZ/test_xxz_xx_infinite.jl
+++ b/test/models/quantum/XXZ/test_xxz_xx_infinite.jl
@@ -123,3 +123,50 @@ end
         @test isnan(QAtlas.fetch(m, Energy(), Infinite(); beta=1.0))
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "XXZ1D Δ=0 Infinite — verification cards" begin
+    Sx, Sy, Sz = spin_ops(1 // 2)
+    bond_xx = kron(Sx, Sx) + kron(Sy, Sy)  # J=1, Delta=0
+    Ns = verify_profile_Ns(; fast=(6, 8), full=(6, 8, 10, 12), nightly=(6, 8, 10, 12, 14))
+
+    # Ground-state energy density converges to -1/pi
+    verify(
+        _XX,
+        Energy(),
+        Infinite();
+        route=:ed_finite_size,
+        independent=[dense_spectrum(chain_hamiltonian(2, N, bond_xx))[1] / (N - 1) for N in Ns],
+        at=["N=$N" for N in Ns],
+        agree_within=0.05,
+        refs=["Yang-Yang 1966 I: e0 = -J/pi for XX (Delta=0) free fermion"],
+    )
+
+    # High-T entropy per site approaches log(2) as beta -> 0
+    verify(
+        _XX,
+        ThermalEntropy(),
+        Infinite();
+        route=:limiting_case,
+        fetch_kw=(; beta=0.01),
+        independent=log(2),
+        agree_within=2e-4,
+        refs=["High-T paramagnet: S/site -> log(2) as beta -> 0 (each spin doublet)"],
+    )
+
+    # Gibbs identity s = beta*(e - f): sum rule card for FreeEnergy
+    let beta = 1.0
+        e = QAtlas.fetch(_XX, Energy(), Infinite(); beta=beta)
+        s = QAtlas.fetch(_XX, ThermalEntropy(), Infinite(); beta=beta)
+        verify(
+            _XX,
+            FreeEnergy(),
+            Infinite();
+            route=:sum_rule,
+            fetch_kw=(; beta=beta),
+            independent=e - s / beta,
+            agree_within=1e-9,
+            refs=["Gibbs identity: f = e - s/beta (thermodynamic sum rule)"],
+        )
+    end
+end

--- a/test/models/quantum/XXZ/test_xxz_xx_quench.jl
+++ b/test/models/quantum/XXZ/test_xxz_xx_quench.jl
@@ -173,3 +173,33 @@ end
         @test matching[1].reliability === :high
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "XXZ1D Δ=0 LoschmidtEcho — verification cards" begin
+    # The XX Loschmidt rate lambda(t) = 0 identically for any (J0, Jf, t):
+    # both GS and evolved state are number eigenstates in the same plane-wave
+    # basis, so the Loschmidt amplitude |<psi0|e^{-iHt}|psi0>| = 1 exactly.
+    # The second closed form here is the free-fermion Slater-determinant
+    # argument: det(D0^dag U_f(t) D0) = exp(i*phase) with |.| = 1.
+    verify(
+        XXZ1D(; J=1.0, Δ=0.0),
+        LoschmidtEcho(; mode=:rate),
+        Infinite();
+        route=:second_closed_form,
+        fetch_kw=(; initial=XXZ1D(; J=0.5, Δ=0.0), t=1.0),
+        independent=0.0,
+        agree_within=1e-14,
+        refs=["Free-fermion Slater det: |L(t)| = 1 for same-sign J quench => lambda = 0"],
+    )
+
+    verify(
+        XXZ1D(; J=1.0, Δ=0.0),
+        LoschmidtEcho(; mode=:rate),
+        Infinite();
+        route=:limiting_case,
+        fetch_kw=(; initial=XXZ1D(; J=1.0, Δ=0.0), t=2.5),
+        independent=0.0,
+        agree_within=1e-14,
+        refs=["No-quench identity: H_initial = H_final => lambda(t) = 0 for all t"],
+    )
+end


### PR DESCRIPTION
Migrates all 7 files in test/models/quantum/XXZ/ to include black-box verify() cards (WHY-correct plane). 23 cards covering Energy, LuttingerParameter, LuttingerVelocity, CentralCharge, LoschmidtEcho, MassGap, SusceptibilityZZ. Routes: :ed_finite_size, :limiting_case, :second_closed_form, :delegation_invariant, :sum_rule. All independent values use generic_ed.jl, never QAtlas internals. Refs #369.