### PR TITLE
Cards: XXZ1D MassGap/OBC at odd N (doublet GS) (#381)

### DIFF
--- a/test/models/quantum/XXZ/test_xxz1d_obc_massgap_batch.jl
+++ b/test/models/quantum/XXZ/test_xxz1d_obc_massgap_batch.jl
@@ -1,0 +1,28 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# test/models/quantum/XXZ/test_xxz1d_obc_massgap_batch.jl
+#
+# At odd N the spin-1/2 OBC XXZ chain has a doublet ground state in
+# the m_z = ±1/2 sectors (by total-S^z parity + Z2 inversion of the xy
+# plane), so the spectral gap above the GS sector vanishes: Δ = 0.
+# Holds for all Δ at odd N.
+# Pure verify(); branches off main. Refs #381.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Test
+
+@testset "XXZ1D — MassGap/OBC at odd N = 0 (doublet GS) (#381 batch)" begin
+    for (J, Δ) in ((1.0, 0.5), (1.0, 1.0), (1.0, 2.0), (2.0, -0.5))
+        for N in (3, 5, 7)
+            verify(
+                XXZ1D(),
+                MassGap(),
+                OBC(N);
+                route=:second_closed_form,
+                independent=0.0,
+                agree_within=1e-10,
+                refs=["XXZ1D OBC odd N: m_z = ±1/2 doublet GS by U(1) S^z conservation + xy-Z2 symmetry ⇒ Δ = 0"],
+                fetch_kw=(; J=J, Δ=Δ),
+            )
+        end
+    end
+end

--- a/test/models/quantum/XXZ/test_xxz1d_obc_massgap_batch.jl
+++ b/test/models/quantum/XXZ/test_xxz1d_obc_massgap_batch.jl
@@ -11,7 +11,7 @@
 using QAtlas, Test
 
 @testset "XXZ1D — MassGap/OBC at odd N = 0 (doublet GS) (#381 batch)" begin
-    for (J, Δ) in ((1.0, 0.5), (1.0, 1.0), (1.0, 2.0), (2.0, -0.5))
+    for (J, Δ) in ((1.0, 0.5), (1.0, 1.0), (1.0, 2.0), (2.0, -0.5), (1.0, -2.0))
         for N in (3, 5, 7)
             verify(
                 XXZ1D(),


### PR DESCRIPTION
Adds verify() card for **XXZ1D/MassGap/OBC** at odd N.

The XXZ chain at odd N has a degenerate m_z = ±1/2 doublet GS by U(1) S^z conservation + xy-plane Z2 symmetry, so the spectral gap within the GS sector vanishes identically (Δ = 0). Holds for all Δ.

Card sweeps (J, Δ) and N ∈ {3, 5, 7}. Even-N gap is deferred. Refs #381.
