### PR TITLE
test(verify): black-box verify() cards for universalities group (#369, batch 6/8)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.20.1"
+version = "0.20.7"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/test/universalities/test_bcft.jl
+++ b/test/universalities/test_bcft.jl
@@ -50,3 +50,25 @@ end
         m, ResidualEntropy(), Infinite(); state=:something
     )
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "BCFT — verification cards" begin
+    # The :fixed, :fixed_plus, :fixed_minus and :identity boundary
+    # conditions are physically the same g-factor; the boundary entropy
+    # must agree across these independently labelled states.
+    let m = BCFT()
+        s_ref = QAtlas.fetch(m, ResidualEntropy(), Infinite(); state=:fixed)
+        for st in (:fixed_plus, :fixed_minus, :identity)
+            verify(
+                m,
+                ResidualEntropy(),
+                Infinite();
+                route=:delegation_invariant,
+                fetch_kw=(; state=st),
+                independent=s_ref,
+                agree_within=1e-10,
+                refs=["Affleck-Ludwig g-theorem: equivalent boundary states share log g"],
+            )
+        end
+    end
+end

--- a/test/universalities/test_conformal_bootstrap.jl
+++ b/test/universalities/test_conformal_bootstrap.jl
@@ -54,3 +54,29 @@ end
     @test_throws DomainError QAtlas.fetch(m, ConformalWeights(), Infinite(); field=:T)
     @test_throws DomainError QAtlas.fetch(m, ConformalWeights(), Infinite(); field=:O)
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "ConformalBootstrap — verification cards" begin
+    # 3D Ising conformal bootstrap (Kos-Poland-Simmons-Duffin-Vichi 2016
+    # "Precision Islands"): Δ_σ ≈ 0.5181489, Δ_ε ≈ 1.412625 (literature).
+    verify(
+        ConformalBootstrap(),
+        ConformalWeights(),
+        Infinite();
+        route=:literature_value,
+        fetch_kw=(; field=:σ),
+        independent=0.5181489,
+        agree_within=1e-5,
+        refs=["KPSD-Vichi 2016 Precision Islands: 3D Ising Δ_σ ≈ 0.5181489"],
+    )
+    verify(
+        ConformalBootstrap(),
+        ConformalWeights(),
+        Infinite();
+        route=:literature_value,
+        fetch_kw=(; field=:ε),
+        independent=1.412625,
+        agree_within=1e-4,
+        refs=["KPSD-Vichi 2016 Precision Islands: 3D Ising Δ_ε ≈ 1.412625"],
+    )
+end

--- a/test/universalities/test_tricritical_ising.jl
+++ b/test/universalities/test_tricritical_ising.jl
@@ -62,3 +62,18 @@ end
             QAtlas.fetch(mm, ConformalWeights(); r=r, s=s)
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TricriticalIsing — verification cards" begin
+    # Tricritical Ising = minimal model M(5,4): c = 1 - 6(p-q)²/(pq)
+    # with (p,q)=(5,4) => c = 7/10 (independent Kac/minimal-model formula).
+    verify(
+        TricriticalIsing(),
+        CentralCharge(),
+        Infinite();
+        route=:second_closed_form,
+        independent=1 - 6 * (5 - 4)^2 / (5 * 4),
+        agree_within=1e-12,
+        refs=["M(5,4): c = 1 - 6(p-q)²/(pq) = 7/10"],
+    )
+end

--- a/test/universalities/test_tricritical_potts3.jl
+++ b/test/universalities/test_tricritical_potts3.jl
@@ -55,3 +55,18 @@ end
     # Identity primary appears with h = 0
     @test any(x -> x.h == 0, pf_tp)
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TricriticalPotts3 — verification cards" begin
+    # Tricritical 3-state Potts = minimal model M(7,6): c = 6/7
+    # (independent Kac/minimal-model formula 1 - 6(p-q)²/(pq)).
+    verify(
+        TricriticalPotts3(),
+        CentralCharge(),
+        Infinite();
+        route=:second_closed_form,
+        independent=1 - 6 * (7 - 6)^2 / (7 * 6),
+        agree_within=1e-12,
+        refs=["M(7,6): c = 1 - 6(p-q)²/(pq) = 6/7"],
+    )
+end

--- a/test/universalities/test_ttbar.jl
+++ b/test/universalities/test_ttbar.jl
@@ -26,3 +26,29 @@ end
         @test QAtlas.fetch(TTbar(; c=0.5, λ=λ), CentralCharge(), Infinite()) == 0.5
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TTbar — verification cards" begin
+    # The TTbar deformation preserves the central charge: c is the
+    # undeformed seed value for any λ (independent of src).
+    verify(
+        TTbar(),
+        CentralCharge(),
+        Infinite();
+        route=:second_closed_form,
+        independent=1.0,
+        agree_within=1e-12,
+        refs=["TTbar is a marginal deformation: c invariant (default seed c=1)"],
+    )
+    for c0 in (0.5, 1.5, 2.0)
+        verify(
+            TTbar(; c=c0, λ=0.7),
+            CentralCharge(),
+            Infinite();
+            route=:second_closed_form,
+            independent=c0,
+            agree_within=1e-12,
+            refs=["TTbar preserves the seed central charge c for any λ"],
+        )
+    end
+end

--- a/test/universalities/test_zn_clock.jl
+++ b/test/universalities/test_zn_clock.jl
@@ -27,3 +27,27 @@ end
     @test_throws DomainError ZnClock(; n=0)
     @test_throws DomainError ZnClock(; n=-1)
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "ZnClock — verification cards" begin
+    # n=2 clock = Ising = M(4,3): c = 1 - 6(p-q)²/(pq) = 1/2
+    verify(
+        ZnClock(; n=2),
+        CentralCharge(),
+        Infinite();
+        route=:second_closed_form,
+        independent=1 - 6 * (4 - 3)^2 // (4 * 3),
+        agree_within=1e-12,
+        refs=["n=2 clock = Ising = M(4,3): c = 1/2"],
+    )
+    # n=3 clock = 3-state Potts = M(6,5): c = 4/5
+    verify(
+        ZnClock(; n=3),
+        CentralCharge(),
+        Infinite();
+        route=:second_closed_form,
+        independent=1 - 6 * (6 - 5)^2 // (6 * 5),
+        agree_within=1e-12,
+        refs=["n=3 clock = 3-state Potts = M(6,5): c = 4/5"],
+    )
+end

--- a/test/universalities/test_zn_parafermion.jl
+++ b/test/universalities/test_zn_parafermion.jl
@@ -39,3 +39,20 @@ end
     @test_throws DomainError ZnParafermion(; n=0)
     @test_throws DomainError ZnParafermion(; n=-3)
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "ZnParafermion — verification cards" begin
+    # Fateev-Zamolodchikov Z_n parafermion CFT: c = 2(n-1)/(n+2)
+    # (independent closed form).
+    for n in (2, 3, 4, 5)
+        verify(
+            ZnParafermion(; n=n),
+            CentralCharge(),
+            Infinite();
+            route=:second_closed_form,
+            independent=2 * (n - 1) // (n + 2),
+            agree_within=1e-12,
+            refs=["Fateev-Zamolodchikov: Z_n parafermion c = 2(n-1)/(n+2)"],
+        )
+    end
+end


### PR DESCRIPTION
Batch 6/8 of issue #369. 7 of 14 files in test/universalities/ get verify cards.

Carded: tricritical_ising (M(5,4) c=7/10), tricritical_potts3 (M(7,6) c=6/7), ttbar (c invariant), zn_parafermion (c=2(n-1)/(n+2)), zn_clock (n=2/3 minimal models), conformal_bootstrap (3D Ising KPSD-Vichi 2016), bcft (boundary-state g delegation).

Skipped 7 with no verify-compatible surface: minimal_models/wzw/exponents/rmt use 2-arg fetch (no positional bc; verify() requires fetch(m,q,bc)); E8/CriticalExponents return non-scalars; cft_casimir has no model fetch. Documented, not forced.

Version bump 0.20.7 + blue-format. Refs #369
