### PR TITLE
test(verify): black-box verify() cards for classical group (#369, batch 4/8)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.20.1"
+version = "0.20.5"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/test/models/classical/test_IsingSquare_critical.jl
+++ b/test/models/classical/test_IsingSquare_critical.jl
@@ -27,3 +27,19 @@ using QAtlas, Test
     @test exp.γ == exp.β * (exp.δ - 1)            # Widom
     @test exp.η == 2 - exp.γ // exp.ν             # Fisher
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "IsingSquare critical — verification cards" begin
+    # CriticalExponents() returns a NamedTuple (non-scalar; covered by
+    # the delegation tests above).  The scalar Onsager Tc anchors the
+    # same critical point with an independent closed form.
+    verify(
+        IsingSquare(; J=1.0),
+        CriticalTemperature(),
+        Infinite();
+        route=:second_closed_form,
+        independent=2.0 / log(1 + sqrt(2)),
+        agree_within=1e-10,
+        refs=["Onsager 1944: Tc = 2J / log(1+√2) ≈ 2.269185 (β=1/8 universality anchor)"],
+    )
+end

--- a/test/models/classical/test_IsingSquare_thermal.jl
+++ b/test/models/classical/test_IsingSquare_thermal.jl
@@ -116,3 +116,45 @@ end
         @test c_fetch ≈ c_ad rtol = 1e-2  # central-diff vs ForwardDiff slack
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "IsingSquare thermal — verification cards" begin
+    # Energy density low-T limit: every bond aligned => ε -> -2J
+    verify(
+        IsingSquare(; J=1.0),
+        Energy(:per_site),
+        Infinite();
+        route=:limiting_case,
+        fetch_kw=(; beta=20.0),
+        independent=-2.0,
+        agree_within=1e-6,
+        refs=["T -> 0: all bonds satisfied, ε = -2J (square lattice, 2 bonds/site)"],
+    )
+
+    # High-T entropy per site -> log 2 (free spins)
+    verify(
+        IsingSquare(; J=1.0),
+        ThermalEntropy(),
+        Infinite();
+        route=:limiting_case,
+        fetch_kw=(; beta=1e-4),
+        independent=log(2),
+        agree_within=1e-3,
+        refs=["β -> 0: spins decouple, s -> log 2"],
+    )
+
+    # PBC free energy vs brute-force exact partition: f = -(1/β) log Z / N
+    for (L, β) in ((3, 0.3), (3, 0.5))
+        Z = exact_partition(L, L, 1.0, β)
+        verify(
+            IsingSquare(; Lx=L, Ly=L, J=1.0),
+            FreeEnergy(),
+            PBC(0);
+            route=:ed_finite_size,
+            fetch_kw=(; beta=β, Lx=L, Ly=L, J=1.0),
+            independent=-(1 / β) * log(Z) / (L * L),
+            agree_within=1e-6,
+            refs=["Brute-force Z: f/N = -(1/β) log Z / N (square_pbc_bond_pairs)"],
+        )
+    end
+end

--- a/test/models/classical/test_curie_weiss_ising.jl
+++ b/test/models/classical/test_curie_weiss_ising.jl
@@ -102,3 +102,39 @@ end
     @test exp.α + 2 * exp.β + exp.γ == 2
     @test exp.γ == exp.β * (exp.δ - 1)
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "CurieWeissIsing — verification cards" begin
+    # Mean-field critical temperature Tc = J (independent: the
+    # self-consistency m = tanh(βJm) linearises to βc J = 1 => Tc = J).
+    for J in (0.5, 1.0, 2.5)
+        verify(
+            CurieWeissIsing(; J=J),
+            CriticalTemperature(),
+            Infinite();
+            route=:second_closed_form,
+            independent=J,
+            agree_within=1e-12,
+            refs=["Mean-field: linearised self-consistency gives βc J = 1 => Tc = J"],
+        )
+    end
+
+    # Spontaneous magnetization solves m = tanh(βJm); independently
+    # re-solved here by fixed-point iteration (not from src).
+    let J = 1.0, β = 2.0
+        m = 0.9
+        for _ in 1:200
+            m = tanh(β * J * m)
+        end
+        verify(
+            CurieWeissIsing(; J=J),
+            SpontaneousMagnetization(),
+            Infinite();
+            route=:second_closed_form,
+            fetch_kw=(; beta=β),
+            independent=m,
+            agree_within=1e-8,
+            refs=["Curie-Weiss self-consistency m = tanh(βJm), independent fixed point"],
+        )
+    end
+end

--- a/test/models/classical/test_ising_chain_1d.jl
+++ b/test/models/classical/test_ising_chain_1d.jl
@@ -87,3 +87,45 @@ end
     @test_throws DomainError QAtlas.fetch(m, FreeEnergy(), Infinite(); beta=0)
     @test_throws DomainError QAtlas.fetch(m, CorrelationLength(), Infinite(); beta=-1.0)
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "IsingChain1D — verification cards" begin
+    # 1D Ising has no finite-T transition (Mermin-Wagner / Ising 1925).
+    verify(
+        IsingChain1D(; J=1.0),
+        CriticalTemperature(),
+        Infinite();
+        route=:limiting_case,
+        independent=0.0,
+        agree_within=1e-12,
+        refs=["Ising 1925: no finite-T order in 1D, Tc = 0"],
+    )
+
+    # h=0 free energy: f = -(1/β) log(2 cosh βJ) (independent closed form)
+    for (J, β) in ((1.0, 0.5), (1.0, 2.0), (1.7, 1.0))
+        verify(
+            IsingChain1D(; J=J),
+            FreeEnergy(),
+            Infinite();
+            route=:second_closed_form,
+            fetch_kw=(; beta=β),
+            independent=-(1 / β) * log(2 * cosh(β * J)),
+            agree_within=1e-10,
+            refs=["Ising 1925: f = -(1/β) log(2 cosh βJ) at h = 0"],
+        )
+    end
+
+    # h=0 correlation length: ξ = 1 / log(coth βJ)
+    for (J, β) in ((1.0, 1.0), (1.0, 2.0))
+        verify(
+            IsingChain1D(; J=J),
+            CorrelationLength(),
+            Infinite();
+            route=:second_closed_form,
+            fetch_kw=(; beta=β),
+            independent=1 / log(coth(β * J)),
+            agree_within=1e-9,
+            refs=["Ising 1925: ξ = 1 / log(coth βJ) at h = 0"],
+        )
+    end
+end

--- a/test/models/classical/test_ising_onsager_yang.jl
+++ b/test/models/classical/test_ising_onsager_yang.jl
@@ -81,3 +81,49 @@ end
         @test M_scaled ≈ M2 atol = 1e-14
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "IsingSquare Onsager-Yang — verification cards" begin
+    # Onsager 1944: Tc set by sinh(2 βc J) = 1 => Tc = 2J / log(1 + √2).
+    for J in (1.0, 2.0)
+        verify(
+            IsingSquare(; J=J),
+            CriticalTemperature(),
+            Infinite();
+            route=:second_closed_form,
+            independent=2 * J / log(1 + sqrt(2)),
+            agree_within=1e-10,
+            refs=["Onsager 1944: sinh(2 βc J) = 1 => Tc = 2J / log(1+√2)"],
+        )
+    end
+
+    # Yang 1952: m = (1 - sinh^{-4}(2βJ))^{1/8} below Tc; 0 above.
+    let J = 1.0
+        βc = log(1 + sqrt(2)) / (2J)
+        for β in (1.1 * βc, 1.5 * βc, 2.0 * βc)
+            s = sinh(2 * β * J)
+            m_ind = (1 - s^(-4))^(1 / 8)
+            verify(
+                IsingSquare(; J=J),
+                SpontaneousMagnetization(),
+                Infinite();
+                route=:second_closed_form,
+                fetch_kw=(; β=β),
+                independent=m_ind,
+                agree_within=1e-9,
+                refs=["Yang 1952: m = (1 - sinh^{-4}(2βJ))^{1/8}, exponent 1/8"],
+            )
+        end
+        # T >= Tc: magnetization vanishes
+        verify(
+            IsingSquare(; J=J),
+            SpontaneousMagnetization(),
+            Infinite();
+            route=:limiting_case,
+            fetch_kw=(; β=0.9 * βc),
+            independent=0.0,
+            agree_within=1e-10,
+            refs=["Yang 1952: m = 0 for T >= Tc"],
+        )
+    end
+end

--- a/test/models/classical/test_ising_square_pfaffian.jl
+++ b/test/models/classical/test_ising_square_pfaffian.jl
@@ -67,3 +67,33 @@ using QAtlas, Test
         end
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "IsingSquare PartitionFunction — verification cards" begin
+    # Brute-force exact_partition (independent of the transfer-matrix
+    # / Pfaffian path) on small PBC lattices.
+    for (L, β, J) in ((3, 0.3, 1.0), (3, 0.5, 1.0), (4, 0.2, 1.0))
+        verify(
+            IsingSquare(; Lx=L, Ly=L, J=J),
+            PartitionFunction(),
+            PBC(0);
+            route=:ed_finite_size,
+            fetch_kw=(; β=β, Lx=L, Ly=L, J=J),
+            independent=exact_partition(L, L, J, β),
+            agree_within=1e-6,
+            refs=["Brute-force Σ_σ exp(-βE) over 2^(L²) configs (square_pbc_bond_pairs)"],
+        )
+    end
+
+    # β = 0: every configuration has weight 1 => Z = 2^(Lx·Ly)
+    verify(
+        IsingSquare(; Lx=3, Ly=3, J=1.0),
+        PartitionFunction(),
+        PBC(0);
+        route=:limiting_case,
+        fetch_kw=(; β=0.0, Lx=3, Ly=3, J=1.0),
+        independent=2.0^9,
+        agree_within=1e-6,
+        refs=["β = 0: all 2^N configs weight 1 => Z = 2^N"],
+    )
+end

--- a/test/models/classical/test_ising_triangular.jl
+++ b/test/models/classical/test_ising_triangular.jl
@@ -118,3 +118,44 @@ end
     # universality class.  Direct IsingSquare cross-check enabled after #346 lands.
     @test exp.β == QAtlas.fetch(QAtlas.Universality(:Ising), CriticalExponents(); d=2).β
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "IsingTriangular — verification cards" begin
+    # FM (J < 0): Houtappel 1950 Tc = 4|J| / log 3
+    for J in (-1.0, -2.0)
+        verify(
+            IsingTriangular(; J=J),
+            CriticalTemperature(),
+            Infinite();
+            route=:second_closed_form,
+            independent=4 * abs(J) / log(3),
+            agree_within=1e-9,
+            refs=["Houtappel 1950: FM triangular Tc = 4|J| / log 3"],
+        )
+    end
+
+    # AFM (J > 0): frustrated, no order (Wannier 1950) => Tc = 0
+    verify(
+        IsingTriangular(; J=1.0),
+        CriticalTemperature(),
+        Infinite();
+        route=:limiting_case,
+        independent=0.0,
+        agree_within=1e-12,
+        refs=["Wannier 1950: AFM triangular is fully frustrated, Tc = 0"],
+    )
+
+    # AFM residual entropy: Wannier integral S = (2/π) ∫_0^{π/3} log(2cosθ) dθ
+    let J = 1.0
+        S_w, _ = quadgk(θ -> log(2 * cos(θ)), 0, π / 3)
+        verify(
+            IsingTriangular(; J=J),
+            ResidualEntropy(),
+            Infinite();
+            route=:second_closed_form,
+            independent=(2 / π) * S_w,
+            agree_within=1e-6,
+            refs=["Wannier 1950: S = (2/π) ∫_0^{π/3} log(2cosθ) dθ ≈ 0.323066"],
+        )
+    end
+end

--- a/test/models/classical/test_liouville_cft.jl
+++ b/test/models/classical/test_liouville_cft.jl
@@ -88,3 +88,30 @@ end
         LiouvilleCFT(; b=-1.0), ConformalWeights(), Infinite(); α=0.5
     )
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "LiouvilleCFT — verification cards" begin
+    # Liouville central charge c(b) = 1 + 6 (b + 1/b)² (independent formula)
+    for b in (0.5, 1.0, 1.7)
+        verify(
+            LiouvilleCFT(; b=b),
+            CentralCharge(),
+            Infinite();
+            route=:second_closed_form,
+            independent=1 + 6 * (b + 1 / b)^2,
+            agree_within=1e-9,
+            refs=["Liouville CFT: c = 1 + 6 (b + 1/b)²  (c=25 at b=1)"],
+        )
+    end
+
+    # Duality c(b) = c(1/b)
+    verify(
+        LiouvilleCFT(; b=2.0),
+        CentralCharge(),
+        Infinite();
+        route=:second_closed_form,
+        independent=1 + 6 * (0.5 + 1 / 0.5)^2,
+        agree_within=1e-9,
+        refs=["Liouville b <-> 1/b duality: c(2) = c(1/2)"],
+    )
+end

--- a/test/models/classical/test_logarithmic_cft.jl
+++ b/test/models/classical/test_logarithmic_cft.jl
@@ -10,3 +10,17 @@ using QAtlas, Test
     # Idempotent — no hidden state
     @test QAtlas.fetch(LogarithmicCFT(), CentralCharge(), Infinite()) === c
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "LogarithmicCFT — verification cards" begin
+    # Logarithmic CFT (c=0 / percolation-type): central charge is exactly 0.
+    verify(
+        LogarithmicCFT(),
+        CentralCharge(),
+        Infinite();
+        route=:second_closed_form,
+        independent=0.0,
+        agree_within=1e-12,
+        refs=["Logarithmic CFT: c = 0 (identity conformal dimension vanishes)"],
+    )
+end

--- a/test/models/classical/test_random_bond_ising_2d.jl
+++ b/test/models/classical/test_random_bond_ising_2d.jl
@@ -47,3 +47,18 @@ end
     @test QAtlas.fetch(RandomBondIsing2D(; p=1.0), CentralCharge(), Infinite()) ==
         QAtlas.fetch(QAtlas.Universality{:Ising}(), CentralCharge(); d=2)
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "RandomBondIsing2D — verification cards" begin
+    # At p = 1 (pure FM) the model reduces to the clean 2D Ising
+    # universality: c = 1/2 (delegation invariant to MinimalModel(4,3)).
+    verify(
+        RandomBondIsing2D(; J=1.0, p=1.0),
+        CentralCharge(),
+        Infinite();
+        route=:delegation_invariant,
+        independent=0.5,
+        agree_within=1e-12,
+        refs=["p=1 reduces to clean 2D Ising: c = 1/2 (M(4,3))"],
+    )
+end

--- a/test/models/classical/test_rfim.jl
+++ b/test/models/classical/test_rfim.jl
@@ -31,3 +31,21 @@ end
         RFIM(; Δ=1.0), CriticalTemperature(), Infinite(); d=0
     )
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "RFIM — verification cards" begin
+    # Imry-Ma 1975: the lower critical dimension of the RFIM is 2, so
+    # for d <= 2 there is no finite-temperature order => Tc = 0.
+    for d in (1, 2)
+        verify(
+            RFIM(; Δ=0.5),
+            CriticalTemperature(),
+            Infinite();
+            route=:second_closed_form,
+            fetch_kw=(; d=d),
+            independent=0.0,
+            agree_within=1e-12,
+            refs=["Imry-Ma 1975: RFIM lower critical dimension is 2 => Tc = 0 for d ≤ 2"],
+        )
+    end
+end

--- a/test/models/classical/test_sherrington_kirkpatrick.jl
+++ b/test/models/classical/test_sherrington_kirkpatrick.jl
@@ -44,3 +44,30 @@ end
     @test_throws DomainError QAtlas.fetch(m, Energy{:per_site}(), Infinite(); J=0.0)
     @test_throws DomainError QAtlas.fetch(m, Energy{:per_site}(), Infinite(); J=-1.0)
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "SherringtonKirkpatrick — verification cards" begin
+    # Spin-glass transition Tc = J (mean-field saddle point)
+    for J in (1.0, 2.0)
+        verify(
+            SherringtonKirkpatrick(; J=J),
+            CriticalTemperature(),
+            Infinite();
+            route=:second_closed_form,
+            independent=Float64(J),
+            agree_within=1e-12,
+            refs=["SK mean-field: spin-glass transition at Tc = J"],
+        )
+    end
+
+    # T=0 Parisi full-RSB ground-state energy density (literature numeric)
+    verify(
+        SherringtonKirkpatrick(; J=1.0),
+        Energy(:per_site),
+        Infinite();
+        route=:literature_value,
+        independent=-0.7631667,
+        agree_within=1e-4,
+        refs=["Crisanti-Rizzo 2002 / Parisi full-RSB: e0 ≈ -0.7631667 (J=1)"],
+    )
+end

--- a/test/models/classical/test_six_vertex.jl
+++ b/test/models/classical/test_six_vertex.jl
@@ -143,3 +143,28 @@ end
     # Default constructor lands on square ice.
     @test SixVertex() === SixVertex(1.0, 1.0, 1.0)
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "SixVertex — verification cards" begin
+    # Square ice (a=b=c=1): Lieb 1967 residual entropy S = (3/2) log(4/3)
+    verify(
+        SixVertex(; a=1.0, b=1.0, c=1.0),
+        ResidualEntropy(),
+        Infinite();
+        route=:second_closed_form,
+        independent=(3 / 2) * log(4 / 3),
+        agree_within=1e-9,
+        refs=["Lieb 1967: square-ice residual entropy S = (3/2) log(4/3) ≈ 0.4315"],
+    )
+
+    # Ferroelectric phase (Δ > 1, e.g. a large): f = -log(max(a,b)), S = 0
+    verify(
+        SixVertex(; a=3.0, b=1.0, c=1.0),
+        ResidualEntropy(),
+        Infinite();
+        route=:limiting_case,
+        independent=0.0,
+        agree_within=1e-10,
+        refs=["Ferroelectric phase (Δ>1): frozen, residual entropy S = 0"],
+    )
+end

--- a/test/models/classical/test_sle_kappa.jl
+++ b/test/models/classical/test_sle_kappa.jl
@@ -60,3 +60,33 @@ end
         SLEkappa(; κ=2.0), FractalDimension(), Infinite(); κ=-1.0
     )
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "SLEkappa — verification cards" begin
+    # SLE central charge c(κ) = (3κ - 8)(6 - κ) / (2κ) (independent formula)
+    for (κ, name) in ((3.0, "Ising"), (8 / 3, "SAW"), (4.0, "GFF"), (6.0, "percolation"))
+        c_ind = (3κ - 8) * (6 - κ) / (2κ)
+        verify(
+            SLEkappa(; κ=κ),
+            CentralCharge(),
+            Infinite();
+            route=:second_closed_form,
+            independent=c_ind,
+            agree_within=1e-9,
+            refs=["SLE: c(κ) = (3κ-8)(6-κ)/(2κ) [$name at κ=$κ]"],
+        )
+    end
+
+    # Beffara 2008 fractal dimension D = 1 + κ/8 (κ < 8)
+    for κ in (2.0, 8 / 3, 3.0, 4.0, 6.0)
+        verify(
+            SLEkappa(; κ=κ),
+            FractalDimension(),
+            Infinite();
+            route=:second_closed_form,
+            independent=1 + κ / 8,
+            agree_within=1e-9,
+            refs=["Beffara 2008: SLE_κ curve fractal dimension D = 1 + κ/8"],
+        )
+    end
+end

--- a/test/models/classical/test_spin_ice.jl
+++ b/test/models/classical/test_spin_ice.jl
@@ -18,3 +18,17 @@ using QAtlas, Test
     @test S_per_spin < 0.20479
     @test S_per_spin > 0.20         # comfortably above the Pauling −1 % band
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "SpinIce — verification cards" begin
+    # Pauling 1935 ice-rule residual entropy S = (1/2) log(3/2)
+    verify(
+        SpinIce(),
+        ResidualEntropy(),
+        Infinite();
+        route=:second_closed_form,
+        independent=0.5 * log(3 / 2),
+        agree_within=1e-9,
+        refs=["Pauling 1935: ice-rule residual entropy S = (1/2) log(3/2) ≈ 0.2027"],
+    )
+end

--- a/test/models/classical/test_tasep.jl
+++ b/test/models/classical/test_tasep.jl
@@ -23,3 +23,30 @@ end
     @test_throws DomainError TASEP(; ρ=-0.1)
     @test_throws DomainError TASEP(; ρ=1.5)
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TASEP — verification cards" begin
+    # Fundamental diagram j(ρ) = p ρ (1 - ρ) (independent closed form)
+    for (p, ρ) in ((1.0, 0.5), (1.0, 0.3), (0.7, 0.5), (1.0, 0.9))
+        verify(
+            TASEP(; p=p, ρ=ρ),
+            SteadyStateCurrent(),
+            Infinite();
+            route=:second_closed_form,
+            independent=p * ρ * (1 - ρ),
+            agree_within=1e-12,
+            refs=["TASEP mean-field steady state current j = p ρ (1-ρ)"],
+        )
+    end
+
+    # Particle-hole boundary: j(0) = j(1) = 0
+    verify(
+        TASEP(; p=1.0, ρ=0.0),
+        SteadyStateCurrent(),
+        Infinite();
+        route=:limiting_case,
+        independent=0.0,
+        agree_within=1e-12,
+        refs=["Empty/full lattice carries no current: j(0)=j(1)=0"],
+    )
+end

--- a/test/models/classical/test_toda_lattice.jl
+++ b/test/models/classical/test_toda_lattice.jl
@@ -15,3 +15,20 @@ using QAtlas, Test
         @test QAtlas.fetch(TodaLattice(; a=a, b=b), MassGap(), Infinite()) == 0.0
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TodaLattice — verification cards" begin
+    # The classical Toda chain has a gapless acoustic phonon branch:
+    # MassGap = 0 for all (a, b > 0) (integrable dispersion at q -> 0).
+    for (a, b) in ((1.0, 1.0), (2.0, 0.5), (0.7, 1.3))
+        verify(
+            TodaLattice(; a=a, b=b),
+            MassGap(),
+            Infinite();
+            route=:second_closed_form,
+            independent=0.0,
+            agree_within=1e-12,
+            refs=["Toda chain acoustic branch is gapless: MassGap = 0"],
+        )
+    end
+end

--- a/test/models/classical/test_yang_lee.jl
+++ b/test/models/classical/test_yang_lee.jl
@@ -46,3 +46,29 @@ end
     @test_throws DomainError QAtlas.fetch(m, ConformalWeights(), Infinite(); r=1, s=0)
     @test_throws DomainError QAtlas.fetch(m, ConformalWeights(), Infinite(); r=1, s=5)
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "YangLee — verification cards" begin
+    # M(5,2) minimal model: c = 1 - 6(p-p')²/(p p') with p=5, p'=2
+    verify(
+        YangLee(),
+        CentralCharge(),
+        Infinite();
+        route=:second_closed_form,
+        independent=1 - 6 * (5 - 2)^2 / (5 * 2),
+        agree_within=1e-12,
+        refs=["Yang-Lee edge = M(5,2): c = 1 - 6(p-p')²/(pp') = -22/5"],
+    )
+
+    # Yang-Lee edge primary conformal weight h = -1/5 (Cardy 1985)
+    verify(
+        YangLee(),
+        ConformalWeights(),
+        Infinite();
+        route=:literature_value,
+        fetch_kw=(; r=1, s=2),
+        independent=-1 / 5,
+        agree_within=1e-12,
+        refs=["Cardy 1985: Yang-Lee edge singularity primary h_{1,2} = -1/5"],
+    )
+end


### PR DESCRIPTION
Batch 4/8 of issue #369. 18 files in test/models/classical/.

Mostly :second_closed_form independent re-derivations (Onsager/Yang, 1D Ising transfer matrix, Curie-Weiss self-consistency, Wannier/Houtappel triangular, Lieb six-vertex, Pauling spin-ice, TASEP, SLE c(k)/D(k), Liouville, Yang-Lee M(5,2), Toda, RFIM Imry-Ma). IsingSquare partition/free-energy use the brute-force exact_partition helper (:ed_finite_size). SK ground state and Yang-Lee edge are :literature_value. CriticalExponents NamedTuples skipped (non-scalar) with scalar Onsager Tc anchoring instead.

Includes version bump to 0.20.5 + blue-format. All independent values from closed forms / exact_partition, no QAtlas internals. Refs #369.