### PR TITLE
Cards: Heisenberg1D Magnetization{X,Y,Z}/OBC SU(2) zero (#381)

### DIFF
--- a/test/models/quantum/Heisenberg/test_heisenberg1d_obc_mag_batch.jl
+++ b/test/models/quantum/Heisenberg/test_heisenberg1d_obc_mag_batch.jl
@@ -21,7 +21,7 @@ using QAtlas, Test
                         Heisenberg1D(),
                         q,
                         OBC(N);
-                        route=:second_closed_form,
+                        route=:limiting_case,
                         independent=0.0,
                         agree_within=1e-10,
                         refs=["SU(2) symmetry of the Heisenberg Hamiltonian: <S^α>_β = 0 for α ∈ {x,y,z} in the unbroken thermal ensemble, exact for any J, N, β"],

--- a/test/models/quantum/Heisenberg/test_heisenberg1d_obc_mag_batch.jl
+++ b/test/models/quantum/Heisenberg/test_heisenberg1d_obc_mag_batch.jl
@@ -1,0 +1,34 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# test/models/quantum/Heisenberg/test_heisenberg1d_obc_mag_batch.jl
+#
+# SU(2)-symmetry verification cards for the OBC Heisenberg chain: the
+# total magnetisations <S^α>/N (α ∈ {x, y, z}) are identically zero in
+# the thermal ensemble at any temperature and any J, N, because the
+# Hamiltonian commutes with each S^α_total generator, so the thermal
+# trace over the symmetric basis annihilates linear magnetisation.
+#
+# Pure verify(); branches off main. Refs #381.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Test
+
+@testset "Heisenberg1D — Magnetization{X,Y,Z}/OBC = 0 (SU(2)) (#381 batch)" begin
+    for J in (0.5, 1.0, 2.0)
+        for N in (4, 6, 8)
+            for β in (1.0, 10.0)
+                for q in (MagnetizationX(), MagnetizationY(), MagnetizationZ())
+                    verify(
+                        Heisenberg1D(),
+                        q,
+                        OBC(N);
+                        route=:second_closed_form,
+                        independent=0.0,
+                        agree_within=1e-10,
+                        refs=["SU(2) symmetry of the Heisenberg Hamiltonian: <S^α>_β = 0 for α ∈ {x,y,z} in the unbroken thermal ensemble, exact for any J, N, β"],
+                        fetch_kw=(; J=J, beta=β),
+                    )
+                end
+            end
+        end
+    end
+end


### PR DESCRIPTION
Adds verify() cards for **Heisenberg1D/Magnetization{X,Y,Z}/OBC** — 3 uncorroborated hubs covered.

SU(2) symmetry of the Heisenberg Hamiltonian forces <S^α>_β = 0 for α ∈ {x,y,z} in the unbroken thermal ensemble, exact for any J, N, β.

Card sweeps J ∈ {0.5, 1.0, 2.0}, N ∈ {4, 6, 8}, β ∈ {1.0, 10.0} across all three axes — 54 verify() calls.

Refs #381.
