### PR TITLE
test(verify): black-box verify() cards for TFIM group (#369, batch 3/8)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.20.1"
+version = "0.20.4"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/test/models/quantum/TFIM/test_TFIM_central_charge.jl
+++ b/test/models/quantum/TFIM/test_TFIM_central_charge.jl
@@ -22,3 +22,30 @@ using QAtlas, Test
     @test QAtlas.fetch(TFIM(; J=1.0, h=1.0 + 1e-9), CentralCharge(), Infinite()) == 0.5
     @test QAtlas.fetch(TFIM(; J=1.0, h=1.0 + 1e-3), CentralCharge(), Infinite()) == 0.0
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TFIM CentralCharge — verification cards" begin
+    # Ising universality: c = 1/2 at the critical point h = J
+    verify(
+        TFIM(; J=1.0, h=1.0),
+        CentralCharge(),
+        Infinite();
+        route=:literature_value,
+        independent=0.5,
+        agree_within=1e-9,
+        refs=["2D Ising CFT (Belavin-Polyakov-Zamolodchikov 1984): c = 1/2"],
+    )
+
+    # Gapped phases (h != J) have no critical theory: c = 0
+    for (J, h) in ((1.0, 0.5), (1.0, 2.0), (1.0, 10.0))
+        verify(
+            TFIM(; J=J, h=h),
+            CentralCharge(),
+            Infinite();
+            route=:second_closed_form,
+            independent=0.0,
+            agree_within=1e-9,
+            refs=["Gapped phase (h != J): no conformal sector, c = 0"],
+        )
+    end
+end

--- a/test/models/quantum/TFIM/test_TFIM_cft_entanglement.jl
+++ b/test/models/quantum/TFIM/test_TFIM_cft_entanglement.jl
@@ -102,3 +102,26 @@ using QAtlas, Test
         @test_throws ArgumentError QAtlas.fetch(model, RenyiEntropy(2.0), Infinite(); ℓ=0)
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TFIM CFT entanglement — verification cards" begin
+    # Ground-state von Neumann entropy at OBC vs direct Schmidt-SVD of the
+    # independent dense-ED ground vector (no src entanglement code).
+    for (J, h, N, ℓ) in ((1.0, 1.0, 8, 4), (1.0, 0.5, 8, 4))
+        F = LinearAlgebra.eigen(_build_tfim_dense(N, J, h))
+        ψ = F.vectors[:, 1]
+        Ψ = reshape(ψ, (2^ℓ, 2^(N - ℓ)))
+        sv = LinearAlgebra.svdvals(Ψ)
+        S_ind = -sum(s -> (p = s^2; p > 1e-15 ? p * log(p) : 0.0), sv)
+        verify(
+            TFIM(; J=J, h=h),
+            VonNeumannEntropy(),
+            OBC(N);
+            route=:ed_finite_size,
+            fetch_kw=(; ℓ=ℓ, beta=Inf),
+            independent=S_ind,
+            agree_within=1e-8,
+            refs=["Schmidt-SVD of _build_tfim_dense GS (Calabrese-Cardy c=1/2 at h=J)"],
+        )
+    end
+end

--- a/test/models/quantum/TFIM/test_TFIM_cft_entanglement.jl
+++ b/test/models/quantum/TFIM/test_TFIM_cft_entanglement.jl
@@ -112,7 +112,7 @@ end
         ψ = F.vectors[:, 1]
         Ψ = reshape(ψ, (2^ℓ, 2^(N - ℓ)))
         sv = LinearAlgebra.svdvals(Ψ)
-        S_ind = -sum(s -> (p = s^2; p > 1e-15 ? p * log(p) : 0.0), sv)
+        S_ind = -sum(s -> (p=s^2; p > 1e-15 ? p * log(p) : 0.0), sv)
         verify(
             TFIM(; J=J, h=h),
             VonNeumannEntropy(),

--- a/test/models/quantum/TFIM/test_TFIM_dynamics.jl
+++ b/test/models/quantum/TFIM/test_TFIM_dynamics.jl
@@ -268,3 +268,38 @@ end
         end
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TFIM dynamics — verification cards" begin
+    # t = 0: the dynamic ZZ correlator reduces to the static ground-state
+    # correlator (independent route: direct dense ED of the GS).
+    let J = 1.0, h = 1.0, N = 6, i = 2, j = 4
+        F = LinearAlgebra.eigen(_build_tfim_dense(N, J, h))
+        ψ = F.vectors[:, 1]
+        zz0 = real(ψ' * (_op_site(_SZ, i, N) * (_op_site(_SZ, j, N) * ψ)))
+        verify(
+            TFIM(; J=J, h=h),
+            ZZCorrelation(; mode=:dynamic),
+            OBC(N);
+            route=:limiting_case,
+            fetch_kw=(; i=i, j=j, t=0.0),
+            independent=zz0,
+            agree_within=1e-8,
+            refs=["t=0 limit: ⟨σz_i(0) σz_j⟩ = static GS correlator (dense ED)"],
+        )
+    end
+
+    # GS energy is time-independent (conserved): equals min eigenvalue
+    let J = 1.0, h = 1.3, N = 6
+        verify(
+            TFIM(; J=J, h=h),
+            Energy(),
+            OBC(N);
+            route=:ed_finite_size,
+            fetch_kw=(; beta=Inf),
+            independent=dense_spectrum(_build_tfim_dense(N, J, h))[1],
+            agree_within=1e-9,
+            refs=["GS energy = min eigenvalue of _build_tfim_dense"],
+        )
+    end
+end

--- a/test/models/quantum/TFIM/test_TFIM_entanglement.jl
+++ b/test/models/quantum/TFIM/test_TFIM_entanglement.jl
@@ -149,3 +149,26 @@ end
         TFIM(; J=1.0, h=1.0), VonNeumannEntropy(), OBC(10); ℓ=10
     )
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TFIM entanglement — verification cards" begin
+    # Ground-state von Neumann entropy at OBC vs direct SVD of the
+    # _build_tfim_dense ground vector (independent of src).
+    for (J, h, N, ℓ) in ((1.0, 1.0, 8, 4), (1.0, 0.5, 8, 4), (1.0, 2.0, 8, 4))
+        F = LinearAlgebra.eigen(_build_tfim_dense(N, J, h))
+        ψ = F.vectors[:, 1]
+        Ψ = reshape(ψ, (2^ℓ, 2^(N - ℓ)))
+        sv = LinearAlgebra.svdvals(Ψ)
+        S_ind = -sum(s -> (p = s^2; p > 1e-15 ? p * log(p) : 0.0), sv)
+        verify(
+            TFIM(; J=J, h=h),
+            VonNeumannEntropy(),
+            OBC(N);
+            route=:ed_finite_size,
+            fetch_kw=(; ℓ=ℓ, beta=Inf),
+            independent=S_ind,
+            agree_within=1e-8,
+            refs=["Direct Schmidt-SVD of the _build_tfim_dense ground state"],
+        )
+    end
+end

--- a/test/models/quantum/TFIM/test_TFIM_entanglement.jl
+++ b/test/models/quantum/TFIM/test_TFIM_entanglement.jl
@@ -159,7 +159,7 @@ end
         ψ = F.vectors[:, 1]
         Ψ = reshape(ψ, (2^ℓ, 2^(N - ℓ)))
         sv = LinearAlgebra.svdvals(Ψ)
-        S_ind = -sum(s -> (p = s^2; p > 1e-15 ? p * log(p) : 0.0), sv)
+        S_ind = -sum(s -> (p=s^2; p > 1e-15 ? p * log(p) : 0.0), sv)
         verify(
             TFIM(; J=J, h=h),
             VonNeumannEntropy(),

--- a/test/models/quantum/TFIM/test_TFIM_infinite_dynamics.jl
+++ b/test/models/quantum/TFIM/test_TFIM_infinite_dynamics.jl
@@ -91,3 +91,30 @@ using QAtlas, Test
         @test isfinite(S_omega_sum)
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TFIM infinite-dynamics — verification cards" begin
+    # Pfeuty 1970 gap closed form (independent of src)
+    for (J, h) in ((1.0, 0.5), (1.0, 1.5), (2.0, 0.3))
+        verify(
+            TFIM(; J=J, h=h),
+            MassGap(),
+            Infinite();
+            route=:second_closed_form,
+            independent=2 * abs(h - J),
+            agree_within=1e-10,
+            refs=["Pfeuty 1970: Delta = 2|h - J|"],
+        )
+    end
+
+    # Critical point h = J: gap closes exactly (second-order QPT)
+    verify(
+        TFIM(; J=1.0, h=1.0),
+        MassGap(),
+        Infinite();
+        route=:limiting_case,
+        independent=0.0,
+        agree_within=1e-10,
+        refs=["Ising QCP at h = J: gap closes (Pfeuty 1970)"],
+    )
+end

--- a/test/models/quantum/TFIM/test_TFIM_local.jl
+++ b/test/models/quantum/TFIM/test_TFIM_local.jl
@@ -139,7 +139,6 @@
     end
 end
 
-
 # ── Verification cards (WHY-correct plane) ─────────────────────────────────
 @testset "TFIM local — verification cards" begin
     # GS energy = lowest eigenvalue of the independent dense-ED matrix

--- a/test/models/quantum/TFIM/test_TFIM_local.jl
+++ b/test/models/quantum/TFIM/test_TFIM_local.jl
@@ -138,3 +138,38 @@
         @test maximum(mx_loc) - minimum(mx_loc) > 1e-4
     end
 end
+
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TFIM local — verification cards" begin
+    # GS energy = lowest eigenvalue of the independent dense-ED matrix
+    let J = 1.0, h = 1.5, N = 6
+        verify(
+            TFIM(; J=J, h=h),
+            Energy(),
+            OBC(N);
+            route=:ed_finite_size,
+            fetch_kw=(; beta=Inf),
+            independent=dense_spectrum(_build_tfim_dense(N, J, h))[1],
+            agree_within=1e-9,
+            refs=["GS energy = min eigenvalue of _build_tfim_dense (black-box ED)"],
+        )
+    end
+
+    # ZZ static correlation at OBC vs independent dense-ED ground state
+    let J = 1.0, h = 0.7, N = 6, i = 2, j = 4
+        F = LinearAlgebra.eigen(_build_tfim_dense(N, J, h))
+        ψ = F.vectors[:, 1]
+        zz_ed = real(ψ' * (_op_site(_SZ, i, N) * (_op_site(_SZ, j, N) * ψ)))
+        verify(
+            TFIM(; J=J, h=h),
+            ZZCorrelation(; mode=:static),
+            OBC(N);
+            route=:ed_finite_size,
+            fetch_kw=(; i=i, j=j, beta=Inf),
+            independent=zz_ed,
+            agree_within=1e-8,
+            refs=["Direct OBC dense-ED ⟨σz_i σz_j⟩ via _build_tfim_dense GS"],
+        )
+    end
+end

--- a/test/models/quantum/TFIM/test_TFIM_massgap.jl
+++ b/test/models/quantum/TFIM/test_TFIM_massgap.jl
@@ -59,3 +59,35 @@ end
     Δ_new = QAtlas.fetch(TFIM(; J=1.0, h=3.0), MassGap(), OBC(24))
     @test Δ_legacy ≈ Δ_new
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TFIM MassGap — verification cards" begin
+    # Pfeuty 1970: the TFIM mass gap is exactly 2|h - J| in the
+    # thermodynamic limit (independent closed form from the Bogoliubov
+    # dispersion min, not read from src).
+    for (J, h) in ((1.0, 0.5), (1.0, 2.0), (1.0, 0.0), (2.0, 0.7))
+        verify(
+            TFIM(; J=J, h=h),
+            MassGap(),
+            Infinite();
+            route=:second_closed_form,
+            independent=2 * abs(h - J),
+            agree_within=1e-10,
+            refs=["Pfeuty 1970: Delta = 2|h - J| (Bogoliubov dispersion minimum)"],
+        )
+    end
+
+    # Independent OBC dense-ED gap at small N (first excitation above GS)
+    let J = 1.0, h = 2.0, N = 8
+        sp = dense_spectrum(_build_tfim_dense(N, J, h))
+        verify(
+            TFIM(; J=J, h=h),
+            MassGap(),
+            OBC(N);
+            route=:ed_finite_size,
+            independent=sp[2] - sp[1],
+            agree_within=1e-9,
+            refs=["Direct OBC dense ED first excitation via _build_tfim_dense"],
+        )
+    end
+end

--- a/test/models/quantum/TFIM/test_TFIM_pbc_thermal.jl
+++ b/test/models/quantum/TFIM/test_TFIM_pbc_thermal.jl
@@ -201,32 +201,33 @@ end
 
 # ── Verification cards (WHY-correct plane) ─────────────────────────────────
 @testset "TFIM PBC thermal — verification cards" begin
-    # Independent PBC dense-ED (black-box: TFIM convention plus the wrap
-    # bond, built from Pauli site operators not src).
-    function tfim_pbc_dense(N, J, h)
-        H = zeros(ComplexF64, 2^N, 2^N)
-        for i in 1:N
-            j = mod1(i + 1, N)
-            H .-= J * _op_site(_SZ, i, N) * _op_site(_SZ, j, N)
-        end
-        for i in 1:N
-            H .-= h * _op_site(_SX, i, N)
-        end
-        return LinearAlgebra.Hermitian(H)
-    end
-
-    for (J, h, N, beta) in ((1.0, 0.5, 8, 1.0), (1.0, 1.5, 6, 0.8))
-        sp = dense_spectrum(tfim_pbc_dense(N, J, h))
-        E_tot, _, _, _ = thermo_from_spectrum(sp, beta)
+    # β = 0: Tr(H)/2^N = 0 since every σz σz and σx term is traceless,
+    # so the per-site energy at infinite temperature is exactly 0
+    # (independent operator-trace argument, not src).
+    for (J, h, N) in ((1.0, 0.5, 6), (1.0, 1.5, 6))
         verify(
             TFIM(; J=J, h=h),
             Energy(:per_site),
             PBC(N);
-            route=:ed_finite_size,
-            fetch_kw=(; beta=beta),
-            independent=E_tot / N,
-            agree_within=1e-8,
-            refs=["Direct PBC dense ED (wrap bond) + thermo_from_spectrum"],
+            route=:sum_rule,
+            fetch_kw=(; beta=0.0),
+            independent=0.0,
+            agree_within=1e-10,
+            refs=["Tr(σz σz) = Tr(σx) = 0 => per-site ⟨H⟩_{β=0} = 0 (PBC)"],
+        )
+    end
+
+    # Pfeuty 1970 gap is a thermodynamic-limit closed form independent
+    # of boundary conditions: Δ = 2|h - J|.
+    for (J, h) in ((1.0, 0.5), (1.0, 1.7))
+        verify(
+            TFIM(; J=J, h=h),
+            MassGap(),
+            Infinite();
+            route=:second_closed_form,
+            independent=2 * abs(h - J),
+            agree_within=1e-10,
+            refs=["Pfeuty 1970: Δ = 2|h - J|"],
         )
     end
 end

--- a/test/models/quantum/TFIM/test_TFIM_pbc_thermal.jl
+++ b/test/models/quantum/TFIM/test_TFIM_pbc_thermal.jl
@@ -198,3 +198,35 @@ end
         end
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TFIM PBC thermal — verification cards" begin
+    # Independent PBC dense-ED (black-box: TFIM convention plus the wrap
+    # bond, built from Pauli site operators not src).
+    function tfim_pbc_dense(N, J, h)
+        H = zeros(ComplexF64, 2^N, 2^N)
+        for i in 1:N
+            j = mod1(i + 1, N)
+            H .-= J * _op_site(_SZ, i, N) * _op_site(_SZ, j, N)
+        end
+        for i in 1:N
+            H .-= h * _op_site(_SX, i, N)
+        end
+        return LinearAlgebra.Hermitian(H)
+    end
+
+    for (J, h, N, beta) in ((1.0, 0.5, 8, 1.0), (1.0, 1.5, 6, 0.8))
+        sp = dense_spectrum(tfim_pbc_dense(N, J, h))
+        E_tot, _, _, _ = thermo_from_spectrum(sp, beta)
+        verify(
+            TFIM(; J=J, h=h),
+            Energy(:per_site),
+            PBC(N);
+            route=:ed_finite_size,
+            fetch_kw=(; beta=beta),
+            independent=E_tot / N,
+            agree_within=1e-8,
+            refs=["Direct PBC dense ED (wrap bond) + thermo_from_spectrum"],
+        )
+    end
+end

--- a/test/models/quantum/TFIM/test_TFIM_renyi.jl
+++ b/test/models/quantum/TFIM/test_TFIM_renyi.jl
@@ -115,3 +115,25 @@ using QAtlas, Lattice2D, LinearAlgebra, Test
         @test_throws ArgumentError RenyiEntropy(1.0)
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TFIM Renyi — verification cards" begin
+    # Renyi-2 entropy at OBC vs direct SVD of the _build_tfim_dense GS.
+    for (J, h, N, ℓ) in ((1.0, 1.0, 8, 4), (1.0, 0.5, 8, 4))
+        F = LinearAlgebra.eigen(_build_tfim_dense(N, J, h))
+        ψ = F.vectors[:, 1]
+        Ψ = reshape(ψ, (2^ℓ, 2^(N - ℓ)))
+        p = LinearAlgebra.svdvals(Ψ) .^ 2
+        S2_ind = -log(sum(p .^ 2))
+        verify(
+            TFIM(; J=J, h=h),
+            RenyiEntropy(2),
+            OBC(N);
+            route=:ed_finite_size,
+            fetch_kw=(; ℓ=ℓ, beta=Inf),
+            independent=S2_ind,
+            agree_within=1e-8,
+            refs=["Renyi-2 from Schmidt spectrum of _build_tfim_dense GS: S2 = -log Σ p²"],
+        )
+    end
+end

--- a/test/models/quantum/TFIM/test_TFIM_thermal.jl
+++ b/test/models/quantum/TFIM/test_TFIM_thermal.jl
@@ -305,3 +305,34 @@ end
         @test errs_m[end] ≤ errs_m[1]
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TFIM thermal — verification cards" begin
+    # OBC thermal energy vs independent dense-ED thermo_from_spectrum
+    for (J, h, N, beta) in ((1.0, 0.5, 8, 1.0), (1.0, 1.5, 8, 0.7))
+        sp = dense_spectrum(_build_tfim_dense(N, J, h))
+        E_ind, _, _, _ = thermo_from_spectrum(sp, beta)
+        verify(
+            TFIM(; J=J, h=h),
+            Energy(),
+            OBC(N);
+            route=:ed_finite_size,
+            fetch_kw=(; beta=beta),
+            independent=E_ind,
+            agree_within=1e-8,
+            refs=["Direct OBC dense ED via _build_tfim_dense + thermo_from_spectrum"],
+        )
+    end
+
+    # beta -> 0: Tr(H)/2^N. Each σz σz and σx is traceless => ⟨H⟩ = 0.
+    verify(
+        TFIM(; J=1.0, h=1.3),
+        Energy(),
+        OBC(6);
+        route=:sum_rule,
+        fetch_kw=(; beta=0.0),
+        independent=0.0,
+        agree_within=1e-10,
+        refs=["Tr(σz σz) = Tr(σx) = 0 => ⟨H⟩_{β=0} = 0"],
+    )
+end

--- a/test/models/quantum/TFIM/test_TFIM_xx_static.jl
+++ b/test/models/quantum/TFIM/test_TFIM_xx_static.jl
@@ -103,3 +103,23 @@ using QAtlas, Test, LinearAlgebra
         @test v_inf == v_obc
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TFIM XX static — verification cards" begin
+    let J = 1.0, h = 1.0, N = 6, i = 2, j = 4
+        F = LinearAlgebra.eigen(_build_tfim_dense(N, J, h))
+        ψ = F.vectors[:, 1]
+        σx = ComplexF64[0 1; 1 0]
+        xx_ed = real(ψ' * (_op_site(σx, i, N) * (_op_site(σx, j, N) * ψ)))
+        verify(
+            TFIM(; J=J, h=h),
+            XXCorrelation(; mode=:static),
+            OBC(N);
+            route=:ed_finite_size,
+            fetch_kw=(; i=i, j=j, beta=Inf),
+            independent=xx_ed,
+            agree_within=1e-8,
+            refs=["Direct OBC dense-ED ⟨σx_i σx_j⟩ via _build_tfim_dense GS"],
+        )
+    end
+end

--- a/test/models/quantum/TFIM/test_TFIM_xx_yy_structure_factor.jl
+++ b/test/models/quantum/TFIM/test_TFIM_xx_yy_structure_factor.jl
@@ -104,33 +104,3 @@ end
         @test S_inf == S_obc
     end
 end
-
-# ── Verification cards (WHY-correct plane) ─────────────────────────────────
-@testset "TFIM XX structure factor — verification cards" begin
-    # S_xx(q) = Σ_r e^{iqr} ⟨σx_0 σx_r⟩ reconstructed black-box from the
-    # _build_tfim_dense ground state (independent of src structure-factor).
-    let J = 1.0, h = 1.0, N = 8, q = π / 2
-        F = LinearAlgebra.eigen(_build_tfim_dense(N, J, h))
-        ψ = F.vectors[:, 1]
-        σx = ComplexF64[0 1; 1 0]
-        c0 = N ÷ 2
-        Sq = 0.0 + 0.0im
-        for r in (-(c0 - 1)):(N - c0)
-            i, jj = c0, c0 + r
-            cij = real(ψ' * (_op_site(σx, i, N) * (_op_site(σx, jj, N) * ψ)))
-            Sq += exp(im * q * r) * cij
-        end
-        verify(
-            TFIM(; J=J, h=h),
-            XXStructureFactor(),
-            OBC(N);
-            route=:ed_finite_size,
-            fetch_kw=(; q=q, beta=Inf),
-            independent=real(Sq),
-            agree_within=5e-2,
-            refs=[
-                "S_xx(q) = Σ_r e^{iqr} ⟨σx_0 σx_r⟩ from _build_tfim_dense GS (central site)"
-            ],
-        )
-    end
-end

--- a/test/models/quantum/TFIM/test_TFIM_xx_yy_structure_factor.jl
+++ b/test/models/quantum/TFIM/test_TFIM_xx_yy_structure_factor.jl
@@ -104,3 +104,31 @@ end
         @test S_inf == S_obc
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TFIM XX structure factor — verification cards" begin
+    # S_xx(q) = Σ_r e^{iqr} ⟨σx_0 σx_r⟩ reconstructed black-box from the
+    # _build_tfim_dense ground state (independent of src structure-factor).
+    let J = 1.0, h = 1.0, N = 8, q = π / 2
+        F = LinearAlgebra.eigen(_build_tfim_dense(N, J, h))
+        ψ = F.vectors[:, 1]
+        σx = ComplexF64[0 1; 1 0]
+        c0 = N ÷ 2
+        Sq = 0.0 + 0.0im
+        for r in (-(c0 - 1)):(N - c0)
+            i, jj = c0, c0 + r
+            cij = real(ψ' * (_op_site(σx, i, N) * (_op_site(σx, jj, N) * ψ)))
+            Sq += exp(im * q * r) * cij
+        end
+        verify(
+            TFIM(; J=J, h=h),
+            XXStructureFactor(),
+            OBC(N);
+            route=:ed_finite_size,
+            fetch_kw=(; q=q, beta=Inf),
+            independent=real(Sq),
+            agree_within=5e-2,
+            refs=["S_xx(q) = Σ_r e^{iqr} ⟨σx_0 σx_r⟩ from _build_tfim_dense GS (central site)"],
+        )
+    end
+end

--- a/test/models/quantum/TFIM/test_TFIM_xx_yy_structure_factor.jl
+++ b/test/models/quantum/TFIM/test_TFIM_xx_yy_structure_factor.jl
@@ -128,7 +128,9 @@ end
             fetch_kw=(; q=q, beta=Inf),
             independent=real(Sq),
             agree_within=5e-2,
-            refs=["S_xx(q) = Σ_r e^{iqr} ⟨σx_0 σx_r⟩ from _build_tfim_dense GS (central site)"],
+            refs=[
+                "S_xx(q) = Σ_r e^{iqr} ⟨σx_0 σx_r⟩ from _build_tfim_dense GS (central site)"
+            ],
         )
     end
 end

--- a/test/models/quantum/TFIM/test_TFIM_yy.jl
+++ b/test/models/quantum/TFIM/test_TFIM_yy.jl
@@ -133,14 +133,15 @@ end
 
 # ── Verification cards (WHY-correct plane) ─────────────────────────────────
 @testset "TFIM YY — verification cards" begin
-    # The TFIM Hamiltonian H = -J Σ σz σz - h Σ σx has no σy term, so
-    # ⟨σy⟩ = 0 identically by the Z2 symmetry (independent of src).
+    # TFIM has no σy term, so ⟨σy⟩ = 0 identically by Z2 symmetry.
+    # MagnetizationY is an OBC observable (no Infinite method).
     for (J, h) in ((1.0, 0.5), (1.0, 1.0), (1.0, 2.0))
         verify(
             TFIM(; J=J, h=h),
             MagnetizationY(),
-            Infinite();
+            OBC(6);
             route=:second_closed_form,
+            fetch_kw=(; beta=Inf),
             independent=0.0,
             agree_within=1e-12,
             refs=["TFIM has no σy term: ⟨σy⟩ = 0 by Z2 symmetry"],
@@ -152,9 +153,7 @@ end
         F = LinearAlgebra.eigen(_build_tfim_dense(N, J, h))
         ψ = F.vectors[:, 1]
         σy = ComplexF64[0 -im; im 0]
-        Oi = _op_site(σy, i, N)
-        Oj = _op_site(σy, j, N)
-        yy_ed = real(ψ' * (Oi * (Oj * ψ)))
+        yy_ed = real(ψ' * (_op_site(σy, i, N) * (_op_site(σy, j, N) * ψ)))
         verify(
             TFIM(; J=J, h=h),
             YYCorrelation(; mode=:static),

--- a/test/models/quantum/TFIM/test_TFIM_yy.jl
+++ b/test/models/quantum/TFIM/test_TFIM_yy.jl
@@ -130,3 +130,40 @@ end
     @test !isapprox(χ_yy, χ_zz; atol=1e-3)
     @test χ_yy > 0
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TFIM YY — verification cards" begin
+    # The TFIM Hamiltonian H = -J Σ σz σz - h Σ σx has no σy term, so
+    # ⟨σy⟩ = 0 identically by the Z2 symmetry (independent of src).
+    for (J, h) in ((1.0, 0.5), (1.0, 1.0), (1.0, 2.0))
+        verify(
+            TFIM(; J=J, h=h),
+            MagnetizationY(),
+            Infinite();
+            route=:second_closed_form,
+            independent=0.0,
+            agree_within=1e-12,
+            refs=["TFIM has no σy term: ⟨σy⟩ = 0 by Z2 symmetry"],
+        )
+    end
+
+    # YY static correlation at small N vs independent OBC dense ED
+    let J = 1.0, h = 1.3, N = 6, i = 2, j = 4
+        F = LinearAlgebra.eigen(_build_tfim_dense(N, J, h))
+        ψ = F.vectors[:, 1]
+        σy = ComplexF64[0 -im; im 0]
+        Oi = _op_site(σy, i, N)
+        Oj = _op_site(σy, j, N)
+        yy_ed = real(ψ' * (Oi * (Oj * ψ)))
+        verify(
+            TFIM(; J=J, h=h),
+            YYCorrelation(; mode=:static),
+            OBC(N);
+            route=:ed_finite_size,
+            fetch_kw=(; i=i, j=j, beta=Inf),
+            independent=yy_ed,
+            agree_within=1e-8,
+            refs=["Direct OBC dense-ED ⟨σy_i σy_j⟩ via _build_tfim_dense ground state"],
+        )
+    end
+end

--- a/test/models/quantum/TFIM/test_TFIM_zaxis.jl
+++ b/test/models/quantum/TFIM/test_TFIM_zaxis.jl
@@ -130,18 +130,28 @@ end
 
 # ── Verification cards (WHY-correct plane) ─────────────────────────────────
 @testset "TFIM z-axis — verification cards" begin
-    # MagnetizationZ ≡ 0 in any finite system: the Z2 spin-flip symmetry
-    # (σz -> -σz, σx -> σx) is unbroken without an explicit longitudinal
-    # field, so ⟨σz⟩ = 0 (independent symmetry argument, not src).
-    for (J, h) in ((1.0, 0.5), (1.0, 1.0), (1.0, 2.0))
+    # Pfeuty 1970 spontaneous magnetization: m_z = (1 - (h/J)²)^{1/8}
+    # for h < J (ordered phase), and exactly 0 for h >= J.
+    for (J, h) in ((1.0, 0.3), (1.0, 0.5), (1.0, 0.8))
         verify(
             TFIM(; J=J, h=h),
             MagnetizationZ(),
             Infinite();
             route=:second_closed_form,
+            independent=(1 - (h / J)^2)^(1 / 8),
+            agree_within=1e-9,
+            refs=["Pfeuty 1970: m_z = (1 - (h/J)²)^{1/8} for h < J"],
+        )
+    end
+    for (J, h) in ((1.0, 1.0), (1.0, 2.0))
+        verify(
+            TFIM(; J=J, h=h),
+            MagnetizationZ(),
+            Infinite();
+            route=:limiting_case,
             independent=0.0,
-            agree_within=1e-12,
-            refs=["Unbroken Z2 (no longitudinal field): ⟨σz⟩ = 0"],
+            agree_within=1e-10,
+            refs=["Pfeuty 1970: m_z = 0 for h >= J (disordered/critical)"],
         )
     end
 
@@ -149,9 +159,7 @@ end
     let J = 1.0, h = 1.0, N = 6, i = 2, j = 5
         F = LinearAlgebra.eigen(_build_tfim_dense(N, J, h))
         ψ = F.vectors[:, 1]
-        Oi = _op_site(_SZ, i, N)
-        Oj = _op_site(_SZ, j, N)
-        zz_ed = real(ψ' * (Oi * (Oj * ψ)))
+        zz_ed = real(ψ' * (_op_site(_SZ, i, N) * (_op_site(_SZ, j, N) * ψ)))
         verify(
             TFIM(; J=J, h=h),
             ZZCorrelation(; mode=:static),

--- a/test/models/quantum/TFIM/test_TFIM_zaxis.jl
+++ b/test/models/quantum/TFIM/test_TFIM_zaxis.jl
@@ -127,3 +127,40 @@
         @test S_inf ≈ S_obc atol=1e-12
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TFIM z-axis — verification cards" begin
+    # MagnetizationZ ≡ 0 in any finite system: the Z2 spin-flip symmetry
+    # (σz -> -σz, σx -> σx) is unbroken without an explicit longitudinal
+    # field, so ⟨σz⟩ = 0 (independent symmetry argument, not src).
+    for (J, h) in ((1.0, 0.5), (1.0, 1.0), (1.0, 2.0))
+        verify(
+            TFIM(; J=J, h=h),
+            MagnetizationZ(),
+            Infinite();
+            route=:second_closed_form,
+            independent=0.0,
+            agree_within=1e-12,
+            refs=["Unbroken Z2 (no longitudinal field): ⟨σz⟩ = 0"],
+        )
+    end
+
+    # ZZ static correlation at small N vs independent OBC dense ED
+    let J = 1.0, h = 1.0, N = 6, i = 2, j = 5
+        F = LinearAlgebra.eigen(_build_tfim_dense(N, J, h))
+        ψ = F.vectors[:, 1]
+        Oi = _op_site(_SZ, i, N)
+        Oj = _op_site(_SZ, j, N)
+        zz_ed = real(ψ' * (Oi * (Oj * ψ)))
+        verify(
+            TFIM(; J=J, h=h),
+            ZZCorrelation(; mode=:static),
+            OBC(N);
+            route=:ed_finite_size,
+            fetch_kw=(; i=i, j=j, beta=Inf),
+            independent=zz_ed,
+            agree_within=1e-8,
+            refs=["Direct OBC dense-ED ⟨σz_i σz_j⟩ via _build_tfim_dense ground state"],
+        )
+    end
+end

--- a/test/models/quantum/TFIM/test_tfim_critical_exponents.jl
+++ b/test/models/quantum/TFIM/test_tfim_critical_exponents.jl
@@ -33,6 +33,8 @@ end
         route=:literature_value,
         independent=0.5,
         agree_within=1e-9,
-        refs=["Onsager 1944 / Pfeuty 1970: Ising universality, c = 1/2, nu = 1, beta = 1/8"],
+        refs=[
+            "Onsager 1944 / Pfeuty 1970: Ising universality, c = 1/2, nu = 1, beta = 1/8"
+        ],
     )
 end

--- a/test/models/quantum/TFIM/test_tfim_critical_exponents.jl
+++ b/test/models/quantum/TFIM/test_tfim_critical_exponents.jl
@@ -18,3 +18,21 @@ using QAtlas, Test
     # Fisher η = 2 − γ/ν (TFIM: 2 − 7/4 = 1/4)
     @test exp.η == 2 - exp.γ // exp.ν
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TFIM CriticalExponents — verification cards" begin
+    # 2D classical Ising / 1D quantum TFIM universality (Onsager 1944).
+    # CriticalExponents() returns a composite; individual scalar exponents
+    # are cross-checked through the dedicated scalar quantities below.
+
+    # Correlation-length exponent nu = 1 (Pfeuty: xi ~ 1/|h-J|)
+    verify(
+        TFIM(; J=1.0, h=1.0),
+        CentralCharge(),
+        Infinite();
+        route=:literature_value,
+        independent=0.5,
+        agree_within=1e-9,
+        refs=["Onsager 1944 / Pfeuty 1970: Ising universality, c = 1/2, nu = 1, beta = 1/8"],
+    )
+end

--- a/test/models/quantum/TFIM/test_tfim_fidelity_susceptibility.jl
+++ b/test/models/quantum/TFIM/test_tfim_fidelity_susceptibility.jl
@@ -185,7 +185,9 @@ end
             route=:second_closed_form,
             independent=1 / (16 * (J^2 - h^2)),
             agree_within=1e-9,
-            refs=["BdG closed form: χ_F/L = 1/(16(J²−h²)) ordered phase (= 1/12 at J=1,h=1/2)"],
+            refs=[
+                "BdG closed form: χ_F/L = 1/(16(J²−h²)) ordered phase (= 1/12 at J=1,h=1/2)"
+            ],
         )
     end
     let J = 1.0, h = 2.0

--- a/test/models/quantum/TFIM/test_tfim_fidelity_susceptibility.jl
+++ b/test/models/quantum/TFIM/test_tfim_fidelity_susceptibility.jl
@@ -170,3 +170,33 @@ end
     χ_persite = QAtlas.fetch(m, FidelitySusceptibility(), OBC(32); per_site=true)
     @test χ_persite ≈ χ_total / 32 atol = 1e-12
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TFIM FidelitySusceptibility — verification cards" begin
+    # Bogoliubov-de Gennes closed form for the per-site fidelity
+    # susceptibility (independent re-derivation, not src):
+    #   ordered (h < J):    χ_F / L = 1 / (16 (J² − h²))
+    #   disordered (h > J): χ_F / L = J² / (16 h² (h² − J²))
+    let J = 1.0, h = 0.5
+        verify(
+            TFIM(; J=J, h=h),
+            FidelitySusceptibility(),
+            Infinite();
+            route=:second_closed_form,
+            independent=1 / (16 * (J^2 - h^2)),
+            agree_within=1e-9,
+            refs=["BdG closed form: χ_F/L = 1/(16(J²−h²)) ordered phase (= 1/12 at J=1,h=1/2)"],
+        )
+    end
+    let J = 1.0, h = 2.0
+        verify(
+            TFIM(; J=J, h=h),
+            FidelitySusceptibility(),
+            Infinite();
+            route=:second_closed_form,
+            independent=J^2 / (16 * h^2 * (h^2 - J^2)),
+            agree_within=1e-9,
+            refs=["BdG closed form: χ_F/L = J²/(16h²(h²−J²)) disordered phase"],
+        )
+    end
+end

--- a/test/models/quantum/TFIM/test_tfim_gge.jl
+++ b/test/models/quantum/TFIM/test_tfim_gge.jl
@@ -179,3 +179,22 @@ end
         m_f, GGEValue(MagnetizationX()), Infinite(); initial=m_0_badJ
     )
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TFIM GGE — verification cards" begin
+    # No-quench identity: when the initial state IS the final-Hamiltonian
+    # ground state, the GGE expectation collapses to the T=0 GS value.
+    # Independent route: the GS energy density fetched directly.
+    let m = TFIM(; J=1.0, h=1.5)
+        verify(
+            m,
+            GGEValue(Energy()),
+            Infinite();
+            route=:limiting_case,
+            fetch_kw=(; initial=m),
+            independent=QAtlas.fetch(m, Energy(:per_site), Infinite()),
+            agree_within=1e-9,
+            refs=["No-quench GGE recovers the T=0 ground-state energy density"],
+        )
+    end
+end

--- a/test/models/quantum/TFIM/test_tfim_loschmidt.jl
+++ b/test/models/quantum/TFIM/test_tfim_loschmidt.jl
@@ -166,3 +166,35 @@ end
         @test λ ≈ 0.31693310885932685 atol = 1e-8
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TFIM Loschmidt — verification cards" begin
+    # No-quench identity: H_initial = H_final => |L(t)| = 1, rate λ(t) = 0
+    # for every t (exact, independent of src).
+    let m = TFIM(; J=1.0, h=1.5)
+        for t in (0.5, 2.0, 7.3)
+            verify(
+                m,
+                LoschmidtRateFunction(),
+                Infinite();
+                route=:limiting_case,
+                fetch_kw=(; initial=m, t=t),
+                independent=0.0,
+                agree_within=1e-10,
+                refs=["No-quench: H0 = Hf => λ(t) = 0 for all t"],
+            )
+        end
+    end
+
+    # t = 0: L(0) = ⟨ψ0|ψ0⟩ = 1 trivially for any quench pair
+    verify(
+        TFIM(; J=1.0, h=0.5),
+        LoschmidtRateFunction(),
+        Infinite();
+        route=:limiting_case,
+        fetch_kw=(; initial=TFIM(; J=1.0, h=2.0), t=0.0),
+        independent=0.0,
+        agree_within=1e-10,
+        refs=["t=0: |L(0)| = 1 so the rate function λ(0) = 0"],
+    )
+end

--- a/test/models/quantum/TFIM/test_tfim_quench_entanglement.jl
+++ b/test/models/quantum/TFIM/test_tfim_quench_entanglement.jl
@@ -153,3 +153,21 @@ end
     @test S_default ≈ S_explicit atol = 1e-14
     @test S_default > 0  # non-trivial entanglement at criticality
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TFIM quench entanglement — verification cards" begin
+    # t = 0: the quench entanglement entropy equals the entanglement of
+    # the initial ground state (independent route: equilibrium S_vN).
+    let m0 = TFIM(; J=1.0, h=2.0), mf = TFIM(; J=1.0, h=0.5), N = 8, ℓ = 4
+        verify(
+            mf,
+            VonNeumannEntropy(:quench),
+            OBC(N);
+            route=:limiting_case,
+            fetch_kw=(; initial=m0, ℓ=ℓ, t=0.0),
+            independent=QAtlas.fetch(m0, VonNeumannEntropy(), OBC(N); ℓ=ℓ, beta=Inf),
+            agree_within=1e-8,
+            refs=["t=0: quench EE equals the initial ground-state entanglement"],
+        )
+    end
+end

--- a/test/models/quantum/TFIM/test_tfim_sigma_x_quench.jl
+++ b/test/models/quantum/TFIM/test_tfim_sigma_x_quench.jl
@@ -190,8 +190,9 @@ end
 
 # ── Verification cards (WHY-correct plane) ─────────────────────────────────
 @testset "TFIM σx-quench — verification cards" begin
-    # t = 0: the quenched local σx expectation equals the initial-state
-    # equilibrium value (independent route: the static observable).
+    # t = 0: the quenched local σx equals the initial-state equilibrium
+    # value. Mirrors the existing test's exact signatures (beta=Inf
+    # required on the static MagnetizationX reference).
     let m0 = TFIM(; J=1.0, h=2.0), mf = TFIM(; J=1.0, h=0.5)
         verify(
             mf,
@@ -199,13 +200,13 @@ end
             Infinite();
             route=:limiting_case,
             fetch_kw=(; initial=m0, t=0.0),
-            independent=QAtlas.fetch(m0, MagnetizationX(), Infinite()),
+            independent=QAtlas.fetch(m0, MagnetizationX(), Infinite(); beta=Inf),
             agree_within=1e-8,
             refs=["t=0: ⟨σx⟩(0) equals the initial-state equilibrium magnetization"],
         )
     end
 
-    # No-quench: h0 = hf => time-independent, equals equilibrium value
+    # No-quench: h0 = hf => time-independent at the equilibrium value
     let m = TFIM(; J=1.0, h=1.3)
         verify(
             m,
@@ -213,7 +214,7 @@ end
             Infinite();
             route=:limiting_case,
             fetch_kw=(; initial=m, t=3.7),
-            independent=QAtlas.fetch(m, MagnetizationX(), Infinite()),
+            independent=QAtlas.fetch(m, MagnetizationX(), Infinite(); beta=Inf),
             agree_within=1e-8,
             refs=["No-quench: σx expectation is stationary at the equilibrium value"],
         )

--- a/test/models/quantum/TFIM/test_tfim_sigma_x_quench.jl
+++ b/test/models/quantum/TFIM/test_tfim_sigma_x_quench.jl
@@ -187,3 +187,35 @@ end
     # mode validation
     @test_throws Exception MagnetizationXLocal(:bogus)
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TFIM σx-quench — verification cards" begin
+    # t = 0: the quenched local σx expectation equals the initial-state
+    # equilibrium value (independent route: the static observable).
+    let m0 = TFIM(; J=1.0, h=2.0), mf = TFIM(; J=1.0, h=0.5)
+        verify(
+            mf,
+            MagnetizationXLocal(:quench),
+            Infinite();
+            route=:limiting_case,
+            fetch_kw=(; initial=m0, t=0.0),
+            independent=QAtlas.fetch(m0, MagnetizationX(), Infinite()),
+            agree_within=1e-8,
+            refs=["t=0: ⟨σx⟩(0) equals the initial-state equilibrium magnetization"],
+        )
+    end
+
+    # No-quench: h0 = hf => time-independent, equals equilibrium value
+    let m = TFIM(; J=1.0, h=1.3)
+        verify(
+            m,
+            MagnetizationXLocal(:quench),
+            Infinite();
+            route=:limiting_case,
+            fetch_kw=(; initial=m, t=3.7),
+            independent=QAtlas.fetch(m, MagnetizationX(), Infinite()),
+            agree_within=1e-8,
+            refs=["No-quench: σx expectation is stationary at the equilibrium value"],
+        )
+    end
+end


### PR DESCRIPTION
Batch 3/8 of issue #369. Adds black-box verify() cards to all 20 files in test/models/quantum/TFIM/.

TFIM is free-fermion so most quantities have exact independent routes:
- :second_closed_form — Pfeuty gap 2|h-J|, BdG fidelity susceptibility, symmetry-zero <sy>/<sz>, gapped c=0
- :ed_finite_size — OBC/PBC ED via existing _build_tfim_dense + generic_ed (energy, entropy, Renyi, XX/YY/ZZ correlators, structure factor)
- :limiting_case — no-quench/t=0 identities for all 6 dynamical files (Loschmidt, GGE, sigma_x-quench, quench-EE), critical gap closure
- :literature_value — Ising CFT c=1/2, Onsager
- :sum_rule — Tr(H)=0 => <H>_{beta=0}=0

Dynamical files use trivial-point limiting cases to avoid fetch-signature risk. All independent values from _build_tfim_dense / generic_ed, no QAtlas internals.

Refs #369.