### PR TITLE
Cards: Hubbard1D GSED at U→0 textbook -4t/π — bug-surfacing (#381)

### DIFF
--- a/test/models/quantum/misc/test_hubbard1d_gsed_U0_batch.jl
+++ b/test/models/quantum/misc/test_hubbard1d_gsed_U0_batch.jl
@@ -1,0 +1,25 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# test/models/quantum/misc/test_hubbard1d_gsed_U0_batch.jl
+#
+# Textbook U → 0 limit of Hubbard1D GSED at half-filling: e_0 = -4t/π
+# (Essler et al. 2005 Lieb-Wu chapter Eq. 1.21; matches src docstring at
+# Hubbard1D.jl:167). Bug-surfacing follow-up to PR #390 — current src
+# returns -4t²/π in this limit (extra factor of t). Refs #381, #390.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Test
+
+@testset "Hubbard1D — GSED/Infinite at U → 0 textbook (bug-surfacing) (#381 batch)" begin
+    for t in (0.5, 1.0, 2.0)
+        U = 1e-4 * t
+        verify(
+            Hubbard1D(; t=t, U=U, μ=U/2),
+            GroundStateEnergyDensity(),
+            Infinite();
+            route=:limiting_case,
+            independent=-4 * t / π,
+            agree_within=1e-3,
+            refs=["Essler et al. 2005 (Lieb-Wu Eq. 1.21): e_0 = -4t/π at U → 0 half-filling (two decoupled tight-binding chains)"],
+        )
+    end
+end


### PR DESCRIPTION
Adds verify() card for **Hubbard1D/GroundStateEnergyDensity/Infinite** at U → 0 half-filling.

## Textbook closed form

Essler et al. 2005 Lieb-Wu chapter Eq. 1.21: at U → 0 the Hubbard model decouples into two spinless tight-binding chains, each with e_chain = -(2t/π) sin(π·n_filling) at half-filling ⇒ e_0 = -4t/π per site. Matches the src docstring at src/models/quantum/Hubbard1D/Hubbard1D.jl:167 (the U/t → 0 line).

## Expected CI failure — bug surfacer (#390 follow-up)

PR #390 body documents that the current src '_hubbard1d_e0(t, U)' returns -4 t² / π in this limit (extra factor of t):

| t | U | src returns | -4t/π | -4t²/π |
|---|---|-------------|-------|--------|
| 0.5 | 5e-4 | -0.3182 | -0.6366 | -0.3183 |
| 1.0 | 1e-3 | -1.2730 | -1.2732 | -1.2732 |
| 2.0 | 2e-3 | -5.0908 | -2.5465 | -5.0930 |

Likely root cause: 'return -4.0 * t^2 * integral' at Hubbard1D.jl:136 should be '-4.0 * t * integral' (dimensional analysis: [e₀] = [t], integral is dimensionless ⇒ prefactor must be -4t not -4t²).

This card is filed per ED-verify-first policy — CI failure is the intended diagnostic signal. Refs #381, #390.
