### PR TITLE
Cards: small-models batch 2 — IsingChain1D/IsingTriangular/TASEP/YangLee/SLEkappa (#381)

### DIFF
--- a/test/models/classical/test_ising_chain_1d.jl
+++ b/test/models/classical/test_ising_chain_1d.jl
@@ -129,3 +129,45 @@ end
         )
     end
 end
+# ── additional verification cards (#381 batch 2) ─────────────────────────
+@testset "IsingChain1D — additional closed-form cards (#381 batch 2)" begin
+    # CriticalTemperature: 1D Ising has no LRO at any T > 0 ⇒ T_c = 0 (Ising 1925).
+    for J in (0.5, 1.0, 2.0)
+        verify(
+            IsingChain1D(; J=J),
+            CriticalTemperature(),
+            Infinite();
+            route=:second_closed_form,
+            independent=0.0,
+            agree_within=0,
+            refs=["Ising 1925: 1D Ising chain has no spontaneous magnetisation at any T > 0 ⇒ T_c = 0"],
+        )
+    end
+    # FreeEnergy: f(β) = -(1/β) log(2 cosh(βJ)) (Ising 1925; standard result).
+    for (J, β) in ((1.0, 0.5), (1.0, 1.0), (1.0, 2.0), (0.5, 1.0))
+        verify(
+            IsingChain1D(; J=J),
+            FreeEnergy(),
+            Infinite();
+            route=:second_closed_form,
+            independent=-(1/β) * log(2 * cosh(β*J)),
+            agree_within=1e-12,
+            refs=["Ising 1925: f(β) = -(1/β) log(2 cosh(βJ)) per site"],
+            fetch_kw=(; beta=β),
+        )
+    end
+    # CorrelationLength: ξ(β) = -1/log(tanh(βJ)) (Ising/Kramers-Wannier closed form).
+    for (J, β) in ((1.0, 0.5), (1.0, 1.0), (1.0, 2.0))
+        verify(
+            IsingChain1D(; J=J),
+            CorrelationLength(),
+            Infinite();
+            route=:second_closed_form,
+            independent=-1/log(tanh(β*J)),
+            agree_within=1e-12,
+            refs=["Kramers-Wannier 1941: ξ(β) = -1/log(tanh(βJ)) per lattice spacing"],
+            fetch_kw=(; beta=β),
+        )
+    end
+end
+

--- a/test/models/classical/test_ising_triangular.jl
+++ b/test/models/classical/test_ising_triangular.jl
@@ -159,3 +159,31 @@ end
         )
     end
 end
+# ── additional verification cards (#381 batch 2) ─────────────────────────
+@testset "IsingTriangular — additional cards (#381 batch 2)" begin
+    # CriticalTemperature: AF triangular Ising is fully frustrated ⇒ no LRO,
+    # T_c = 0 (Wannier 1950).
+    for J in (0.5, 1.0, 2.0)
+        verify(
+            IsingTriangular(; J=J),
+            CriticalTemperature(),
+            Infinite();
+            route=:second_closed_form,
+            independent=0.0,
+            agree_within=0,
+            refs=["Wannier 1950: fully-frustrated AF triangular Ising has no LRO ⇒ T_c = 0"],
+        )
+    end
+    # ResidualEntropy at T=0 of AF triangular Ising: Wannier 1950
+    # closed form S/N = (2/π) ∫_0^(π/3) log(2 cos ω) dω ≈ 0.32306594...
+    verify(
+        IsingTriangular(; J=1.0),
+        ResidualEntropy(),
+        Infinite();
+        route=:literature_value,
+        independent=0.3230659669304534,
+        agree_within=1e-6,
+        refs=["Wannier 1950: AF triangular Ising T=0 residual entropy = 0.32306594... per spin"],
+    )
+end
+

--- a/test/models/classical/test_sle_kappa.jl
+++ b/test/models/classical/test_sle_kappa.jl
@@ -90,3 +90,27 @@ end
         )
     end
 end
+# ── additional verification cards (#381 batch 2) ─────────────────────────
+@testset "SLEkappa — additional cards (#381 batch 2)" begin
+    # Schramm-Loewner evolution SLE(κ) ↔ CFT with central charge
+    # c(κ) = (3κ-8)(6-κ)/(2κ) (Bauer-Bernard 2002 / Cardy 2003).
+    # Test classical κ values:
+    for (κ, c_expected) in (
+        (8//3, 0.0),        # SLE(8/3) ↔ c = 0 (SAW)
+        (3.0, 1//2),        # SLE(3) ↔ c = 1/2 (Ising)
+        (4.0, 1.0),         # SLE(4) ↔ c = 1 (free boson / GFF)
+        (6.0, 0.0),         # SLE(6) ↔ c = 0 (percolation)
+        (8.0, -2.0),        # SLE(8) ↔ c = -2 (UST)
+    )
+        verify(
+            SLEkappa(; κ=κ),
+            CentralCharge(),
+            Infinite();
+            route=:second_closed_form,
+            independent=Float64(c_expected),
+            agree_within=1e-12,
+            refs=["Bauer-Bernard 2002 / Cardy 2003: SLE(κ) ↔ CFT c = (3κ-8)(6-κ)/(2κ)"],
+        )
+    end
+end
+

--- a/test/models/classical/test_tasep.jl
+++ b/test/models/classical/test_tasep.jl
@@ -54,6 +54,9 @@ end
 @testset "TASEP — additional cards (#381 batch 2)" begin
     # Mean-field steady-state current of TASEP at density ρ on the
     # half-filled ring is J = ρ(1-ρ), max J = 1/4 at ρ = 1/2 (Derrida 1998).
+    # NOTE: TASEP() defaults to (p=1.0, ρ=0.5) per the struct constructor
+    # (src/models/classical/TASEP/TASEP.jl), i.e. the half-filled maximal-
+    # current point — exactly what this card is checking.
     verify(
         TASEP(),
         SteadyStateCurrent(),

--- a/test/models/classical/test_tasep.jl
+++ b/test/models/classical/test_tasep.jl
@@ -50,3 +50,18 @@ end
         refs=["Empty/full lattice carries no current: j(0)=j(1)=0"],
     )
 end
+# ── additional verification cards (#381 batch 2) ─────────────────────────
+@testset "TASEP — additional cards (#381 batch 2)" begin
+    # Mean-field steady-state current of TASEP at density ρ on the
+    # half-filled ring is J = ρ(1-ρ), max J = 1/4 at ρ = 1/2 (Derrida 1998).
+    verify(
+        TASEP(),
+        SteadyStateCurrent(),
+        Infinite();
+        route=:second_closed_form,
+        independent=0.25,
+        agree_within=1e-12,
+        refs=["Derrida 1998: TASEP steady-state J = ρ(1-ρ), max at ρ=1/2 ⇒ J = 1/4"],
+    )
+end
+

--- a/test/models/classical/test_yang_lee.jl
+++ b/test/models/classical/test_yang_lee.jl
@@ -72,3 +72,18 @@ end
         refs=["Cardy 1985: Yang-Lee edge singularity primary h_{1,2} = -1/5"],
     )
 end
+# ── additional verification cards (#381 batch 2) ─────────────────────────
+@testset "YangLee — additional cards (#381 batch 2)" begin
+    # Yang-Lee edge singularity is the M(2,5) non-unitary minimal model
+    # with central charge c = -22/5 (Cardy 1985, Yang-Lee 1952).
+    verify(
+        YangLee(),
+        CentralCharge(),
+        Infinite();
+        route=:second_closed_form,
+        independent=-22//5,
+        agree_within=0,
+        refs=["Cardy 1985: Yang-Lee edge is the M(2,5) minimal model ⇒ c = -22/5"],
+    )
+end
+


### PR DESCRIPTION
Adds closed-form verify() cards for 5 previously-untouched small models — **~12 hubs covered**:

- **IsingChain1D**: CriticalTemperature = 0 (Ising 1925; 1D no LRO), FreeEnergy = -(1/β)log(2 cosh βJ), CorrelationLength = -1/log(tanh βJ)
- **IsingTriangular**: CriticalTemperature = 0 (fully-frustrated AF), T=0 ResidualEntropy ≈ 0.3230659669 (Wannier 1950)
- **TASEP**: SteadyStateCurrent ρ(1-ρ) at ρ=1/2 = 1/4 (Derrida 1998)
- **YangLee**: CentralCharge = -22/5 (M(2,5) non-unitary minimal model; Cardy 1985)
- **SLEkappa**: c(κ) = (3κ-8)(6-κ)/(2κ) at κ ∈ {8/3 (SAW), 3 (Ising), 4 (GFF), 6 (perc), 8 (UST)} (Bauer-Bernard 2002 / Cardy 2003)

All closed-form, refs #381.
