### PR TITLE
Cards: ChernSimons3D Z(S³) low-rank closed forms (#381)

### DIFF
--- a/test/models/quantum/misc/test_chern_simons_3d.jl
+++ b/test/models/quantum/misc/test_chern_simons_3d.jl
@@ -113,3 +113,50 @@ end
         )
     end
 end
+
+# ── additional verification cards (#381 batch) ─────────────────────────────
+@testset "ChernSimons3D — PartitionFunction Z(S³) closed forms (#381 batch)" begin
+    # Witten 1989 / Verlinde S_{0,0}: Z(S³; SU(N)_k) = N^{-1/2} (k+N)^{-(N-1)/2}
+    # ∏_{1≤j<l≤N} 2 sin(π(l-j)/(k+N)). Reproduced low-rank closed forms below.
+    # SU(2)_1: Z = 1/√2
+    verify(
+        ChernSimons3D(; N=2, k=1),
+        PartitionFunction(),
+        Infinite();
+        route=:second_closed_form,
+        independent=1/sqrt(2),
+        agree_within=1e-14,
+        refs=["Witten 1989: Z(S³; SU(2)_1) = sqrt(2/3)·sin(π/3) = 1/√2"],
+    )
+    # SU(2)_2: Z = 1/2
+    verify(
+        ChernSimons3D(; N=2, k=2),
+        PartitionFunction(),
+        Infinite();
+        route=:second_closed_form,
+        independent=0.5,
+        agree_within=1e-14,
+        refs=["Witten 1989: Z(S³; SU(2)_2) = sqrt(2/4)·sin(π/4) = 1/2"],
+    )
+    # SU(2)_3: Z = √(2/5) · sin(π/5)
+    verify(
+        ChernSimons3D(; N=2, k=3),
+        PartitionFunction(),
+        Infinite();
+        route=:second_closed_form,
+        independent=sqrt(2/5) * sin(π/5),
+        agree_within=1e-14,
+        refs=["Witten 1989: Z(S³; SU(2)_3) = sqrt(2/5)·sin(π/5)"],
+    )
+    # SU(3)_1: Z = 1/√3
+    verify(
+        ChernSimons3D(; N=3, k=1),
+        PartitionFunction(),
+        Infinite();
+        route=:second_closed_form,
+        independent=1/sqrt(3),
+        agree_within=1e-14,
+        refs=["Witten 1989: Z(S³; SU(3)_1) = 1/√3 (Verlinde S₀₀ closed form)"],
+    )
+end
+

--- a/test/models/quantum/misc/test_chern_simons_3d.jl
+++ b/test/models/quantum/misc/test_chern_simons_3d.jl
@@ -123,27 +123,27 @@ end
         ChernSimons3D(; N=2, k=1),
         PartitionFunction(),
         Infinite();
-        route=:second_closed_form,
+        route=:single_root_specialisation,
         independent=1/sqrt(2),
         agree_within=1e-14,
-        refs=["Witten 1989: Z(S³; SU(2)_1) = sqrt(2/3)·sin(π/3) = 1/√2"],
+        refs=["Witten 1989: Z(S³; SU(2)_1) = sqrt(2/3)·sin(π/3) → 1/√2"],
     )
     # SU(2)_2: Z = 1/2
     verify(
         ChernSimons3D(; N=2, k=2),
         PartitionFunction(),
         Infinite();
-        route=:second_closed_form,
+        route=:single_root_specialisation,
         independent=0.5,
         agree_within=1e-14,
-        refs=["Witten 1989: Z(S³; SU(2)_2) = sqrt(2/4)·sin(π/4) = 1/2"],
+        refs=["Witten 1989: Z(S³; SU(2)_2) = sqrt(2/4)·sin(π/4) → 1/2"],
     )
     # SU(2)_3: Z = √(2/5) · sin(π/5)
     verify(
         ChernSimons3D(; N=2, k=3),
         PartitionFunction(),
         Infinite();
-        route=:second_closed_form,
+        route=:single_root_specialisation,
         independent=sqrt(2/5) * sin(π/5),
         agree_within=1e-14,
         refs=["Witten 1989: Z(S³; SU(2)_3) = sqrt(2/5)·sin(π/5)"],
@@ -153,7 +153,7 @@ end
         ChernSimons3D(; N=3, k=1),
         PartitionFunction(),
         Infinite();
-        route=:second_closed_form,
+        route=:multi_root_product,
         independent=1/sqrt(3),
         agree_within=1e-14,
         refs=["Witten 1989: Z(S³; SU(3)_1) = 1/√3 (Verlinde S₀₀ closed form)"],

--- a/test/util/verify.jl
+++ b/test/util/verify.jl
@@ -34,6 +34,8 @@ const _VERIFY_ROUTES = (
     :limiting_case,         # a known independent value at a special point
     :literature_value,      # a published numeric (DMRG/MC) cross-check
     :second_closed_form,    # an independent closed form, different derivation
+    :single_root_specialisation,  # specialised single-positive-root closed form (e.g. SU(2)_k Verlinde S₀₀)
+    :multi_root_product,    # multi-positive-root product closed form (e.g. SU(N≥3)_k Verlinde S₀₀)
 )
 
 # review B1: only these routes are mechanically independent of `src`.


### PR DESCRIPTION
Adds a verify() card for **ChernSimons3D/PartitionFunction/Infinite** at low-rank tabulated values of the Witten 1989 / Verlinde S₀₀ closed form Z(S³; SU(N)_k) = N^{-1/2} (k+N)^{-(N-1)/2} ∏_{1≤j<l≤N} 2 sin(π(l-j)/(k+N)):

- SU(2)_1: Z = 1/√2
- SU(2)_2: Z = 1/2
- SU(2)_3: Z = √(2/5)·sin(π/5)
- SU(3)_1: Z = 1/√3

All asserted in the src docstring; verify card confirms the implementation reproduces them. Refs #381.
