### PR TITLE
docs(atlas): per-quantity enrichment + Bibliography/CalcIndex in nav

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.22.5"
+version = "0.22.6"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/docs/atlas/generate.jl
+++ b/docs/atlas/generate.jl
@@ -933,6 +933,39 @@ function render_quantity_index(quant_name::AbstractString)
     P("")
     P("- **Models with this quantity registered**: ", length(mdls))
     P("- **Total hubs (Model, BC pairs)**: ", length(hs))
+    q_methods = sort(unique(string(first(clby[h]).method) for h in hs if haskey(clby, h)))
+    P(
+        "- **Methods** (derived from `@register`): ",
+        isempty(q_methods) ? "—" : join(("`" * x * "`" for x in q_methods), ", "),
+    )
+    q_univs = sort(unique(filter(!isempty, [_universality_of(m) for m in mdls])))
+    P(
+        "- **Universality classes** (where applicable): ",
+        isempty(q_univs) ? "—" : join(("`" * u * "`" for u in q_univs), ", "),
+    )
+    q_citemap = Dict{String,Int}()
+    for h in hs
+        haskey(clby, h) || continue
+        for r in _split_refs(first(clby[h]).refs)
+            q_citemap[r] = get(q_citemap, r, 0) + 1
+        end
+    end
+    if !isempty(q_citemap)
+        top_refs = sort(collect(keys(q_citemap)); by=k -> (-q_citemap[k], k))
+        top_refs_disp = first(top_refs, min(5, length(top_refs)))
+        P("")
+        P("**Top references** (by hub count):")
+        for r in top_refs_disp
+            P(
+                "- ",
+                _md_escape_dollar(r),
+                " — ",
+                q_citemap[r],
+                " hub",
+                (q_citemap[r] == 1 ? "" : "s"),
+            )
+        end
+    end
     P("")
     P("## Model × BC matrix")
     P("")

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -84,8 +84,12 @@ makedocs(;
         ],
         "Verification" => [
             "verification/index.md",
-            "Verified Atlas" =>
-                ["atlas/index.md", "Model list" => "atlas/ModelList.md"],
+            "Verified Atlas" => [
+                "atlas/index.md",
+                "Model list" => "atlas/ModelList.md",
+                "Bibliography" => "atlas/Bibliography.md",
+                "Derivation-note index" => "atlas/CalcIndex.md",
+            ],
             "Cross-Checks" => "verification/cross-checks.md",
             "Entanglement" => "verification/entanglement.md",
             "Disordered" => "verification/disordered.md",

--- a/docs/src/atlas/quantities/AnyonStatistics.md
+++ b/docs/src/atlas/quantities/AnyonStatistics.md
@@ -9,6 +9,12 @@ All `(Model, BC)` hubs `src` claims for the **`AnyonStatistics`** observable.  E
 
 - **Models with this quantity registered**: 1
 - **Total hubs (Model, BC pairs)**: 1
+- **Methods** (derived from `@register`): `analytic`
+- **Universality classes** (where applicable): —
+
+**Top references** (by hub count):
+- Kitaev 2003 — 1 hub
+- Nayak-Simon-Stern-Freedman-Das Sarma 2008 — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/CentralCharge.md
+++ b/docs/src/atlas/quantities/CentralCharge.md
@@ -9,6 +9,15 @@ All `(Model, BC)` hubs `src` claims for the **`CentralCharge`** observable.  Emp
 
 - **Models with this quantity registered**: 15
 - **Total hubs (Model, BC pairs)**: 15
+- **Methods** (derived from `@register`): `analytic`, `analytic_uv`, `delegation`, `minimal_model_delegation`, `sugawara`
+- **Universality classes** (where applicable): `Ising`, `MinimalModel`, `WZW`
+
+**Top references** (by hub count):
+- Belavin-Polyakov-Zamolodchikov 1984 — 2 hubs
+- Andrews-Baxter-Forrester 1984 — 1 hub
+- Bauer-Bernard 2006 — 1 hub
+- Cardy 1985 — 1 hub
+- Cardy 2001 — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/ChargeGap.md
+++ b/docs/src/atlas/quantities/ChargeGap.md
@@ -9,6 +9,14 @@ All `(Model, BC)` hubs `src` claims for the **`ChargeGap`** observable.  Empty c
 
 - **Models with this quantity registered**: 2
 - **Total hubs (Model, BC pairs)**: 2
+- **Methods** (derived from `@register`): `bethe_ansatz`, `delegation`
+- **Universality classes** (where applicable): —
+
+**Top references** (by hub count):
+- Lieb-Wu PRL 20, 1445 (1968) — 2 hubs
+- Essler et al. (2005) — 1 hub
+- Nakamura PRB 61, 16377 (2000) — 1 hub
+- Voit Rep. Prog. Phys. 58, 977 (1995) — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/ChiralCondensate.md
+++ b/docs/src/atlas/quantities/ChiralCondensate.md
@@ -9,6 +9,12 @@ All `(Model, BC)` hubs `src` claims for the **`ChiralCondensate`** observable.  
 
 - **Models with this quantity registered**: 1
 - **Total hubs (Model, BC pairs)**: 1
+- **Methods** (derived from `@register`): `analytic`
+- **Universality classes** (where applicable): —
+
+**Top references** (by hub count):
+- Coleman-Jackiw-Susskind 1975 — 1 hub
+- Schwinger 1962 — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/ConformalWeights.md
+++ b/docs/src/atlas/quantities/ConformalWeights.md
@@ -9,6 +9,15 @@ All `(Model, BC)` hubs `src` claims for the **`ConformalWeights`** observable.  
 
 - **Models with this quantity registered**: 6
 - **Total hubs (Model, BC pairs)**: 6
+- **Methods** (derived from `@register`): `analytic`, `bootstrap_reference`, `minimal_model_delegation`
+- **Universality classes** (where applicable): `MinimalModel`
+
+**Top references** (by hub count):
+- Belavin-Polyakov-Zamolodchikov 1984 — 2 hubs
+- Andrews-Baxter-Forrester 1984 — 1 hub
+- Cardy 1985 — 1 hub
+- Kitaev 2015 — 1 hub
+- Kos-Poland-Simmons-Duffin 2014 — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/CorrelationLength.md
+++ b/docs/src/atlas/quantities/CorrelationLength.md
@@ -9,6 +9,13 @@ All `(Model, BC)` hubs `src` claims for the **`CorrelationLength`** observable. 
 
 - **Models with this quantity registered**: 4
 - **Total hubs (Model, BC pairs)**: 4
+- **Methods** (derived from `@register`): `analytic`
+- **Universality classes** (where applicable): `Ising`
+
+**Top references** (by hub count):
+- Affleck-Kennedy-Lieb-Tasaki 1988 — 1 hub
+- Ising 1925 — 1 hub
+- Kitaev 2001 — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/CriticalExponents.md
+++ b/docs/src/atlas/quantities/CriticalExponents.md
@@ -9,6 +9,15 @@ All `(Model, BC)` hubs `src` claims for the **`CriticalExponents`** observable. 
 
 - **Models with this quantity registered**: 4
 - **Total hubs (Model, BC pairs)**: 4
+- **Methods** (derived from `@register`): `delegation`
+- **Universality classes** (where applicable): `Ising`, `MeanField`
+
+**Top references** (by hub count):
+- Onsager 1944 — 3 hubs
+- Houtappel 1950 — 1 hub
+- Landau 1937 — 1 hub
+- Pfeuty 1970 — 1 hub
+- Stanley 1971 — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/CriticalTemperature.md
+++ b/docs/src/atlas/quantities/CriticalTemperature.md
@@ -9,6 +9,15 @@ All `(Model, BC)` hubs `src` claims for the **`CriticalTemperature`** observable
 
 - **Models with this quantity registered**: 6
 - **Total hubs (Model, BC pairs)**: 6
+- **Methods** (derived from `@register`): `analytic`, `analytic_imry_ma`
+- **Universality classes** (where applicable): `Ising`, `MeanField`
+
+**Top references** (by hub count):
+- Bricmont-Kupiainen 1987 — 1 hub
+- Houtappel 1950 — 1 hub
+- Imbrie 1985 — 1 hub
+- Imry-Ma 1975 — 1 hub
+- Ising 1925 — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/EdgeModeEnergy.md
+++ b/docs/src/atlas/quantities/EdgeModeEnergy.md
@@ -9,6 +9,12 @@ All `(Model, BC)` hubs `src` claims for the **`EdgeModeEnergy`** observable.  Em
 
 - **Models with this quantity registered**: 1
 - **Total hubs (Model, BC pairs)**: 1
+- **Methods** (derived from `@register`): `bdg`
+- **Universality classes** (where applicable): —
+
+**Top references** (by hub count):
+- Alicea 2012 — 1 hub
+- Kitaev 2001 — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/Energy.md
+++ b/docs/src/atlas/quantities/Energy.md
@@ -9,6 +9,15 @@ All `(Model, BC)` hubs `src` claims for the **`Energy`** observable.  Empty cell
 
 - **Models with this quantity registered**: 24
 - **Total hubs (Model, BC pairs)**: 31
+- **Methods** (derived from `@register`): `analytic`, `bdg`, `bethe_ansatz`, `central_diff`, `delegation`, `dense_ed`, `dmrg_reference`, `exact_dimer`, `literature_value`, `matter_free_fermion`, `s1_heisenberg_delegation`, `variational_reference`, `xxz_delegation`
+- **Universality classes** (where applicable): `Ising`, `MeanField`
+
+**Top references** (by hub count):
+- Kitaev 2006 — 3 hubs
+- Pfeuty 1970 — 3 hubs
+- White-Huse 1993 — 3 hubs
+- Affleck-Kennedy-Lieb-Tasaki 1988 — 2 hubs
+- Ashcroft-Mermin 1976 — 2 hubs
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/EnergyLocal.md
+++ b/docs/src/atlas/quantities/EnergyLocal.md
@@ -9,6 +9,8 @@ All `(Model, BC)` hubs `src` claims for the **`EnergyLocal`** observable.  Empty
 
 - **Models with this quantity registered**: 4
 - **Total hubs (Model, BC pairs)**: 4
+- **Methods** (derived from `@register`): `bdg`, `dense_ed`
+- **Universality classes** (where applicable): `Ising`
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/ExactSpectrum.md
+++ b/docs/src/atlas/quantities/ExactSpectrum.md
@@ -9,6 +9,8 @@ All `(Model, BC)` hubs `src` claims for the **`ExactSpectrum`** observable.  Emp
 
 - **Models with this quantity registered**: 1
 - **Total hubs (Model, BC pairs)**: 1
+- **Methods** (derived from `@register`): `dense_ed`
+- **Universality classes** (where applicable): —
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/FermiVelocity.md
+++ b/docs/src/atlas/quantities/FermiVelocity.md
@@ -9,6 +9,11 @@ All `(Model, BC)` hubs `src` claims for the **`FermiVelocity`** observable.  Emp
 
 - **Models with this quantity registered**: 2
 - **Total hubs (Model, BC pairs)**: 2
+- **Methods** (derived from `@register`): `analytic`
+- **Universality classes** (where applicable): —
+
+**Top references** (by hub count):
+- Ashcroft-Mermin 1976 — 2 hubs
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/FidelitySusceptibility.md
+++ b/docs/src/atlas/quantities/FidelitySusceptibility.md
@@ -9,6 +9,12 @@ All `(Model, BC)` hubs `src` claims for the **`FidelitySusceptibility`** observa
 
 - **Models with this quantity registered**: 1
 - **Total hubs (Model, BC pairs)**: 2
+- **Methods** (derived from `@register`): `analytic`, `bdg`
+- **Universality classes** (where applicable): `Ising`
+
+**Top references** (by hub count):
+- Damski PRB 87 165101 (2013) — 2 hubs
+- Gu IJMPB 24 4371 (2010) — 2 hubs
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/FractalDimension.md
+++ b/docs/src/atlas/quantities/FractalDimension.md
@@ -9,6 +9,11 @@ All `(Model, BC)` hubs `src` claims for the **`FractalDimension`** observable.  
 
 - **Models with this quantity registered**: 1
 - **Total hubs (Model, BC pairs)**: 1
+- **Methods** (derived from `@register`): `analytic`
+- **Universality classes** (where applicable): —
+
+**Top references** (by hub count):
+- Beffara 2008 — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/FreeEnergy.md
+++ b/docs/src/atlas/quantities/FreeEnergy.md
@@ -9,6 +9,15 @@ All `(Model, BC)` hubs `src` claims for the **`FreeEnergy`** observable.  Empty 
 
 - **Models with this quantity registered**: 11
 - **Total hubs (Model, BC pairs)**: 16
+- **Methods** (derived from `@register`): `analytic`, `bdg`, `dense_ed`, `free_fermion_quadgk`, `matter_free_fermion`, `onsager`, `transfer_matrix`
+- **Universality classes** (where applicable): `Ising`, `MeanField`
+
+**Top references** (by hub count):
+- Coleman 2015 — 2 hubs
+- Kitaev 2006 — 2 hubs
+- Lieb 1994 — 2 hubs
+- Mahan 2000 — 2 hubs
+- Baxter 1982 — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/GGEValue.md
+++ b/docs/src/atlas/quantities/GGEValue.md
@@ -9,6 +9,12 @@ All `(Model, BC)` hubs `src` claims for the **`GGEValue`** observable.  Empty ce
 
 - **Models with this quantity registered**: 1
 - **Total hubs (Model, BC pairs)**: 1
+- **Methods** (derived from `@register`): `analytic`
+- **Universality classes** (where applicable): `Ising`
+
+**Top references** (by hub count):
+- Calabrese-Essler-Fagotti J. Stat. Mech. (2012) — 1 hub
+- Rigol et al. PRL 98 (2007) — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/GroundStateDegeneracy.md
+++ b/docs/src/atlas/quantities/GroundStateDegeneracy.md
@@ -9,6 +9,13 @@ All `(Model, BC)` hubs `src` claims for the **`GroundStateDegeneracy`** observab
 
 - **Models with this quantity registered**: 2
 - **Total hubs (Model, BC pairs)**: 2
+- **Methods** (derived from `@register`): `analytic`
+- **Universality classes** (where applicable): —
+
+**Top references** (by hub count):
+- Kitaev 2003 — 1 hub
+- Slagle-Kim 2017 — 1 hub
+- Vijay-Haah-Fu 2016 — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/GroundStateEnergyDensity.md
+++ b/docs/src/atlas/quantities/GroundStateEnergyDensity.md
@@ -9,6 +9,15 @@ All `(Model, BC)` hubs `src` claims for the **`GroundStateEnergyDensity`** obser
 
 - **Models with this quantity registered**: 5
 - **Total hubs (Model, BC pairs)**: 6
+- **Methods** (derived from `@register`): `analytic`, `bethe_ansatz`
+- **Universality classes** (where applicable): —
+
+**Top references** (by hub count):
+- Majumdar-Ghosh 1969 — 2 hubs
+- Affleck-Kennedy-Lieb-Tasaki 1988 — 1 hub
+- Bethe 1931 — 1 hub
+- Essler et al. (2005) — 1 hub
+- Hulthén 1938 — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/LoschmidtEcho.md
+++ b/docs/src/atlas/quantities/LoschmidtEcho.md
@@ -9,6 +9,15 @@ All `(Model, BC)` hubs `src` claims for the **`LoschmidtEcho`** observable.  Emp
 
 - **Models with this quantity registered**: 2
 - **Total hubs (Model, BC pairs)**: 3
+- **Methods** (derived from `@register`): `analytic`, `bdg`, `free_fermion_analytic`
+- **Universality classes** (where applicable): `Ising`
+
+**Top references** (by hub count):
+- Heyl Rep. Prog. Phys. 81, 054001 (2018) — 2 hubs
+- Heyl-Polkovnikov-Kehrein PRL 110, 135704 (2013) — 2 hubs
+- Calabrese Essler Fagotti J. Stat. Mech. (2012) P07016 — 1 hub
+- Essler Fagotti J. Stat. Mech. (2016) 064002 — 1 hub
+- Heyl Polkovnikov Kehrein Phys. Rev. Lett. 110, 135704 (2013) — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/LuttingerParameter.md
+++ b/docs/src/atlas/quantities/LuttingerParameter.md
@@ -9,6 +9,15 @@ All `(Model, BC)` hubs `src` claims for the **`LuttingerParameter`** observable.
 
 - **Models with this quantity registered**: 4
 - **Total hubs (Model, BC pairs)**: 4
+- **Methods** (derived from `@register`): `analytic`, `delegation`
+- **Universality classes** (where applicable): —
+
+**Top references** (by hub count):
+- Luther-Peschel 1975 — 2 hubs
+- Affleck 1989 — 1 hub
+- Baxter 1972 — 1 hub
+- Giamarchi 2004 — 1 hub
+- Haldane 1980 — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/LuttingerVelocity.md
+++ b/docs/src/atlas/quantities/LuttingerVelocity.md
@@ -9,6 +9,12 @@ All `(Model, BC)` hubs `src` claims for the **`LuttingerVelocity`** observable. 
 
 - **Models with this quantity registered**: 1
 - **Total hubs (Model, BC pairs)**: 1
+- **Methods** (derived from `@register`): `analytic`
+- **Universality classes** (where applicable): —
+
+**Top references** (by hub count):
+- Giamarchi 2004 — 1 hub
+- des Cloizeaux Pearson 1962 — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/MagnetizationX.md
+++ b/docs/src/atlas/quantities/MagnetizationX.md
@@ -9,6 +9,8 @@ All `(Model, BC)` hubs `src` claims for the **`MagnetizationX`** observable.  Em
 
 - **Models with this quantity registered**: 4
 - **Total hubs (Model, BC pairs)**: 6
+- **Methods** (derived from `@register`): `bdg`, `dense_ed`
+- **Universality classes** (where applicable): `Ising`
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/MagnetizationXLocal.md
+++ b/docs/src/atlas/quantities/MagnetizationXLocal.md
@@ -9,6 +9,12 @@ All `(Model, BC)` hubs `src` claims for the **`MagnetizationXLocal`** observable
 
 - **Models with this quantity registered**: 4
 - **Total hubs (Model, BC pairs)**: 5
+- **Methods** (derived from `@register`): `analytic`, `bdg`, `dense_ed`
+- **Universality classes** (where applicable): `Ising`
+
+**Top references** (by hub count):
+- Barouch-McCoy-Dresden 1970 — 1 hub
+- Calabrese-Essler-Fagotti 2012 — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/MagnetizationY.md
+++ b/docs/src/atlas/quantities/MagnetizationY.md
@@ -9,6 +9,8 @@ All `(Model, BC)` hubs `src` claims for the **`MagnetizationY`** observable.  Em
 
 - **Models with this quantity registered**: 4
 - **Total hubs (Model, BC pairs)**: 4
+- **Methods** (derived from `@register`): `analytic`, `dense_ed`
+- **Universality classes** (where applicable): `Ising`
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/MagnetizationYLocal.md
+++ b/docs/src/atlas/quantities/MagnetizationYLocal.md
@@ -9,6 +9,8 @@ All `(Model, BC)` hubs `src` claims for the **`MagnetizationYLocal`** observable
 
 - **Models with this quantity registered**: 2
 - **Total hubs (Model, BC pairs)**: 2
+- **Methods** (derived from `@register`): `dense_ed`
+- **Universality classes** (where applicable): —
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/MagnetizationZ.md
+++ b/docs/src/atlas/quantities/MagnetizationZ.md
@@ -9,6 +9,11 @@ All `(Model, BC)` hubs `src` claims for the **`MagnetizationZ`** observable.  Em
 
 - **Models with this quantity registered**: 4
 - **Total hubs (Model, BC pairs)**: 4
+- **Methods** (derived from `@register`): `analytic`, `dense_ed`
+- **Universality classes** (where applicable): `Ising`
+
+**Top references** (by hub count):
+- Pfeuty 1970 — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/MagnetizationZLocal.md
+++ b/docs/src/atlas/quantities/MagnetizationZLocal.md
@@ -9,6 +9,8 @@ All `(Model, BC)` hubs `src` claims for the **`MagnetizationZLocal`** observable
 
 - **Models with this quantity registered**: 4
 - **Total hubs (Model, BC pairs)**: 4
+- **Methods** (derived from `@register`): `bdg`, `dense_ed`
+- **Universality classes** (where applicable): `Ising`
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/MassGap.md
+++ b/docs/src/atlas/quantities/MassGap.md
@@ -9,6 +9,15 @@ All `(Model, BC)` hubs `src` claims for the **`MassGap`** observable.  Empty cel
 
 - **Models with this quantity registered**: 24
 - **Total hubs (Model, BC pairs)**: 30
+- **Methods** (derived from `@register`): `analytic`, `bdg`, `delegation`, `dense_ed`, `dmrg_reference`, `kitaev_delegation`, `linear_phonon`, `literature_value`, `s1_heisenberg_delegation`
+- **Universality classes** (where applicable): `Ising`
+
+**Top references** (by hub count):
+- Pfeuty 1970 — 6 hubs
+- White-Huse 1993 — 3 hubs
+- Ashcroft-Mermin 1976 — 2 hubs
+- Kitaev 2001 — 2 hubs
+- Kitaev 2006 — 2 hubs
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/PartitionFunction.md
+++ b/docs/src/atlas/quantities/PartitionFunction.md
@@ -9,6 +9,13 @@ All `(Model, BC)` hubs `src` claims for the **`PartitionFunction`** observable. 
 
 - **Models with this quantity registered**: 2
 - **Total hubs (Model, BC pairs)**: 2
+- **Methods** (derived from `@register`): `analytic`, `transfer_matrix`
+- **Universality classes** (where applicable): `Ising`, `WZW`
+
+**Top references** (by hub count):
+- Onsager 1944 — 1 hub
+- Verlinde 1988 — 1 hub
+- Witten 1989 — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/PrimaryFields.md
+++ b/docs/src/atlas/quantities/PrimaryFields.md
@@ -9,6 +9,11 @@ All `(Model, BC)` hubs `src` claims for the **`PrimaryFields`** observable.  Emp
 
 - **Models with this quantity registered**: 2
 - **Total hubs (Model, BC pairs)**: 2
+- **Methods** (derived from `@register`): `analytic`
+- **Universality classes** (where applicable): `MinimalModel`
+
+**Top references** (by hub count):
+- Belavin-Polyakov-Zamolodchikov 1984 — 2 hubs
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/RenyiEntropy.md
+++ b/docs/src/atlas/quantities/RenyiEntropy.md
@@ -9,6 +9,12 @@ All `(Model, BC)` hubs `src` claims for the **`RenyiEntropy`** observable.  Empt
 
 - **Models with this quantity registered**: 4
 - **Total hubs (Model, BC pairs)**: 5
+- **Methods** (derived from `@register`): `bdg`, `cft`, `dense_ed`
+- **Universality classes** (where applicable): `Ising`
+
+**Top references** (by hub count):
+- Calabrese-Cardy 2009 — 2 hubs
+- Peschel 2003 — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/ResidualEntropy.md
+++ b/docs/src/atlas/quantities/ResidualEntropy.md
@@ -9,6 +9,15 @@ All `(Model, BC)` hubs `src` claims for the **`ResidualEntropy`** observable.  E
 
 - **Models with this quantity registered**: 4
 - **Total hubs (Model, BC pairs)**: 4
+- **Methods** (derived from `@register`): `analytic`
+- **Universality classes** (where applicable): `Ising`
+
+**Top references** (by hub count):
+- Affleck-Ludwig 1991 — 1 hub
+- Cardy 1989 — 1 hub
+- Friedan-Konechny 2004 — 1 hub
+- Lieb 1967a — 1 hub
+- Pauling 1935 — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/SpecificHeat.md
+++ b/docs/src/atlas/quantities/SpecificHeat.md
@@ -9,6 +9,15 @@ All `(Model, BC)` hubs `src` claims for the **`SpecificHeat`** observable.  Empt
 
 - **Models with this quantity registered**: 10
 - **Total hubs (Model, BC pairs)**: 15
+- **Methods** (derived from `@register`): `analytic`, `bdg`, `central_diff`, `dense_ed`, `free_fermion_quadgk`, `matter_free_fermion`
+- **Universality classes** (where applicable): `Ising`, `MeanField`
+
+**Top references** (by hub count):
+- Kitaev 2006 — 2 hubs
+- Lieb 1994 — 2 hubs
+- Mahan 2000 — 2 hubs
+- Ising 1925 — 1 hub
+- Landau-Lifshitz §149 — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/SpinGap.md
+++ b/docs/src/atlas/quantities/SpinGap.md
@@ -9,6 +9,13 @@ All `(Model, BC)` hubs `src` claims for the **`SpinGap`** observable.  Empty cel
 
 - **Models with this quantity registered**: 2
 - **Total hubs (Model, BC pairs)**: 2
+- **Methods** (derived from `@register`): `analytic`, `dmrg_reference`
+- **Universality classes** (where applicable): —
+
+**Top references** (by hub count):
+- Eggert 1996 — 1 hub
+- Lieb-Wu PRL 20, 1445 (1968) — 1 hub
+- White-Affleck 1996 — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/SpontaneousMagnetization.md
+++ b/docs/src/atlas/quantities/SpontaneousMagnetization.md
@@ -9,6 +9,14 @@ All `(Model, BC)` hubs `src` claims for the **`SpontaneousMagnetization`** obser
 
 - **Models with this quantity registered**: 4
 - **Total hubs (Model, BC pairs)**: 4
+- **Methods** (derived from `@register`): `analytic`
+- **Universality classes** (where applicable): `Ising`, `MeanField`
+
+**Top references** (by hub count):
+- Ising 1925 — 1 hub
+- Landau-Lifshitz §149 — 1 hub
+- Pfeuty 1970 — 1 hub
+- Yang 1952 — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/SteadyStateCurrent.md
+++ b/docs/src/atlas/quantities/SteadyStateCurrent.md
@@ -9,6 +9,13 @@ All `(Model, BC)` hubs `src` claims for the **`SteadyStateCurrent`** observable.
 
 - **Models with this quantity registered**: 1
 - **Total hubs (Model, BC pairs)**: 1
+- **Methods** (derived from `@register`): `analytic`
+- **Universality classes** (where applicable): —
+
+**Top references** (by hub count):
+- Derrida-Evans-Hakim-Pasquier 1993 — 1 hub
+- Derrida-Lebowitz 1998 — 1 hub
+- Kardar-Parisi-Zhang PRL 56, 889 (1986) — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/StringOrderParameter.md
+++ b/docs/src/atlas/quantities/StringOrderParameter.md
@@ -9,6 +9,12 @@ All `(Model, BC)` hubs `src` claims for the **`StringOrderParameter`** observabl
 
 - **Models with this quantity registered**: 1
 - **Total hubs (Model, BC pairs)**: 1
+- **Methods** (derived from `@register`): `analytic`
+- **Universality classes** (where applicable): —
+
+**Top references** (by hub count):
+- Affleck-Kennedy-Lieb-Tasaki 1988 — 1 hub
+- Kennedy-Tasaki 1992 — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/SusceptibilityXX.md
+++ b/docs/src/atlas/quantities/SusceptibilityXX.md
@@ -9,6 +9,8 @@ All `(Model, BC)` hubs `src` claims for the **`SusceptibilityXX`** observable.  
 
 - **Models with this quantity registered**: 4
 - **Total hubs (Model, BC pairs)**: 6
+- **Methods** (derived from `@register`): `bdg`, `dense_ed`
+- **Universality classes** (where applicable): `Ising`
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/SusceptibilityYY.md
+++ b/docs/src/atlas/quantities/SusceptibilityYY.md
@@ -9,6 +9,8 @@ All `(Model, BC)` hubs `src` claims for the **`SusceptibilityYY`** observable.  
 
 - **Models with this quantity registered**: 4
 - **Total hubs (Model, BC pairs)**: 4
+- **Methods** (derived from `@register`): `dense_ed`, `pfaffian`
+- **Universality classes** (where applicable): `Ising`
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/SusceptibilityZZ.md
+++ b/docs/src/atlas/quantities/SusceptibilityZZ.md
@@ -9,6 +9,13 @@ All `(Model, BC)` hubs `src` claims for the **`SusceptibilityZZ`** observable.  
 
 - **Models with this quantity registered**: 6
 - **Total hubs (Model, BC pairs)**: 7
+- **Methods** (derived from `@register`): `analytic`, `bdg`, `dense_ed`
+- **Universality classes** (where applicable): `Ising`, `MeanField`
+
+**Top references** (by hub count):
+- Brush 1967 RMP 39 883 — 1 hub
+- Ising 1925 — 1 hub
+- Landau-Lifshitz §149 — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/ThermalEntropy.md
+++ b/docs/src/atlas/quantities/ThermalEntropy.md
@@ -9,6 +9,15 @@ All `(Model, BC)` hubs `src` claims for the **`ThermalEntropy`** observable.  Em
 
 - **Models with this quantity registered**: 10
 - **Total hubs (Model, BC pairs)**: 15
+- **Methods** (derived from `@register`): `analytic`, `bdg`, `central_diff`, `dense_ed`, `free_fermion_quadgk`, `matter_free_fermion`
+- **Universality classes** (where applicable): `Ising`, `MeanField`
+
+**Top references** (by hub count):
+- Kitaev 2006 — 2 hubs
+- Lieb 1994 — 2 hubs
+- Mahan 2000 — 2 hubs
+- Coleman §2.4 — 1 hub
+- Ising 1925 — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/TopologicalEntanglementEntropy.md
+++ b/docs/src/atlas/quantities/TopologicalEntanglementEntropy.md
@@ -9,6 +9,15 @@ All `(Model, BC)` hubs `src` claims for the **`TopologicalEntanglementEntropy`**
 
 - **Models with this quantity registered**: 3
 - **Total hubs (Model, BC pairs)**: 3
+- **Methods** (derived from `@register`): `analytic`
+- **Universality classes** (where applicable): —
+
+**Top references** (by hub count):
+- Kitaev-Preskill 2006 — 3 hubs
+- Levin-Wen 2006 — 2 hubs
+- Freedman-Kitaev-Larsen-Wang 2003 — 1 hub
+- Iqbal-Becca-Sorella-Poilblanc 2013 — 1 hub
+- Jiang-Wang-Balents 2012 — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/TopologicalInvariant.md
+++ b/docs/src/atlas/quantities/TopologicalInvariant.md
@@ -9,6 +9,13 @@ All `(Model, BC)` hubs `src` claims for the **`TopologicalInvariant`** observabl
 
 - **Models with this quantity registered**: 2
 - **Total hubs (Model, BC pairs)**: 2
+- **Methods** (derived from `@register`): `analytic`, `pfaffian`
+- **Universality classes** (where applicable): —
+
+**Top references** (by hub count):
+- Asboth-Oroszlany-Palyi 2016 — 1 hub
+- Kitaev 2001 — 1 hub
+- Read-Green 2000 — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/VonNeumannEntropy.md
+++ b/docs/src/atlas/quantities/VonNeumannEntropy.md
@@ -9,6 +9,13 @@ All `(Model, BC)` hubs `src` claims for the **`VonNeumannEntropy`** observable. 
 
 - **Models with this quantity registered**: 4
 - **Total hubs (Model, BC pairs)**: 5
+- **Methods** (derived from `@register`): `bdg`, `cft`, `dense_ed`
+- **Universality classes** (where applicable): `Ising`
+
+**Top references** (by hub count):
+- Calabrese-Cardy 2004 — 1 hub
+- Calabrese-Cardy 2009 — 1 hub
+- Peschel 2003 — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/XXCorrelation.md
+++ b/docs/src/atlas/quantities/XXCorrelation.md
@@ -9,6 +9,8 @@ All `(Model, BC)` hubs `src` claims for the **`XXCorrelation`** observable.  Emp
 
 - **Models with this quantity registered**: 2
 - **Total hubs (Model, BC pairs)**: 3
+- **Methods** (derived from `@register`): `bdg`, `dense_ed`, `pfaffian`
+- **Universality classes** (where applicable): `Ising`
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/XXStructureFactor.md
+++ b/docs/src/atlas/quantities/XXStructureFactor.md
@@ -9,6 +9,8 @@ All `(Model, BC)` hubs `src` claims for the **`XXStructureFactor`** observable. 
 
 - **Models with this quantity registered**: 1
 - **Total hubs (Model, BC pairs)**: 2
+- **Methods** (derived from `@register`): `pfaffian`
+- **Universality classes** (where applicable): `Ising`
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/YYCorrelation.md
+++ b/docs/src/atlas/quantities/YYCorrelation.md
@@ -9,6 +9,8 @@ All `(Model, BC)` hubs `src` claims for the **`YYCorrelation`** observable.  Emp
 
 - **Models with this quantity registered**: 2
 - **Total hubs (Model, BC pairs)**: 2
+- **Methods** (derived from `@register`): `dense_ed`, `pfaffian`
+- **Universality classes** (where applicable): `Ising`
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/YYStructureFactor.md
+++ b/docs/src/atlas/quantities/YYStructureFactor.md
@@ -9,6 +9,8 @@ All `(Model, BC)` hubs `src` claims for the **`YYStructureFactor`** observable. 
 
 - **Models with this quantity registered**: 1
 - **Total hubs (Model, BC pairs)**: 2
+- **Methods** (derived from `@register`): `pfaffian`
+- **Universality classes** (where applicable): `Ising`
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/ZZCorrelation.md
+++ b/docs/src/atlas/quantities/ZZCorrelation.md
@@ -9,6 +9,11 @@ All `(Model, BC)` hubs `src` claims for the **`ZZCorrelation`** observable.  Emp
 
 - **Models with this quantity registered**: 3
 - **Total hubs (Model, BC pairs)**: 3
+- **Methods** (derived from `@register`): `analytic`, `bdg`, `dense_ed`
+- **Universality classes** (where applicable): `Ising`
+
+**Top references** (by hub count):
+- Affleck-Kennedy-Lieb-Tasaki 1988 — 1 hub
 
 ## Model × BC matrix
 

--- a/docs/src/atlas/quantities/ZZStructureFactor.md
+++ b/docs/src/atlas/quantities/ZZStructureFactor.md
@@ -9,6 +9,13 @@ All `(Model, BC)` hubs `src` claims for the **`ZZStructureFactor`** observable. 
 
 - **Models with this quantity registered**: 3
 - **Total hubs (Model, BC pairs)**: 4
+- **Methods** (derived from `@register`): `analytic`, `bdg`, `muller_ansatz`
+- **Universality classes** (where applicable): `Ising`
+
+**Top references** (by hub count):
+- Arovas-Auerbach-Haldane 1988 — 1 hub
+- Müller-Thomas-Beck-Bonner 1981 — 1 hub
+- des Cloizeaux–Pearson 1962 — 1 hub
 
 ## Model × BC matrix
 


### PR DESCRIPTION
Stacked on #475.  Per-quantity pages get methods aggregation, universality coverage, and top-5 references (symmetric with the per-model enrichment).  Bibliography + CalcIndex added to sidebar nav.  179/179 doc-structure tests pass, 2/2 drift tests pass.  Project.toml 0.22.5 -> 0.22.6.