### PR TITLE
Cards: Compass1D MassGap closed form (#381)

### DIFF
--- a/test/models/quantum/misc/test_compass1d.jl
+++ b/test/models/quantum/misc/test_compass1d.jl
@@ -51,3 +51,21 @@ end
         )
     end
 end
+
+# ── additional verification card (#381 batch) ─────────────────────────────
+@testset "Compass1D — MassGap closed form (#381 batch)" begin
+    # Brzezicki-Dziarmaga-Oles 2007: Δ = 2|J_x - J_y| (Jordan-Wigner dual of
+    # the dimerised Kitaev chain). Gap closes at J_x = J_y (first-order QPT).
+    for (Jx, Jy) in ((1.0, 0.5), (1.0, 2.0), (0.7, 0.3), (2.0, 1.0))
+        verify(
+            Compass1D(; J_x=Jx, J_y=Jy),
+            MassGap(),
+            Infinite();
+            route=:second_closed_form,
+            independent=2 * abs(Jx - Jy),
+            agree_within=1e-14,
+            refs=["Brzezicki-Dziarmaga-Oles 2007 PRB 75 134415: Δ = 2|J_x - J_y| (JW-dual dimerised Kitaev chain)"],
+        )
+    end
+end
+

--- a/test/models/quantum/misc/test_compass1d.jl
+++ b/test/models/quantum/misc/test_compass1d.jl
@@ -56,14 +56,17 @@ end
 @testset "Compass1D — MassGap closed form (#381 batch)" begin
     # Brzezicki-Dziarmaga-Oles 2007: Δ = 2|J_x - J_y| (Jordan-Wigner dual of
     # the dimerised Kitaev chain). Gap closes at J_x = J_y (first-order QPT).
-    for (Jx, Jy) in ((1.0, 0.5), (1.0, 2.0), (0.7, 0.3), (2.0, 1.0))
+    # (1.0, 1.0) is included as a degenerate-gap regression guard: with
+    # independent = 2*abs(0) = 0.0 exactly in IEEE 754, this also exercises
+    # the hub at the critical point Δ = 0.
+    for (Jx, Jy) in ((1.0, 0.5), (1.0, 1.0), (1.0, 2.0), (0.7, 0.3), (2.0, 1.0))
         verify(
             Compass1D(; J_x=Jx, J_y=Jy),
             MassGap(),
             Infinite();
             route=:second_closed_form,
             independent=2 * abs(Jx - Jy),
-            agree_within=1e-14,
+            agree_within=1e-12,
             refs=["Brzezicki-Dziarmaga-Oles 2007 PRB 75 134415: Δ = 2|J_x - J_y| (JW-dual dimerised Kitaev chain)"],
         )
     end


### PR DESCRIPTION
Adds a verify() card for **Compass1D/MassGap/Infinite**.

- Brzezicki-Dziarmaga-Oles 2007 PRB 75 134415: Δ = 2|J_x - J_y|
- Jordan-Wigner dual of the dimerised Kitaev / p-wave wire
- Gap closes at J_x = J_y (first-order QPT between X-bond- and Y-bond-dimerised ground states)
- Card sweeps (J_x, J_y) ∈ {(1,0.5), (1,2), (0.7,0.3), (2,1)}

Refs #381.
