### PR TITLE
Cards: S1Heisenberg1D Magnetization{X,Y,Z}/OBC SU(2) zero (#381)

### DIFF
--- a/test/models/quantum/Heisenberg/test_s1heisenberg1d_obc_mag_batch.jl
+++ b/test/models/quantum/Heisenberg/test_s1heisenberg1d_obc_mag_batch.jl
@@ -15,14 +15,14 @@ using QAtlas, Test
             for β in (1.0, 10.0)
                 for q in (MagnetizationX(), MagnetizationY(), MagnetizationZ())
                     verify(
-                        S1Heisenberg1D(),
+                        S1Heisenberg1D(; J=J),
                         q,
                         OBC(N);
-                        route=:second_closed_form,
+                        route=:limiting_case,
                         independent=0.0,
                         agree_within=1e-10,
                         refs=["SU(2) symmetry of S=1 Heisenberg: <S^α>_β = 0 for α ∈ {x,y,z} in the unbroken thermal ensemble"],
-                        fetch_kw=(; J=J, beta=β),
+                        fetch_kw=(; beta=β),
                     )
                 end
             end

--- a/test/models/quantum/Heisenberg/test_s1heisenberg1d_obc_mag_batch.jl
+++ b/test/models/quantum/Heisenberg/test_s1heisenberg1d_obc_mag_batch.jl
@@ -1,0 +1,31 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# test/models/quantum/Heisenberg/test_s1heisenberg1d_obc_mag_batch.jl
+#
+# SU(2)-symmetry verification cards for the OBC spin-1 Heisenberg chain:
+# total magnetisations <S^α>/N (α ∈ {x,y,z}) vanish in the thermal
+# ensemble at any J, N, β, by SU(2) symmetry of the Hamiltonian.
+# Pure verify(); branches off main. Refs #381.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Test
+
+@testset "S1Heisenberg1D — Magnetization{X,Y,Z}/OBC = 0 (SU(2)) (#381 batch)" begin
+    for J in (0.5, 1.0, 2.0)
+        for N in (3, 4, 5, 6)
+            for β in (1.0, 10.0)
+                for q in (MagnetizationX(), MagnetizationY(), MagnetizationZ())
+                    verify(
+                        S1Heisenberg1D(),
+                        q,
+                        OBC(N);
+                        route=:second_closed_form,
+                        independent=0.0,
+                        agree_within=1e-10,
+                        refs=["SU(2) symmetry of S=1 Heisenberg: <S^α>_β = 0 for α ∈ {x,y,z} in the unbroken thermal ensemble"],
+                        fetch_kw=(; J=J, beta=β),
+                    )
+                end
+            end
+        end
+    end
+end


### PR DESCRIPTION
Adds verify() cards for **S1Heisenberg1D/Magnetization{X,Y,Z}/OBC** — 3 uncorroborated hubs.

SU(2) symmetry of the S=1 Heisenberg Hamiltonian forces <S^α>_β = 0 for α ∈ {x,y,z} in the unbroken thermal ensemble, exact for any J, N, β.

Card sweeps J ∈ {0.5, 1.0, 2.0}, N ∈ {3, 4, 5, 6}, β ∈ {1.0, 10.0} across all three axes. Refs #381.
