### PR TITLE
Cards: Hubbard1D Lieb-Wu — SpinGap + ChargeGap(U→0) (#381)

### DIFF
--- a/test/models/quantum/misc/test_hubbard1d.jl
+++ b/test/models/quantum/misc/test_hubbard1d.jl
@@ -130,3 +130,41 @@ end
         Hubbard1D(; U=-1e-13), LuttingerParameter(), Infinite()
     )
 end
+
+# ── additional verification cards (#381 batch) ─────────────────────────────
+# Scope note: GroundStateEnergyDensity at U → 0 was deliberately omitted
+# from this batch — the src `_hubbard1d_e0` returns -4t²/π (not the
+# textbook free-fermion value -4t/π) at the U → 0 half-filling limit;
+# the prefactor discrepancy is a separate src issue from corroboration.
+@testset "Hubbard1D — additional Lieb-Wu cards (#381 batch)" begin
+    # SpinGap/Infinite: rigorous Lieb-Wu (1968) — spinon sector is gapless
+    # at any U > 0 by SU(2) symmetry + Bethe ansatz. Δ_s = 0 exactly.
+    for (t, U) in ((1.0, 0.5), (1.0, 4.0), (2.0, 8.0))
+        verify(
+            Hubbard1D(; t=t, U=U, μ=U/2),
+            SpinGap(),
+            Infinite();
+            route=:second_closed_form,
+            independent=0.0,
+            agree_within=1e-14,
+            refs=["Lieb-Wu 1968 (Bethe ansatz): Δ_s = 0 for all U > 0 (gapless spinons by SU(2) symmetry)"],
+        )
+    end
+
+    # ChargeGap/Infinite, U → 0 limit: Mott gap is exponentially small,
+    # Δ_c ∝ exp(-2π t / U). At U = 0.05 t the gap is ≈ 1e-54, so the
+    # limiting Δ_c → 0 check is satisfied to absolute tolerance 1e-30.
+    for t in (0.5, 1.0, 2.0)
+        U = 5e-2 * t
+        verify(
+            Hubbard1D(; t=t, U=U, μ=U/2),
+            ChargeGap(),
+            Infinite();
+            route=:limiting_case,
+            independent=0.0,
+            agree_within=1e-30,
+            refs=["Lieb-Wu 1968: Δ_c → 0 as U → 0 with exponential form Δ_c ∝ exp(-2π t / U)"],
+        )
+    end
+end
+

--- a/test/models/quantum/misc/test_hubbard1d.jl
+++ b/test/models/quantum/misc/test_hubbard1d.jl
@@ -146,23 +146,28 @@ end
             Infinite();
             route=:second_closed_form,
             independent=0.0,
-            agree_within=1e-14,
+            agree_within=0,
             refs=["Lieb-Wu 1968 (Bethe ansatz): Δ_s = 0 for all U > 0 (gapless spinons by SU(2) symmetry)"],
         )
     end
 
-    # ChargeGap/Infinite, U → 0 limit: Mott gap is exponentially small,
-    # Δ_c ∝ exp(-2π t / U). At U = 0.05 t the gap is ≈ 1e-54, so the
-    # limiting Δ_c → 0 check is satisfied to absolute tolerance 1e-30.
+    # ChargeGap/Infinite, U → 0 limit: the Mott gap is exponentially small,
+    # Δ_c ∝ exp(-2π t / U). Using U = 0.3 t gives Δ_c ≈ exp(-2π/0.3) ≈ 5e-10,
+    # which IS representable in Float64 (the earlier U = 0.05 t put the gap
+    # at ~10⁻⁵⁵, deep under Float64 normal range — that would test
+    # underflow-to-zero, not the limiting-case physics). The
+    # route=:limiting_case marker (not :second_closed_form like the
+    # sibling cards) signals that Δ_c → 0 is an asymptotic statement,
+    # not an exact closed form at finite U.
     for t in (0.5, 1.0, 2.0)
-        U = 5e-2 * t
+        U = 3e-1 * t
         verify(
             Hubbard1D(; t=t, U=U, μ=U/2),
             ChargeGap(),
             Infinite();
             route=:limiting_case,
             independent=0.0,
-            agree_within=1e-30,
+            agree_within=1e-4,
             refs=["Lieb-Wu 1968: Δ_c → 0 as U → 0 with exponential form Δ_c ∝ exp(-2π t / U)"],
         )
     end


### PR DESCRIPTION
Adds verify() cards for two uncorroborated **Hubbard1D** half-filling hubs:

- **SpinGap / Infinite** — Δ_s = 0 exactly for all U > 0 (Lieb-Wu 1968 rigorous gapless-spinon result by SU(2) symmetry + Bethe ansatz)
- **ChargeGap / Infinite, U → 0 limit** — Δ_c ∝ exp(-2π t / U) → 0 (Lieb-Wu)

## Out-of-scope finding (separate src issue)

While preparing this batch I observed that 'fetch(Hubbard1D(t,U,μ=U/2), GroundStateEnergyDensity(), Infinite())' returns '-4 t² / π' (not the textbook free-fermion value '-4 t / π') in the U → 0 half-filling limit. Empirically:

| t | U | model returns | -4t/π | -4t²/π |
|---|---|---|---|---|
| 0.5 | 5e-4 | -0.3181 | -0.6366 | -0.3183 |
| 1.0 | 1e-3 | -1.2730 | -1.2732 | -1.2732 |
| 2.0 | 2e-3 | -5.0908 | -2.5465 | -5.0930 |

The src docstring at 'src/models/quantum/Hubbard1D/Hubbard1D.jl:167' asserts the textbook 'E₀/N → -4t/π' but the implementation '_hubbard1d_e0' returns '-4 t² ∫'  — an apparent prefactor bug (or docstring bug) that should be triaged separately. **No GSED verify card is included in this PR** to avoid blocking on a pre-existing src/doc discrepancy.

Locally: 6/6 verify @tests pass. Refs #381.
