### PR TITLE
docs(atlas): CONTRIBUTING comprehensive table + latent calc helper

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -273,7 +273,20 @@ After adding or changing any `@register`, regenerate the atlas:
 julia --project=docs docs/atlas/generate.jl
 ```
 
-This rewrites `docs/src/atlas/index.md`, per-hub pages under `docs/src/atlas/hubs/`, the facet pages under `docs/src/atlas/by/`, **the per-model index pages under `docs/src/atlas/models/<Model>.md`** (showing each model's hubs as a `Quantity × BC` matrix), **the per-quantity index pages under `docs/src/atlas/quantities/<Quantity>.md`** (the inverse `Model × BC` matrix), and **`docs/src/atlas/ModelList.md`** (the top-level searchable catalog with one row per model and columns derived from existing `@register` fields: methods used, assurance distribution, ED-feasibility, regimes).
+This rewrites every auto-generated atlas surface, all derived from the fixed substrate (registry + INVENTORY + R1 assurance + ED_INFEASIBLE_MODELS + calc/*.md filenames):
+
+| Auto-generated page | Content | Derived from |
+|---|---|---|
+| `docs/src/atlas/index.md` | top atlas + risk-linter + per-model breakdown table | registry + INVENTORY |
+| `docs/src/atlas/ModelList.md` | top searchable catalog, one row per model, columns: Universality, #K, methods, assurance distribution, ED-feasibility, regimes | substrate-derived |
+| `docs/src/atlas/models/<Model>.md` × 58 | per-model `Quantity × BC` matrix, **Convention** block (from `# CONVENTION` header), **Derivation notes** (matched calc/*.md), aggregated methods + refs | registry + INVENTORY + src file comment + calc filenames |
+| `docs/src/atlas/quantities/<Quantity>.md` × 51 | inverse `Model × BC` matrix, methods aggregation, universality coverage, top references | registry + INVENTORY |
+| `docs/src/atlas/hubs/<Model>_<Quantity>_<BC>.md` × 263 | per-hub card with `src` claim, corroboration cards table, reconstructed `verify(...)` call, **Derivation note** link, three-way back-links (Model, Quantity, Atlas) | registry + INVENTORY |
+| `docs/src/atlas/by/{model,quantity,bc,level,mechanism,regime}.md` | 1D facet aggregators | INVENTORY |
+| `docs/src/atlas/Bibliography.md` | all citations, deduplicated, with hub backlinks sorted by hub-count | registry refs |
+| `docs/src/atlas/CalcIndex.md` | inverse view: every `docs/src/calc/*.md` ↔ matched models | calc filenames |
+
+The `test/INVENTORY.jsonl` drift guard then enforces that the regenerated inventory matches the committed one:
 
 Adding a new `@register` entry therefore automatically:
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.22.7"
+version = "0.22.8"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/docs/atlas/generate.jl
+++ b/docs/atlas/generate.jl
@@ -803,6 +803,22 @@ function _calc_files_for_model(model_name::AbstractString)
     return out
 end
 
+# Hub-level (model + quantity) calc match: stricter than the per-model
+# matcher.  Returns only those calc/*.md whose filename mentions BOTH
+# the model alias AND the quantity name (lower-cased substring).
+function _calc_files_for_hub(model_name::AbstractString, quant_name::AbstractString)
+    aliases = _model_calc_aliases(model_name)
+    qlo = lowercase(quant_name)
+    strict = String[]
+    for f in _CALC_FILES
+        flo = lowercase(f)
+        any(a -> length(a) >= 3 && occursin(a, flo), aliases) || continue
+        length(qlo) >= 3 && occursin(qlo, flo) || continue
+        push!(strict, f)
+    end
+    return strict
+end
+
 function _split_refs(s::AbstractString)
     isempty(s) && return String[]
     return [strip(r) for r in split(s, "|") if !isempty(strip(r))]


### PR DESCRIPTION
Stacked on #477.  CONTRIBUTING.md gets a comprehensive 8-row table of all auto-generated atlas pages and their derivations (substrate field columns).  Plus a latent _calc_files_for_hub helper for future per-hub Derivation-note injection (hoisting work deferred).  Guards: 2/2 + 179/179.  Project.toml 0.22.7 -> 0.22.8.