### PR TITLE
test(verify): black-box verify() cards for misc group (#369, batch 7/8)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.20.1"
+version = "0.20.8"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/test/models/quantum/misc/test_aklt2d.jl
+++ b/test/models/quantum/misc/test_aklt2d.jl
@@ -16,3 +16,18 @@ end
     m = AKLT2D(; J=1.0)
     @test_throws DomainError QAtlas.fetch(m, Energy{:per_site}(), Infinite(); J=0.0)
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "AKLT2D — verification cards" begin
+    for J in (0.5, 1.0, 2.5)
+        verify(
+            AKLT2D(; J=J),
+            Energy(:per_site),
+            Infinite();
+            route=:second_closed_form,
+            independent=0.0,
+            agree_within=1e-12,
+            refs=["Frustration-free: sum of non-negative projectors => e0 = 0"],
+        )
+    end
+end

--- a/test/models/quantum/misc/test_chern_simons_3d.jl
+++ b/test/models/quantum/misc/test_chern_simons_3d.jl
@@ -97,3 +97,19 @@ end
     @test_throws DomainError QAtlas.fetch(m, PartitionFunction(), Infinite(); N=1)
     @test_throws DomainError QAtlas.fetch(m, PartitionFunction(), Infinite(); k=0)
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "ChernSimons3D — verification cards" begin
+    # SU(2)_k WZW central charge c = 3k/(k+2) (Knizhnik-Zamolodchikov).
+    for k in (1, 2, 3, 6)
+        verify(
+            ChernSimons3D(; N=2, k=k),
+            CentralCharge(),
+            Infinite();
+            route=:second_closed_form,
+            independent=3k // (k + 2),
+            agree_within=1e-10,
+            refs=["SU(2)_k WZW: c = 3k/(k+2) (Knizhnik-Zamolodchikov 1984)"],
+        )
+    end
+end

--- a/test/models/quantum/misc/test_cluster1d.jl
+++ b/test/models/quantum/misc/test_cluster1d.jl
@@ -28,3 +28,27 @@ end
     @test_throws DomainError QAtlas.fetch(m, Energy{:per_site}(), Infinite(); J=0.0)
     @test_throws DomainError QAtlas.fetch(m, MassGap(), Infinite(); J=-2.0)
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "Cluster1D — verification cards" begin
+    for J in (0.5, 1.0, 3.0)
+        verify(
+            Cluster1D(; J=J),
+            Energy(:per_site),
+            Infinite();
+            route=:second_closed_form,
+            independent=(-J),
+            agree_within=1e-12,
+            refs=["Cluster-state Hamiltonian: e0 = -J (exact stabiliser ground state)"],
+        )
+        verify(
+            Cluster1D(; J=J),
+            MassGap(),
+            Infinite();
+            route=:second_closed_form,
+            independent=2J,
+            agree_within=1e-12,
+            refs=["Cluster model gap = 2J"],
+        )
+    end
+end

--- a/test/models/quantum/misc/test_compass1d.jl
+++ b/test/models/quantum/misc/test_compass1d.jl
@@ -36,3 +36,18 @@ end
         @test Δ_ab == 2.0 * abs(a - b)
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "Compass1D — verification cards" begin
+    for (jx, jy) in ((1.0, 0.5), (2.0, 0.5), (1.0, 1.0))
+        verify(
+            Compass1D(; J_x=jx, J_y=jy),
+            MassGap(),
+            Infinite();
+            route=:second_closed_form,
+            independent=2 * abs(jx - jy),
+            agree_within=1e-10,
+            refs=["1D compass model gap = 2|J_x - J_y|"],
+        )
+    end
+end

--- a/test/models/quantum/misc/test_fibonacci_anyons.jl
+++ b/test/models/quantum/misc/test_fibonacci_anyons.jl
@@ -16,3 +16,17 @@ using QAtlas, Test
     # since 2 = √4 > √(φ+2) = √3.618.  So γ_Fib < γ_Z2.
     @test γ < log(2)
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "FibonacciAnyons — verification cards" begin
+    phi = (1 + sqrt(5)) / 2
+    verify(
+        FibonacciAnyons(),
+        TopologicalEntanglementEntropy(),
+        Infinite();
+        route=:second_closed_form,
+        independent=0.5 * log(2 + phi),
+        agree_within=1e-9,
+        refs=["Fibonacci TQFT: gamma = (1/2) log(2 + phi), phi = golden ratio"],
+    )
+end

--- a/test/models/quantum/misc/test_gross_neveu.jl
+++ b/test/models/quantum/misc/test_gross_neveu.jl
@@ -47,3 +47,18 @@ end
     @test_throws DomainError QAtlas.fetch(m, MassGap(), Infinite(); Λ=1.0, g=-0.5)
     @test_throws DomainError QAtlas.fetch(m, MassGap(), Infinite(); Λ=1.0, N=0)
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "GrossNeveu — verification cards" begin
+    for N in (1, 2, 5)
+        verify(
+            GrossNeveu(; N=N, g=0.0),
+            CentralCharge(),
+            Infinite();
+            route=:second_closed_form,
+            independent=N,
+            agree_within=1e-10,
+            refs=["UV free-fermion fixed point: c = N at g = 0"],
+        )
+    end
+end

--- a/test/models/quantum/misc/test_kitaev1d.jl
+++ b/test/models/quantum/misc/test_kitaev1d.jl
@@ -215,3 +215,37 @@ end
     @test isfinite(Δgap)
     @test Δgap > 0
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "Kitaev1D — verification cards" begin
+    # Sweet spot (t=Δ, μ=0): bulk gap = 2|Δ|
+    verify(
+        Kitaev1D(; μ=0.0, t=1.0, Δ=1.0),
+        MassGap(),
+        Infinite();
+        route=:second_closed_form,
+        independent=2.0,
+        agree_within=1e-9,
+        refs=["Kitaev chain sweet spot: gap = 2|Δ|"],
+    )
+    # Trivial phase |μ|>2|t|: gap = |μ| - 2|t|
+    verify(
+        Kitaev1D(; μ=3.0, t=1.0, Δ=1.0),
+        MassGap(),
+        Infinite();
+        route=:second_closed_form,
+        independent=1.0,
+        agree_within=1e-9,
+        refs=["Kitaev chain trivial phase: gap = ||μ| - 2|t||"],
+    )
+    # Critical point |μ|=2|t|: gapless
+    verify(
+        Kitaev1D(; μ=2.0, t=1.0, Δ=1.0),
+        MassGap(),
+        Infinite();
+        route=:second_closed_form,
+        independent=0.0,
+        agree_within=1e-9,
+        refs=["Kitaev chain topological transition at |μ|=2|t|: gap = 0"],
+    )
+end

--- a/test/models/quantum/misc/test_long_range_ising1d.jl
+++ b/test/models/quantum/misc/test_long_range_ising1d.jl
@@ -32,3 +32,19 @@ end
     @test_throws DomainError LongRangeIsing1D(; h=-1.0)
     @test_throws DomainError LongRangeIsing1D(; α=0.0)
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "LongRangeIsing1D — verification cards" begin
+    # α = ∞ (NN limit) delegates to TFIM: gap Δ = 2|h - J| (Pfeuty).
+    for (J, h) in ((1.0, 2.0), (2.0, 0.5), (1.5, 0.7))
+        verify(
+            LongRangeIsing1D(; J=J, h=h),
+            MassGap(),
+            Infinite();
+            route=:delegation_invariant,
+            independent=2 * abs(h - J),
+            agree_within=1e-9,
+            refs=["α=∞ NN limit delegates to TFIM: Δ = 2|h - J| (Pfeuty 1970)"],
+        )
+    end
+end

--- a/test/models/quantum/misc/test_long_range_xy1d.jl
+++ b/test/models/quantum/misc/test_long_range_xy1d.jl
@@ -19,3 +19,19 @@ end
     @test_throws DomainError LongRangeXY1D(; J=-1.0)
     @test_throws DomainError LongRangeXY1D(; α=0.0)
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "LongRangeXY1D — verification cards" begin
+    # α = ∞ NN XX chain is gapless for |h| <= 2J (free-fermion band).
+    for h in (0.0, 1.0, 2.0)
+        verify(
+            LongRangeXY1D(; h=h),
+            MassGap(),
+            Infinite();
+            route=:second_closed_form,
+            independent=0.0,
+            agree_within=1e-10,
+            refs=["NN XX chain: gapless for |h| <= 2J (free fermion)"],
+        )
+    end
+end

--- a/test/models/quantum/misc/test_mixed_field_ising1d.jl
+++ b/test/models/quantum/misc/test_mixed_field_ising1d.jl
@@ -51,3 +51,19 @@ end
         MixedFieldIsing1D(; J=1.0, h_x=1.0, h_z=1e-13), MassGap(), Infinite()
     )
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "MixedFieldIsing1D — verification cards" begin
+    # h_z = 0 reduces to TFIM: gap Δ = 2|h_x - J| (Pfeuty).
+    for (J, hx) in ((1.0, 2.0), (1.0, 3.0), (2.0, 1.0))
+        verify(
+            MixedFieldIsing1D(; J=J, h_x=hx, h_z=0.0),
+            MassGap(),
+            Infinite();
+            route=:delegation_invariant,
+            independent=2 * abs(hx - J),
+            agree_within=1e-9,
+            refs=["h_z=0 delegates to TFIM: Δ = 2|h_x - J| (Pfeuty 1970)"],
+        )
+    end
+end

--- a/test/models/quantum/misc/test_ppip_2dsc.jl
+++ b/test/models/quantum/misc/test_ppip_2dsc.jl
@@ -32,3 +32,25 @@ end
     @test_throws DomainError PpIp2DSC(; μ=0.0)
     @test_throws DomainError PpIp2DSC(; μ=-1.0)
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "PpIp2DSC — verification cards" begin
+    verify(
+        PpIp2DSC(),
+        CentralCharge(),
+        Infinite();
+        route=:second_closed_form,
+        independent=1 // 2,
+        agree_within=1e-10,
+        refs=["Chiral p+ip edge: single chiral Majorana CFT c = 1/2"],
+    )
+    verify(
+        PpIp2DSC(),
+        TopologicalInvariant(),
+        Infinite();
+        route=:second_closed_form,
+        independent=1,
+        agree_within=1e-10,
+        refs=["p+ip weak-pairing phase: first Chern number = 1"],
+    )
+end

--- a/test/models/quantum/misc/test_pxp1d.jl
+++ b/test/models/quantum/misc/test_pxp1d.jl
@@ -36,3 +36,16 @@ end
     m = PXP1D(; Ω=1.0)
     @test_throws DomainError QAtlas.fetch(m, Energy{:per_site}(), Infinite(); Ω=0.0)
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "PXP1D — verification cards" begin
+    verify(
+        PXP1D(),
+        Energy(:per_site),
+        Infinite();
+        route=:literature_value,
+        independent=-0.6516,
+        agree_within=5e-3,
+        refs=["PXP scar literature (Turner 2018 / Lin-Motrunich 2019): e0 ~ -0.6516"],
+    )
+end

--- a/test/models/quantum/misc/test_schwinger_model.jl
+++ b/test/models/quantum/misc/test_schwinger_model.jl
@@ -53,3 +53,18 @@ end
         SchwingerModel(; e=1.0), ChiralCondensate(), Infinite(); e=-1.5
     )
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "SchwingerModel — verification cards" begin
+    for e in (1.0, 2.0, 3.0)
+        verify(
+            SchwingerModel(; e=e, m=0.0),
+            MassGap(),
+            Infinite();
+            route=:second_closed_form,
+            independent=e / sqrt(pi),
+            agree_within=1e-9,
+            refs=["Massless Schwinger model: m_gamma = e / sqrt(pi) (exact)"],
+        )
+    end
+end

--- a/test/models/quantum/misc/test_shastry_sutherland.jl
+++ b/test/models/quantum/misc/test_shastry_sutherland.jl
@@ -48,7 +48,7 @@ end
 @testset "ShastrySutherland — verification cards" begin
     for (J, Jp) in ((0.1, 1.0), (0.6, 2.0), (0.3, 1.5))
         verify(
-            ShastrySutherland(; J=J, Jp=Jp),
+            QAtlas.ShastrySutherland(; J=J, Jp=Jp),
             Energy(:per_site),
             Infinite();
             route=:second_closed_form,

--- a/test/models/quantum/misc/test_shastry_sutherland.jl
+++ b/test/models/quantum/misc/test_shastry_sutherland.jl
@@ -43,3 +43,18 @@ end
         QAtlas.ShastrySutherland(; J=0.0, Jp=-1.0), Energy(:per_site), Infinite()
     )
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "ShastrySutherland — verification cards" begin
+    for (J, Jp) in ((0.1, 1.0), (0.6, 2.0), (0.3, 1.5))
+        verify(
+            ShastrySutherland(; J=J, Jp=Jp),
+            Energy(:per_site),
+            Infinite();
+            route=:second_closed_form,
+            independent=-3 * Jp / 8,
+            agree_within=1e-10,
+            refs=["Shastry-Sutherland 1981: exact dimer e0 = -3 Jp / 8 (dimer phase)"],
+        )
+    end
+end

--- a/test/models/quantum/misc/test_syk.jl
+++ b/test/models/quantum/misc/test_syk.jl
@@ -42,3 +42,19 @@ end
     @test_throws DomainError QAtlas.fetch(m, ConformalWeights(), Infinite(); field=:O)
     @test_throws DomainError QAtlas.fetch(m, ConformalWeights(), Infinite(); field=:ε)
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "SYK — verification cards" begin
+    for q in (2, 4, 6, 8)
+        verify(
+            SYK(; q=q),
+            ConformalWeights(),
+            Infinite();
+            route=:second_closed_form,
+            fetch_kw=(; field=:ψ),
+            independent=1 // q,
+            agree_within=1e-10,
+            refs=["SYK IR Majorana conformal dimension Delta_psi = 1/q"],
+        )
+    end
+end

--- a/test/models/quantum/misc/test_tight_binding1d.jl
+++ b/test/models/quantum/misc/test_tight_binding1d.jl
@@ -95,3 +95,34 @@ using QAtlas: TightBinding1D, Energy, MassGap, FermiVelocity, Infinite, fetch
         @test_throws DomainError TightBinding1D(; t=-1.0)
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TightBinding1D — verification cards" begin
+    verify(
+        TightBinding1D(; t=1.0, μ=0.0),
+        Energy(:per_site),
+        Infinite();
+        route=:second_closed_form,
+        independent=-2 / pi,
+        agree_within=1e-9,
+        refs=["Half-filled tight-binding chain: e0 = -2t/pi"],
+    )
+    verify(
+        TightBinding1D(; t=1.0, μ=0.0),
+        MassGap(),
+        Infinite();
+        route=:second_closed_form,
+        independent=0.0,
+        agree_within=1e-10,
+        refs=["Half filling: gapless Fermi surface"],
+    )
+    verify(
+        TightBinding1D(; t=1.0, μ=3.0),
+        MassGap(),
+        Infinite();
+        route=:second_closed_form,
+        independent=1.0,
+        agree_within=1e-9,
+        refs=["Band insulator mu > 2t: gap = |mu| - 2t"],
+    )
+end

--- a/test/models/quantum/misc/test_tight_binding_v1d.jl
+++ b/test/models/quantum/misc/test_tight_binding_v1d.jl
@@ -99,3 +99,27 @@ end
         TightBindingV1D(; V=-1e-13), Energy(:per_site), Infinite()
     )
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TightBindingV1D — verification cards" begin
+    # V = 0 free-fermion subspace: half-filling is gapless.
+    verify(
+        TightBindingV1D(),
+        MassGap(),
+        Infinite();
+        route=:second_closed_form,
+        independent=0.0,
+        agree_within=1e-10,
+        refs=["V=0 half-filled chain: gapless Fermi surface"],
+    )
+    # μ > 2t band insulator: gap = |μ| - 2t
+    verify(
+        TightBindingV1D(; μ=3.0),
+        MassGap(),
+        Infinite();
+        route=:second_closed_form,
+        independent=1.0,
+        agree_within=1e-9,
+        refs=["V=0, μ>2t: band-insulator gap = |μ| - 2t"],
+    )
+end

--- a/test/models/quantum/misc/test_toric_code.jl
+++ b/test/models/quantum/misc/test_toric_code.jl
@@ -144,3 +144,34 @@ using QAtlas, Test
         @test_throws DomainError QAtlas.fetch(m, GroundStateDegeneracy(), PBC(0); genus=-3)
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "ToricCode — verification cards" begin
+    verify(
+        ToricCode(; J_e=1.0, J_m=1.0),
+        GroundStateEnergyDensity(),
+        Infinite();
+        route=:second_closed_form,
+        independent=-2.0,
+        agree_within=1e-10,
+        refs=["Kitaev 2003: toric-code e0 = -(J_e + J_m)"],
+    )
+    verify(
+        ToricCode(; J_e=1.0, J_m=1.0),
+        MassGap(),
+        Infinite();
+        route=:second_closed_form,
+        independent=2.0,
+        agree_within=1e-10,
+        refs=["Toric-code gap = 2 min(J_e, J_m)"],
+    )
+    verify(
+        ToricCode(; J_e=1.0, J_m=1.0),
+        TopologicalEntanglementEntropy(),
+        Infinite();
+        route=:second_closed_form,
+        independent=log(2),
+        agree_within=1e-10,
+        refs=["Z2 topological order: gamma = log 2 (Kitaev-Preskill)"],
+    )
+end

--- a/test/models/quantum/misc/test_x_cube.jl
+++ b/test/models/quantum/misc/test_x_cube.jl
@@ -32,3 +32,20 @@ end
         XCube(), GroundStateDegeneracy(), PBC(); Lx=2, Ly=0, Lz=2
     )
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "XCube — verification cards" begin
+    # X-cube fracton GSD on the 3-torus: log2(GSD) = 2(Lx+Ly+Lz) - 3.
+    for (Lx, Ly, Lz) in ((2, 2, 2), (3, 3, 3))
+        verify(
+            XCube(),
+            GroundStateDegeneracy(),
+            PBC();
+            route=:second_closed_form,
+            fetch_kw=(; Lx=Lx, Ly=Ly, Lz=Lz),
+            independent=2.0^(2 * (Lx + Ly + Lz) - 3),
+            agree_within=0.5,
+            refs=["X-cube fracton order: log2 GSD = 2(Lx+Ly+Lz) - 3"],
+        )
+    end
+end

--- a/test/models/quantum/misc/test_xyh1d.jl
+++ b/test/models/quantum/misc/test_xyh1d.jl
@@ -75,3 +75,34 @@ end
         XYh1D(; Jx=1.0, Jy=0.5, h=0.0), Energy{:per_site}(), Infinite()
     )
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "XYh1D — verification cards" begin
+    verify(
+        XYh1D(),
+        Energy(:per_site),
+        Infinite();
+        route=:second_closed_form,
+        independent=-4 / pi,
+        agree_within=1e-9,
+        refs=["Lieb-Schultz-Mattis 1961: XX chain e0 = -4/pi (Pauli σ convention)"],
+    )
+    verify(
+        XYh1D(),
+        MassGap(),
+        Infinite();
+        route=:second_closed_form,
+        independent=0.0,
+        agree_within=1e-10,
+        refs=["XX limit h=0: gapless"],
+    )
+    verify(
+        XYh1D(; h=3.0),
+        MassGap(),
+        Infinite();
+        route=:second_closed_form,
+        independent=2.0,
+        agree_within=1e-9,
+        refs=["Polarized |h|>2J: gap = 2(|h| - 2J)"],
+    )
+end


### PR DESCRIPTION
Batch 7/8 of issue #369. 20 of 22 remaining test/models/quantum/misc/ files get verify cards (AKLT pilot already done; Hubbard1D/ExtendedHubbard1D skipped — Lieb-Wu integrals, no closed form).

Mostly :second_closed_form (AKLT2D frustration-free, Cluster1D, Compass1D, Fibonacci TEE, Schwinger e/sqrt(pi), Shastry-Sutherland -3Jp/8, SYK 1/q, tight-binding -2/pi, XYh1D -4/pi, ToricCode e0/gap/TEE, GrossNeveu c=N, p+ip c=1/2, Kitaev1D gaps, ChernSimons3D SU(2)_k, XCube fracton GSD), plus :delegation_invariant (LongRange/MixedField -> TFIM Pfeuty) and :literature_value (PXP scar).

Signatures Explore-mapped from existing fetch calls, not guessed. Version bump 0.20.8 + blue-format. Refs #369
