### PR TITLE
infra: CI lint + CONVENTION headers backfill for 40 model files

### DIFF
--- a/src/models/quantum/AKLT/AKLT1D.jl
+++ b/src/models/quantum/AKLT/AKLT1D.jl
@@ -38,6 +38,10 @@
 #     Phys. Rev. B 88, 245118 (2013); arXiv:1308.3631 — DMRG gap.
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Spin S (this file)
+#   Observable:  Spin S         (QAtlas-wide spin convention; see docs/src/conventions.md)
+
 using LinearAlgebra: I, Hermitian, eigvals, kron
 
 """

--- a/src/models/quantum/AKLT2D/AKLT2D.jl
+++ b/src/models/quantum/AKLT2D/AKLT2D.jl
@@ -35,6 +35,10 @@
 #      and higher dimensions", cond-mat/0407066 (2004) — PEPS realisation.
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Spin S (this file)
+#   Observable:  Spin S         (QAtlas-wide spin convention; see docs/src/conventions.md)
+
 """
     AKLT2D(; J::Real = 1.0) <: AbstractQAtlasModel
 

--- a/src/models/quantum/ChernSimons3D/ChernSimons3D.jl
+++ b/src/models/quantum/ChernSimons3D/ChernSimons3D.jl
@@ -35,6 +35,11 @@
 #   - V. G. Knizhnik, A. B. Zamolodchikov, Nucl. Phys. B 247, 83 (1984).
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Stabilizer / operator product
+#   Observable:  Operator-product expectations (Wilson loops, GSD, TEE, S-matrix entries); convention-free
+#   Reference:   docs/src/conventions.md §Topological / operator-product
+
 """
     ChernSimons3D(; N::Integer = 2, k::Integer = 1) <: AbstractQAtlasModel
 

--- a/src/models/quantum/Cluster1D/Cluster1D.jl
+++ b/src/models/quantum/Cluster1D/Cluster1D.jl
@@ -33,6 +33,10 @@
 #     — relation to two coupled Kitaev chains.
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Pauli σ (this file)
+#   Observable:  Spin S = σ/2  (QAtlas-wide spin convention; see docs/src/conventions.md)
+
 """
     Cluster1D(; J::Real = 1.0) <: AbstractQAtlasModel
 

--- a/src/models/quantum/Compass1D/Compass1D.jl
+++ b/src/models/quantum/Compass1D/Compass1D.jl
@@ -31,6 +31,10 @@
 #     of Physics 321, 2 (2006) — JW-dual dimerised Kitaev chain.
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Pauli σ (this file)
+#   Observable:  Spin S = σ/2  (QAtlas-wide spin convention; see docs/src/conventions.md)
+
 """
     Compass1D(; J_x::Real = 1.0, J_y::Real = 1.0) <: AbstractQAtlasModel
 

--- a/src/models/quantum/DMIHeisenberg1D/DMIHeisenberg1D.jl
+++ b/src/models/quantum/DMIHeisenberg1D/DMIHeisenberg1D.jl
@@ -40,6 +40,10 @@
 #     spin-½ Heisenberg-DM chain.
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Spin S (this file)
+#   Observable:  Spin S         (QAtlas-wide spin convention; see docs/src/conventions.md)
+
 """
     DMIHeisenberg1D(; J::Real = 1.0, D::Real = 0.0) <: AbstractQAtlasModel
 

--- a/src/models/quantum/ExtendedHubbard1D/ExtendedHubbard1D.jl
+++ b/src/models/quantum/ExtendedHubbard1D/ExtendedHubbard1D.jl
@@ -25,6 +25,11 @@
 #     diagram of the U-V chain at half filling.
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Fermion bilinears c†c
+#   Observable:  Fermion (number n = c†c, bilinear ⟨c†_i c_j⟩); derived spin observables follow spin S = σ/2
+#   Reference:   docs/src/conventions.md §Fermion convention
+
 """
     ExtendedHubbard1D(; t::Real = 1.0, U::Real = 4.0, V::Real = 0.0)
         <: AbstractQAtlasModel

--- a/src/models/quantum/FibonacciAnyons/FibonacciAnyons.jl
+++ b/src/models/quantum/FibonacciAnyons/FibonacciAnyons.jl
@@ -1,3 +1,8 @@
+# CONVENTION
+#   Hamiltonian: Stabilizer / operator product
+#   Observable:  Operator-product expectations (Wilson loops, GSD, TEE, S-matrix entries); convention-free
+#   Reference:   docs/src/conventions.md §Topological / operator-product
+
 """
     FibonacciAnyons <: AbstractQAtlasModel
 

--- a/src/models/quantum/GrossNeveu/GrossNeveu.jl
+++ b/src/models/quantum/GrossNeveu/GrossNeveu.jl
@@ -30,6 +30,11 @@
 #   - N. Andrei, J. H. Lowenstein, Phys. Rev. Lett. 43, 1698 (1979).
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Fermion bilinears c†c
+#   Observable:  Fermion (number n = c†c, bilinear ⟨c†_i c_j⟩); derived spin observables follow spin S = σ/2
+#   Reference:   docs/src/conventions.md §Fermion convention
+
 """
     GrossNeveu(; N::Integer = 1, g::Real = 0.0) <: AbstractQAtlasModel
 

--- a/src/models/quantum/Heisenberg/Heisenberg.jl
+++ b/src/models/quantum/Heisenberg/Heisenberg.jl
@@ -28,6 +28,10 @@
 # Dispatch tags
 # ═══════════════════════════════════════════════════════════════════════════════
 
+# CONVENTION
+#   Hamiltonian: Spin S (this file)
+#   Observable:  Spin S         (QAtlas-wide spin convention; see docs/src/conventions.md)
+
 """
     Heisenberg1D
 

--- a/src/models/quantum/Heisenberg/HeisenbergS1.jl
+++ b/src/models/quantum/Heisenberg/HeisenbergS1.jl
@@ -22,6 +22,10 @@
 #   T. Kennedy and H. Tasaki, Phys. Rev. B 45, 304 (1992) — string order.
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Spin S (this file)
+#   Observable:  Spin S         (QAtlas-wide spin convention; see docs/src/conventions.md)
+
 using LinearAlgebra: I, Diagonal, Hermitian, eigen, eigvals, kron, tr
 
 """

--- a/src/models/quantum/HeisenbergXYZ/HeisenbergXYZ.jl
+++ b/src/models/quantum/HeisenbergXYZ/HeisenbergXYZ.jl
@@ -29,6 +29,10 @@
 #   - L. D. Faddeev, L. A. Takhtajan, J. Soviet Math. 24, 241 (1984).
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Spin S (this file)
+#   Observable:  Spin S         (QAtlas-wide spin convention; see docs/src/conventions.md)
+
 """
     HeisenbergXYZ(; Jx::Real = 1.0, Jy::Real = 1.0, Jz::Real = 1.0)
         <: AbstractQAtlasModel

--- a/src/models/quantum/Hubbard1D/Hubbard1D.jl
+++ b/src/models/quantum/Hubbard1D/Hubbard1D.jl
@@ -40,6 +40,11 @@
 #     reminiscence", Physica A 321, 1 (2003).
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Fermion bilinears c†c
+#   Observable:  Fermion (number n = c†c, bilinear ⟨c†_i c_j⟩); derived spin observables follow spin S = σ/2
+#   Reference:   docs/src/conventions.md §Fermion convention
+
 using QuadGK: quadgk
 using SpecialFunctions: besselj0, besselj1
 

--- a/src/models/quantum/J1J2Heisenberg1D/J1J2Heisenberg1D.jl
+++ b/src/models/quantum/J1J2Heisenberg1D/J1J2Heisenberg1D.jl
@@ -41,6 +41,10 @@
 #     short-range order.
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Spin S (this file)
+#   Observable:  Spin S         (QAtlas-wide spin convention; see docs/src/conventions.md)
+
 """
     J1J2Heisenberg1D(; J1::Real = 1.0, J2::Real = 0.5) <: AbstractQAtlasModel
 

--- a/src/models/quantum/KagomeHeisenbergAFM/KagomeHeisenbergAFM.jl
+++ b/src/models/quantum/KagomeHeisenbergAFM/KagomeHeisenbergAFM.jl
@@ -35,6 +35,10 @@
 #     Phys. Rev. B 87, 060405(R) (2013).
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Spin S (this file)
+#   Observable:  Spin S         (QAtlas-wide spin convention; see docs/src/conventions.md)
+
 """
     KagomeHeisenbergAFM(; J::Real = 1.0) <: AbstractQAtlasModel
 

--- a/src/models/quantum/Kitaev1D/Kitaev1D.jl
+++ b/src/models/quantum/Kitaev1D/Kitaev1D.jl
@@ -38,6 +38,10 @@
 #     Insulators", Lect. Notes Phys. 919 (2016) — Pfaffian invariant.
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Pauli σ (this file)
+#   Observable:  Spin S = σ/2  (QAtlas-wide spin convention; see docs/src/conventions.md)
+
 using LinearAlgebra: eigvals, Symmetric
 using QuadGK: quadgk
 

--- a/src/models/quantum/KitaevHeisenberg/KitaevHeisenberg.jl
+++ b/src/models/quantum/KitaevHeisenberg/KitaevHeisenberg.jl
@@ -32,6 +32,10 @@
 #     077204 (2014).
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Pauli σ (this file)
+#   Observable:  Spin S = σ/2  (QAtlas-wide spin convention; see docs/src/conventions.md)
+
 """
     KitaevHeisenberg(; K::Real = 1.0, J::Real = 0.0, Γ::Real = 0.0)
         <: AbstractQAtlasModel

--- a/src/models/quantum/KitaevHoneycomb/KitaevHoneycomb.jl
+++ b/src/models/quantum/KitaevHoneycomb/KitaevHoneycomb.jl
@@ -49,6 +49,10 @@
 #   - E. H. Lieb, PRL 73, 2158 (1994) — flux-free ground state.
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Pauli σ (this file)
+#   Observable:  Spin S = σ/2  (QAtlas-wide spin convention; see docs/src/conventions.md)
+
 using LinearAlgebra: svdvals
 using QuadGK: quadgk
 

--- a/src/models/quantum/LongRangeIsing1D/LongRangeIsing1D.jl
+++ b/src/models/quantum/LongRangeIsing1D/LongRangeIsing1D.jl
@@ -31,6 +31,10 @@
 #       *Phys. Rev. Lett.* **113**, 030601 (2014).
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Pauli σ (this file)
+#   Observable:  Spin S = σ/2  (QAtlas-wide spin convention; see docs/src/conventions.md)
+
 """
     LongRangeIsing1D(; J::Real = 1.0, h::Real = 1.0, α::Real = Inf)
         <: AbstractQAtlasModel

--- a/src/models/quantum/LongRangeXY1D/LongRangeXY1D.jl
+++ b/src/models/quantum/LongRangeXY1D/LongRangeXY1D.jl
@@ -37,6 +37,10 @@
 #     023001 (2017).
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Pauli σ (this file)
+#   Observable:  Spin S = σ/2  (QAtlas-wide spin convention; see docs/src/conventions.md)
+
 """
     LongRangeXY1D(; J::Real = 1.0, h::Real = 0.0, α::Real = Inf)
         <: AbstractQAtlasModel

--- a/src/models/quantum/MajumdarGhosh/MajumdarGhosh.jl
+++ b/src/models/quantum/MajumdarGhosh/MajumdarGhosh.jl
@@ -48,6 +48,10 @@
 #     Δ ≈ 0.234 J at the MG point.
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Spin S (this file)
+#   Observable:  Spin S         (QAtlas-wide spin convention; see docs/src/conventions.md)
+
 """
     MajumdarGhosh(; J::Real = 1.0) <: AbstractQAtlasModel
 

--- a/src/models/quantum/MixedFieldIsing1D/MixedFieldIsing1D.jl
+++ b/src/models/quantum/MixedFieldIsing1D/MixedFieldIsing1D.jl
@@ -26,6 +26,10 @@
 #   - Banuls, Cirac & Hastings, Phys. Rev. Lett. 106, 050405 (2011)
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Pauli σ (this file)
+#   Observable:  Spin S = σ/2  (QAtlas-wide spin convention; see docs/src/conventions.md)
+
 """
     MixedFieldIsing1D(; J = 1.0, h_x = 1.0, h_z = 0.0) <: AbstractQAtlasModel
 

--- a/src/models/quantum/PXP1D/PXP1D.jl
+++ b/src/models/quantum/PXP1D/PXP1D.jl
@@ -44,6 +44,11 @@
 #   - M. Serbyn, D. A. Abanin, Z. Papić, Rep. Prog. Phys. 84, 086601 (2021).
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Pauli σ with Rydberg blockade projectors P_i = (1 - σ^z_i)/2
+#   Observable:  Spin S = σ/2 for MagnetizationX/Y/Z-family; occupation n ∈ [0,1] for density-family
+#   Reference:   docs/src/conventions.md §Hard-core boson / Rydberg
+
 """
     PXP1D(; Ω::Real = 1.0) <: AbstractQAtlasModel
 

--- a/src/models/quantum/PpIp2DSC/PpIp2DSC.jl
+++ b/src/models/quantum/PpIp2DSC/PpIp2DSC.jl
@@ -36,6 +36,11 @@
 #   - A. Y. Kitaev, *Ann. Phys.* **321**, 2 (2006).
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Fermion bilinears c†c
+#   Observable:  Fermion (number n = c†c, bilinear ⟨c†_i c_j⟩); derived spin observables follow spin S = σ/2
+#   Reference:   docs/src/conventions.md §Fermion convention
+
 """
     PpIp2DSC(; Δ₀::Real = 1.0, μ::Real = 1.0) <: AbstractQAtlasModel
 

--- a/src/models/quantum/S1AnisotropicD1D/S1AnisotropicD1D.jl
+++ b/src/models/quantum/S1AnisotropicD1D/S1AnisotropicD1D.jl
@@ -36,6 +36,10 @@
 #     205104 (2017) — phase boundary refinement & string order parameter.
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Spin S (this file)
+#   Observable:  Spin S         (QAtlas-wide spin convention; see docs/src/conventions.md)
+
 """
     S1AnisotropicD1D(; J::Real = 1.0, D::Real = 0.0) <: AbstractQAtlasModel
 

--- a/src/models/quantum/S1XXZ1D/S1XXZ1D.jl
+++ b/src/models/quantum/S1XXZ1D/S1XXZ1D.jl
@@ -25,6 +25,10 @@
 #   Y.-C. Tzeng, H. Yang, M.-F. Yang, Phys. Rev. B 96, 064419 (2017).
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Spin S (this file)
+#   Observable:  Spin S         (QAtlas-wide spin convention; see docs/src/conventions.md)
+
 """
     S1XXZ1D(; J::Real = 1.0, Δ::Real = 1.0) <: AbstractQAtlasModel
 

--- a/src/models/quantum/SYK/SYK.jl
+++ b/src/models/quantum/SYK/SYK.jl
@@ -36,6 +36,11 @@
 #   - J. Maldacena, D. Stanford, Phys. Rev. D 94, 106002 (2016).
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Fermion bilinears c†c
+#   Observable:  Fermion (number n = c†c, bilinear ⟨c†_i c_j⟩); derived spin observables follow spin S = σ/2
+#   Reference:   docs/src/conventions.md §Fermion convention
+
 """
     SYK(; q::Integer = 4) <: AbstractQAtlasModel
 

--- a/src/models/quantum/SchwingerModel/SchwingerModel.jl
+++ b/src/models/quantum/SchwingerModel/SchwingerModel.jl
@@ -27,6 +27,11 @@
 #   - S. Coleman, R. Jackiw, L. Susskind, Annals Phys. 93, 267 (1975).
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Fermion bilinears c†c
+#   Observable:  Fermion (number n = c†c, bilinear ⟨c†_i c_j⟩); derived spin observables follow spin S = σ/2
+#   Reference:   docs/src/conventions.md §Fermion convention
+
 """
     SchwingerModel(; e::Real = 1.0, m::Real = 0.0) <: AbstractQAtlasModel
 

--- a/src/models/quantum/ShastrySutherland/ShastrySutherland.jl
+++ b/src/models/quantum/ShastrySutherland/ShastrySutherland.jl
@@ -40,6 +40,11 @@
 # (PRL 84, 4461, 2000); later series-expansion / iPEPS work (Corboz-Mila 2013;
 # Boos-Toldin 2019) refines this within the same band.  Revisit if a tighter
 # bound becomes the community consensus.
+
+# CONVENTION
+#   Hamiltonian: Spin S (this file)
+#   Observable:  Spin S         (QAtlas-wide spin convention; see docs/src/conventions.md)
+
 const _SS_DIMER_PHASE_ALPHA_CRIT = 0.675
 
 """

--- a/src/models/quantum/TFIM/TFIM.jl
+++ b/src/models/quantum/TFIM/TFIM.jl
@@ -15,6 +15,10 @@
 # `src/deprecate/legacy_tfim.jl`.
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Pauli σ (this file)
+#   Observable:  Spin S = σ/2  (QAtlas-wide spin convention; see docs/src/conventions.md)
+
 using LinearAlgebra: eigvals, Symmetric
 using QuadGK: quadgk
 

--- a/src/models/quantum/TightBinding1D/TightBinding1D.jl
+++ b/src/models/quantum/TightBinding1D/TightBinding1D.jl
@@ -46,6 +46,11 @@
 #     Harcourt College Publishers (1976), chapter 9.
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Fermion bilinears c†c
+#   Observable:  Fermion (number n = c†c, bilinear ⟨c†_i c_j⟩); derived spin observables follow spin S = σ/2
+#   Reference:   docs/src/conventions.md §Fermion convention
+
 """
     TightBinding1D(; t::Real = 1.0, μ::Real = 0.0) <: AbstractQAtlasModel
 

--- a/src/models/quantum/TightBindingV1D/TightBindingV1D.jl
+++ b/src/models/quantum/TightBindingV1D/TightBindingV1D.jl
@@ -38,6 +38,11 @@
 #     Chapter 9 (tight-binding bands).
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Fermion bilinears c†c
+#   Observable:  Fermion (number n = c†c, bilinear ⟨c†_i c_j⟩); derived spin observables follow spin S = σ/2
+#   Reference:   docs/src/conventions.md §Fermion convention
+
 """
     TightBindingV1D(t::Real, V::Real, μ::Real)
     TightBindingV1D(; t=1.0, V=0.0, μ=0.0)

--- a/src/models/quantum/ToricCode/ToricCode.jl
+++ b/src/models/quantum/ToricCode/ToricCode.jl
@@ -72,6 +72,11 @@
 #     Rev. Mod. Phys. 80, 1083 (2008).
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Stabilizer / operator product
+#   Observable:  Operator-product expectations (Wilson loops, GSD, TEE, S-matrix entries); convention-free
+#   Reference:   docs/src/conventions.md §Topological / operator-product
+
 """
     ToricCode(; J_e::Real = 1.0, J_m::Real = 1.0) <: AbstractQAtlasModel
 

--- a/src/models/quantum/XCube/XCube.jl
+++ b/src/models/quantum/XCube/XCube.jl
@@ -35,6 +35,11 @@
 #   - K. Slagle, Y. B. Kim, Phys. Rev. B 96, 195139 (2017).
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Stabilizer / operator product
+#   Observable:  Operator-product expectations (Wilson loops, GSD, TEE, S-matrix entries); convention-free
+#   Reference:   docs/src/conventions.md §Topological / operator-product
+
 """
     XCube() <: AbstractQAtlasModel
 

--- a/src/models/quantum/XXZ/XXZ.jl
+++ b/src/models/quantum/XXZ/XXZ.jl
@@ -57,6 +57,10 @@
 #     Oxford University Press (2004), §6 for Luttinger parameter & velocity.
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Spin S (this file)
+#   Observable:  Spin S         (QAtlas-wide spin convention; see docs/src/conventions.md)
+
 """
     XXZ1D(; J::Real = 1.0, Δ::Real = 0.0) <: AbstractQAtlasModel
 

--- a/src/models/quantum/XYh1D/XYh1D.jl
+++ b/src/models/quantum/XYh1D/XYh1D.jl
@@ -37,6 +37,10 @@
 #   - S. Sachdev, *Quantum Phase Transitions* (2nd ed., CUP 2011), §2.
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Pauli σ (this file)
+#   Observable:  Spin S = σ/2  (QAtlas-wide spin convention; see docs/src/conventions.md)
+
 """
     XYh1D(; Jx::Real = 1.0, Jy::Real = 1.0, h::Real = 0.0) <: AbstractQAtlasModel
 

--- a/src/models/quantum/tightbinding/regular/Honeycomb.jl
+++ b/src/models/quantum/tightbinding/regular/Honeycomb.jl
@@ -34,6 +34,11 @@
 # Dispatch tags
 # ═══════════════════════════════════════════════════════════════════════════════
 
+# CONVENTION
+#   Hamiltonian: Fermion bilinears c†c
+#   Observable:  Fermion (number n = c†c, bilinear ⟨c†_i c_j⟩); derived spin observables follow spin S = σ/2
+#   Reference:   docs/src/conventions.md §Fermion convention
+
 """
     Honeycomb(; t::Real = 1.0, Lx::Int = 0, Ly::Int = 0) <: AbstractQAtlasModel
 

--- a/src/models/quantum/tightbinding/regular/Kagome.jl
+++ b/src/models/quantum/tightbinding/regular/Kagome.jl
@@ -26,6 +26,11 @@
 #     topology in frustrated hopping models", Phys. Rev. B 78, 125104 (2008).
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: Fermion bilinears c†c
+#   Observable:  Fermion (number n = c†c, bilinear ⟨c†_i c_j⟩); derived spin observables follow spin S = σ/2
+#   Reference:   docs/src/conventions.md §Fermion convention
+
 using LinearAlgebra: Symmetric, eigvals
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/src/models/quantum/tightbinding/regular/Lieb.jl
+++ b/src/models/quantum/tightbinding/regular/Lieb.jl
@@ -41,6 +41,11 @@
 # Dispatch tag
 # ═══════════════════════════════════════════════════════════════════════════════
 
+# CONVENTION
+#   Hamiltonian: Fermion bilinears c†c
+#   Observable:  Fermion (number n = c†c, bilinear ⟨c†_i c_j⟩); derived spin observables follow spin S = σ/2
+#   Reference:   docs/src/conventions.md §Fermion convention
+
 """
     Lieb
 

--- a/src/models/quantum/tightbinding/regular/Triangular.jl
+++ b/src/models/quantum/tightbinding/regular/Triangular.jl
@@ -35,6 +35,11 @@
 # Dispatch tag
 # ═══════════════════════════════════════════════════════════════════════════════
 
+# CONVENTION
+#   Hamiltonian: Fermion bilinears c†c
+#   Observable:  Fermion (number n = c†c, bilinear ⟨c†_i c_j⟩); derived spin observables follow spin S = σ/2
+#   Reference:   docs/src/conventions.md §Fermion convention
+
 """
     Triangular
 

--- a/test/ci/universe.jl
+++ b/test/ci/universe.jl
@@ -17,6 +17,7 @@ const ALL_DIRS = [
     "models/quantum/KitaevHoneycomb/",
     "models/quantum/misc/",
     "identities/",
+    "lint/",
     "verification/tightbinding/",
     "verification/tfim_ising/",
     "verification/heisenberg_xxz/",

--- a/test/lint/test_convention_declarations.jl
+++ b/test/lint/test_convention_declarations.jl
@@ -1,0 +1,118 @@
+# test/lint/test_convention_declarations.jl
+#
+# Lint: every quantum-model source file declaring `struct ... <: AbstractQAtlasModel`
+# MUST carry a `# CONVENTION` header block near the top of the file, followed by
+# at least two non-empty comment lines describing Hamiltonian/Observable choices.
+#
+# Spec: docs/src/conventions.md (landed in PR #438).
+#
+# Scope: src/models/quantum/  (recursive).
+#
+# Rules enforced
+# ──────────────
+#   1. The file MUST contain a line matching `^\s*#\s*CONVENTION\s*$`.
+#   2. That CONVENTION line MUST be followed by ≥ 2 non-empty comment lines
+#      (each starting with `#`).
+#   3. The CONVENTION header MUST appear BEFORE the first `using` or
+#      `struct ... <: AbstractQAtlasModel` declaration.
+#
+# Test failures print the offending file path (relative to the package root).
+
+using Test
+
+const _STRUCT_RE   = r"struct\s+\S+\s*(\{[^}]*\})?\s*<:\s*AbstractQAtlasModel"
+const _CONV_RE     = r"^\s*#\s*CONVENTION\s*$"
+const _USING_RE    = r"^\s*using\b"
+const _COMMENT_RE  = r"^\s*#"
+const _PKG_ROOT    = normpath(joinpath(@__DIR__, "..", ".."))
+const _SCAN_ROOT   = joinpath(_PKG_ROOT, "src", "models", "quantum")
+
+"Collect every `.jl` file under `src/models/quantum/`."
+function _collect_model_files(root::AbstractString)
+    files = String[]
+    for (d, _, fs) in walkdir(root)
+        for f in fs
+            endswith(f, ".jl") && push!(files, joinpath(d, f))
+        end
+    end
+    return sort!(files)
+end
+
+"Return (declares_model, has_convention, followed_by_two_comments, before_code) for `path`."
+function _audit(path::AbstractString)
+    lines = readlines(path)
+    declares_model = any(occursin(_STRUCT_RE, ln) for ln in lines)
+
+    conv_idx = findfirst(ln -> occursin(_CONV_RE, ln), lines)
+    has_convention = conv_idx !== nothing
+
+    followed_by_two_comments = false
+    if has_convention
+        c = 0
+        for j in (conv_idx + 1):min(conv_idx + 10, length(lines))
+            ln = lines[j]
+            if occursin(_COMMENT_RE, ln) && !isempty(strip(ln)) &&
+               strip(ln) != "#"
+                c += 1
+                if c >= 2
+                    followed_by_two_comments = true
+                    break
+                end
+            elseif isempty(strip(ln))
+                continue
+            else
+                break  # non-comment, non-blank breaks the block
+            end
+        end
+    end
+
+    # Header MUST precede first `using` or model `struct` line.
+    first_code_idx = findfirst(
+        ln -> occursin(_USING_RE, ln) || occursin(_STRUCT_RE, ln),
+        lines,
+    )
+    before_code = if has_convention && first_code_idx !== nothing
+        conv_idx < first_code_idx
+    else
+        has_convention  # if no code line found, treat as OK
+    end
+
+    return (; declares_model, has_convention, followed_by_two_comments, before_code)
+end
+
+@testset "convention declarations" begin
+    @test isdir(_SCAN_ROOT)
+
+    files = _collect_model_files(_SCAN_ROOT)
+    @test !isempty(files)
+
+    missing_header   = String[]
+    short_header     = String[]
+    misplaced_header = String[]
+
+    for f in files
+        rep = _audit(f)
+        rep.declares_model || continue
+        rel = relpath(f, _PKG_ROOT)
+        if !rep.has_convention
+            push!(missing_header, rel)
+        else
+            rep.followed_by_two_comments || push!(short_header, rel)
+            rep.before_code             || push!(misplaced_header, rel)
+        end
+    end
+
+    if !isempty(missing_header)
+        @error "Files declaring AbstractQAtlasModel struct but missing `# CONVENTION` header" missing_header
+    end
+    if !isempty(short_header)
+        @error "Files with `# CONVENTION` header followed by < 2 non-empty comment lines" short_header
+    end
+    if !isempty(misplaced_header)
+        @error "Files where `# CONVENTION` header appears after first `using`/`struct` line" misplaced_header
+    end
+
+    @test isempty(missing_header)
+    @test isempty(short_header)
+    @test isempty(misplaced_header)
+end


### PR DESCRIPTION
## Summary

- Adds a test-suite lint (`test/lint/test_convention_declarations.jl`) that enforces a `# CONVENTION` header block on every quantum model source file declaring `struct ... <: AbstractQAtlasModel`.
- Backfills the header in all **40 existing files** under `src/models/quantum/` so the lint passes from this commit.
- Wires the new `test/lint/` directory into the canonical test universe by adding `"lint/"` to `ALL_DIRS` in `test/ci/universe.jl`.

The headers document the Hamiltonian and Observable conventions used by each file, anchored to the operator-conventions policy in **PR #438** (`docs/src/conventions.md`).

## Lint rules enforced

For every `.jl` file under `src/models/quantum/` (recursive) that declares a model struct:

1. A line matching `^\s*#\s*CONVENTION\s*$` MUST be present.
2. The CONVENTION line MUST be followed by **>= 2 non-empty comment lines**.
3. The header MUST appear **before** the first `using` or model `struct` line.

Failures print the offending file paths grouped by violation category (missing / short / misplaced).

## Header categories used (5 total)

| Category | Files | Hamiltonian | Observable |
|---|---|---|---|
| Pauli-sigma Hamiltonian, spin-S observable | 10 | Pauli sigma | Spin S = sigma/2 |
| Spin-S Hamiltonian, spin-S observable      | 13 | Spin S      | Spin S |
| Fermion bilinears                          | 12 | c-dagger c bilinears | number n = c-dagger c, bilinear <c-dag_i c_j> |
| Stabilizer / topological                   |  4 | Stabilizer / operator product | Operator-product expectations (convention-free) |
| Rydberg / PXP                              |  1 | Pauli sigma + blockade projectors P_i = (1 - sigma^z_i)/2 | Spin S = sigma/2 for magnetisation; n in [0,1] for density |

## What this PR does NOT change

This change is **purely additive**:
- Comment-only headers in 40 model files (no code touched).
- One new lint test file.
- One new entry in `ALL_DIRS`.

**No observable values, physics, or public APIs are modified.** The per-observable convention migrations (e.g. flipping a sign or rescaling a magnetisation value to match the spin-S convention) come as separate follow-up PRs, one per affected observable.

## Test plan

- [x] `julia --project=. -e 'using Test; include("test/lint/test_convention_declarations.jl")'` passes locally (5/5).
- [x] `test/ci/universe.jl` completeness guard passes (135 = 134 + 1 new lint file).
- [ ] CI lint shard (the new `lint/` group) runs the lint and passes.
- [ ] Full CI is unaffected by the header insertion (header lines are pure Julia comments, parsed and discarded).

Refs #438.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
