### PR TITLE
Cards: small-models batch 5 — S1XXZ1D + S1AnisotropicD1D Haldane reduction (#381)

### DIFF
--- a/test/models/quantum/Heisenberg/test_s1_anisotropic_d1d.jl
+++ b/test/models/quantum/Heisenberg/test_s1_anisotropic_d1d.jl
@@ -117,26 +117,32 @@ end
 end
 # ── additional verification cards (#381 batch 5) ─────────────────────────
 @testset "S1AnisotropicD1D — D=0 isotropic Haldane reduction (#381 batch 5)" begin
-    # At D=0 the S=1 single-ion anisotropy chain reduces to the
-    # SU(2)-symmetric S=1 Heisenberg AF, the Haldane chain.
-    # DMRG (White 1993): e₀ ≈ -1.40148, Haldane gap ≈ 0.41048 J.
-    verify(
-        S1AnisotropicD1D(; J=1.0, D=0.0),
-        Energy(:per_site),
-        Infinite();
-        route=:limiting_case,
-        independent=-1.40148403897,
-        agree_within=1e-6,
-        refs=["White 1993 PRL 69 2863: S=1 Heisenberg DMRG e₀ ≈ -1.4014840 (D=0 reduction of single-ion anisotropy chain)"],
-    )
-    verify(
-        S1AnisotropicD1D(; J=1.0, D=0.0),
-        MassGap(),
-        Infinite();
-        route=:limiting_case,
-        independent=0.41048,
-        agree_within=1e-3,
-        refs=["White 1993 / Wang-Qin-Hu 2012: S=1 Heisenberg Haldane gap ≈ 0.41048 J"],
-    )
+    # At D=0 the S=1 single-ion anisotropy chain delegates to the
+    # SU(2)-symmetric S=1 Heisenberg AF (the Haldane chain).
+    # DMRG (White 1993): e₀ ≈ -1.40148 J, Haldane gap ≈ 0.41048 J.
+    # route=:delegation_invariant captures the actual test semantics
+    # (code-path delegation at D=0) more accurately than :limiting_case.
+    # J-scan covers default J=1 and one off-default point J=2 to verify
+    # the delegation respects linear J scaling.
+    for J in (1.0, 2.0)
+        verify(
+            S1AnisotropicD1D(; J=J, D=0.0),
+            Energy(:per_site),
+            Infinite();
+            route=:delegation_invariant,
+            independent=-1.40148403897 * J,
+            agree_within=1e-6,
+            refs=["White 1993 PRL 69 2863: S=1 Heisenberg DMRG e₀ ≈ -1.4014840 · J (D=0 delegation; J-linear scaling)"],
+        )
+        verify(
+            S1AnisotropicD1D(; J=J, D=0.0),
+            MassGap(),
+            Infinite();
+            route=:delegation_invariant,
+            independent=0.41048 * J,
+            agree_within=1e-3,
+            refs=["White 1993 / Wang-Qin-Hu 2012: S=1 Heisenberg Haldane gap ≈ 0.41048 · J (D=0 delegation; J-linear scaling)"],
+        )
+    end
 end
 

--- a/test/models/quantum/Heisenberg/test_s1_anisotropic_d1d.jl
+++ b/test/models/quantum/Heisenberg/test_s1_anisotropic_d1d.jl
@@ -115,3 +115,28 @@ end
         refs=["Linear J scaling: e(2J) = 2 e(J) for spin-1 Heisenberg"],
     )
 end
+# ── additional verification cards (#381 batch 5) ─────────────────────────
+@testset "S1AnisotropicD1D — D=0 isotropic Haldane reduction (#381 batch 5)" begin
+    # At D=0 the S=1 single-ion anisotropy chain reduces to the
+    # SU(2)-symmetric S=1 Heisenberg AF, the Haldane chain.
+    # DMRG (White 1993): e₀ ≈ -1.40148, Haldane gap ≈ 0.41048 J.
+    verify(
+        S1AnisotropicD1D(; J=1.0, D=0.0),
+        Energy(:per_site),
+        Infinite();
+        route=:limiting_case,
+        independent=-1.40148403897,
+        agree_within=1e-6,
+        refs=["White 1993 PRL 69 2863: S=1 Heisenberg DMRG e₀ ≈ -1.4014840 (D=0 reduction of single-ion anisotropy chain)"],
+    )
+    verify(
+        S1AnisotropicD1D(; J=1.0, D=0.0),
+        MassGap(),
+        Infinite();
+        route=:limiting_case,
+        independent=0.41048,
+        agree_within=1e-3,
+        refs=["White 1993 / Wang-Qin-Hu 2012: S=1 Heisenberg Haldane gap ≈ 0.41048 J"],
+    )
+end
+

--- a/test/models/quantum/Heisenberg/test_s1_xxz1d.jl
+++ b/test/models/quantum/Heisenberg/test_s1_xxz1d.jl
@@ -82,3 +82,29 @@ end
         refs=["Linear J scaling: e(3J) = 3 e(J) for spin-1 Heisenberg point"],
     )
 end
+# ── additional verification cards (#381 batch 5) ─────────────────────────
+@testset "S1XXZ1D — Δ=1 isotropic Haldane reduction (#381 batch 5)" begin
+    # At Δ=1 the spin-1 XXZ chain reduces to the SU(2)-symmetric S=1
+    # Heisenberg AF, the Haldane chain. DMRG (White 1993, PRL 69 2863):
+    #   e₀ ≈ -1.401484038971   per site
+    #   Δ_Haldane ≈ 0.41048      gap (Wang-Qin-Hu 2012 refinement)
+    verify(
+        S1XXZ1D(; J=1.0, Δ=1.0),
+        Energy(:per_site),
+        Infinite();
+        route=:limiting_case,
+        independent=-1.40148403897,
+        agree_within=1e-6,
+        refs=["White 1993 PRL 69 2863: S=1 Heisenberg DMRG e₀ ≈ -1.4014840 (Δ=1 isotropic reduction of XXZ)"],
+    )
+    verify(
+        S1XXZ1D(; J=1.0, Δ=1.0),
+        MassGap(),
+        Infinite();
+        route=:limiting_case,
+        independent=0.41048,
+        agree_within=1e-3,
+        refs=["White 1993 / Wang-Qin-Hu 2012: S=1 Heisenberg Haldane gap ≈ 0.41048 J"],
+    )
+end
+

--- a/test/models/quantum/Heisenberg/test_s1_xxz1d.jl
+++ b/test/models/quantum/Heisenberg/test_s1_xxz1d.jl
@@ -84,27 +84,33 @@ end
 end
 # ── additional verification cards (#381 batch 5) ─────────────────────────
 @testset "S1XXZ1D — Δ=1 isotropic Haldane reduction (#381 batch 5)" begin
-    # At Δ=1 the spin-1 XXZ chain reduces to the SU(2)-symmetric S=1
-    # Heisenberg AF, the Haldane chain. DMRG (White 1993, PRL 69 2863):
+    # At Δ=1 the spin-1 XXZ chain delegates to the SU(2)-symmetric S=1
+    # Heisenberg AF (the Haldane chain). DMRG (White 1993, PRL 69 2863):
     #   e₀ ≈ -1.401484038971   per site
     #   Δ_Haldane ≈ 0.41048      gap (Wang-Qin-Hu 2012 refinement)
-    verify(
-        S1XXZ1D(; J=1.0, Δ=1.0),
-        Energy(:per_site),
-        Infinite();
-        route=:limiting_case,
-        independent=-1.40148403897,
-        agree_within=1e-6,
-        refs=["White 1993 PRL 69 2863: S=1 Heisenberg DMRG e₀ ≈ -1.4014840 (Δ=1 isotropic reduction of XXZ)"],
-    )
-    verify(
-        S1XXZ1D(; J=1.0, Δ=1.0),
-        MassGap(),
-        Infinite();
-        route=:limiting_case,
-        independent=0.41048,
-        agree_within=1e-3,
-        refs=["White 1993 / Wang-Qin-Hu 2012: S=1 Heisenberg Haldane gap ≈ 0.41048 J"],
-    )
+    # route=:delegation_invariant captures the actual test semantics
+    # (code-path delegation at Δ=1) more accurately than :limiting_case.
+    # J-scan covers default J=1 and one off-default point J=2 to verify
+    # the delegation respects linear J scaling.
+    for J in (1.0, 2.0)
+        verify(
+            S1XXZ1D(; J=J, Δ=1.0),
+            Energy(:per_site),
+            Infinite();
+            route=:delegation_invariant,
+            independent=-1.40148403897 * J,
+            agree_within=1e-6,
+            refs=["White 1993 PRL 69 2863: S=1 Heisenberg DMRG e₀ ≈ -1.4014840 · J (Δ=1 delegation; J-linear scaling)"],
+        )
+        verify(
+            S1XXZ1D(; J=J, Δ=1.0),
+            MassGap(),
+            Infinite();
+            route=:delegation_invariant,
+            independent=0.41048 * J,
+            agree_within=1e-3,
+            refs=["White 1993 / Wang-Qin-Hu 2012: S=1 Heisenberg Haldane gap ≈ 0.41048 · J (Δ=1 delegation; J-linear scaling)"],
+        )
+    end
 end
 


### PR DESCRIPTION
Adds verify() cards at the isotropic-point Haldane reduction for **S1XXZ1D** and **S1AnisotropicD1D** — 4 hubs.

At the special parameter values Δ=1 (S1XXZ1D) and D=0 (S1AnisotropicD1D) both models reduce to the SU(2)-symmetric S=1 Heisenberg AF = Haldane chain. DMRG (White 1993 PRL 69 2863):
- Energy/Infinite ≈ -1.40148403897 per site
- MassGap/Infinite (Haldane gap) ≈ 0.41048 J

Refs #381.
