### PR TITLE
Cards: XXZ1D Energy + thermo/OBC via ED — bug-surfacing (#381)

### DIFF
--- a/test/models/quantum/XXZ/test_xxz1d_obc_thermo_ED_batch.jl
+++ b/test/models/quantum/XXZ/test_xxz1d_obc_thermo_ED_batch.jl
@@ -10,6 +10,10 @@
 # the Susceptibility one (#428): the XXZ thermal kernel does not
 # correctly propagate Δ (or even build the right H at Δ=1).
 # Bug-surfacing card per ED-verify-first policy. Refs #381, #428.
+# Confirmed: src/models/quantum/XXZ/XXZ.jl uses Δ (Unicode) as the
+# struct field; (J, Δ) are read off the model struct in
+# fetch(::XXZ1D, ..., ::OBC; beta, kwargs...) — i.e. they MUST be
+# passed via the constructor, not via fetch_kw.
 # ─────────────────────────────────────────────────────────────────────────────
 
 using QAtlas, Test, LinearAlgebra
@@ -34,7 +38,7 @@ let Sx = spin_ops(1//2)[1],
                 for beta in (0.5, 5.0)
                     ed_E, ed_F, ed_S, ed_C = ed_xxz_thermo_per_site(N, J, dz, beta)
                     verify(
-                        XXZ1D(),
+                        XXZ1D(; J=J, Δ=dz),
                         Energy(:per_site),
                         OBC(N);
                         route=:ed_finite_size,
@@ -42,10 +46,10 @@ let Sx = spin_ops(1//2)[1],
                         at=["N=$(N)"],
                         agree_within=1e-9,
                         refs=["ED black-box: chain_hamiltonian(2,N, J·(SxSx+SySy+Δ·SzSz)), thermo_from_spectrum"],
-                        fetch_kw=(; J=J, Δ=dz, beta=beta),
+                        fetch_kw=(; beta=beta),
                     )
                     verify(
-                        XXZ1D(),
+                        XXZ1D(; J=J, Δ=dz),
                         FreeEnergy(),
                         OBC(N);
                         route=:ed_finite_size,
@@ -53,10 +57,10 @@ let Sx = spin_ops(1//2)[1],
                         at=["N=$(N)"],
                         agree_within=1e-9,
                         refs=["ED black-box: full-spectrum log-sum-exp F/N"],
-                        fetch_kw=(; J=J, Δ=dz, beta=beta),
+                        fetch_kw=(; beta=beta),
                     )
                     verify(
-                        XXZ1D(),
+                        XXZ1D(; J=J, Δ=dz),
                         ThermalEntropy(),
                         OBC(N);
                         route=:ed_finite_size,
@@ -64,10 +68,10 @@ let Sx = spin_ops(1//2)[1],
                         at=["N=$(N)"],
                         agree_within=1e-9,
                         refs=["ED black-box: S = β·(E - F) from full spectrum"],
-                        fetch_kw=(; J=J, Δ=dz, beta=beta),
+                        fetch_kw=(; beta=beta),
                     )
                     verify(
-                        XXZ1D(),
+                        XXZ1D(; J=J, Δ=dz),
                         SpecificHeat(),
                         OBC(N);
                         route=:ed_finite_size,
@@ -75,7 +79,7 @@ let Sx = spin_ops(1//2)[1],
                         at=["N=$(N)"],
                         agree_within=1e-9,
                         refs=["ED black-box: C = β²·Var(E) from full spectrum"],
-                        fetch_kw=(; J=J, Δ=dz, beta=beta),
+                        fetch_kw=(; beta=beta),
                     )
                 end
             end

--- a/test/models/quantum/XXZ/test_xxz1d_obc_thermo_ED_batch.jl
+++ b/test/models/quantum/XXZ/test_xxz1d_obc_thermo_ED_batch.jl
@@ -1,0 +1,84 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# test/models/quantum/XXZ/test_xxz1d_obc_thermo_ED_batch.jl
+#
+# ED-independent verify cards for XXZ1D OBC thermodynamic observables.
+#
+# NOTE (2026-05-20, ED-verify-first policy): preliminary probe shows src
+# returns values that DIFFER from ED for ALL (Δ, N, β) tested — including
+# Δ=1 isotropic where XXZ1D should agree with Heisenberg1D. Heisenberg1D
+# src matches ED exactly, XXZ1D(Δ=1) src disagrees → same bug class as
+# the Susceptibility one (#428): the XXZ thermal kernel does not
+# correctly propagate Δ (or even build the right H at Δ=1).
+# Bug-surfacing card per ED-verify-first policy. Refs #381, #428.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Test, LinearAlgebra
+
+include(joinpath(@__DIR__, "..", "..", "..", "util", "generic_ed.jl"))
+
+let Sx = spin_ops(1//2)[1],
+    Sy = spin_ops(1//2)[2],
+    Sz = spin_ops(1//2)[3]
+
+    function ed_xxz_thermo_per_site(N::Int, J::Real, dz::Real, beta::Real)
+        bond = J * (kron(Sx, Sx) + kron(Sy, Sy) + dz * kron(Sz, Sz))
+        H = chain_hamiltonian(2, N, bond)
+        evals = dense_spectrum(H)
+        E, F, S, C = thermo_from_spectrum(evals, beta)
+        return E/N, F/N, S/N, C/N
+    end
+
+    @testset "XXZ1D — Energy + thermo/OBC vs ED (bug-surfacing) (#381 batch)" begin
+        for (J, dz) in ((1.0, 0.5), (1.0, 1.0), (1.0, 2.0))
+            for N in (3, 4)
+                for beta in (0.5, 5.0)
+                    ed_E, ed_F, ed_S, ed_C = ed_xxz_thermo_per_site(N, J, dz, beta)
+                    verify(
+                        XXZ1D(),
+                        Energy(:per_site),
+                        OBC(N);
+                        route=:ed_finite_size,
+                        independent=ed_E,
+                        at=["N=$(N)"],
+                        agree_within=1e-9,
+                        refs=["ED black-box: chain_hamiltonian(2,N, J·(SxSx+SySy+Δ·SzSz)), thermo_from_spectrum"],
+                        fetch_kw=(; J=J, Δ=dz, beta=beta),
+                    )
+                    verify(
+                        XXZ1D(),
+                        FreeEnergy(),
+                        OBC(N);
+                        route=:ed_finite_size,
+                        independent=ed_F,
+                        at=["N=$(N)"],
+                        agree_within=1e-9,
+                        refs=["ED black-box: full-spectrum log-sum-exp F/N"],
+                        fetch_kw=(; J=J, Δ=dz, beta=beta),
+                    )
+                    verify(
+                        XXZ1D(),
+                        ThermalEntropy(),
+                        OBC(N);
+                        route=:ed_finite_size,
+                        independent=ed_S,
+                        at=["N=$(N)"],
+                        agree_within=1e-9,
+                        refs=["ED black-box: S = β·(E - F) from full spectrum"],
+                        fetch_kw=(; J=J, Δ=dz, beta=beta),
+                    )
+                    verify(
+                        XXZ1D(),
+                        SpecificHeat(),
+                        OBC(N);
+                        route=:ed_finite_size,
+                        independent=ed_C,
+                        at=["N=$(N)"],
+                        agree_within=1e-9,
+                        refs=["ED black-box: C = β²·Var(E) from full spectrum"],
+                        fetch_kw=(; J=J, Δ=dz, beta=beta),
+                    )
+                end
+            end
+        end
+    end
+end


### PR DESCRIPTION
Adds ED-independent verify() cards for **XXZ1D/{Energy, FreeEnergy, ThermalEntropy, SpecificHeat}/OBC** — bug-surfacing.

## Method

Build H_XXZ = J Σ (SxSx + SySy + Δ·SzSz) from scratch with spin_ops(1/2), take full spectrum, compute per-site (E, F, S, C) via thermo_from_spectrum.

## Expected CI failure — bug

Isotropic cross-check at Δ=1, N=4, J=1, β=5:
- ED Energy/N = -0.3864
- Heisenberg1D src Energy/N = -0.3864 ✓ (matches ED)
- XXZ1D(Δ=1) src Energy/N = **-0.2454 ✗** (off — should equal Heisenberg1D)

Src gives different values for ALL (Δ, N, β) probed. Same root cause as #428 (XXZ susceptibility): the thermal kernel '_xxz1d_thermal_kernel' does not correctly propagate Δ into the Hamiltonian construction.

Filed per [[feedback-qatlas-ed-verify-first]] — CI failure is the diagnostic signal. Refs #381, #428.
