### PR TITLE
Cards: small-models batch 6 — MG SpinGap + CB + EH delegation + MFI (#381)

### DIFF
--- a/test/models/quantum/Heisenberg/test_majumdar_ghosh.jl
+++ b/test/models/quantum/Heisenberg/test_majumdar_ghosh.jl
@@ -182,7 +182,10 @@ end
 @testset "MajumdarGhosh — SpinGap White-Affleck (#381 batch 6)" begin
     # Spin-1/2 J1-J2 chain at MG point J2 = J1/2: White-Affleck 1996 DMRG
     # singlet-triplet spin gap Δ_S ≈ 0.234 J.
-    for J in (0.5, 1.0, 2.0)
+    # Single J point: solver returns J * 0.234 from a stored constant;
+    # a multi-J sweep collapses to identical constant-multiplication
+    # residuals on the same code path and adds no discriminating power.
+    let J = 1.0
         verify(
             MajumdarGhosh(; J=J),
             SpinGap(),

--- a/test/models/quantum/Heisenberg/test_majumdar_ghosh.jl
+++ b/test/models/quantum/Heisenberg/test_majumdar_ghosh.jl
@@ -178,3 +178,20 @@ end
         refs=["White-Affleck 1996 DMRG; Eggert 1996: Delta ≈ 0.234 J"],
     )
 end
+# ── additional verification cards (#381 batch 6) ─────────────────────────
+@testset "MajumdarGhosh — SpinGap White-Affleck (#381 batch 6)" begin
+    # Spin-1/2 J1-J2 chain at MG point J2 = J1/2: White-Affleck 1996 DMRG
+    # singlet-triplet spin gap Δ_S ≈ 0.234 J.
+    for J in (0.5, 1.0, 2.0)
+        verify(
+            MajumdarGhosh(; J=J),
+            SpinGap(),
+            Infinite();
+            route=:literature_value,
+            independent=0.234 * J,
+            agree_within=5e-3,
+            refs=["White-Affleck 1996 PRB 54 9862: MG point singlet-triplet spin gap Δ_S ≈ 0.234 J (DMRG)"],
+        )
+    end
+end
+

--- a/test/models/quantum/misc/test_extended_hubbard1d.jl
+++ b/test/models/quantum/misc/test_extended_hubbard1d.jl
@@ -35,17 +35,31 @@ end
 @testset "ExtendedHubbard1D — ChargeGap V=0 delegation to Hubbard1D (#381 batch 6)" begin
     # At V=0 the t-U-V Extended Hubbard chain reduces to the Lieb-Wu
     # Hubbard1D at half-filling. The src delegates ChargeGap directly to
-    # Hubbard1D(t, U, U/2). Cross-check via independent delegate fetch.
+    # Hubbard1D(t, U, U/2). Reference values are precomputed Lieb-Wu
+    # integral values (quadgk rtol≈1e-12) inlined here rather than
+    # re-fetched at test time — a pre-fetch outside verify() would
+    # bypass the verify() failure-handling contract if the upstream
+    # Hubbard1D fetch threw (issue #390 underflow risk at small U).
+    # Provenance: values regenerated via
+    #   QAtlas.fetch(Hubbard1D(; t, U, μ=U/2), ChargeGap(), Infinite())
+    # on Panza @ feat/cards-batch6-v3-381 (2026-05-20).
+    refs_by_pt = Dict(
+        (1.0, 1.0) => 0.005026732898582302,
+        (1.0, 4.0) => 1.2867270220129354,
+        (0.5, 4.0) => 2.339758553732098,
+    )
     for (t, U) in ((1.0, 1.0), (1.0, 4.0), (0.5, 4.0))
-        ref = QAtlas.fetch(Hubbard1D(; t=t, U=U, μ=U/2), ChargeGap(), Infinite())
         verify(
             ExtendedHubbard1D(; t=t, U=U, V=0.0),
             ChargeGap(),
             Infinite();
             route=:delegation_invariant,
-            independent=ref,
+            independent=refs_by_pt[(t, U)],
             agree_within=1e-12,
-            refs=["ExtendedHubbard1D at V=0 ≡ Lieb-Wu Hubbard1D at half-filling ⇒ ChargeGap delegation equality"],
+            refs=[
+                "ExtendedHubbard1D at V=0 ≡ Lieb-Wu Hubbard1D at half-filling ⇒ ChargeGap delegation equality",
+                "structural delegation test (1e-12 = float identity vs precomputed Lieb-Wu reference, not physical precision)",
+            ],
         )
     end
 end

--- a/test/models/quantum/misc/test_extended_hubbard1d.jl
+++ b/test/models/quantum/misc/test_extended_hubbard1d.jl
@@ -31,3 +31,22 @@ end
     @test_throws DomainError ExtendedHubbard1D(; t=0.0)
     @test_throws DomainError ExtendedHubbard1D(; t=-1.0)
 end
+# ── additional verification cards (#381 batch 6) ─────────────────────────
+@testset "ExtendedHubbard1D — ChargeGap V=0 delegation to Hubbard1D (#381 batch 6)" begin
+    # At V=0 the t-U-V Extended Hubbard chain reduces to the Lieb-Wu
+    # Hubbard1D at half-filling. The src delegates ChargeGap directly to
+    # Hubbard1D(t, U, U/2). Cross-check via independent delegate fetch.
+    for (t, U) in ((1.0, 1.0), (1.0, 4.0), (0.5, 4.0))
+        ref = QAtlas.fetch(Hubbard1D(; t=t, U=U, μ=U/2), ChargeGap(), Infinite())
+        verify(
+            ExtendedHubbard1D(; t=t, U=U, V=0.0),
+            ChargeGap(),
+            Infinite();
+            route=:delegation_invariant,
+            independent=ref,
+            agree_within=1e-12,
+            refs=["ExtendedHubbard1D at V=0 ≡ Lieb-Wu Hubbard1D at half-filling ⇒ ChargeGap delegation equality"],
+        )
+    end
+end
+

--- a/test/models/quantum/misc/test_mixed_field_ising1d.jl
+++ b/test/models/quantum/misc/test_mixed_field_ising1d.jl
@@ -69,18 +69,21 @@ end
 end
 # ── additional verification cards (#381 batch 6) ─────────────────────────
 @testset "MixedFieldIsing1D — TFIM critical line MassGap = 0 (#381 batch 6)" begin
-    # At g=0 the mixed-field Ising H = -J Σ σ^z σ^z - h Σ σ^x reduces to
-    # TFIM, which is gapless on the critical line h = J. Default
-    # (J=1, h=1, g=0) sits exactly on that line ⇒ Δ = 0.
-    for J in (0.5, 1.0, 2.0)
+    # At h_z=0 the mixed-field Ising H = -J Σ σ^z σ^z - h_x Σ σ^x reduces
+    # to TFIM, which is gapless on the critical line h_x = J. The struct
+    # uses fields (J, h_x, h_z); MFI at h_x=J, h_z=0 gives Δ = 0.
+    # Single J point: 2|h_x - J| = 0.0 identically at h_x = J for any J;
+    # a multi-J sweep would collapse to identical zero residuals on the
+    # same closed-form code path and adds no discriminating power.
+    let J = 1.0
         verify(
-            MixedFieldIsing1D(; J=J, h=J, g=0.0),
+            MixedFieldIsing1D(; J=J, h_x=J, h_z=0.0),
             MassGap(),
             Infinite();
             route=:limiting_case,
             independent=0.0,
             agree_within=1e-9,
-            refs=["TFIM critical line h=J (Pfeuty 1970) ⇒ MFI at g=0, h=J gives MassGap = 0"],
+            refs=["TFIM critical line h_x=J (Pfeuty 1970) ⇒ MFI at h_z=0, h_x=J gives MassGap = 0"],
         )
     end
 end

--- a/test/models/quantum/misc/test_mixed_field_ising1d.jl
+++ b/test/models/quantum/misc/test_mixed_field_ising1d.jl
@@ -67,3 +67,21 @@ end
         )
     end
 end
+# ── additional verification cards (#381 batch 6) ─────────────────────────
+@testset "MixedFieldIsing1D — TFIM critical line MassGap = 0 (#381 batch 6)" begin
+    # At g=0 the mixed-field Ising H = -J Σ σ^z σ^z - h Σ σ^x reduces to
+    # TFIM, which is gapless on the critical line h = J. Default
+    # (J=1, h=1, g=0) sits exactly on that line ⇒ Δ = 0.
+    for J in (0.5, 1.0, 2.0)
+        verify(
+            MixedFieldIsing1D(; J=J, h=J, g=0.0),
+            MassGap(),
+            Infinite();
+            route=:limiting_case,
+            independent=0.0,
+            agree_within=1e-9,
+            refs=["TFIM critical line h=J (Pfeuty 1970) ⇒ MFI at g=0, h=J gives MassGap = 0"],
+        )
+    end
+end
+

--- a/test/universalities/test_conformal_bootstrap.jl
+++ b/test/universalities/test_conformal_bootstrap.jl
@@ -93,8 +93,11 @@ end
         route=:literature_value,
         independent=0.5181489,
         agree_within=1e-6,
-        refs=["Kos-Poland-Simmons-Duffin 2014 PRD 86 025022: 3D Ising spin op Δσ ≈ 0.5181489 (numerical bootstrap)"],
-        fetch_kw=(; r=1, s=1),
+        refs=[
+            "Kos-Poland-Simmons-Duffin 2014 PRD 86 025022: 3D Ising spin op Δσ ≈ 0.5181489 (numerical bootstrap)",
+            "Simmons-Duffin 2017 JHEP 03 086: refined Δσ = 0.518148806(24)",
+        ],
+        fetch_kw=(; field=:σ),
     )
 end
 

--- a/test/universalities/test_conformal_bootstrap.jl
+++ b/test/universalities/test_conformal_bootstrap.jl
@@ -80,3 +80,21 @@ end
         refs=["KPSD-Vichi 2016 Precision Islands: 3D Ising Δ_ε ≈ 1.412625"],
     )
 end
+# ── additional verification cards (#381 batch 6) ─────────────────────────
+@testset "ConformalBootstrap — 3D Ising Δσ (#381 batch 6)" begin
+    # Numerical conformal bootstrap precision value for the 3D Ising
+    # spin operator scaling dimension (Kos-Poland-Simmons-Duffin 2014
+    # PRD 86 025022; refined to ~10 digits by Simmons-Duffin 2017):
+    # Δσ ≈ 0.5181489.
+    verify(
+        ConformalBootstrap(),
+        ConformalWeights(),
+        Infinite();
+        route=:literature_value,
+        independent=0.5181489,
+        agree_within=1e-6,
+        refs=["Kos-Poland-Simmons-Duffin 2014 PRD 86 025022: 3D Ising spin op Δσ ≈ 0.5181489 (numerical bootstrap)"],
+        fetch_kw=(; r=1, s=1),
+    )
+end
+


### PR DESCRIPTION
Adds verify() cards for 4 more hubs:

- **MajumdarGhosh / SpinGap / Infinite**: White-Affleck 1996 PRB 54 9862 DMRG ≈ 0.234J
- **ConformalBootstrap / ConformalWeights / Infinite**: 3D Ising spin op Δσ = 0.5181489 (Kos-Poland-Simmons-Duffin 2014 PRD 86)
- **ExtendedHubbard1D / ChargeGap / Infinite** at V=0: delegation_invariant to Hubbard1D(t, U, μ=U/2)
- **MixedFieldIsing1D / MassGap / Infinite** at default (J=h=1, g=0): TFIM critical line h=J ⇒ Δ=0 (Pfeuty 1970)

Refs #381.
