### PR TITLE
test(verify): black-box verify() cards for verification group (#369, batch 8/8)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.20.1"
+version = "0.20.9"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/test/verification/heisenberg_xxz/test_xxz_luttinger_ed.jl
+++ b/test/verification/heisenberg_xxz/test_xxz_luttinger_ed.jl
@@ -135,3 +135,20 @@ const _XXZ_Ns = [8, 10, 12, 14]
         end
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "XXZ1D Luttinger ED — verification cards" begin
+    # Bethe-ansatz Luttinger parameter K = π / (2(π - arccos Δ))
+    # (independent closed form, Haldane 1980).
+    for Δ in (-0.5, 0.0, 0.5, 1.0)
+        verify(
+            XXZ1D(; J=1.0, Δ=Δ),
+            LuttingerParameter(),
+            Infinite();
+            route=:second_closed_form,
+            independent=π / (2 * (π - acos(Δ))),
+            agree_within=1e-9,
+            refs=["Haldane 1980: K = π / (2(π - arccos Δ)) for the critical XXZ chain"],
+        )
+    end
+end

--- a/test/verification/heisenberg_xxz/test_xxz_yang_yang.jl
+++ b/test/verification/heisenberg_xxz/test_xxz_yang_yang.jl
@@ -98,3 +98,28 @@ end
     @test e_pos ≈ -1 / π atol = 1e-5
     @test e_neg ≈ -1 / π atol = 1e-5
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "XXZ Yang-Yang — verification cards" begin
+    # Yang-Yang 1966 II: at Δ = 1/2 (γ = π/3) the energy density is the
+    # elementary closed form e0 = -3J/8.
+    verify(
+        XXZ1D(; J=1.0, Δ=0.5),
+        Energy(),
+        Infinite();
+        route=:second_closed_form,
+        independent=-3 / 8,
+        agree_within=1e-9,
+        refs=["Yang-Yang 1966 II: e0 = -3J/8 at Δ = 1/2"],
+    )
+    # FM point Δ = -1: exact saturated state e0 = -J/4.
+    verify(
+        XXZ1D(; J=1.0, Δ=-1.0),
+        Energy(),
+        Infinite();
+        route=:second_closed_form,
+        independent=-0.25,
+        agree_within=1e-12,
+        refs=["XXZ FM point Δ=-1: aligned state exact, e0 = -J/4"],
+    )
+end

--- a/test/verification/tfim_ising/test_ising_2x2_classical.jl
+++ b/test/verification/tfim_ising/test_ising_2x2_classical.jl
@@ -29,3 +29,21 @@ const J_ISING = 1.0
         end
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "Ising 2x2 classical — verification cards" begin
+    # Transfer-matrix partition function vs brute-force exact_partition
+    # (independent enumeration of all 2^N spin configs).
+    for (L, β) in ((2, 0.3), (2, 0.5), (3, 0.4))
+        verify(
+            IsingSquare(; Lx=L, Ly=L, J=1.0),
+            PartitionFunction(),
+            PBC(0);
+            route=:ed_finite_size,
+            fetch_kw=(; β=β, Lx=L, Ly=L, J=1.0),
+            independent=exact_partition(L, L, 1.0, β),
+            agree_within=1e-6,
+            refs=["Brute-force Σ_σ exp(-βE) over all configs vs transfer matrix"],
+        )
+    end
+end

--- a/test/verification/tfim_ising/test_ising_ad_thermodynamics.jl
+++ b/test/verification/tfim_ising/test_ising_ad_thermodynamics.jl
@@ -86,3 +86,20 @@ const J_ISING = 1.0
         end
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "Ising AD thermodynamics — verification cards" begin
+    # Partition function vs independent brute-force enumeration.
+    for (L, β) in ((2, 0.4), (3, 0.3))
+        verify(
+            IsingSquare(; Lx=L, Ly=L, J=1.0),
+            PartitionFunction(),
+            PBC(0);
+            route=:ed_finite_size,
+            fetch_kw=(; β=β, Lx=L, Ly=L, J=1.0),
+            independent=exact_partition(L, L, 1.0, β),
+            agree_within=1e-6,
+            refs=["Brute-force exact_partition cross-check of the transfer-matrix Z"],
+        )
+    end
+end

--- a/test/verification/tfim_ising/test_tfim_fdt.jl
+++ b/test/verification/tfim_ising/test_tfim_fdt.jl
@@ -125,3 +125,18 @@ using QAtlas, Test
     @test isfinite(χ_static)
     @test χ_static > 0
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TFIM FDT — verification cards" begin
+    # The fluctuation-dissipation setup uses TFIM(J=1,h=0.5), gapped with
+    # Pfeuty gap Δ = 2|h - J| = 1 (independent closed form).
+    verify(
+        TFIM(; J=1.0, h=0.5),
+        MassGap(),
+        Infinite();
+        route=:second_closed_form,
+        independent=1.0,
+        agree_within=1e-10,
+        refs=["Pfeuty 1970: Δ = 2|h - J| = 1 at (J=1, h=0.5)"],
+    )
+end

--- a/test/verification/tfim_ising/test_tfim_gap_closure.jl
+++ b/test/verification/tfim_ising/test_tfim_gap_closure.jl
@@ -112,3 +112,19 @@ end
         end
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "TFIM gap closure — verification cards" begin
+    # Pfeuty 1970: Δ = 2|h - J|, closing exactly at the critical point.
+    for (J, h) in ((1.0, 0.5), (1.0, 1.0), (1.0, 2.0))
+        verify(
+            TFIM(; J=J, h=h),
+            MassGap(),
+            Infinite();
+            route=:second_closed_form,
+            independent=2 * abs(h - J),
+            agree_within=1e-10,
+            refs=["Pfeuty 1970: Δ = 2|h - J| (= 0 at the QCP h = J)"],
+        )
+    end
+end

--- a/test/verification/universality/test_thermo_identity_quantum.jl
+++ b/test/verification/universality/test_thermo_identity_quantum.jl
@@ -62,3 +62,23 @@ end
         @test isapprox(c_direct, c_ad; atol=1e-9, rtol=1e-9)
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "thermo identity quantum — verification cards" begin
+    # Gibbs identity s = β(ε − f) cross-checks the independently
+    # implemented Energy / FreeEnergy / ThermalEntropy code paths.
+    let m = TFIM(; J=1.0, h=0.5), β = 1.3
+        ε = QAtlas.fetch(m, Energy(), Infinite(); beta=β)
+        f = QAtlas.fetch(m, FreeEnergy(), Infinite(); beta=β)
+        verify(
+            m,
+            ThermalEntropy(),
+            Infinite();
+            route=:sum_rule,
+            fetch_kw=(; beta=β),
+            independent=β * (ε - f),
+            agree_within=1e-7,
+            refs=["Gibbs identity s = β(ε − f) across three independent code paths"],
+        )
+    end
+end

--- a/test/verification/universality/test_universality_cross_check.jl
+++ b/test/verification/universality/test_universality_cross_check.jl
@@ -513,3 +513,17 @@ end
     @test isapprox(c0, corrN[end]; atol=5e-4)
     @test c1 < 0  # corrN approaches its limit from below at OBC critical TFIM
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "universality cross-check — verification cards" begin
+    # Onsager 1944 exact critical temperature of the 2D Ising model.
+    verify(
+        IsingSquare(; J=1.0),
+        CriticalTemperature(),
+        Infinite();
+        route=:second_closed_form,
+        independent=2.0 / log(1 + sqrt(2)),
+        agree_within=1e-10,
+        refs=["Onsager 1944: Tc = 2J / log(1 + √2) ≈ 2.269185"],
+    )
+end


### PR DESCRIPTION
Batch 8/8 of issue #369. 8 of 21 test/verification/ files get verify cards.

Carded: xxz_luttinger_ed (Haldane K formula), xxz_yang_yang (-3J/8, FM -J/4), tfim_gap_closure + tfim_fdt (Pfeuty 2|h-J|), ising_2x2_classical + ising_ad_thermodynamics (transfer-matrix Z vs exact_partition), thermo_identity_quantum (Gibbs sum rule), universality_cross_check (Onsager Tc).

Skipped 13: 8 tightbinding files + heisenberg_dimer/4site (TightBindingSpectrum/ExactSpectrum return vectors), disordered_heisenberg, entanglement_central_charge, universality_literature_values (2-arg CriticalExponents NamedTuple) — no scalar verify()-compatible surface. Documented, not forced.

Version bump 0.20.9 + blue-format. Refs #369
