### PR TITLE
Cards: TFIM FidelitySusceptibility/OBC at J=0 = 0 (#381)

### DIFF
--- a/test/models/quantum/TFIM/test_TFIM_fidelity_susc_J0_batch.jl
+++ b/test/models/quantum/TFIM/test_TFIM_fidelity_susc_J0_batch.jl
@@ -1,10 +1,12 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # test/models/quantum/TFIM/test_TFIM_fidelity_susc_J0_batch.jl
 #
-# At J = 0 the TFIM Hamiltonian H = -h Σ σ_x has GS = |+⟩^N independent of h
-# (only the energy depends on h, not the eigenstate).  Changing h is a pure
-# rescaling that does not rotate the GS, so the fidelity susceptibility
-# χ_F = |⟨∂_h ψ_0|∂_h ψ_0⟩_⊥|² vanishes identically.
+# At J = 0 the TFIM Hamiltonian H = -h Σ σ_x has GS = |+⟩^N (trivial
+# paramagnet) independent of h — only the energy depends on h, not the
+# eigenstate.  The fidelity susceptibility χ_F here is computed with
+# respect to the transverse field h (∂_h-derivative); since ⟨ψ(h)|ψ(h+dh)⟩ = 1
+# identically, χ_F(∂_h) = 0 exactly.  Note: this is NOT the same as ∂_J χ_F,
+# which is non-zero at J = 0.
 # Pure verify(); branches off main. Refs #381.
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -20,7 +22,7 @@ using QAtlas, Test
                 route=:second_closed_form,
                 independent=0.0,
                 agree_within=1e-12,
-                refs=["TFIM J=0: GS = |+⟩^N is h-independent ⇒ fidelity susceptibility χ_F = 0 exactly"],
+                refs=["χ_F via ∂_h (transverse field derivative): at J=0 the GS is the trivial paramagnet |+⟩^N independent of h, so ⟨ψ(h)|ψ(h+dh)⟩ = 1 ⇒ χ_F(∂_h) = 0 exactly. (∂_J derivative would be non-zero — convention here is ∂_h.)"],
             )
         end
     end

--- a/test/models/quantum/TFIM/test_TFIM_fidelity_susc_J0_batch.jl
+++ b/test/models/quantum/TFIM/test_TFIM_fidelity_susc_J0_batch.jl
@@ -1,0 +1,27 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# test/models/quantum/TFIM/test_TFIM_fidelity_susc_J0_batch.jl
+#
+# At J = 0 the TFIM Hamiltonian H = -h Σ σ_x has GS = |+⟩^N independent of h
+# (only the energy depends on h, not the eigenstate).  Changing h is a pure
+# rescaling that does not rotate the GS, so the fidelity susceptibility
+# χ_F = |⟨∂_h ψ_0|∂_h ψ_0⟩_⊥|² vanishes identically.
+# Pure verify(); branches off main. Refs #381.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Test
+
+@testset "TFIM — FidelitySusceptibility/OBC at J=0 = 0 (#381 batch)" begin
+    for h in (0.5, 1.0, 2.0)
+        for N in (4, 8, 12)
+            verify(
+                TFIM(; J=0.0, h=h),
+                FidelitySusceptibility(),
+                OBC(N);
+                route=:second_closed_form,
+                independent=0.0,
+                agree_within=1e-12,
+                refs=["TFIM J=0: GS = |+⟩^N is h-independent ⇒ fidelity susceptibility χ_F = 0 exactly"],
+            )
+        end
+    end
+end


### PR DESCRIPTION
Adds verify() card for **TFIM/FidelitySusceptibility/OBC** at J=0.

At J=0 the TFIM Hamiltonian H = -h Σ σ_x has GS = |+⟩^N independent of h (only the energy rescales with h, the GS direction is fixed) ⇒ χ_F = 0 exactly. Refs #381.
