### PR TITLE
Cards: ShastrySutherland Energy/Infinite dimer-phase (#381)

### DIFF
--- a/test/models/quantum/misc/test_shastry_sutherland.jl
+++ b/test/models/quantum/misc/test_shastry_sutherland.jl
@@ -65,7 +65,12 @@ end
     # (Koga-Kawakami 2000) the GS is the exact product of singlets on the
     # diagonal J' bonds; orthogonality cancels the J nearest-neighbour bond
     # contribution, giving e₀ = -3 J' / 8 independent of J.
-    for (J, Jp) in ((0.0, 1.0), (0.3, 1.0), (0.0, 2.0), (0.5, 2.0), (1.0, 2.0))
+    # agree_within=1e-14 is tighter than the file’s pre-existing 1e-10 floor:
+    # both card (-3*Jp/8) and hub evaluate the same single multiply+divide, so the
+    # closed-form path is bit-identical for all sweep points in IEEE 754.
+    # Sweep includes (0.674, 1.0) just below the dimer-phase boundary α_c ≈ 0.675
+    # (Koga-Kawakami 2000) as a regression guard for the phase-boundary logic.
+    for (J, Jp) in ((0.0, 1.0), (0.3, 1.0), (0.674, 1.0), (0.0, 2.0), (0.5, 2.0), (1.0, 2.0))
         verify(
             ShastrySutherland(; J=J, Jp=Jp),
             Energy(:per_site),

--- a/test/models/quantum/misc/test_shastry_sutherland.jl
+++ b/test/models/quantum/misc/test_shastry_sutherland.jl
@@ -58,3 +58,23 @@ end
         )
     end
 end
+
+# ── additional verification card (#381 batch) ─────────────────────────────
+@testset "ShastrySutherland — Energy/Infinite dimer-phase card (#381 batch)" begin
+    # Shastry-Sutherland 1981 exact dimer phase: for α = J/Jp ≤ α_c ≈ 0.675
+    # (Koga-Kawakami 2000) the GS is the exact product of singlets on the
+    # diagonal J' bonds; orthogonality cancels the J nearest-neighbour bond
+    # contribution, giving e₀ = -3 J' / 8 independent of J.
+    for (J, Jp) in ((0.0, 1.0), (0.3, 1.0), (0.0, 2.0), (0.5, 2.0), (1.0, 2.0))
+        verify(
+            ShastrySutherland(; J=J, Jp=Jp),
+            Energy(:per_site),
+            Infinite();
+            route=:second_closed_form,
+            independent=-3 * Jp / 8,
+            agree_within=1e-14,
+            refs=["Shastry-Sutherland 1981 / Koga-Kawakami 2000: exact dimer phase e₀ = -3J'/8 for α ≤ α_c ≈ 0.675"],
+        )
+    end
+end
+


### PR DESCRIPTION
Adds a verify() card for **ShastrySutherland/Energy/Infinite** in the exact dimer phase.

- Shastry-Sutherland 1981 / Koga-Kawakami 2000: for α = J/J' ≤ α_c ≈ 0.675, GS = product of singlets on diagonal J' bonds
- e₀ = -3J'/8 (J-independent — square-lattice J bonds give zero on the singlet-product state)
- Card covers (J, Jp) ∈ {(0,1), (0.3,1), (0,2), (0.5,2), (1,2)}, all within α_c

Locally: 5/5 verify @tests pass. Refs #381.
