### PR TITLE
Cards: KitaevHoneycomb MassGap/Infinite closed form (#381)

### DIFF
--- a/test/models/quantum/KitaevHoneycomb/test_KitaevHoneycomb.jl
+++ b/test/models/quantum/KitaevHoneycomb/test_KitaevHoneycomb.jl
@@ -309,8 +309,11 @@ end
     for (Kx, Ky, Kz, Δ_expected) in (
         # Gapless isotropic / B-phase points: Δ = 0
         (1.0, 1.0, 1.0, 0.0),
-        (1.0, 1.0, 1.5, 0.0),     # |Kz|=1.5 ≤ 1+1 = 2
-        (0.5, 0.5, 0.9, 0.0),     # gapless boundary inside
+        (1.0, 1.0, 1.5, 0.0),     # gapless interior: |Kz|=1.5 < 1+1 = 2
+        (0.5, 0.5, 0.9, 0.0),     # gapless interior: |Kz|=0.9 < 0.5+0.5 = 1.0
+        # True B-phase boundary: |K_max| = sum_of_others (Δ = 0 by the max(·,0) clamp).
+        (1.0, 1.0, 2.0, 0.0),     # boundary: |Kz|=2.0 = 1+1
+        (0.5, 0.5, 1.0, 0.0),     # boundary: |Kz|=1.0 = 0.5+0.5
         # Gapped A_z phase: Kz > Kx + Ky
         (1.0, 1.0, 3.0, 2 * (3.0 - 2.0)),  # = 2.0
         (0.5, 0.5, 2.0, 2 * (2.0 - 1.0)),  # = 2.0

--- a/test/models/quantum/KitaevHoneycomb/test_KitaevHoneycomb.jl
+++ b/test/models/quantum/KitaevHoneycomb/test_KitaevHoneycomb.jl
@@ -299,3 +299,35 @@ end
         refs=["Kitaev 2006: isotropic honeycomb e0 ≈ -0.78729862 |K|"],
     )
 end
+
+# ── additional verification card (#381 batch) ─────────────────────────────
+@testset "KitaevHoneycomb — MassGap/Infinite closed form (#381 batch)" begin
+    # Kitaev 2006: Δ = 2 · max(|K_max| − |K_others_sum|, 0).
+    # In gapless A/B/C phase (|K_γ| ≤ sum of others for all γ) ⇒ Δ = 0.
+    # In gapped A_γ phase (one |K_γ| exceeds the sum of the other two) the
+    # excess sets the single-Majorana gap.
+    for (Kx, Ky, Kz, Δ_expected) in (
+        # Gapless isotropic / B-phase points: Δ = 0
+        (1.0, 1.0, 1.0, 0.0),
+        (1.0, 1.0, 1.5, 0.0),     # |Kz|=1.5 ≤ 1+1 = 2
+        (0.5, 0.5, 0.9, 0.0),     # gapless boundary inside
+        # Gapped A_z phase: Kz > Kx + Ky
+        (1.0, 1.0, 3.0, 2 * (3.0 - 2.0)),  # = 2.0
+        (0.5, 0.5, 2.0, 2 * (2.0 - 1.0)),  # = 2.0
+        # Gapped A_x phase: Kx > Ky + Kz
+        (3.0, 1.0, 1.0, 2.0),
+        # Gapped A_y phase: Ky > Kx + Kz
+        (0.5, 4.0, 0.5, 2 * (4.0 - 1.0)),  # = 6.0
+    )
+        verify(
+            KitaevHoneycomb(; Kx=Kx, Ky=Ky, Kz=Kz),
+            MassGap(),
+            Infinite();
+            route=:second_closed_form,
+            independent=Δ_expected,
+            agree_within=1e-12,
+            refs=["Kitaev 2006 Annals 321: Δ = 2·max(|K_max| − |K_others_sum|, 0); gapped iff one |K_γ| > sum of others"],
+        )
+    end
+end
+


### PR DESCRIPTION
Adds a verify() card for **KitaevHoneycomb/MassGap/Infinite**.

Kitaev 2006 Annals 321: Δ = 2·max(|K_max| − |K_others_sum|, 0).
- Gapless A/B/C phase (each |K_γ| ≤ sum of other two) ⇒ Δ = 0
- Gapped A_γ phase (one |K_γ| > sum of others) ⇒ Δ = 2·(excess)

Card covers 7 parameter points: isotropic + 2 gapless boundaries + 4 gapped (one in each of A_x, A_y, A_z phases). Refs #381.
