### PR TITLE
docs(atlas): per-model CONVENTION block display

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.22.6"
+version = "0.22.7"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/docs/atlas/generate.jl
+++ b/docs/atlas/generate.jl
@@ -704,6 +704,47 @@ end
 # ── TIER-1 VIEW GENERATORS (ModelList + per-model + per-quantity) ──────────
 
 # ── TIER-1 EXT HELPERS (universality + calc + refs) ─────────────────────────
+
+# CONVENTION block extraction: parse the standard header comment
+#   # CONVENTION
+#   #   Hamiltonian: ...
+#   #   Observable: ...
+#   #   Reference: ...
+# from src/models/<class>/<Model>/<Model>.jl.  The block is enforced by
+# the CI lint (`test/lint/`) on new model files; older files (e.g.
+# IsingSquare) may not have it — return an empty list in that case.
+function _convention_path(model_name::AbstractString)
+    for class in ("classical", "quantum")
+        p = joinpath(ROOT, "src", "models", class, model_name, model_name * ".jl")
+        isfile(p) && return p
+    end
+    return ""
+end
+
+function _parse_convention(model_name::AbstractString)
+    path = _convention_path(model_name)
+    isempty(path) && return Pair{String,String}[]
+    lines = readlines(path)
+    out = Pair{String,String}[]
+    in_block = false
+    for ln in lines
+        s = rstrip(ln)
+        if !in_block
+            if startswith(s, "# CONVENTION")
+                in_block = true
+            end
+            continue
+        end
+        if isempty(s) || !startswith(s, "#")
+            break
+        end
+        m = match(r"^#\s{2,}([^:]+?):\s*(.*)$", s)
+        m === nothing && break
+        push!(out, strip(m.captures[1]) => strip(m.captures[2]))
+    end
+    return out
+end
+
 # Universality detection: scan the model's CriticalExponents claim notes/refs
 # for known QAtlas universality-class tokens (src/universalities/*.jl).  Used
 # by ModelList; substrate-derived (zero @register annotation added).
@@ -810,6 +851,27 @@ function render_model_index(model_name::AbstractString)
     for h in hs
         levcounts[levelcode(h)] = get(levcounts, levelcode(h), 0) + 1
     end
+    conv = _parse_convention(model_name)
+    P("## Convention")
+    P("")
+    if isempty(conv)
+        P(
+            "_No `CONVENTION` header found in `src/models/<class>/",
+            model_name,
+            "/",
+            model_name,
+            ".jl` (model file may predate the lint; see ",
+            "`docs/src/conventions.md` for the project-wide ",
+            "convention policy)._",
+        )
+    else
+        P("| Field | Value |")
+        P("|---|---|")
+        for (k, v) in conv
+            P("| ", k, " | ", _md_escape_dollar(v), " |")
+        end
+    end
+    P("")
     P("## Coverage")
     P("")
     P("| Level | Count |")

--- a/docs/src/atlas/models/AKLT1D.md
+++ b/docs/src/atlas/models/AKLT1D.md
@@ -5,6 +5,10 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`AKLT1D`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+_No `CONVENTION` header found in `src/models/<class>/AKLT1D/AKLT1D.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/AKLT2D.md
+++ b/docs/src/atlas/models/AKLT2D.md
@@ -5,6 +5,13 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`AKLT2D`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Spin S (this file) |
+| Observable | Spin S         (QAtlas-wide spin convention; see docs/src/conventions.md) |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/BCFT.md
+++ b/docs/src/atlas/models/BCFT.md
@@ -5,6 +5,10 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`BCFT`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+_No `CONVENTION` header found in `src/models/<class>/BCFT/BCFT.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/ChernSimons3D.md
+++ b/docs/src/atlas/models/ChernSimons3D.md
@@ -5,6 +5,14 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`ChernSimons3D`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Stabilizer / operator product |
+| Observable | Operator-product expectations (Wilson loops, GSD, TEE, S-matrix entries); convention-free |
+| Reference | docs/src/conventions.md §Topological / operator-product |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/Cluster1D.md
+++ b/docs/src/atlas/models/Cluster1D.md
@@ -5,6 +5,13 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`Cluster1D`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Pauli σ (this file) |
+| Observable | Spin S = σ/2  (QAtlas-wide spin convention; see docs/src/conventions.md) |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/Compass1D.md
+++ b/docs/src/atlas/models/Compass1D.md
@@ -5,6 +5,13 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`Compass1D`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Pauli σ (this file) |
+| Observable | Spin S = σ/2  (QAtlas-wide spin convention; see docs/src/conventions.md) |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/ConformalBootstrap.md
+++ b/docs/src/atlas/models/ConformalBootstrap.md
@@ -5,6 +5,10 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`ConformalBootstrap`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+_No `CONVENTION` header found in `src/models/<class>/ConformalBootstrap/ConformalBootstrap.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/CurieWeissIsing.md
+++ b/docs/src/atlas/models/CurieWeissIsing.md
@@ -5,6 +5,14 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`CurieWeissIsing`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | -(J/N)*Σ σσ - h*Σ σ  (FM convention, h ≥ 0 → m* ≥ 0) |
+| Observable | Spin-1/2 (σ ∈ {±1}) |
+| Reference | docs/src/conventions.md §Spin convention |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/DMIHeisenberg1D.md
+++ b/docs/src/atlas/models/DMIHeisenberg1D.md
@@ -5,6 +5,13 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`DMIHeisenberg1D`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Spin S (this file) |
+| Observable | Spin S         (QAtlas-wide spin convention; see docs/src/conventions.md) |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/ExtendedHubbard1D.md
+++ b/docs/src/atlas/models/ExtendedHubbard1D.md
@@ -5,6 +5,14 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`ExtendedHubbard1D`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Fermion bilinears c†c |
+| Observable | Fermion (number n = c†c, bilinear ⟨c†_i c_j⟩); derived spin observables follow spin S = σ/2 |
+| Reference | docs/src/conventions.md §Fermion convention |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/FibonacciAnyons.md
+++ b/docs/src/atlas/models/FibonacciAnyons.md
@@ -5,6 +5,14 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`FibonacciAnyons`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Stabilizer / operator product |
+| Observable | Operator-product expectations (Wilson loops, GSD, TEE, S-matrix entries); convention-free |
+| Reference | docs/src/conventions.md §Topological / operator-product |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/GrossNeveu.md
+++ b/docs/src/atlas/models/GrossNeveu.md
@@ -5,6 +5,14 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`GrossNeveu`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Fermion bilinears c†c |
+| Observable | Fermion (number n = c†c, bilinear ⟨c†_i c_j⟩); derived spin observables follow spin S = σ/2 |
+| Reference | docs/src/conventions.md §Fermion convention |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/Heisenberg1D.md
+++ b/docs/src/atlas/models/Heisenberg1D.md
@@ -5,6 +5,10 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`Heisenberg1D`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+_No `CONVENTION` header found in `src/models/<class>/Heisenberg1D/Heisenberg1D.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/HeisenbergXYZ.md
+++ b/docs/src/atlas/models/HeisenbergXYZ.md
@@ -5,6 +5,13 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`HeisenbergXYZ`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Spin S (this file) |
+| Observable | Spin S         (QAtlas-wide spin convention; see docs/src/conventions.md) |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/Hubbard1D.md
+++ b/docs/src/atlas/models/Hubbard1D.md
@@ -5,6 +5,14 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`Hubbard1D`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Fermion bilinears c†c |
+| Observable | Fermion (number n = c†c, bilinear ⟨c†_i c_j⟩); derived spin observables follow spin S = σ/2 |
+| Reference | docs/src/conventions.md §Fermion convention |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/IsingChain1D.md
+++ b/docs/src/atlas/models/IsingChain1D.md
@@ -5,6 +5,10 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`IsingChain1D`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+_No `CONVENTION` header found in `src/models/<class>/IsingChain1D/IsingChain1D.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/IsingSquare.md
+++ b/docs/src/atlas/models/IsingSquare.md
@@ -5,6 +5,10 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`IsingSquare`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+_No `CONVENTION` header found in `src/models/<class>/IsingSquare/IsingSquare.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/IsingTriangular.md
+++ b/docs/src/atlas/models/IsingTriangular.md
@@ -5,6 +5,10 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`IsingTriangular`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+_No `CONVENTION` header found in `src/models/<class>/IsingTriangular/IsingTriangular.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/J1J2Heisenberg1D.md
+++ b/docs/src/atlas/models/J1J2Heisenberg1D.md
@@ -5,6 +5,13 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`J1J2Heisenberg1D`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Spin S (this file) |
+| Observable | Spin S         (QAtlas-wide spin convention; see docs/src/conventions.md) |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/KagomeHeisenbergAFM.md
+++ b/docs/src/atlas/models/KagomeHeisenbergAFM.md
@@ -5,6 +5,13 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`KagomeHeisenbergAFM`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Spin S (this file) |
+| Observable | Spin S         (QAtlas-wide spin convention; see docs/src/conventions.md) |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/Kitaev1D.md
+++ b/docs/src/atlas/models/Kitaev1D.md
@@ -5,6 +5,13 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`Kitaev1D`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Pauli σ (this file) |
+| Observable | Spin S = σ/2  (QAtlas-wide spin convention; see docs/src/conventions.md) |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/KitaevHeisenberg.md
+++ b/docs/src/atlas/models/KitaevHeisenberg.md
@@ -5,6 +5,13 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`KitaevHeisenberg`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Pauli σ (this file) |
+| Observable | Spin S = σ/2  (QAtlas-wide spin convention; see docs/src/conventions.md) |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/KitaevHoneycomb.md
+++ b/docs/src/atlas/models/KitaevHoneycomb.md
@@ -5,6 +5,13 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`KitaevHoneycomb`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Pauli σ (this file) |
+| Observable | Spin S = σ/2  (QAtlas-wide spin convention; see docs/src/conventions.md) |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/LiouvilleCFT.md
+++ b/docs/src/atlas/models/LiouvilleCFT.md
@@ -5,6 +5,10 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`LiouvilleCFT`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+_No `CONVENTION` header found in `src/models/<class>/LiouvilleCFT/LiouvilleCFT.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/LogarithmicCFT.md
+++ b/docs/src/atlas/models/LogarithmicCFT.md
@@ -5,6 +5,10 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`LogarithmicCFT`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+_No `CONVENTION` header found in `src/models/<class>/LogarithmicCFT/LogarithmicCFT.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/LongRangeIsing1D.md
+++ b/docs/src/atlas/models/LongRangeIsing1D.md
@@ -5,6 +5,13 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`LongRangeIsing1D`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Pauli σ (this file) |
+| Observable | Spin S = σ/2  (QAtlas-wide spin convention; see docs/src/conventions.md) |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/LongRangeXY1D.md
+++ b/docs/src/atlas/models/LongRangeXY1D.md
@@ -5,6 +5,13 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`LongRangeXY1D`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Pauli σ (this file) |
+| Observable | Spin S = σ/2  (QAtlas-wide spin convention; see docs/src/conventions.md) |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/MajumdarGhosh.md
+++ b/docs/src/atlas/models/MajumdarGhosh.md
@@ -5,6 +5,13 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`MajumdarGhosh`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Spin S (this file) |
+| Observable | Spin S         (QAtlas-wide spin convention; see docs/src/conventions.md) |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/MixedFieldIsing1D.md
+++ b/docs/src/atlas/models/MixedFieldIsing1D.md
@@ -5,6 +5,13 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`MixedFieldIsing1D`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Pauli σ (this file) |
+| Observable | Spin S = σ/2  (QAtlas-wide spin convention; see docs/src/conventions.md) |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/PXP1D.md
+++ b/docs/src/atlas/models/PXP1D.md
@@ -5,6 +5,14 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`PXP1D`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Pauli σ with Rydberg blockade projectors P_i = (1 - σ^z_i)/2 |
+| Observable | Spin S = σ/2 for MagnetizationX/Y/Z-family; occupation n ∈ [0,1] for density-family |
+| Reference | docs/src/conventions.md §Hard-core boson / Rydberg |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/PpIp2DSC.md
+++ b/docs/src/atlas/models/PpIp2DSC.md
@@ -5,6 +5,14 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`PpIp2DSC`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Fermion bilinears c†c |
+| Observable | Fermion (number n = c†c, bilinear ⟨c†_i c_j⟩); derived spin observables follow spin S = σ/2 |
+| Reference | docs/src/conventions.md §Fermion convention |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/RFIM.md
+++ b/docs/src/atlas/models/RFIM.md
@@ -5,6 +5,10 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`RFIM`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+_No `CONVENTION` header found in `src/models/<class>/RFIM/RFIM.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/RandomBondIsing2D.md
+++ b/docs/src/atlas/models/RandomBondIsing2D.md
@@ -5,6 +5,10 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`RandomBondIsing2D`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+_No `CONVENTION` header found in `src/models/<class>/RandomBondIsing2D/RandomBondIsing2D.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/S1AnisotropicD1D.md
+++ b/docs/src/atlas/models/S1AnisotropicD1D.md
@@ -5,6 +5,13 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`S1AnisotropicD1D`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Spin S (this file) |
+| Observable | Spin S         (QAtlas-wide spin convention; see docs/src/conventions.md) |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/S1Heisenberg1D.md
+++ b/docs/src/atlas/models/S1Heisenberg1D.md
@@ -5,6 +5,10 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`S1Heisenberg1D`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+_No `CONVENTION` header found in `src/models/<class>/S1Heisenberg1D/S1Heisenberg1D.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/S1XXZ1D.md
+++ b/docs/src/atlas/models/S1XXZ1D.md
@@ -5,6 +5,13 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`S1XXZ1D`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Spin S (this file) |
+| Observable | Spin S         (QAtlas-wide spin convention; see docs/src/conventions.md) |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/SLEkappa.md
+++ b/docs/src/atlas/models/SLEkappa.md
@@ -5,6 +5,10 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`SLEkappa`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+_No `CONVENTION` header found in `src/models/<class>/SLEkappa/SLEkappa.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/SYK.md
+++ b/docs/src/atlas/models/SYK.md
@@ -5,6 +5,14 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`SYK`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Fermion bilinears c†c |
+| Observable | Fermion (number n = c†c, bilinear ⟨c†_i c_j⟩); derived spin observables follow spin S = σ/2 |
+| Reference | docs/src/conventions.md §Fermion convention |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/SchwingerModel.md
+++ b/docs/src/atlas/models/SchwingerModel.md
@@ -5,6 +5,14 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`SchwingerModel`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Fermion bilinears c†c |
+| Observable | Fermion (number n = c†c, bilinear ⟨c†_i c_j⟩); derived spin observables follow spin S = σ/2 |
+| Reference | docs/src/conventions.md §Fermion convention |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/ShastrySutherland.md
+++ b/docs/src/atlas/models/ShastrySutherland.md
@@ -5,6 +5,13 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`ShastrySutherland`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Spin S (this file) |
+| Observable | Spin S         (QAtlas-wide spin convention; see docs/src/conventions.md) |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/SherringtonKirkpatrick.md
+++ b/docs/src/atlas/models/SherringtonKirkpatrick.md
@@ -5,6 +5,10 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`SherringtonKirkpatrick`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+_No `CONVENTION` header found in `src/models/<class>/SherringtonKirkpatrick/SherringtonKirkpatrick.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/SixVertex.md
+++ b/docs/src/atlas/models/SixVertex.md
@@ -5,6 +5,10 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`SixVertex`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+_No `CONVENTION` header found in `src/models/<class>/SixVertex/SixVertex.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/SpinIce.md
+++ b/docs/src/atlas/models/SpinIce.md
@@ -5,6 +5,10 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`SpinIce`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+_No `CONVENTION` header found in `src/models/<class>/SpinIce/SpinIce.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/TASEP.md
+++ b/docs/src/atlas/models/TASEP.md
@@ -5,6 +5,10 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`TASEP`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+_No `CONVENTION` header found in `src/models/<class>/TASEP/TASEP.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/TFIM.md
+++ b/docs/src/atlas/models/TFIM.md
@@ -5,6 +5,13 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`TFIM`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Pauli σ (this file) |
+| Observable | Spin S = σ/2  (QAtlas-wide spin convention; see docs/src/conventions.md) |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/TTbar.md
+++ b/docs/src/atlas/models/TTbar.md
@@ -5,6 +5,10 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`TTbar`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+_No `CONVENTION` header found in `src/models/<class>/TTbar/TTbar.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/TightBinding1D.md
+++ b/docs/src/atlas/models/TightBinding1D.md
@@ -5,6 +5,14 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`TightBinding1D`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Fermion bilinears c†c |
+| Observable | Fermion (number n = c†c, bilinear ⟨c†_i c_j⟩); derived spin observables follow spin S = σ/2 |
+| Reference | docs/src/conventions.md §Fermion convention |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/TightBindingV1D.md
+++ b/docs/src/atlas/models/TightBindingV1D.md
@@ -5,6 +5,14 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`TightBindingV1D`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Fermion bilinears c†c |
+| Observable | Fermion (number n = c†c, bilinear ⟨c†_i c_j⟩); derived spin observables follow spin S = σ/2 |
+| Reference | docs/src/conventions.md §Fermion convention |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/TodaLattice.md
+++ b/docs/src/atlas/models/TodaLattice.md
@@ -5,6 +5,10 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`TodaLattice`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+_No `CONVENTION` header found in `src/models/<class>/TodaLattice/TodaLattice.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/ToricCode.md
+++ b/docs/src/atlas/models/ToricCode.md
@@ -5,6 +5,14 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`ToricCode`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Stabilizer / operator product |
+| Observable | Operator-product expectations (Wilson loops, GSD, TEE, S-matrix entries); convention-free |
+| Reference | docs/src/conventions.md §Topological / operator-product |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/TricriticalIsing.md
+++ b/docs/src/atlas/models/TricriticalIsing.md
@@ -5,6 +5,10 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`TricriticalIsing`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+_No `CONVENTION` header found in `src/models/<class>/TricriticalIsing/TricriticalIsing.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/TricriticalPotts3.md
+++ b/docs/src/atlas/models/TricriticalPotts3.md
@@ -5,6 +5,10 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`TricriticalPotts3`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+_No `CONVENTION` header found in `src/models/<class>/TricriticalPotts3/TricriticalPotts3.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/XCube.md
+++ b/docs/src/atlas/models/XCube.md
@@ -5,6 +5,14 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`XCube`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Stabilizer / operator product |
+| Observable | Operator-product expectations (Wilson loops, GSD, TEE, S-matrix entries); convention-free |
+| Reference | docs/src/conventions.md §Topological / operator-product |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/XXZ1D.md
+++ b/docs/src/atlas/models/XXZ1D.md
@@ -5,6 +5,10 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`XXZ1D`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+_No `CONVENTION` header found in `src/models/<class>/XXZ1D/XXZ1D.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/XYh1D.md
+++ b/docs/src/atlas/models/XYh1D.md
@@ -5,6 +5,13 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`XYh1D`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+| Field | Value |
+|---|---|
+| Hamiltonian | Pauli σ (this file) |
+| Observable | Spin S = σ/2  (QAtlas-wide spin convention; see docs/src/conventions.md) |
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/YangLee.md
+++ b/docs/src/atlas/models/YangLee.md
@@ -5,6 +5,10 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`YangLee`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+_No `CONVENTION` header found in `src/models/<class>/YangLee/YangLee.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/ZnClock.md
+++ b/docs/src/atlas/models/ZnClock.md
@@ -5,6 +5,10 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`ZnClock`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+_No `CONVENTION` header found in `src/models/<class>/ZnClock/ZnClock.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+
 ## Coverage
 
 | Level | Count |

--- a/docs/src/atlas/models/ZnParafermion.md
+++ b/docs/src/atlas/models/ZnParafermion.md
@@ -5,6 +5,10 @@
 
 All `(Quantity, BC)` hubs `src` claims for **`ZnParafermion`**.  Cells link to the per-hub card; `—` = not yet implemented at that BC.  The shape of the matrix is the *gap visualisation*: empty cells are where physics could be added next.
 
+## Convention
+
+_No `CONVENTION` header found in `src/models/<class>/ZnParafermion/ZnParafermion.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+
 ## Coverage
 
 | Level | Count |


### PR DESCRIPTION
Stacked on #476.  Each per-model page (`docs/src/atlas/models/<Model>.md`) now shows a **Convention** section parsed from the `CONVENTION` header comment in `src/models/<class>/<Model>/<Model>.jl` — the same block the CI lint already enforces (per the v0.19 convention-header initiative, tasks #8/#9).

## Example

CurieWeissIsing:

| Field       | Value                                              |
|-------------|----------------------------------------------------|
| Hamiltonian | -(J/N)\*Σ σσ - h\*Σ σ  (FM convention, h ≥ 0)       |
| Observable  | Spin-1/2 (σ ∈ {±1})                                |
| Reference   | docs/src/conventions.md §Spin convention           |

## Why useful

Solves the recurring reader question "why does IsingTriangular use J > 0 = AFM but IsingSquare use J > 0 = FM?": the difference is now visible side-by-side via the per-model pages without leaving the atlas.

## Edge case

Models predating the lint (e.g. `IsingSquare`) get an **honest absence note** instead of a silent blank — never fabricated.  A follow-up could backfill those headers (separate concern; not blocking this PR).

## Test plan

- [x] Regen: 58 model pages updated with Convention section
- [x] `test_inventory_drift.jl` 2/2
- [x] `test_doc_structure.jl` 179/179
- [x] Format clean
- Project.toml: 0.22.6 → 0.22.7

## Stack

- #474 (`feat/docs-tier1-matrices`) — base Tier-1
- #475 (`feat/docs-tier1-ext`) — Universality + Bibliography + CalcIndex
- #476 (`feat/docs-quant-enrich`) — per-Q enrichment + nav
- **this PR** (`feat/docs-convention`) — per-model CONVENTION display
