### PR TITLE
test(verify): black-box verify() cards for Heisenberg group (#369, batch 2/8)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.20.1"
+version = "0.20.3"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/test/models/quantum/Heisenberg/test_Heisenberg1D_thermal.jl
+++ b/test/models/quantum/Heisenberg/test_Heisenberg1D_thermal.jl
@@ -96,3 +96,49 @@ end
     v_heis_inf = QAtlas.fetch(Heisenberg1D(), MassGap(), Infinite())
     @test v_heis_inf == 0.0
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "Heisenberg1D thermal OBC — verification cards" begin
+    Sx, Sy, Sz = spin_ops(1 // 2)
+
+    # MassGap in the gapless Luttinger liquid regime is exactly 0
+    verify(
+        Heisenberg1D(),
+        MassGap(),
+        Infinite();
+        route=:second_closed_form,
+        independent=0.0,
+        agree_within=1e-14,
+        refs=["Heisenberg chain is gapless (des Cloizeaux-Pearson 1962): gap = 0"],
+    )
+
+    # OBC thermal energy at N=4, beta=1 vs independent ED (thermo_from_spectrum)
+    let J = 1.0, N = 4, beta = 1.0
+        bond = J * (kron(Sx, Sx) + kron(Sy, Sy) + kron(Sz, Sz))
+        E_ind, _, _, _ = thermo_from_spectrum(dense_spectrum(chain_hamiltonian(2, N, bond)), beta)
+        verify(
+            Heisenberg1D(),
+            Energy(),
+            OBC(N);
+            route=:ed_finite_size,
+            fetch_kw=(; beta=beta, J=J),
+            independent=E_ind,
+            agree_within=1e-9,
+            refs=["Direct OBC ED via generic_ed chain_hamiltonian + thermo_from_spectrum"],
+        )
+    end
+
+    # Delegation invariant: Heisenberg1D thermal OBC === XXZ1D(Delta=1) at same J
+    let beta = 1.0, N = 4
+        verify(
+            Heisenberg1D(),
+            Energy(),
+            OBC(N);
+            route=:delegation_invariant,
+            fetch_kw=(; beta=beta, J=1.5),
+            independent=QAtlas.fetch(XXZ1D(; J=1.5, Δ=1.0), Energy(), OBC(N); beta=beta),
+            agree_within=1e-12,
+            refs=["Heisenberg1D thermal OBC delegates to XXZ1D(Delta=1): same J must match"],
+        )
+    end
+end

--- a/test/models/quantum/Heisenberg/test_Heisenberg1D_thermal.jl
+++ b/test/models/quantum/Heisenberg/test_Heisenberg1D_thermal.jl
@@ -115,7 +115,9 @@ end
     # OBC thermal energy at N=4, beta=1 vs independent ED (thermo_from_spectrum)
     let J = 1.0, N = 4, beta = 1.0
         bond = J * (kron(Sx, Sx) + kron(Sy, Sy) + kron(Sz, Sz))
-        E_ind, _, _, _ = thermo_from_spectrum(dense_spectrum(chain_hamiltonian(2, N, bond)), beta)
+        E_ind, _, _, _ = thermo_from_spectrum(
+            dense_spectrum(chain_hamiltonian(2, N, bond)), beta
+        )
         verify(
             Heisenberg1D(),
             Energy(),
@@ -138,7 +140,9 @@ end
             fetch_kw=(; beta=beta, J=1.5),
             independent=QAtlas.fetch(XXZ1D(; J=1.5, Δ=1.0), Energy(), OBC(N); beta=beta),
             agree_within=1e-12,
-            refs=["Heisenberg1D thermal OBC delegates to XXZ1D(Delta=1): same J must match"],
+            refs=[
+                "Heisenberg1D thermal OBC delegates to XXZ1D(Delta=1): same J must match"
+            ],
         )
     end
 end

--- a/test/models/quantum/Heisenberg/test_S1Heisenberg1D_observables.jl
+++ b/test/models/quantum/Heisenberg/test_S1Heisenberg1D_observables.jl
@@ -251,3 +251,45 @@ end
         @test ε ≈ E_total / N rtol=1e-12
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "S1Heisenberg1D observables — verification cards" begin
+    Sx, Sy, Sz = spin_ops(1)  # spin-1, local dimension d=3
+    heis1_bond(J) = J * (kron(Sx, Sx) + kron(Sy, Sy) + kron(Sz, Sz))
+
+    # Energy per site Infinite: White-Huse 1993 DMRG literature value
+    verify(
+        S1Heisenberg1D(; J=1.0),
+        Energy(:per_site),
+        Infinite();
+        route=:literature_value,
+        independent=-1.401484038971,
+        agree_within=1e-6,
+        refs=["White-Huse 1993 DMRG: e ≈ -1.401484 J (spin-1 Haldane chain)"],
+    )
+
+    # Independent spin-1 OBC ED trend toward the DMRG thermodynamic value
+    let Ns = verify_profile_Ns(; fast=(6, 8), full=(6, 8), nightly=(6, 8))
+        verify(
+            S1Heisenberg1D(; J=1.0),
+            Energy(:per_site),
+            Infinite();
+            route=:ed_finite_size,
+            independent=[dense_spectrum(chain_hamiltonian(3, N, heis1_bond(1.0)))[1] / N for N in Ns],
+            at=["N=$N" for N in Ns],
+            agree_within=0.3,
+            refs=["Finite-N spin-1 OBC ED is a coarse approximant of the DMRG e (gapped, slow)"],
+        )
+    end
+
+    # Haldane gap Infinite: White-Huse 1993 DMRG literature value
+    verify(
+        S1Heisenberg1D(; J=1.0),
+        MassGap(),
+        Infinite();
+        route=:literature_value,
+        independent=0.41048,
+        agree_within=1e-4,
+        refs=["White-Huse 1993 DMRG: Haldane gap Delta ≈ 0.41048 J"],
+    )
+end

--- a/test/models/quantum/Heisenberg/test_S1Heisenberg1D_observables.jl
+++ b/test/models/quantum/Heisenberg/test_S1Heisenberg1D_observables.jl
@@ -275,10 +275,14 @@ end
             Energy(:per_site),
             Infinite();
             route=:ed_finite_size,
-            independent=[dense_spectrum(chain_hamiltonian(3, N, heis1_bond(1.0)))[1] / N for N in Ns],
+            independent=[
+                dense_spectrum(chain_hamiltonian(3, N, heis1_bond(1.0)))[1] / N for N in Ns
+            ],
             at=["N=$N" for N in Ns],
             agree_within=0.3,
-            refs=["Finite-N spin-1 OBC ED is a coarse approximant of the DMRG e (gapped, slow)"],
+            refs=[
+                "Finite-N spin-1 OBC ED is a coarse approximant of the DMRG e (gapped, slow)",
+            ],
         )
     end
 

--- a/test/models/quantum/Heisenberg/test_S1Heisenberg1D_thermal.jl
+++ b/test/models/quantum/Heisenberg/test_S1Heisenberg1D_thermal.jl
@@ -119,7 +119,9 @@ end
     # OBC thermal energy at N=4, beta=1 vs independent spin-1 ED
     let J = 1.0, N = 4, beta = 1.0
         bond = J * (kron(Sx, Sx) + kron(Sy, Sy) + kron(Sz, Sz))
-        E_ind, _, _, _ = thermo_from_spectrum(dense_spectrum(chain_hamiltonian(3, N, bond)), beta)
+        E_ind, _, _, _ = thermo_from_spectrum(
+            dense_spectrum(chain_hamiltonian(3, N, bond)), beta
+        )
         verify(
             S1Heisenberg1D(; J=J),
             Energy(),
@@ -128,7 +130,9 @@ end
             fetch_kw=(; beta=beta),
             independent=E_ind,
             agree_within=1e-9,
-            refs=["Direct spin-1 OBC ED via generic_ed chain_hamiltonian + thermo_from_spectrum"],
+            refs=[
+                "Direct spin-1 OBC ED via generic_ed chain_hamiltonian + thermo_from_spectrum",
+            ],
         )
     end
 end

--- a/test/models/quantum/Heisenberg/test_S1Heisenberg1D_thermal.jl
+++ b/test/models/quantum/Heisenberg/test_S1Heisenberg1D_thermal.jl
@@ -93,3 +93,42 @@ end
     )
     @test_throws ArgumentError QAtlas._s1_heisenberg_hamiltonian_matrix(S1Heisenberg1D(), 1)
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "S1Heisenberg1D thermal OBC — verification cards" begin
+    Sx, Sy, Sz = spin_ops(1)  # spin-1, local dimension d=3
+
+    # N=2 dimer: exact spin-1 bond spectrum [-2J (singlet x1),
+    # -J (triplet x3), +J (quintet x5)].  Independent thermal energy
+    # from this exact 9-level spectrum.
+    let J = 1.0, beta = 1.0
+        evals = vcat(fill(-2J, 1), fill(-J, 3), fill(J, 5))
+        E_ind, _, _, _ = thermo_from_spectrum(evals, beta)
+        verify(
+            S1Heisenberg1D(; J=J),
+            Energy(),
+            OBC(2);
+            route=:second_closed_form,
+            fetch_kw=(; beta=beta),
+            independent=E_ind,
+            agree_within=1e-9,
+            refs=["Exact spin-1 dimer spectrum: S_tot in {0,1,2} -> {-2J,-J,+J}"],
+        )
+    end
+
+    # OBC thermal energy at N=4, beta=1 vs independent spin-1 ED
+    let J = 1.0, N = 4, beta = 1.0
+        bond = J * (kron(Sx, Sx) + kron(Sy, Sy) + kron(Sz, Sz))
+        E_ind, _, _, _ = thermo_from_spectrum(dense_spectrum(chain_hamiltonian(3, N, bond)), beta)
+        verify(
+            S1Heisenberg1D(; J=J),
+            Energy(),
+            OBC(N);
+            route=:ed_finite_size,
+            fetch_kw=(; beta=beta),
+            independent=E_ind,
+            agree_within=1e-9,
+            refs=["Direct spin-1 OBC ED via generic_ed chain_hamiltonian + thermo_from_spectrum"],
+        )
+    end
+end

--- a/test/models/quantum/Heisenberg/test_dmi_heisenberg1d.jl
+++ b/test/models/quantum/Heisenberg/test_dmi_heisenberg1d.jl
@@ -67,7 +67,9 @@ end
         Energy(:per_site),
         Infinite();
         route=:ed_finite_size,
-        independent=[dense_spectrum(chain_hamiltonian(2, N, heis_bond(1.0)))[1] / N for N in Ns],
+        independent=[
+            dense_spectrum(chain_hamiltonian(2, N, heis_bond(1.0)))[1] / N for N in Ns
+        ],
         at=["N=$N" for N in Ns],
         agree_within=0.1,
         refs=["Hulthen 1938: e0 = J(1/4 - log 2), spin-1/2 Heisenberg OBC ED"],

--- a/test/models/quantum/Heisenberg/test_dmi_heisenberg1d.jl
+++ b/test/models/quantum/Heisenberg/test_dmi_heisenberg1d.jl
@@ -43,3 +43,33 @@ end
         DMIHeisenberg1D(; J=1.0, D=1e-13), Energy{:per_site}(), Infinite()
     )
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "DMIHeisenberg1D — verification cards" begin
+    Sx, Sy, Sz = spin_ops(1 // 2)
+    heis_bond(J) = J * (kron(Sx, Sx) + kron(Sy, Sy) + kron(Sz, Sz))
+    Ns = verify_profile_Ns(; fast=(6, 8), full=(6, 8, 10, 12), nightly=(6, 8, 10, 12, 14))
+
+    # D=0 delegates to Heisenberg1D (Hulthen e0 = J(1/4 - log 2))
+    verify(
+        DMIHeisenberg1D(; J=1.0, D=0.0),
+        Energy(:per_site),
+        Infinite();
+        route=:delegation_invariant,
+        independent=QAtlas.fetch(Heisenberg1D(), GroundStateEnergyDensity(), Infinite()),
+        agree_within=1e-12,
+        refs=["DMIHeisenberg1D(D=0) delegates to Heisenberg1D: independent code paths"],
+    )
+
+    # Independent OBC ED convergence to the Hulthen value
+    verify(
+        DMIHeisenberg1D(; J=1.0, D=0.0),
+        Energy(:per_site),
+        Infinite();
+        route=:ed_finite_size,
+        independent=[dense_spectrum(chain_hamiltonian(2, N, heis_bond(1.0)))[1] / N for N in Ns],
+        at=["N=$N" for N in Ns],
+        agree_within=0.1,
+        refs=["Hulthen 1938: e0 = J(1/4 - log 2), spin-1/2 Heisenberg OBC ED"],
+    )
+end

--- a/test/models/quantum/Heisenberg/test_heisenberg1d_luttinger.jl
+++ b/test/models/quantum/Heisenberg/test_heisenberg1d_luttinger.jl
@@ -11,3 +11,28 @@ using QAtlas, Test
     # Delegation invariant: bit-identical to XXZ1D at Δ=1
     @test K === QAtlas.fetch(QAtlas.XXZ1D(; Δ=1.0), LuttingerParameter(), Infinite())
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "Heisenberg1D LuttingerParameter — verification cards" begin
+    # K = 1/2 at the SU(2) isotropic point (Luther-Peschel 1975)
+    verify(
+        Heisenberg1D(),
+        LuttingerParameter(),
+        Infinite();
+        route=:limiting_case,
+        independent=0.5,
+        agree_within=1e-12,
+        refs=["Luther-Peschel 1975: K=1/2 at SU(2) isotropic point, J-independent"],
+    )
+
+    # Delegation invariant: Heisenberg1D === XXZ1D(Delta=1)
+    verify(
+        Heisenberg1D(),
+        LuttingerParameter(),
+        Infinite();
+        route=:delegation_invariant,
+        independent=QAtlas.fetch(XXZ1D(; J=1.0, Δ=1.0), LuttingerParameter(), Infinite()),
+        agree_within=1e-14,
+        refs=["Heisenberg1D delegates to XXZ1D(Delta=1): two code paths must agree"],
+    )
+end

--- a/test/models/quantum/Heisenberg/test_heisenberg_spinon.jl
+++ b/test/models/quantum/Heisenberg/test_heisenberg_spinon.jl
@@ -173,3 +173,42 @@ using QAtlas, Test
         end
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "Heisenberg1D spinon ZZStructureFactor — verification cards" begin
+    # Independent re-derivation of the Müller ansatz from the
+    # des Cloizeaux-Pearson two-spinon dispersion bounds (not read from src):
+    #   ε_L(q) = (π J / 2) |sin q|,  ε_U(q) = π J |sin(q/2)|
+    #   S^zz(q,ω) = Θ[ω-ε_L] Θ[ε_U-ω] / (2 √(ω² - ε_L²))
+    let J = 1.0, q = π / 2, ω = 2.0
+        εL = (π * J / 2) * abs(sin(q))
+        εU = π * J * abs(sin(q / 2))
+        @assert εL < ω < εU "pick (q,ω) inside the two-spinon continuum"
+        S_indep = 1 / (2 * sqrt(ω^2 - εL^2))
+        verify(
+            Heisenberg1D(),
+            ZZStructureFactor(),
+            Infinite();
+            route=:second_closed_form,
+            fetch_kw=(; q=q, ω=ω, J=J, method=:muller),
+            independent=S_indep,
+            agree_within=1e-12,
+            refs=["Müller-Thomas-Beck-Bonner 1981; des Cloizeaux-Pearson 1962 dispersion"],
+        )
+    end
+
+    # Support boundary: S = 0 just above the upper continuum edge ε_U
+    let J = 1.0, q = π / 2
+        εU = π * J * abs(sin(q / 2))
+        verify(
+            Heisenberg1D(),
+            ZZStructureFactor(),
+            Infinite();
+            route=:second_closed_form,
+            fetch_kw=(; q=q, ω=εU + 0.5, J=J, method=:muller),
+            independent=0.0,
+            agree_within=1e-14,
+            refs=["Two-spinon continuum has compact support: S=0 for ω > ε_U(q)"],
+        )
+    end
+end

--- a/test/models/quantum/Heisenberg/test_j1j2_heisenberg1d.jl
+++ b/test/models/quantum/Heisenberg/test_j1j2_heisenberg1d.jl
@@ -82,7 +82,9 @@ end
         Energy(:per_site),
         Infinite();
         route=:delegation_invariant,
-        independent=QAtlas.fetch(MajumdarGhosh(; J=1.0), GroundStateEnergyDensity(), Infinite()),
+        independent=QAtlas.fetch(
+            MajumdarGhosh(; J=1.0), GroundStateEnergyDensity(), Infinite()
+        ),
         agree_within=1e-12,
         refs=["J1J2 at J2=J1/2 delegates to MajumdarGhosh (exact dimer, -3J/8)"],
     )
@@ -97,7 +99,9 @@ end
             independent=[j1j2_pbc_e0(N, 1.0, 0.5) for N in Ns],
             at=["N=$N" for N in Ns],
             agree_within=1e-6,
-            refs=["Majumdar-Ghosh 1969: exact dimer GS, E0/N = -3J/8 size-independent (PBC even N)"],
+            refs=[
+                "Majumdar-Ghosh 1969: exact dimer GS, E0/N = -3J/8 size-independent (PBC even N)",
+            ],
         )
     end
 end

--- a/test/models/quantum/Heisenberg/test_j1j2_heisenberg1d.jl
+++ b/test/models/quantum/Heisenberg/test_j1j2_heisenberg1d.jl
@@ -46,3 +46,58 @@ end
     @test_throws DomainError J1J2Heisenberg1D(; J1=-1.0, J2=0.5)
     @test_throws DomainError J1J2Heisenberg1D(; J1=1.0, J2=-0.1)
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "J1J2Heisenberg1D — verification cards" begin
+    # Independent J1-J2 PBC ground-state energy density (spin-1/2),
+    # built black-box from site operators (never QAtlas internals).
+    function j1j2_pbc_e0(N, J1, J2)
+        Sx, Sy, Sz = spin_ops(1 // 2)
+        SS(i, j) =
+            site_op(Sx, 2, N, i) * site_op(Sx, 2, N, j) +
+            site_op(Sy, 2, N, i) * site_op(Sy, 2, N, j) +
+            site_op(Sz, 2, N, i) * site_op(Sz, 2, N, j)
+        H = zeros(ComplexF64, 2^N, 2^N)
+        for i in 1:N
+            H .+= J1 * SS(i, mod1(i + 1, N))
+            H .+= J2 * SS(i, mod1(i + 2, N))
+        end
+        return dense_spectrum(H)[1] / N
+    end
+
+    # j = 0 (pure Heisenberg): delegates to Heisenberg1D, e0 = J1(1/4 - log 2)
+    verify(
+        J1J2Heisenberg1D(; J1=1.0, J2=0.0),
+        Energy(:per_site),
+        Infinite();
+        route=:delegation_invariant,
+        independent=QAtlas.fetch(Heisenberg1D(), GroundStateEnergyDensity(), Infinite()),
+        agree_within=1e-12,
+        refs=["J1J2 at J2=0 delegates to Heisenberg1D (Hulthen 1938)"],
+    )
+
+    # j = 1/2 (Majumdar-Ghosh): delegates to MajumdarGhosh, e0 = -3 J1 / 8
+    verify(
+        J1J2Heisenberg1D(; J1=1.0, J2=0.5),
+        Energy(:per_site),
+        Infinite();
+        route=:delegation_invariant,
+        independent=QAtlas.fetch(MajumdarGhosh(; J=1.0), GroundStateEnergyDensity(), Infinite()),
+        agree_within=1e-12,
+        refs=["J1J2 at J2=J1/2 delegates to MajumdarGhosh (exact dimer, -3J/8)"],
+    )
+
+    # j = 1/2 MG point: independent PBC ED -> exact dimer -3 J1 / 8 (even N)
+    let Ns = verify_profile_Ns(; fast=(6, 8), full=(6, 8, 10, 12), nightly=(6, 8, 10, 12))
+        verify(
+            J1J2Heisenberg1D(; J1=1.0, J2=0.5),
+            Energy(:per_site),
+            Infinite();
+            route=:ed_finite_size,
+            independent=[j1j2_pbc_e0(N, 1.0, 0.5) for N in Ns],
+            at=["N=$N" for N in Ns],
+            agree_within=1e-6,
+            refs=["Majumdar-Ghosh 1969: exact dimer GS, E0/N = -3J/8 size-independent (PBC even N)"],
+        )
+    end
+end

--- a/test/models/quantum/Heisenberg/test_kagome_heisenberg_afm.jl
+++ b/test/models/quantum/Heisenberg/test_kagome_heisenberg_afm.jl
@@ -50,7 +50,9 @@ end
         route=:literature_value,
         independent=-0.4386,
         agree_within=5e-3,
-        refs=["Yan-Huse-White 2011; Depenbrock-McCulloch-Schollwöck 2012 DMRG: e ≈ -0.4386 J"],
+        refs=[
+            "Yan-Huse-White 2011; Depenbrock-McCulloch-Schollwöck 2012 DMRG: e ≈ -0.4386 J"
+        ],
     )
 
     verify(

--- a/test/models/quantum/Heisenberg/test_kagome_heisenberg_afm.jl
+++ b/test/models/quantum/Heisenberg/test_kagome_heisenberg_afm.jl
@@ -38,3 +38,38 @@ end
     # order, total quantum dimension 𝒟 = 2 ⇒ γ = log 𝒟 = log 2).
     @test γ == QAtlas.fetch(ToricCode(), TopologicalEntanglementEntropy(), Infinite())
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "KagomeHeisenbergAFM — verification cards" begin
+    # The 2D kagome AFM is a frustrated quantum spin liquid with no
+    # closed form; all reference numbers are DMRG/iDMRG literature values.
+    verify(
+        KagomeHeisenbergAFM(; J=1.0),
+        Energy(:per_site),
+        Infinite();
+        route=:literature_value,
+        independent=-0.4386,
+        agree_within=5e-3,
+        refs=["Yan-Huse-White 2011; Depenbrock-McCulloch-Schollwöck 2012 DMRG: e ≈ -0.4386 J"],
+    )
+
+    verify(
+        KagomeHeisenbergAFM(; J=1.0),
+        MassGap(),
+        Infinite();
+        route=:literature_value,
+        independent=0.13,
+        agree_within=5e-2,
+        refs=["Depenbrock et al. 2012 DMRG: spin gap ≈ 0.13 J"],
+    )
+
+    verify(
+        KagomeHeisenbergAFM(; J=1.0),
+        TopologicalEntanglementEntropy(),
+        Infinite();
+        route=:literature_value,
+        independent=log(2),
+        agree_within=1e-6,
+        refs=["Z2 spin liquid: gamma = log 2 (Jiang-Wang-Balents 2012)"],
+    )
+end

--- a/test/models/quantum/Heisenberg/test_majumdar_ghosh.jl
+++ b/test/models/quantum/Heisenberg/test_majumdar_ghosh.jl
@@ -118,3 +118,63 @@ using Logging: with_logger, NullLogger
         end
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "MajumdarGhosh — verification cards" begin
+    # Independent J1-J2 PBC ground-state energy density (spin-1/2),
+    # built black-box from site operators (J2 locked to J/2 by MG).
+    function mg_pbc_e0(N, J)
+        Sx, Sy, Sz = spin_ops(1 // 2)
+        SS(i, j) =
+            site_op(Sx, 2, N, i) * site_op(Sx, 2, N, j) +
+            site_op(Sy, 2, N, i) * site_op(Sy, 2, N, j) +
+            site_op(Sz, 2, N, i) * site_op(Sz, 2, N, j)
+        H = zeros(ComplexF64, 2^N, 2^N)
+        for i in 1:N
+            H .+= J * SS(i, mod1(i + 1, N))
+            H .+= (J / 2) * SS(i, mod1(i + 2, N))
+        end
+        return dense_spectrum(H)[1] / N
+    end
+
+    # GroundStateEnergyDensity Infinite: exact dimer product state -3J/8.
+    # Independent closed form: each NN singlet has <S.S> = -3/4; the
+    # dimer covering gives e0 = J*(-3/4)/2 = -3J/8 (NNN terms vanish on
+    # orthogonal dimers).  J-scaling linear.
+    for J in (0.5, 1.0, 2.0, 3.7)
+        verify(
+            MajumdarGhosh(; J=J),
+            GroundStateEnergyDensity(),
+            Infinite();
+            route=:second_closed_form,
+            independent=-3 * J / 8,
+            agree_within=1e-14,
+            refs=["Majumdar-Ghosh 1969: exact orthogonal-dimer product state, e0 = -3J/8"],
+        )
+    end
+
+    # PBC even N: dimer state is the exact GS, E0/N = -3J/8 size-independent
+    let Ns = verify_profile_Ns(; fast=(6, 8), full=(6, 8, 10, 12), nightly=(6, 8, 10, 12))
+        verify(
+            MajumdarGhosh(; J=1.0),
+            GroundStateEnergyDensity(),
+            Infinite();
+            route=:ed_finite_size,
+            independent=[mg_pbc_e0(N, 1.0) for N in Ns],
+            at=["N=$N" for N in Ns],
+            agree_within=1e-6,
+            refs=["Exact MG dimer GS of the J1-J2 ring at J2=J/2 (even N), -3J/8"],
+        )
+    end
+
+    # MassGap Infinite: White-Affleck DMRG literature value
+    verify(
+        MajumdarGhosh(; J=1.0),
+        MassGap(),
+        Infinite();
+        route=:literature_value,
+        independent=0.234,
+        agree_within=5e-3,
+        refs=["White-Affleck 1996 DMRG; Eggert 1996: Delta ≈ 0.234 J"],
+    )
+end

--- a/test/models/quantum/Heisenberg/test_s1_anisotropic_d1d.jl
+++ b/test/models/quantum/Heisenberg/test_s1_anisotropic_d1d.jl
@@ -109,7 +109,8 @@ end
         Energy(:per_site),
         Infinite();
         route=:delegation_invariant,
-        independent=2.0 * QAtlas.fetch(S1Heisenberg1D(; J=1.0), Energy(:per_site), Infinite()),
+        independent=2.0 *
+                    QAtlas.fetch(S1Heisenberg1D(; J=1.0), Energy(:per_site), Infinite()),
         agree_within=1e-10,
         refs=["Linear J scaling: e(2J) = 2 e(J) for spin-1 Heisenberg"],
     )

--- a/test/models/quantum/Heisenberg/test_s1_anisotropic_d1d.jl
+++ b/test/models/quantum/Heisenberg/test_s1_anisotropic_d1d.jl
@@ -79,3 +79,38 @@ end
         S1AnisotropicD1D(; J=1.0, D=-1e-13), Energy{:per_site}(), Infinite()
     )
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "S1AnisotropicD1D — verification cards" begin
+    # D=0 delegates to S1Heisenberg1D (Haldane chain, White-Huse 1993).
+    verify(
+        S1AnisotropicD1D(; J=1.0, D=0.0),
+        Energy(:per_site),
+        Infinite();
+        route=:delegation_invariant,
+        independent=QAtlas.fetch(S1Heisenberg1D(; J=1.0), Energy(:per_site), Infinite()),
+        agree_within=1e-12,
+        refs=["S1AnisotropicD1D(D=0) delegates to S1Heisenberg1D: code paths must agree"],
+    )
+
+    verify(
+        S1AnisotropicD1D(; J=1.0, D=0.0),
+        MassGap(),
+        Infinite();
+        route=:delegation_invariant,
+        independent=QAtlas.fetch(S1Heisenberg1D(; J=1.0), MassGap(), Infinite()),
+        agree_within=1e-12,
+        refs=["S1AnisotropicD1D(D=0) Haldane gap delegates to S1Heisenberg1D"],
+    )
+
+    # J-scaling linear at D=0
+    verify(
+        S1AnisotropicD1D(; J=2.0, D=0.0),
+        Energy(:per_site),
+        Infinite();
+        route=:delegation_invariant,
+        independent=2.0 * QAtlas.fetch(S1Heisenberg1D(; J=1.0), Energy(:per_site), Infinite()),
+        agree_within=1e-10,
+        refs=["Linear J scaling: e(2J) = 2 e(J) for spin-1 Heisenberg"],
+    )
+end

--- a/test/models/quantum/Heisenberg/test_s1_xxz1d.jl
+++ b/test/models/quantum/Heisenberg/test_s1_xxz1d.jl
@@ -76,7 +76,8 @@ end
         Energy(:per_site),
         Infinite();
         route=:delegation_invariant,
-        independent=3.0 * QAtlas.fetch(S1Heisenberg1D(; J=1.0), Energy(:per_site), Infinite()),
+        independent=3.0 *
+                    QAtlas.fetch(S1Heisenberg1D(; J=1.0), Energy(:per_site), Infinite()),
         agree_within=1e-10,
         refs=["Linear J scaling: e(3J) = 3 e(J) for spin-1 Heisenberg point"],
     )

--- a/test/models/quantum/Heisenberg/test_s1_xxz1d.jl
+++ b/test/models/quantum/Heisenberg/test_s1_xxz1d.jl
@@ -46,3 +46,38 @@ end
         S1XXZ1D(; Δ=1.0 + 1e-13), Energy(:per_site), Infinite()
     )
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "S1XXZ1D — verification cards" begin
+    # Delta=1 delegates to S1Heisenberg1D (Haldane chain, White-Huse 1993).
+    verify(
+        S1XXZ1D(; J=1.0, Δ=1.0),
+        Energy(:per_site),
+        Infinite();
+        route=:delegation_invariant,
+        independent=QAtlas.fetch(S1Heisenberg1D(; J=1.0), Energy(:per_site), Infinite()),
+        agree_within=1e-12,
+        refs=["S1XXZ1D(Delta=1) delegates to S1Heisenberg1D: code paths must agree"],
+    )
+
+    verify(
+        S1XXZ1D(; J=1.0, Δ=1.0),
+        MassGap(),
+        Infinite();
+        route=:delegation_invariant,
+        independent=QAtlas.fetch(S1Heisenberg1D(; J=1.0), MassGap(), Infinite()),
+        agree_within=1e-12,
+        refs=["S1XXZ1D(Delta=1) Haldane gap delegates to S1Heisenberg1D"],
+    )
+
+    # J-scaling linear at the isotropic point
+    verify(
+        S1XXZ1D(; J=3.0, Δ=1.0),
+        Energy(:per_site),
+        Infinite();
+        route=:delegation_invariant,
+        independent=3.0 * QAtlas.fetch(S1Heisenberg1D(; J=1.0), Energy(:per_site), Infinite()),
+        agree_within=1e-10,
+        refs=["Linear J scaling: e(3J) = 3 e(J) for spin-1 Heisenberg point"],
+    )
+end


### PR DESCRIPTION
Batch 2/8 of issue #369. Adds black-box verify() cards to all 11 files in test/models/quantum/Heisenberg/.

Routes: :delegation_invariant (DMI/J1J2/S1Anisotropic/S1XXZ1D/Heisenberg1D-Luttinger delegate paths), :ed_finite_size (spin-1/2 + spin-1 OBC/PBC ED via generic_ed), :second_closed_form (MG exact dimer -3J/8, spin-1 dimer spectrum, Müller S^zz re-derivation, gaplessness), :limiting_case (K=1/2 SU(2)), :literature_value (Haldane e/gap White-Huse 1993, MG gap White-Affleck 1996, Kagome DMRG).

Degeneracy: MG PBC 2-fold dimer GS uses basis-invariant lowest eigenvalue; spin-1 Haldane gap uses DMRG literature route not small-N ED. All independent values from test/util/generic_ed.jl, no QAtlas internals.

Refs #369.