### PR TITLE
test(verify): black-box verify() cards for identities group (#369, batch 5/8)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.20.1"
+version = "0.20.6"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/test/identities/test_TFIM_dynamic_symmetries.jl
+++ b/test/identities/test_TFIM_dynamic_symmetries.jl
@@ -200,3 +200,21 @@ end
     far_im_slope = (imag(c_p) - imag(c_m)) / (2δ)
     @test abs(far_im_slope) < 1e-10
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TFIM dynamic symmetries — verification cards" begin
+    # The dynamic-correlator symmetry tested here rests on the TFIM
+    # Bogoliubov spectrum; its gap is the Pfeuty 1970 closed form
+    # Δ = 2|h - J| (independent of src).
+    for h in (0.5, 1.5, 2.0)
+        verify(
+            TFIM(; J=1.0, h=h),
+            MassGap(),
+            Infinite();
+            route=:second_closed_form,
+            independent=2 * abs(h - 1.0),
+            agree_within=1e-10,
+            refs=["Pfeuty 1970: Δ = 2|h - J| (Bogoliubov dispersion minimum)"],
+        )
+    end
+end

--- a/test/identities/test_TFIM_limits_cross_model.jl
+++ b/test/identities/test_TFIM_limits_cross_model.jl
@@ -134,3 +134,22 @@ end
 # Heisenberg1D ↔ XXZ1D(Δ=1) cross-model equivalence is already verified
 # in `test/models/test_Heisenberg1D_thermal.jl` for every observable on
 # the delegator surface, so we do not duplicate it here.
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TFIM limits cross-model — verification cards" begin
+    # At J = 0 the TFIM reduces to decoupled spins in a field:
+    # H = -h Σ σx, so the exact per-site energy is -h tanh(βh)
+    # (independent single-spin closed form, not src).
+    for (h, β) in ((1.0, 0.7), (0.5, 1.5), (2.0, 0.3))
+        verify(
+            TFIM(; J=0.0, h=h),
+            Energy(:per_site),
+            OBC(6);
+            route=:second_closed_form,
+            fetch_kw=(; beta=β),
+            independent=-h * tanh(β * h),
+            agree_within=1e-8,
+            refs=["J=0 decoupled spins: ε = -h tanh(βh) per site"],
+        )
+    end
+end

--- a/test/identities/test_cross_bc_scaling.jl
+++ b/test/identities/test_cross_bc_scaling.jl
@@ -222,3 +222,21 @@ end
         @test abs(f_pbc - f_inf) / max(abs(f_inf), 1e-3) < 0.01
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "cross-BC scaling — verification cards" begin
+    # β = 0: every TFIM bond/field term is traceless => per-site
+    # ⟨H⟩_{β=0} = 0 exactly (independent operator-trace sum rule).
+    for bc in (Infinite(), OBC(8), PBC(8))
+        verify(
+            TFIM(; J=1.0, h=0.5),
+            Energy(:per_site),
+            bc;
+            route=:sum_rule,
+            fetch_kw=(; beta=0.0),
+            independent=0.0,
+            agree_within=1e-9,
+            refs=["Tr(σz σz)=Tr(σx)=0 => per-site ⟨H⟩_{β=0}=0 across all BC"],
+        )
+    end
+end

--- a/test/identities/test_identities_Heisenberg1D.jl
+++ b/test/identities/test_identities_Heisenberg1D.jl
@@ -34,3 +34,30 @@ end
         @test r.abs_err < 1e-12
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "Heisenberg1D identities — verification cards" begin
+    # Heisenberg1D delegates to XXZ1D(Δ=1); both code paths must agree.
+    verify(
+        Heisenberg1D(),
+        GroundStateEnergyDensity(),
+        Infinite();
+        route=:delegation_invariant,
+        independent=QAtlas.fetch(
+            XXZ1D(; J=1.0, Δ=1.0), GroundStateEnergyDensity(), Infinite()
+        ),
+        agree_within=1e-12,
+        refs=["Heisenberg1D ≡ XXZ1D(Δ=1): Hulthén e0 = J(1/4 − log 2)"],
+    )
+
+    # Closed-form Hulthén value cross-check (second derivation).
+    verify(
+        Heisenberg1D(),
+        GroundStateEnergyDensity(),
+        Infinite();
+        route=:second_closed_form,
+        independent=0.25 - log(2.0),
+        agree_within=1e-12,
+        refs=["Hulthén 1938: e0 = 1/4 − log 2"],
+    )
+end

--- a/test/identities/test_identities_IsingSquare.jl
+++ b/test/identities/test_identities_IsingSquare.jl
@@ -43,3 +43,19 @@ end
     @test all(r.status !== :fail for r in results)
     @test count(r -> r.status === :skipped, results) == 3
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "IsingSquare identities — verification cards" begin
+    # Onsager 1944 critical temperature: sinh(2 βc J) = 1.
+    for J in (1.0, 2.0)
+        verify(
+            IsingSquare(; J=J),
+            CriticalTemperature(),
+            Infinite();
+            route=:second_closed_form,
+            independent=2 * J / log(1 + sqrt(2)),
+            agree_within=1e-10,
+            refs=["Onsager 1944: Tc = 2J / log(1+√2)"],
+        )
+    end
+end

--- a/test/identities/test_identities_KitaevHoneycomb.jl
+++ b/test/identities/test_identities_KitaevHoneycomb.jl
@@ -58,3 +58,23 @@ end
         @test c ≈ -β^2 * dε rtol = 1e-3
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "KitaevHoneycomb identities — verification cards" begin
+    # Gibbs identity s = β(ε − f) cross-checks the three independently
+    # implemented thermodynamic functions on the Kitaev honeycomb model.
+    let m = KitaevHoneycomb(; Kx=1.0, Ky=1.0, Kz=1.0), Lx = 2, Ly = 2, β = 1.0
+        ε = QAtlas.fetch(m, Energy(:per_site), OBC(0); Lx=Lx, Ly=Ly, beta=β)
+        f = QAtlas.fetch(m, FreeEnergy(), OBC(0); Lx=Lx, Ly=Ly, beta=β)
+        verify(
+            m,
+            ThermalEntropy(),
+            OBC(0);
+            route=:sum_rule,
+            fetch_kw=(; Lx=Lx, Ly=Ly, beta=β),
+            independent=β * (ε - f),
+            agree_within=1e-7,
+            refs=["Gibbs identity s = β(ε − f) on the Kitaev honeycomb"],
+        )
+    end
+end

--- a/test/identities/test_identities_S1Heisenberg1D.jl
+++ b/test/identities/test_identities_S1Heisenberg1D.jl
@@ -44,3 +44,28 @@ end
         @test r.abs_err < 1e-12
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "S1Heisenberg1D identities — verification cards" begin
+    # White-Huse 1993 DMRG Haldane-chain energy density (literature).
+    verify(
+        S1Heisenberg1D(; J=1.0),
+        Energy(:per_site),
+        Infinite();
+        route=:literature_value,
+        independent=-1.401484038971,
+        agree_within=1e-6,
+        refs=["White-Huse 1993 DMRG: e ≈ -1.401484 J (spin-1 Haldane chain)"],
+    )
+
+    # Haldane gap literature value.
+    verify(
+        S1Heisenberg1D(; J=1.0),
+        MassGap(),
+        Infinite();
+        route=:literature_value,
+        independent=0.41048,
+        agree_within=1e-4,
+        refs=["White-Huse 1993 DMRG: Haldane gap Δ ≈ 0.41048 J"],
+    )
+end

--- a/test/identities/test_identities_TFIM.jl
+++ b/test/identities/test_identities_TFIM.jl
@@ -78,3 +78,19 @@ end
         @test all(r.status === :pass for r in results)
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TFIM identities — verification cards" begin
+    # Pfeuty 1970 gap closed form (independent of src).
+    for (J, h) in ((1.0, 0.5), (1.0, 1.0), (1.0, 2.0))
+        verify(
+            TFIM(; J=J, h=h),
+            MassGap(),
+            Infinite();
+            route=:second_closed_form,
+            independent=2 * abs(h - J),
+            agree_within=1e-10,
+            refs=["Pfeuty 1970: Δ = 2|h - J|"],
+        )
+    end
+end

--- a/test/identities/test_identities_TFIM_pbc.jl
+++ b/test/identities/test_identities_TFIM_pbc.jl
@@ -47,3 +47,29 @@ end
     results = verify_thermodynamic_identities(model, PBC(8); βs=βs, atol=1e-5)
     @test all(r.status === :pass for r in results)
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TFIM PBC identities — verification cards" begin
+    # β = 0: traceless terms => per-site ⟨H⟩ = 0 (PBC sum rule).
+    verify(
+        TFIM(; J=1.0, h=0.5),
+        Energy(:per_site),
+        PBC(6);
+        route=:sum_rule,
+        fetch_kw=(; beta=0.0),
+        independent=0.0,
+        agree_within=1e-9,
+        refs=["Tr(σz σz)=Tr(σx)=0 => per-site ⟨H⟩_{β=0}=0 (PBC)"],
+    )
+
+    # Pfeuty gap is boundary-independent in the thermodynamic limit.
+    verify(
+        TFIM(; J=1.0, h=0.5),
+        MassGap(),
+        Infinite();
+        route=:second_closed_form,
+        independent=2 * abs(0.5 - 1.0),
+        agree_within=1e-10,
+        refs=["Pfeuty 1970: Δ = 2|h - J| (BC-independent)"],
+    )
+end

--- a/test/identities/test_identities_XXZ1D.jl
+++ b/test/identities/test_identities_XXZ1D.jl
@@ -75,3 +75,28 @@ end
         @test all(r.status !== :fail for r in results)
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "XXZ1D identities — verification cards" begin
+    # FM point Δ = -1: exact saturated ground state, e0 = -J/4.
+    verify(
+        XXZ1D(; J=1.0, Δ=-1.0),
+        GroundStateEnergyDensity(),
+        Infinite();
+        route=:second_closed_form,
+        independent=-0.25,
+        agree_within=1e-12,
+        refs=["XXZ FM point Δ=-1: aligned state exact, e0 = -J/4"],
+    )
+
+    # Δ = 1 ≡ Heisenberg1D (independent code path).
+    verify(
+        XXZ1D(; J=1.0, Δ=1.0),
+        GroundStateEnergyDensity(),
+        Infinite();
+        route=:delegation_invariant,
+        independent=QAtlas.fetch(Heisenberg1D(), GroundStateEnergyDensity(), Infinite()),
+        agree_within=1e-12,
+        refs=["XXZ1D(Δ=1) ≡ Heisenberg1D: independent code paths must agree"],
+    )
+end

--- a/test/identities/test_property_invariants.jl
+++ b/test/identities/test_property_invariants.jl
@@ -244,3 +244,24 @@ end
         @test abs(c_xx) ≤ 1 + 1e-10
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "property invariants — verification cards" begin
+    # Gibbs identity s = β(ε − f): the entropy is cross-checked against
+    # the independently-implemented Energy and FreeEnergy via the
+    # thermodynamic sum rule (three separate code paths must agree).
+    let m = TFIM(; J=1.0, h=0.5), β = 1.3, N = 6
+        ε = QAtlas.fetch(m, Energy(:per_site), OBC(N); beta=β)
+        f = QAtlas.fetch(m, FreeEnergy(), OBC(N); beta=β)
+        verify(
+            m,
+            ThermalEntropy(),
+            OBC(N);
+            route=:sum_rule,
+            fetch_kw=(; beta=β),
+            independent=β * (ε - f),
+            agree_within=1e-7,
+            refs=["Gibbs identity s = β(ε − f) across Energy/FreeEnergy/Entropy paths"],
+        )
+    end
+end


### PR DESCRIPTION
Batch 5/8 of issue #369. 11 files in test/identities/ (cross-model and cross-BC consistency harnesses).

Robust routes only:
- sum_rule: beta=0 traceless per-site H=0; Gibbs s=beta(e-f) across independently implemented Energy/FreeEnergy/Entropy
- second_closed_form: Pfeuty gap, J=0 decoupled spins -h tanh(beta h), Onsager Tc, XXZ FM -J/4, Hulthen
- delegation_invariant: Heisenberg1D == XXZ1D(Delta=1)
- literature_value: White-Huse Haldane

Signatures mirrored from each file existing fetch calls (grep-verified, lesson applied from TFIM batch). Version bump 0.20.6 + blue-format.

Refs #369
