### PR TITLE
test(verify): black-box verify() cards for KitaevHoneycomb group (#369, final batch 9)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.20.1"
+version = "0.20.10"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/test/models/quantum/KitaevHoneycomb/test_KitaevHoneycomb.jl
+++ b/test/models/quantum/KitaevHoneycomb/test_KitaevHoneycomb.jl
@@ -284,3 +284,18 @@ end
         @test E_fl ≈ E_ed rtol = 1e-10
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "KitaevHoneycomb — verification cards" begin
+    # Isotropic Kitaev honeycomb ground-state energy density: the exact
+    # Kitaev-2006 Brillouin-zone integral value (literature constant).
+    verify(
+        KitaevHoneycomb(; Kx=1.0, Ky=1.0, Kz=1.0),
+        Energy(),
+        Infinite();
+        route=:literature_value,
+        independent=-0.7872986216706852,
+        agree_within=1e-6,
+        refs=["Kitaev 2006: isotropic honeycomb e0 ≈ -0.78729862 |K|"],
+    )
+end

--- a/test/models/quantum/KitaevHoneycomb/test_KitaevHoneycomb_thermal.jl
+++ b/test/models/quantum/KitaevHoneycomb/test_KitaevHoneycomb_thermal.jl
@@ -196,3 +196,23 @@ using ForwardDiff
         end
     end
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "KitaevHoneycomb thermal — verification cards" begin
+    # Gibbs identity s = β(ε − f) cross-checks the independently
+    # implemented Energy / FreeEnergy / ThermalEntropy code paths.
+    let m = KitaevHoneycomb(; Kx=1.0, Ky=1.0, Kz=1.0), β = 1.0
+        ε = QAtlas.fetch(m, Energy(:per_site), Infinite(); beta=β)
+        f = QAtlas.fetch(m, FreeEnergy(), Infinite(); beta=β)
+        verify(
+            m,
+            ThermalEntropy(),
+            Infinite();
+            route=:sum_rule,
+            fetch_kw=(; beta=β),
+            independent=β * (ε - f),
+            agree_within=1e-6,
+            refs=["Gibbs identity s = β(ε − f) across three independent code paths"],
+        )
+    end
+end

--- a/test/models/quantum/KitaevHoneycomb/test_kitaev_heisenberg.jl
+++ b/test/models/quantum/KitaevHoneycomb/test_kitaev_heisenberg.jl
@@ -40,3 +40,20 @@ end
         KitaevHeisenberg(; K=1.0, J=0.1, Γ=0.1), MassGap(), Infinite()
     )
 end
+
+# ── Verification cards (WHY-correct plane) ─────────────────────────────────
+@testset "KitaevHeisenberg — verification cards" begin
+    # Pure Kitaev point (J=0, Γ=0): gapless Z2 spin liquid at the
+    # isotropic coupling => MassGap = 0 (Kitaev 2006).
+    for K in (0.5, 1.0, 2.0)
+        verify(
+            KitaevHeisenberg(; K=K, J=0.0, Γ=0.0),
+            MassGap(),
+            Infinite();
+            route=:second_closed_form,
+            independent=0.0,
+            agree_within=1e-10,
+            refs=["Kitaev 2006: isotropic pure-Kitaev point is gapless (Δ = 0)"],
+        )
+    end
+end


### PR DESCRIPTION
Final batch of issue #369. All 3 test/models/quantum/KitaevHoneycomb/ files get verify cards:
- kitaev_heisenberg: pure-Kitaev gapless MassGap=0 (Kitaev 2006)
- KitaevHoneycomb: isotropic e0 ≈ -0.78729862 |K| (exact BZ integral, literature)
- KitaevHoneycomb_thermal: Gibbs s=β(ε-f) sum rule

Completes the #369 migration across all 9 model groups. Version bump 0.20.10 + blue-format. Refs #369
