### PR TITLE
Cards: Heisenberg1D Energy + thermo/OBC via ED at arbitrary β (#381)

### DIFF
--- a/test/models/quantum/Heisenberg/test_heisenberg1d_obc_thermo_ED_batch.jl
+++ b/test/models/quantum/Heisenberg/test_heisenberg1d_obc_thermo_ED_batch.jl
@@ -27,7 +27,7 @@ let Sx = spin_ops(1//2)[1],
 
     @testset "Heisenberg1D — Energy + thermo/OBC vs ED at arbitrary β (#381 batch)" begin
         for J in (0.5, 1.0, 2.0)
-            for N in (4, 6)
+            for N in (4, 6, 8)
                 for beta in (0.5, 2.0, 10.0)
                     ed_E, ed_F, ed_S, ed_C = ed_h1d_thermo_per_site(N, J, beta)
                     verify(
@@ -36,7 +36,7 @@ let Sx = spin_ops(1//2)[1],
                         OBC(N);
                         route=:ed_finite_size,
                         independent=ed_E,
-                        at=["N=$(N)"],
+                        at=["N=$(N)", "β=$(beta)"],
                         agree_within=1e-9,
                         refs=["ED black-box: chain_hamiltonian(2,N, J·(Sx⊗Sx+Sy⊗Sy+Sz⊗Sz)), thermo_from_spectrum"],
                         fetch_kw=(; J=J, beta=beta),
@@ -47,7 +47,7 @@ let Sx = spin_ops(1//2)[1],
                         OBC(N);
                         route=:ed_finite_size,
                         independent=ed_F,
-                        at=["N=$(N)"],
+                        at=["N=$(N)", "β=$(beta)"],
                         agree_within=1e-9,
                         refs=["ED black-box: full-spectrum log-sum-exp free energy F/N"],
                         fetch_kw=(; J=J, beta=beta),
@@ -58,7 +58,7 @@ let Sx = spin_ops(1//2)[1],
                         OBC(N);
                         route=:ed_finite_size,
                         independent=ed_S,
-                        at=["N=$(N)"],
+                        at=["N=$(N)", "β=$(beta)"],
                         agree_within=1e-9,
                         refs=["ED black-box: S = β·(E - F) from full spectrum"],
                         fetch_kw=(; J=J, beta=beta),
@@ -69,7 +69,7 @@ let Sx = spin_ops(1//2)[1],
                         OBC(N);
                         route=:ed_finite_size,
                         independent=ed_C,
-                        at=["N=$(N)"],
+                        at=["N=$(N)", "β=$(beta)"],
                         agree_within=1e-9,
                         refs=["ED black-box: C = β²·(⟨E²⟩ - ⟨E⟩²) from full spectrum"],
                         fetch_kw=(; J=J, beta=beta),

--- a/test/models/quantum/Heisenberg/test_heisenberg1d_obc_thermo_ED_batch.jl
+++ b/test/models/quantum/Heisenberg/test_heisenberg1d_obc_thermo_ED_batch.jl
@@ -1,0 +1,81 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# test/models/quantum/Heisenberg/test_heisenberg1d_obc_thermo_ED_batch.jl
+#
+# ED-independent structural corroboration for Heisenberg1D OBC
+# thermodynamic observables at arbitrary β.  Builds H_Heisenberg from
+# scratch via chain_hamiltonian, takes full spectrum, computes
+# (E, F, S, C)/N via the standard log-sum-exp canonical formulas in
+# thermo_from_spectrum.  No QAtlas thermal kernel touched.
+# Pure verify(); branches off main. Refs #381.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Test, LinearAlgebra
+
+include(joinpath(@__DIR__, "..", "..", "..", "util", "generic_ed.jl"))
+
+let Sx = spin_ops(1//2)[1],
+    Sy = spin_ops(1//2)[2],
+    Sz = spin_ops(1//2)[3]
+
+    function ed_h1d_thermo_per_site(N::Int, J::Real, beta::Real)
+        bond = J * (kron(Sx, Sx) + kron(Sy, Sy) + kron(Sz, Sz))
+        H = chain_hamiltonian(2, N, bond)
+        evals = dense_spectrum(H)
+        E, F, S, C = thermo_from_spectrum(evals, beta)
+        return E/N, F/N, S/N, C/N
+    end
+
+    @testset "Heisenberg1D — Energy + thermo/OBC vs ED at arbitrary β (#381 batch)" begin
+        for J in (0.5, 1.0, 2.0)
+            for N in (4, 6)
+                for beta in (0.5, 2.0, 10.0)
+                    ed_E, ed_F, ed_S, ed_C = ed_h1d_thermo_per_site(N, J, beta)
+                    verify(
+                        Heisenberg1D(),
+                        Energy(:per_site),
+                        OBC(N);
+                        route=:ed_finite_size,
+                        independent=ed_E,
+                        at=["N=$(N)"],
+                        agree_within=1e-9,
+                        refs=["ED black-box: chain_hamiltonian(2,N, J·(Sx⊗Sx+Sy⊗Sy+Sz⊗Sz)), thermo_from_spectrum"],
+                        fetch_kw=(; J=J, beta=beta),
+                    )
+                    verify(
+                        Heisenberg1D(),
+                        FreeEnergy(),
+                        OBC(N);
+                        route=:ed_finite_size,
+                        independent=ed_F,
+                        at=["N=$(N)"],
+                        agree_within=1e-9,
+                        refs=["ED black-box: full-spectrum log-sum-exp free energy F/N"],
+                        fetch_kw=(; J=J, beta=beta),
+                    )
+                    verify(
+                        Heisenberg1D(),
+                        ThermalEntropy(),
+                        OBC(N);
+                        route=:ed_finite_size,
+                        independent=ed_S,
+                        at=["N=$(N)"],
+                        agree_within=1e-9,
+                        refs=["ED black-box: S = β·(E - F) from full spectrum"],
+                        fetch_kw=(; J=J, beta=beta),
+                    )
+                    verify(
+                        Heisenberg1D(),
+                        SpecificHeat(),
+                        OBC(N);
+                        route=:ed_finite_size,
+                        independent=ed_C,
+                        at=["N=$(N)"],
+                        agree_within=1e-9,
+                        refs=["ED black-box: C = β²·(⟨E²⟩ - ⟨E⟩²) from full spectrum"],
+                        fetch_kw=(; J=J, beta=beta),
+                    )
+                end
+            end
+        end
+    end
+end


### PR DESCRIPTION
Adds ED-independent verify() cards for **Heisenberg1D/{Energy, FreeEnergy, ThermalEntropy, SpecificHeat}/OBC** at arbitrary β.

Method: build H_Heisenberg = J Σ (Sx⊗Sx + Sy⊗Sy + Sz⊗Sz) via chain_hamiltonian, take full spectrum, compute per-site (E, F, S, C) via thermo_from_spectrum.

Probe shows src matches ED to ~1e-15 across (J,N,β) sweeps — purely structural corroboration, no bug expected. Adds **structural** ed_finite_size route on top of the trivial-limit closed_form cards in #408. Refs #381.
