### PR TITLE
docs(atlas): hoist TIER-1 EXT HELPERS + per-hub Derivation-note

### DIFF
--- a/docs/atlas/generate.jl
+++ b/docs/atlas/generate.jl
@@ -169,540 +169,7 @@ const LEGEND = string(
     "published / DMRG value.",
 )
 
-# ── per-hub pages ────────────────────────────────────────────────────
-hubsdir = joinpath(ROOT, "docs", "src", "atlas", "hubs")
-mkpath(hubsdir)
-for h in claimed
-    cl = first(clby[h])
-    cs = cardsof(h)
-    lev, bdg, adm = levelof(h)
-    hio = IOBuffer()
-    HP(s...) = println(hio, string(s...))
-    HP("# ", bdg, " `", h, "`")
-    HP("")
-    HP(BANNER)
-    HP("")
-    HP("!!! ", adm, " \"Assurance level: ", lev, "\"")
-    if lev == "uncorroborated-but-feasible"
-        HP(
-            "    `src` claims this hub and dense ED is feasible, but no ",
-            "corroboration card exists. **Actionable**: add a ",
-            "`route = :ed_finite_size` or `:second_closed_form` card.",
-        )
-    elseif lev == "cited-only"
-        HP(
-            "    Backed only by a literature citation",
-            if ed_infeasible(h)
-                " (model is ED-infeasible — this is the ceiling)."
-            else
-                " — no in-repo independent re-derivation yet."
-            end,
-        )
-    elseif lev == "coherent"
-        HP(
-            "    An independent card exists and the value satisfies an ",
-            "internal invariant; no external value re-derives it yet.",
-        )
-    else
-        HP("    Independently corroborated. See the cards below.")
-    end
-    HP("")
-    HP("## `src` claim")
-    HP("")
-    HP(
-        "- method `",
-        cl.method,
-        "`, reliability `",
-        cl.reliability,
-        "`",
-        isempty(cl.refs) ? "" : string(", refs: ", _md_escape_dollar(cl.refs)),
-    )
-    isempty(cl.notes) || HP("- ", _md_escape_dollar(cl.notes))
-    HP("")
-    HP("## Corroboration")
-    HP("")
-    if isempty(cs)
-        HP(
-            "_No corroboration card._ ",
-            if ed_infeasible(h)
-                "Model is ED-infeasible — frontier (cited-only), not a gap."
-            else
-                "Flagged by the R1 risk-linter (`src` claims this hub, ED is feasible, no independent card)."
-            end,
-        )
-    else
-        HP("| regime | mechanism | independence | refs | file |")
-        HP("|---|---|---|---|---|")
-        for c in cs
-            b = c.independence == "structural" ? "🟢 structural" : "🟡 asserted"
-            HP(
-                "| `",
-                c.regime,
-                "` | `",
-                c.mechanism,
-                "` | ",
-                b,
-                " | ",
-                _md_escape_dollar(c.refs),
-                " | `",
-                c.file,
-                "` |",
-            )
-        end
-    end
-    if !isempty(cs)
-        HP("")
-        HP("## Test calls")
-        HP("")
-        HP(
-            "_The exact `verify(...)` call the harness executed for this hub (reconstructed from the test AST):_",
-        )
-        HP("")
-        for c in cs
-            HP("```julia")
-            HP(c.srctext)
-            HP("```")
-            HP("")
-        end
-    end
-    HP("")
-    HP("## Assurance (provisional)")
-    HP("")
-    HP("- level: **", lev, "** ", bdg)
-    HP(
-        "- cards: ",
-        length(cs),
-        " · model ED-",
-        ed_infeasible(h) ? "infeasible (frontier)" : "feasible",
-    )
-    HP("- RES not wired — measured residuals / confidence are not shown yet.")
-    HP("")
-    HP(
-        "[← Model: `",
-        modelof(h),
-        "`](../models/",
-        modelof(h),
-        ".md) · ",
-        "[Quantity: `",
-        quantof(h),
-        "`](../quantities/",
-        _quant_slugof(quantof(h)),
-        ".md) · ",
-        "[Atlas index](../index.md)",
-    )
-    write(joinpath(hubsdir, slugof(h) * ".md"), String(take!(hio)))
-end
-
-# ── faceted index pages (R5) ─────────────────────────────────────────
-bydir = joinpath(ROOT, "docs", "src", "atlas", "by")
-mkpath(bydir)
-function write_facet(fname, title, groups, blurb)
-    fio = IOBuffer()
-    FP(s...) = println(fio, string(s...))
-    FP("# ", title)
-    FP("")
-    FP(BANNER)
-    FP("")
-    FP(blurb)
-    FP("")
-    for k in sort(collect(keys(groups)))
-        hs = sort(groups[k])
-        FP("## `", k, "` (", length(hs), ")")
-        FP("")
-        for h in hs
-            FP("- ", facet_link(h))
-        end
-        FP("")
-    end
-    FP("[← back to the Atlas index](../index.md)")
-    write(joinpath(bydir, fname), String(take!(fio)))
-end
-write_facet(
-    "model.md", "Atlas — by model", G_model, "Every `src`-claimed hub grouped by model."
-)
-write_facet(
-    "quantity.md",
-    "Atlas — by quantity",
-    G_quant,
-    "Grouped by the observable (the `Quantity` axis of the locked Model/Quantity/BC schema).",
-)
-write_facet(
-    "bc.md",
-    "Atlas — by boundary condition",
-    G_bc,
-    "Grouped by boundary condition (`Infinite` / `OBC` / `PBC` …).",
-)
-write_facet(
-    "level.md",
-    "Atlas — by assurance level",
-    G_level,
-    "Grouped by the R1 assurance level. `uncorroborated-but-feasible` is the only actionable bucket.",
-)
-write_facet(
-    "mechanism.md",
-    "Atlas — by corroboration mechanism",
-    G_mech,
-    "Grouped by the `route` the verify card used. A hub appears under each mechanism it has a card for.",
-)
-write_facet(
-    "regime.md",
-    "Atlas — by regime",
-    G_regime,
-    "Grouped by the named physical regime resolved from the test call (`@sweep` = loop-variable, not yet a named point).",
-)
-byidx = IOBuffer()
-BI(s...) = println(byidx, string(s...))
-BI("# Atlas — faceted search")
-BI("")
-BI(BANNER)
-BI("")
-BI(
-    "Full-text search is the bar at the top of every page (Documenter ",
-    "built-in — indexes every hub and facet page). Faceted indices over ",
-    "the locked **Model / Quantity / BC @ regime** schema:",
-)
-BI("")
-BI("- [By model](model.md) — ", length(G_model), " models")
-BI("- [By quantity](quantity.md) — ", length(G_quant), " observables")
-BI("- [By boundary condition](bc.md) — ", length(G_bc), " BCs")
-BI("- [By assurance level](level.md) — R1 taxonomy")
-BI("- [By corroboration mechanism](mechanism.md) — verify `route`")
-BI("- [By regime](regime.md) — resolved physical regimes")
-BI("")
-BI("[← back to the Atlas index](../index.md)")
-write(joinpath(bydir, "index.md"), String(take!(byidx)))
-
-# ── atlas index ──────────────────────────────────────────────────────
-io = IOBuffer()
-P(s...) = println(io, string(s...))
-P("# QAtlas — Verified Exact-Solution Atlas")
-P("")
-P(BANNER)
-P("")
-P(LEGEND)
-P("")
-P("## Coverage (all models)")
-P("")
-P("| | count |")
-P("|---|---|")
-P("| Hubs `src` claims (registry) | ", length(claimed), " |")
-P("| ED-feasible claimed (risk denominator) | ", nfeas, " |")
-P("| ED-infeasible claimed (frontier, excluded) | ", length(claimed) - nfeas, " |")
-P("| 🟣 universality-corroborated | ", length(L_UNIV), " |")
-P("| 🟢 corroborated-at-p | ", length(L_EDP), " |")
-P("| 🔵 coherent | ", length(L_COH), " |")
-P("| ⚪ cited-only (frontier — neutral) | ", length(L_CITED), " |")
-P("| 🟠 uncorroborated-but-feasible (**actionable risk**) | ", length(L_RISK), " |")
-P("| Inventory cards scanned (whole test/) | ", length(cards), " |")
-P(
-    "| Registry files parsed | ",
-    length(regfiles) - length(regfail),
-    " / ",
-    length(regfiles),
-    " |",
-)
-P("| Models | ", length(models), " |")
-P("")
-P(
-    "**Externally-corroborated rate** (🟣+🟢 over ED-feasible claimed): **",
-    rate_struct,
-    "%** · **in-repo-verified rate** (incl. 🔵 coherent): **",
-    rate_inrepo,
-    "%**",
-)
-P("")
-P("## Browse by facet")
-P("")
-P(
-    "[**Faceted search →**](by/index.md) · ",
-    "[by model](by/model.md) · [by quantity](by/quantity.md) · ",
-    "[by BC](by/bc.md) · [by level](by/level.md) · ",
-    "[by mechanism](by/mechanism.md) · [by regime](by/regime.md). ",
-    "Full-text search is the top bar (Documenter built-in).",
-)
-
-P("")
-P("")
-P("## Reference & derivation indices")
-P("")
-P(
-    "Two more substrate-derived indices: ",
-    "**[Bibliography](Bibliography.md)** — every citation with hub backlinks; ",
-    "**[Derivation-note index](CalcIndex.md)** — each `docs/src/calc/*.md` mapped to its model(s).",
-)
-P("")
-P("## Model & Quantity matrices (Zettelkasten layer)")
-P("")
-P(
-    "Each model has a per-model index showing its hubs as a ",
-    "`Quantity × BC` matrix; each quantity has the inverse view ",
-    "(`Model × BC`).  Empty cells = gap visualisation (physics not ",
-    "yet implemented).  Use the **[Model list](ModelList.md)** for a ",
-    "searchable top-catalog.",
-)
-P("")
-P("## 🟠 R1 risk-linter — actionable only")
-P("")
-P(
-    "`src` claims the hub, the model is ED-**feasible**, yet zero ",
-    "corroboration cards exist. `cited-only` (frontier) and ED-infeasible ",
-    "hubs are **not** listed here — they are the honest ceiling, not a gap.",
-)
-P("")
-if isempty(L_RISK)
-    P("!!! tip \"No actionable risk\"")
-    P("    Every ED-feasible claimed hub has at least one corroboration card.")
-else
-    P("!!! warning \"", length(L_RISK), " actionable hub(s)\"")
-    for h in sort(L_RISK)
-        P("    - [`", h, "`](hubs/", slugof(h), ".md)")
-    end
-end
-P("")
-P("## Per-model breakdown")
-P("")
-P("| model | claimed | 🟣 | 🟢 | 🔵 | ⚪ | 🟠 | ED |")
-P("|---|---|---|---|---|---|---|---|")
-for m in models
-    hs = filter(h -> modelof(h) == m, claimed)
-    P(
-        "| `",
-        m,
-        "` | ",
-        length(hs),
-        " | ",
-        count(h -> levelcode(h) == AtlasInventory.UNIVERSALITY_CORROBORATED, hs),
-        " | ",
-        count(h -> levelcode(h) == AtlasInventory.CORROBORATED_AT_P, hs),
-        " | ",
-        count(h -> levelcode(h) == AtlasInventory.COHERENT, hs),
-        " | ",
-        count(h -> levelcode(h) == AtlasInventory.CITED_ONLY, hs),
-        " | ",
-        count(h -> levelcode(h) == AtlasInventory.UNCORROBORATED_BUT_FEASIBLE, hs),
-        " | ",
-        (m in AtlasInventory.ED_INFEASIBLE_MODELS ? "infeasible" : "feasible"),
-        " |",
-    )
-end
-P("")
-P("## Hubs (", length(claimed), ") — select to drill down")
-P("")
-for m in models
-    hs = sort(filter(h -> modelof(h) == m, claimed))
-    P("### `", m, "` (", length(hs), ")")
-    P("")
-    for h in hs
-        P("- ", badgeof(h), " [`", h, "`](hubs/", slugof(h), ".md) — ", levname(h))
-    end
-    P("")
-end
-
-out = joinpath(ROOT, "docs", "src", "atlas", "index.md")
-mkpath(dirname(out))
-write(out, String(take!(io)))
-println(
-    "wrote ",
-    out,
-    " + ",
-    length(claimed),
-    " per-hub pages + 7 facet pages  models=",
-    length(models),
-    " hubs=",
-    length(claimed),
-    " cards=",
-    length(cards),
-    " regfail=",
-    length(regfail),
-    "  R1[univ=",
-    length(L_UNIV),
-    " edp=",
-    length(L_EDP),
-    " coh=",
-    length(L_COH),
-    " cited=",
-    length(L_CITED),
-    " risk=",
-    length(L_RISK),
-    "] feas=",
-    nfeas,
-    " rate_struct=",
-    rate_struct,
-    " rate_inrepo=",
-    rate_inrepo,
-)
-
-# ─── Auto-inject "Verified hubs" section into hand-written model pages ──────
-# Closes the model-page <-> atlas-hub coherence gap. For each mapped docs
-# page, writes a fresh `## Verified hubs` table between START / END
-# markers; if markers are absent, the section is appended at end of file.
-
-const MODEL_DOC_MAP = Dict{String,String}(
-    "TFIM" => "docs/src/models/quantum/tfim.md",
-    "Heisenberg1D" => "docs/src/models/quantum/heisenberg.md",
-    "S1Heisenberg1D" => "docs/src/models/quantum/heisenberg.md",
-    "HeisenbergXYZ" => "docs/src/models/quantum/heisenberg.md",
-    "DMIHeisenberg1D" => "docs/src/models/quantum/heisenberg.md",
-    "J1J2Heisenberg1D" => "docs/src/models/quantum/heisenberg.md",
-    "MajumdarGhosh" => "docs/src/models/quantum/majumdar_ghosh.md",
-    "Hubbard1D" => "docs/src/models/quantum/hubbard1d.md",
-    "ExtendedHubbard1D" => "docs/src/models/quantum/hubbard1d.md",
-    "KitaevHoneycomb" => "docs/src/models/quantum/kitaev-honeycomb.md",
-    "KitaevHeisenberg" => "docs/src/models/quantum/kitaev-honeycomb.md",
-    "Kitaev1D" => "docs/src/models/quantum/kitaev1d.md",
-    "ToricCode" => "docs/src/models/quantum/toric-code.md",
-    "XXZ1D" => "docs/src/models/quantum/xxz.md",
-    "S1XXZ1D" => "docs/src/models/quantum/xxz.md",
-    "IsingSquare" => "docs/src/models/classical/ising-square.md",
-    "IsingTriangular" => "docs/src/models/classical/ising-triangular.md",
-    "SixVertex" => "docs/src/models/classical/six-vertex.md",
-)
-
-const _PAGE_TO_MODELS = let
-    d = Dict{String,Vector{String}}()
-    for (m, page) in MODEL_DOC_MAP
-        push!(get!(d, page, String[]), m)
-    end
-    for (_, ms) in d
-        sort!(ms)
-    end
-    d
-end
-
-_posix(p::AbstractString) = replace(p, '\\' => '/')
-
-const _ATLAS_HUBS_BEGIN = "<!-- ATLAS:HUBS:START -- auto-generated by docs/atlas/generate.jl. Do not edit by hand; edits between these markers are overwritten on next regen. -->"
-const _ATLAS_HUBS_END = "<!-- ATLAS:HUBS:END -->"
-
-function render_hub_section(page_rel, model_names)
-    page_dir = dirname(joinpath(ROOT, page_rel))
-    io = IOBuffer()
-    P = (xs...) -> println(io, xs...)
-    relevant = sort(filter(h -> modelof(h) in model_names, claimed))
-    atlas_rel = _posix(relpath(joinpath(ROOT, "docs/src/atlas/index.md"), page_dir))
-    P(_ATLAS_HUBS_BEGIN)
-    P()
-    P("## Verified hubs")
-    P()
-    n = length(model_names)
-    subj = n == 1 ? "this model registers" : "these $(n) models register"
-    nh = length(relevant)
-    hub_word = nh == 1 ? "hub" : "hubs"
-    P(
-        "In the [Verified Atlas](",
-        atlas_rel,
-        "), ",
-        subj,
-        " ",
-        nh,
-        " ",
-        hub_word,
-        " (quantity / BC pair). The badge column shows the R1 assurance level; click a hub link to see the exact `verify(...)` calls, references, and corroboration mechanism.",
-    )
-    P()
-    if nh == 0
-        P("_No hubs registered yet._")
-        P()
-    else
-        if n == 1
-            P("| Quantity | BC | Assurance | Cards |")
-            P("|---|---|---|---|")
-            for h in relevant
-                hub_page = joinpath(ROOT, "docs/src/atlas/hubs/$(slugof(h)).md")
-                rp = _posix(relpath(hub_page, page_dir))
-                P(
-                    "| [`",
-                    quantof(h),
-                    "`](",
-                    rp,
-                    ") | `",
-                    bcof(h),
-                    "` | ",
-                    badgeof(h),
-                    " ",
-                    levname(h),
-                    " | ",
-                    length(cardsof(h)),
-                    " |",
-                )
-            end
-        else
-            P("| Model | Quantity | BC | Assurance | Cards |")
-            P("|---|---|---|---|---|")
-            for h in relevant
-                hub_page = joinpath(ROOT, "docs/src/atlas/hubs/$(slugof(h)).md")
-                rp = _posix(relpath(hub_page, page_dir))
-                P(
-                    "| `",
-                    modelof(h),
-                    "` | [`",
-                    quantof(h),
-                    "`](",
-                    rp,
-                    ") | `",
-                    bcof(h),
-                    "` | ",
-                    badgeof(h),
-                    " ",
-                    levname(h),
-                    " | ",
-                    length(cardsof(h)),
-                    " |",
-                )
-            end
-        end
-        P()
-    end
-    P(_ATLAS_HUBS_END)
-    return String(take!(io))
-end
-
-function inject_hub_section!(page_rel, model_names)
-    p = joinpath(ROOT, page_rel)
-    if !isfile(p)
-        @warn "ATLAS hub-inject skip: page not found" page = page_rel
-        return nothing
-    end
-    content = read(p, String)
-    section = render_hub_section(page_rel, model_names)
-    b = findfirst(_ATLAS_HUBS_BEGIN, content)
-    e = findfirst(_ATLAS_HUBS_END, content)
-    # Explicit marker-pair validation: refuse to write when only one of
-    # START/END is present or when they are misordered. Without this an
-    # orphaned START at the top of the page would be paired with the
-    # appended-section END at the bottom on the NEXT regen, silently
-    # nuking everything between them.
-    if (b === nothing) != (e === nothing)
-        @warn "ATLAS hub-inject skip: page has only one of START/END marker; refusing to mutate to avoid data loss" page =
-            page_rel
-        return nothing
-    end
-    if b !== nothing && e !== nothing && first(e) <= last(b)
-        @warn "ATLAS hub-inject skip: START/END markers in wrong order; refusing to mutate" page =
-            page_rel
-        return nothing
-    end
-    if b !== nothing && e !== nothing
-        new = content[1:(first(b) - 1)] * section * content[(last(e) + 1):end]
-    else
-        new = rstrip(content, '\n') * "\n\n---\n\n" * section * "\n"
-    end
-    # Normalize trailing newlines so re-runs are byte-stable (without this
-    # the append path leaves a trailing "\n\n" that grows by 1 newline on
-    # each subsequent replacement-path regen).
-    new = rstrip(new, '\n') * "\n"
-    if new != content
-        write(p, new)
-        println("  injected hubs into ", page_rel)
-    end
-end
-
-for page in sort(collect(keys(_PAGE_TO_MODELS)))
-    inject_hub_section!(page, _PAGE_TO_MODELS[page])
-end
-
-# ── TIER-1 VIEW GENERATORS (ModelList + per-model + per-quantity) ──────────
-
+# HOISTED: TIER-1 EXT HELPERS
 # ── TIER-1 EXT HELPERS (universality + calc + refs) ─────────────────────────
 
 # CONVENTION block extraction: parse the standard header comment
@@ -1163,6 +630,552 @@ println(
     length(quants_all),
     " quantity pages + ModelList.md",
 )
+
+# ── per-hub pages ────────────────────────────────────────────────────
+hubsdir = joinpath(ROOT, "docs", "src", "atlas", "hubs")
+mkpath(hubsdir)
+for h in claimed
+    cl = first(clby[h])
+    cs = cardsof(h)
+    lev, bdg, adm = levelof(h)
+    hio = IOBuffer()
+    HP(s...) = println(hio, string(s...))
+    HP("# ", bdg, " `", h, "`")
+    HP("")
+    HP(BANNER)
+    HP("")
+    HP("!!! ", adm, " \"Assurance level: ", lev, "\"")
+    if lev == "uncorroborated-but-feasible"
+        HP(
+            "    `src` claims this hub and dense ED is feasible, but no ",
+            "corroboration card exists. **Actionable**: add a ",
+            "`route = :ed_finite_size` or `:second_closed_form` card.",
+        )
+    elseif lev == "cited-only"
+        HP(
+            "    Backed only by a literature citation",
+            if ed_infeasible(h)
+                " (model is ED-infeasible — this is the ceiling)."
+            else
+                " — no in-repo independent re-derivation yet."
+            end,
+        )
+    elseif lev == "coherent"
+        HP(
+            "    An independent card exists and the value satisfies an ",
+            "internal invariant; no external value re-derives it yet.",
+        )
+    else
+        HP("    Independently corroborated. See the cards below.")
+    end
+    HP("")
+    HP("## `src` claim")
+    HP("")
+    HP(
+        "- method `",
+        cl.method,
+        "`, reliability `",
+        cl.reliability,
+        "`",
+        isempty(cl.refs) ? "" : string(", refs: ", _md_escape_dollar(cl.refs)),
+    )
+    isempty(cl.notes) || HP("- ", _md_escape_dollar(cl.notes))
+    HP("")
+    HP("## Corroboration")
+    HP("")
+    if isempty(cs)
+        HP(
+            "_No corroboration card._ ",
+            if ed_infeasible(h)
+                "Model is ED-infeasible — frontier (cited-only), not a gap."
+            else
+                "Flagged by the R1 risk-linter (`src` claims this hub, ED is feasible, no independent card)."
+            end,
+        )
+    else
+        HP("| regime | mechanism | independence | refs | file |")
+        HP("|---|---|---|---|---|")
+        for c in cs
+            b = c.independence == "structural" ? "🟢 structural" : "🟡 asserted"
+            HP(
+                "| `",
+                c.regime,
+                "` | `",
+                c.mechanism,
+                "` | ",
+                b,
+                " | ",
+                _md_escape_dollar(c.refs),
+                " | `",
+                c.file,
+                "` |",
+            )
+        end
+    end
+    if !isempty(cs)
+        HP("")
+        HP("## Test calls")
+        HP("")
+        HP(
+            "_The exact `verify(...)` call the harness executed for this hub (reconstructed from the test AST):_",
+        )
+        HP("")
+        for c in cs
+            HP("```julia")
+            HP(c.srctext)
+            HP("```")
+            HP("")
+        end
+    end
+    HP("")
+    HP("## Assurance (provisional)")
+    HP("")
+    HP("- level: **", lev, "** ", bdg)
+    HP(
+        "- cards: ",
+        length(cs),
+        " · model ED-",
+        ed_infeasible(h) ? "infeasible (frontier)" : "feasible",
+    )
+    HP("- RES not wired — measured residuals / confidence are not shown yet.")
+    HP("")
+    cf_hub = _calc_files_for_hub(modelof(h), quantof(h))
+    if !isempty(cf_hub)
+        HP("")
+        HP("## Derivation note")
+        HP("")
+        HP("Matched by filename substring (model + quantity); substrate-derived:")
+        HP("")
+        for f in cf_hub
+            HP("- [`", f, "`](../../calc/", f, ")")
+        end
+    end
+    HP("")
+    HP(
+        "[← Model: `",
+        modelof(h),
+        "`](../models/",
+        modelof(h),
+        ".md) · ",
+        "[Quantity: `",
+        quantof(h),
+        "`](../quantities/",
+        _quant_slugof(quantof(h)),
+        ".md) · ",
+        "[Atlas index](../index.md)",
+    )
+    write(joinpath(hubsdir, slugof(h) * ".md"), String(take!(hio)))
+end
+
+# ── faceted index pages (R5) ─────────────────────────────────────────
+bydir = joinpath(ROOT, "docs", "src", "atlas", "by")
+mkpath(bydir)
+function write_facet(fname, title, groups, blurb)
+    fio = IOBuffer()
+    FP(s...) = println(fio, string(s...))
+    FP("# ", title)
+    FP("")
+    FP(BANNER)
+    FP("")
+    FP(blurb)
+    FP("")
+    for k in sort(collect(keys(groups)))
+        hs = sort(groups[k])
+        FP("## `", k, "` (", length(hs), ")")
+        FP("")
+        for h in hs
+            FP("- ", facet_link(h))
+        end
+        FP("")
+    end
+    FP("[← back to the Atlas index](../index.md)")
+    write(joinpath(bydir, fname), String(take!(fio)))
+end
+write_facet(
+    "model.md", "Atlas — by model", G_model, "Every `src`-claimed hub grouped by model."
+)
+write_facet(
+    "quantity.md",
+    "Atlas — by quantity",
+    G_quant,
+    "Grouped by the observable (the `Quantity` axis of the locked Model/Quantity/BC schema).",
+)
+write_facet(
+    "bc.md",
+    "Atlas — by boundary condition",
+    G_bc,
+    "Grouped by boundary condition (`Infinite` / `OBC` / `PBC` …).",
+)
+write_facet(
+    "level.md",
+    "Atlas — by assurance level",
+    G_level,
+    "Grouped by the R1 assurance level. `uncorroborated-but-feasible` is the only actionable bucket.",
+)
+write_facet(
+    "mechanism.md",
+    "Atlas — by corroboration mechanism",
+    G_mech,
+    "Grouped by the `route` the verify card used. A hub appears under each mechanism it has a card for.",
+)
+write_facet(
+    "regime.md",
+    "Atlas — by regime",
+    G_regime,
+    "Grouped by the named physical regime resolved from the test call (`@sweep` = loop-variable, not yet a named point).",
+)
+byidx = IOBuffer()
+BI(s...) = println(byidx, string(s...))
+BI("# Atlas — faceted search")
+BI("")
+BI(BANNER)
+BI("")
+BI(
+    "Full-text search is the bar at the top of every page (Documenter ",
+    "built-in — indexes every hub and facet page). Faceted indices over ",
+    "the locked **Model / Quantity / BC @ regime** schema:",
+)
+BI("")
+BI("- [By model](model.md) — ", length(G_model), " models")
+BI("- [By quantity](quantity.md) — ", length(G_quant), " observables")
+BI("- [By boundary condition](bc.md) — ", length(G_bc), " BCs")
+BI("- [By assurance level](level.md) — R1 taxonomy")
+BI("- [By corroboration mechanism](mechanism.md) — verify `route`")
+BI("- [By regime](regime.md) — resolved physical regimes")
+BI("")
+BI("[← back to the Atlas index](../index.md)")
+write(joinpath(bydir, "index.md"), String(take!(byidx)))
+
+# ── atlas index ──────────────────────────────────────────────────────
+io = IOBuffer()
+P(s...) = println(io, string(s...))
+P("# QAtlas — Verified Exact-Solution Atlas")
+P("")
+P(BANNER)
+P("")
+P(LEGEND)
+P("")
+P("## Coverage (all models)")
+P("")
+P("| | count |")
+P("|---|---|")
+P("| Hubs `src` claims (registry) | ", length(claimed), " |")
+P("| ED-feasible claimed (risk denominator) | ", nfeas, " |")
+P("| ED-infeasible claimed (frontier, excluded) | ", length(claimed) - nfeas, " |")
+P("| 🟣 universality-corroborated | ", length(L_UNIV), " |")
+P("| 🟢 corroborated-at-p | ", length(L_EDP), " |")
+P("| 🔵 coherent | ", length(L_COH), " |")
+P("| ⚪ cited-only (frontier — neutral) | ", length(L_CITED), " |")
+P("| 🟠 uncorroborated-but-feasible (**actionable risk**) | ", length(L_RISK), " |")
+P("| Inventory cards scanned (whole test/) | ", length(cards), " |")
+P(
+    "| Registry files parsed | ",
+    length(regfiles) - length(regfail),
+    " / ",
+    length(regfiles),
+    " |",
+)
+P("| Models | ", length(models), " |")
+P("")
+P(
+    "**Externally-corroborated rate** (🟣+🟢 over ED-feasible claimed): **",
+    rate_struct,
+    "%** · **in-repo-verified rate** (incl. 🔵 coherent): **",
+    rate_inrepo,
+    "%**",
+)
+P("")
+P("## Browse by facet")
+P("")
+P(
+    "[**Faceted search →**](by/index.md) · ",
+    "[by model](by/model.md) · [by quantity](by/quantity.md) · ",
+    "[by BC](by/bc.md) · [by level](by/level.md) · ",
+    "[by mechanism](by/mechanism.md) · [by regime](by/regime.md). ",
+    "Full-text search is the top bar (Documenter built-in).",
+)
+
+P("")
+P("")
+P("## Reference & derivation indices")
+P("")
+P(
+    "Two more substrate-derived indices: ",
+    "**[Bibliography](Bibliography.md)** — every citation with hub backlinks; ",
+    "**[Derivation-note index](CalcIndex.md)** — each `docs/src/calc/*.md` mapped to its model(s).",
+)
+P("")
+P("## Model & Quantity matrices (Zettelkasten layer)")
+P("")
+P(
+    "Each model has a per-model index showing its hubs as a ",
+    "`Quantity × BC` matrix; each quantity has the inverse view ",
+    "(`Model × BC`).  Empty cells = gap visualisation (physics not ",
+    "yet implemented).  Use the **[Model list](ModelList.md)** for a ",
+    "searchable top-catalog.",
+)
+P("")
+P("## 🟠 R1 risk-linter — actionable only")
+P("")
+P(
+    "`src` claims the hub, the model is ED-**feasible**, yet zero ",
+    "corroboration cards exist. `cited-only` (frontier) and ED-infeasible ",
+    "hubs are **not** listed here — they are the honest ceiling, not a gap.",
+)
+P("")
+if isempty(L_RISK)
+    P("!!! tip \"No actionable risk\"")
+    P("    Every ED-feasible claimed hub has at least one corroboration card.")
+else
+    P("!!! warning \"", length(L_RISK), " actionable hub(s)\"")
+    for h in sort(L_RISK)
+        P("    - [`", h, "`](hubs/", slugof(h), ".md)")
+    end
+end
+P("")
+P("## Per-model breakdown")
+P("")
+P("| model | claimed | 🟣 | 🟢 | 🔵 | ⚪ | 🟠 | ED |")
+P("|---|---|---|---|---|---|---|---|")
+for m in models
+    hs = filter(h -> modelof(h) == m, claimed)
+    P(
+        "| `",
+        m,
+        "` | ",
+        length(hs),
+        " | ",
+        count(h -> levelcode(h) == AtlasInventory.UNIVERSALITY_CORROBORATED, hs),
+        " | ",
+        count(h -> levelcode(h) == AtlasInventory.CORROBORATED_AT_P, hs),
+        " | ",
+        count(h -> levelcode(h) == AtlasInventory.COHERENT, hs),
+        " | ",
+        count(h -> levelcode(h) == AtlasInventory.CITED_ONLY, hs),
+        " | ",
+        count(h -> levelcode(h) == AtlasInventory.UNCORROBORATED_BUT_FEASIBLE, hs),
+        " | ",
+        (m in AtlasInventory.ED_INFEASIBLE_MODELS ? "infeasible" : "feasible"),
+        " |",
+    )
+end
+P("")
+P("## Hubs (", length(claimed), ") — select to drill down")
+P("")
+for m in models
+    hs = sort(filter(h -> modelof(h) == m, claimed))
+    P("### `", m, "` (", length(hs), ")")
+    P("")
+    for h in hs
+        P("- ", badgeof(h), " [`", h, "`](hubs/", slugof(h), ".md) — ", levname(h))
+    end
+    P("")
+end
+
+out = joinpath(ROOT, "docs", "src", "atlas", "index.md")
+mkpath(dirname(out))
+write(out, String(take!(io)))
+println(
+    "wrote ",
+    out,
+    " + ",
+    length(claimed),
+    " per-hub pages + 7 facet pages  models=",
+    length(models),
+    " hubs=",
+    length(claimed),
+    " cards=",
+    length(cards),
+    " regfail=",
+    length(regfail),
+    "  R1[univ=",
+    length(L_UNIV),
+    " edp=",
+    length(L_EDP),
+    " coh=",
+    length(L_COH),
+    " cited=",
+    length(L_CITED),
+    " risk=",
+    length(L_RISK),
+    "] feas=",
+    nfeas,
+    " rate_struct=",
+    rate_struct,
+    " rate_inrepo=",
+    rate_inrepo,
+)
+
+# ─── Auto-inject "Verified hubs" section into hand-written model pages ──────
+# Closes the model-page <-> atlas-hub coherence gap. For each mapped docs
+# page, writes a fresh `## Verified hubs` table between START / END
+# markers; if markers are absent, the section is appended at end of file.
+
+const MODEL_DOC_MAP = Dict{String,String}(
+    "TFIM" => "docs/src/models/quantum/tfim.md",
+    "Heisenberg1D" => "docs/src/models/quantum/heisenberg.md",
+    "S1Heisenberg1D" => "docs/src/models/quantum/heisenberg.md",
+    "HeisenbergXYZ" => "docs/src/models/quantum/heisenberg.md",
+    "DMIHeisenberg1D" => "docs/src/models/quantum/heisenberg.md",
+    "J1J2Heisenberg1D" => "docs/src/models/quantum/heisenberg.md",
+    "MajumdarGhosh" => "docs/src/models/quantum/majumdar_ghosh.md",
+    "Hubbard1D" => "docs/src/models/quantum/hubbard1d.md",
+    "ExtendedHubbard1D" => "docs/src/models/quantum/hubbard1d.md",
+    "KitaevHoneycomb" => "docs/src/models/quantum/kitaev-honeycomb.md",
+    "KitaevHeisenberg" => "docs/src/models/quantum/kitaev-honeycomb.md",
+    "Kitaev1D" => "docs/src/models/quantum/kitaev1d.md",
+    "ToricCode" => "docs/src/models/quantum/toric-code.md",
+    "XXZ1D" => "docs/src/models/quantum/xxz.md",
+    "S1XXZ1D" => "docs/src/models/quantum/xxz.md",
+    "IsingSquare" => "docs/src/models/classical/ising-square.md",
+    "IsingTriangular" => "docs/src/models/classical/ising-triangular.md",
+    "SixVertex" => "docs/src/models/classical/six-vertex.md",
+)
+
+const _PAGE_TO_MODELS = let
+    d = Dict{String,Vector{String}}()
+    for (m, page) in MODEL_DOC_MAP
+        push!(get!(d, page, String[]), m)
+    end
+    for (_, ms) in d
+        sort!(ms)
+    end
+    d
+end
+
+_posix(p::AbstractString) = replace(p, '\\' => '/')
+
+const _ATLAS_HUBS_BEGIN = "<!-- ATLAS:HUBS:START -- auto-generated by docs/atlas/generate.jl. Do not edit by hand; edits between these markers are overwritten on next regen. -->"
+const _ATLAS_HUBS_END = "<!-- ATLAS:HUBS:END -->"
+
+function render_hub_section(page_rel, model_names)
+    page_dir = dirname(joinpath(ROOT, page_rel))
+    io = IOBuffer()
+    P = (xs...) -> println(io, xs...)
+    relevant = sort(filter(h -> modelof(h) in model_names, claimed))
+    atlas_rel = _posix(relpath(joinpath(ROOT, "docs/src/atlas/index.md"), page_dir))
+    P(_ATLAS_HUBS_BEGIN)
+    P()
+    P("## Verified hubs")
+    P()
+    n = length(model_names)
+    subj = n == 1 ? "this model registers" : "these $(n) models register"
+    nh = length(relevant)
+    hub_word = nh == 1 ? "hub" : "hubs"
+    P(
+        "In the [Verified Atlas](",
+        atlas_rel,
+        "), ",
+        subj,
+        " ",
+        nh,
+        " ",
+        hub_word,
+        " (quantity / BC pair). The badge column shows the R1 assurance level; click a hub link to see the exact `verify(...)` calls, references, and corroboration mechanism.",
+    )
+    P()
+    if nh == 0
+        P("_No hubs registered yet._")
+        P()
+    else
+        if n == 1
+            P("| Quantity | BC | Assurance | Cards |")
+            P("|---|---|---|---|")
+            for h in relevant
+                hub_page = joinpath(ROOT, "docs/src/atlas/hubs/$(slugof(h)).md")
+                rp = _posix(relpath(hub_page, page_dir))
+                P(
+                    "| [`",
+                    quantof(h),
+                    "`](",
+                    rp,
+                    ") | `",
+                    bcof(h),
+                    "` | ",
+                    badgeof(h),
+                    " ",
+                    levname(h),
+                    " | ",
+                    length(cardsof(h)),
+                    " |",
+                )
+            end
+        else
+            P("| Model | Quantity | BC | Assurance | Cards |")
+            P("|---|---|---|---|---|")
+            for h in relevant
+                hub_page = joinpath(ROOT, "docs/src/atlas/hubs/$(slugof(h)).md")
+                rp = _posix(relpath(hub_page, page_dir))
+                P(
+                    "| `",
+                    modelof(h),
+                    "` | [`",
+                    quantof(h),
+                    "`](",
+                    rp,
+                    ") | `",
+                    bcof(h),
+                    "` | ",
+                    badgeof(h),
+                    " ",
+                    levname(h),
+                    " | ",
+                    length(cardsof(h)),
+                    " |",
+                )
+            end
+        end
+        P()
+    end
+    P(_ATLAS_HUBS_END)
+    return String(take!(io))
+end
+
+function inject_hub_section!(page_rel, model_names)
+    p = joinpath(ROOT, page_rel)
+    if !isfile(p)
+        @warn "ATLAS hub-inject skip: page not found" page = page_rel
+        return nothing
+    end
+    content = read(p, String)
+    section = render_hub_section(page_rel, model_names)
+    b = findfirst(_ATLAS_HUBS_BEGIN, content)
+    e = findfirst(_ATLAS_HUBS_END, content)
+    # Explicit marker-pair validation: refuse to write when only one of
+    # START/END is present or when they are misordered. Without this an
+    # orphaned START at the top of the page would be paired with the
+    # appended-section END at the bottom on the NEXT regen, silently
+    # nuking everything between them.
+    if (b === nothing) != (e === nothing)
+        @warn "ATLAS hub-inject skip: page has only one of START/END marker; refusing to mutate to avoid data loss" page =
+            page_rel
+        return nothing
+    end
+    if b !== nothing && e !== nothing && first(e) <= last(b)
+        @warn "ATLAS hub-inject skip: START/END markers in wrong order; refusing to mutate" page =
+            page_rel
+        return nothing
+    end
+    if b !== nothing && e !== nothing
+        new = content[1:(first(b) - 1)] * section * content[(last(e) + 1):end]
+    else
+        new = rstrip(content, '\n') * "\n\n---\n\n" * section * "\n"
+    end
+    # Normalize trailing newlines so re-runs are byte-stable (without this
+    # the append path leaves a trailing "\n\n" that grows by 1 newline on
+    # each subsequent replacement-path regen).
+    new = rstrip(new, '\n') * "\n"
+    if new != content
+        write(p, new)
+        println("  injected hubs into ", page_rel)
+    end
+end
+
+for page in sort(collect(keys(_PAGE_TO_MODELS)))
+    inject_hub_section!(page, _PAGE_TO_MODELS[page])
+end
+
+# ── TIER-1 VIEW GENERATORS (ModelList + per-model + per-quantity) ──────────
 
 # ── TIER-1 EXT EMITTERS (Bibliography + CalcIndex) ──────────────────────────
 function render_bibliography()

--- a/docs/src/atlas/hubs/AKLT1D_CorrelationLength_Infinite.md
+++ b/docs/src/atlas/hubs/AKLT1D_CorrelationLength_Infinite.md
@@ -37,4 +37,5 @@ verify(AKLT1D(), CorrelationLength(), Infinite(); route = :second_closed_form, i
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `AKLT1D`](../models/AKLT1D.md) · [Quantity: `CorrelationLength`](../quantities/CorrelationLength.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/AKLT1D_Energy_Infinite.md
+++ b/docs/src/atlas/hubs/AKLT1D_Energy_Infinite.md
@@ -42,4 +42,5 @@ verify(AKLT1D(), Energy(:per_site), Infinite(); route = :ed_finite_size, indepen
 - cards: 3 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `AKLT1D`](../models/AKLT1D.md) · [Quantity: `Energy`](../quantities/Energy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/AKLT1D_ExactSpectrum_OBC.md
+++ b/docs/src/atlas/hubs/AKLT1D_ExactSpectrum_OBC.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `AKLT1D`](../models/AKLT1D.md) · [Quantity: `ExactSpectrum`](../quantities/ExactSpectrum.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/AKLT1D_GroundStateEnergyDensity_Infinite.md
+++ b/docs/src/atlas/hubs/AKLT1D_GroundStateEnergyDensity_Infinite.md
@@ -37,4 +37,5 @@ verify(AKLT1D(; J = J), GroundStateEnergyDensity(), Infinite(); route = :second_
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `AKLT1D`](../models/AKLT1D.md) · [Quantity: `GroundStateEnergyDensity`](../quantities/GroundStateEnergyDensity.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/AKLT1D_MassGap_Infinite.md
+++ b/docs/src/atlas/hubs/AKLT1D_MassGap_Infinite.md
@@ -37,4 +37,5 @@ verify(AKLT1D(; J = J), MassGap(), Infinite(); route = :literature_value, indepe
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `AKLT1D`](../models/AKLT1D.md) · [Quantity: `MassGap`](../quantities/MassGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/AKLT1D_StringOrderParameter_Infinite.md
+++ b/docs/src/atlas/hubs/AKLT1D_StringOrderParameter_Infinite.md
@@ -37,4 +37,5 @@ verify(AKLT1D(), StringOrderParameter(), Infinite(); route = :second_closed_form
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `AKLT1D`](../models/AKLT1D.md) · [Quantity: `StringOrderParameter`](../quantities/StringOrderParameter.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/AKLT1D_ZZCorrelation_Infinite.md
+++ b/docs/src/atlas/hubs/AKLT1D_ZZCorrelation_Infinite.md
@@ -37,4 +37,5 @@ verify(AKLT1D(), ZZCorrelation(; mode = :static), Infinite(); route = :second_cl
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `AKLT1D`](../models/AKLT1D.md) · [Quantity: `ZZCorrelation`](../quantities/ZZCorrelation.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/AKLT1D_ZZStructureFactor_Infinite.md
+++ b/docs/src/atlas/hubs/AKLT1D_ZZStructureFactor_Infinite.md
@@ -37,4 +37,5 @@ verify(AKLT1D(), ZZStructureFactor(), Infinite(); route = :second_closed_form, i
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `AKLT1D`](../models/AKLT1D.md) · [Quantity: `ZZStructureFactor`](../quantities/ZZStructureFactor.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/AKLT2D_Energy_Infinite.md
+++ b/docs/src/atlas/hubs/AKLT2D_Energy_Infinite.md
@@ -37,4 +37,5 @@ verify(AKLT2D(; J = J), Energy(:per_site), Infinite(); route = :second_closed_fo
 - cards: 2 · model ED-infeasible (frontier)
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `AKLT2D`](../models/AKLT2D.md) · [Quantity: `Energy`](../quantities/Energy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/BCFT_ResidualEntropy_Infinite.md
+++ b/docs/src/atlas/hubs/BCFT_ResidualEntropy_Infinite.md
@@ -32,4 +32,5 @@ verify(BCFT(), ResidualEntropy(), Infinite(); route = :second_closed_form, indep
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `BCFT`](../models/BCFT.md) · [Quantity: `ResidualEntropy`](../quantities/ResidualEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/ChernSimons3D_CentralCharge_Infinite.md
+++ b/docs/src/atlas/hubs/ChernSimons3D_CentralCharge_Infinite.md
@@ -32,4 +32,5 @@ verify(ChernSimons3D(; N = 2, k = k), CentralCharge(), Infinite(); route = :seco
 - cards: 1 · model ED-infeasible (frontier)
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `ChernSimons3D`](../models/ChernSimons3D.md) · [Quantity: `CentralCharge`](../quantities/CentralCharge.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/ChernSimons3D_PartitionFunction_Infinite.md
+++ b/docs/src/atlas/hubs/ChernSimons3D_PartitionFunction_Infinite.md
@@ -47,4 +47,5 @@ verify(ChernSimons3D(; N = 2, k = 3), PartitionFunction(), Infinite(); route = :
 - cards: 4 · model ED-infeasible (frontier)
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `ChernSimons3D`](../models/ChernSimons3D.md) · [Quantity: `PartitionFunction`](../quantities/PartitionFunction.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Cluster1D_Energy_Infinite.md
+++ b/docs/src/atlas/hubs/Cluster1D_Energy_Infinite.md
@@ -37,4 +37,5 @@ verify(Cluster1D(; J = J), Energy(:per_site), Infinite(); route = :second_closed
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Cluster1D`](../models/Cluster1D.md) · [Quantity: `Energy`](../quantities/Energy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Cluster1D_MassGap_Infinite.md
+++ b/docs/src/atlas/hubs/Cluster1D_MassGap_Infinite.md
@@ -37,4 +37,5 @@ verify(Cluster1D(; J = J), MassGap(), Infinite(); route = :second_closed_form, i
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Cluster1D`](../models/Cluster1D.md) · [Quantity: `MassGap`](../quantities/MassGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Compass1D_MassGap_Infinite.md
+++ b/docs/src/atlas/hubs/Compass1D_MassGap_Infinite.md
@@ -37,4 +37,5 @@ verify(Compass1D(; J_x = Jx, J_y = Jy), MassGap(), Infinite(); route = :second_c
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Compass1D`](../models/Compass1D.md) · [Quantity: `MassGap`](../quantities/MassGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/ConformalBootstrap_ConformalWeights_Infinite.md
+++ b/docs/src/atlas/hubs/ConformalBootstrap_ConformalWeights_Infinite.md
@@ -42,4 +42,5 @@ verify(ConformalBootstrap(), ConformalWeights(), Infinite(); route = :literature
 - cards: 3 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `ConformalBootstrap`](../models/ConformalBootstrap.md) · [Quantity: `ConformalWeights`](../quantities/ConformalWeights.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/CurieWeissIsing_CriticalExponents_Infinite.md
+++ b/docs/src/atlas/hubs/CurieWeissIsing_CriticalExponents_Infinite.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `CurieWeissIsing`](../models/CurieWeissIsing.md) · [Quantity: `CriticalExponents`](../quantities/CriticalExponents.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/CurieWeissIsing_CriticalTemperature_Infinite.md
+++ b/docs/src/atlas/hubs/CurieWeissIsing_CriticalTemperature_Infinite.md
@@ -32,4 +32,5 @@ verify(CurieWeissIsing(; J = J), CriticalTemperature(), Infinite(); route = :sec
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `CurieWeissIsing`](../models/CurieWeissIsing.md) · [Quantity: `CriticalTemperature`](../quantities/CriticalTemperature.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/CurieWeissIsing_Energy_Infinite.md
+++ b/docs/src/atlas/hubs/CurieWeissIsing_Energy_Infinite.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `CurieWeissIsing`](../models/CurieWeissIsing.md) · [Quantity: `Energy`](../quantities/Energy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/CurieWeissIsing_FreeEnergy_Infinite.md
+++ b/docs/src/atlas/hubs/CurieWeissIsing_FreeEnergy_Infinite.md
@@ -32,4 +32,5 @@ verify(CurieWeissIsing(; J = J, h = 0.0), FreeEnergy(), Infinite(); route = :lim
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `CurieWeissIsing`](../models/CurieWeissIsing.md) · [Quantity: `FreeEnergy`](../quantities/FreeEnergy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/CurieWeissIsing_SpecificHeat_Infinite.md
+++ b/docs/src/atlas/hubs/CurieWeissIsing_SpecificHeat_Infinite.md
@@ -32,4 +32,5 @@ verify(CurieWeissIsing(; J = J, h = 0.0), SpecificHeat(), Infinite(); route = :l
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `CurieWeissIsing`](../models/CurieWeissIsing.md) · [Quantity: `SpecificHeat`](../quantities/SpecificHeat.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/CurieWeissIsing_SpontaneousMagnetization_Infinite.md
+++ b/docs/src/atlas/hubs/CurieWeissIsing_SpontaneousMagnetization_Infinite.md
@@ -32,4 +32,5 @@ verify(CurieWeissIsing(; J = J), SpontaneousMagnetization(), Infinite(); route =
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `CurieWeissIsing`](../models/CurieWeissIsing.md) · [Quantity: `SpontaneousMagnetization`](../quantities/SpontaneousMagnetization.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/CurieWeissIsing_SusceptibilityZZ_Infinite.md
+++ b/docs/src/atlas/hubs/CurieWeissIsing_SusceptibilityZZ_Infinite.md
@@ -32,4 +32,5 @@ verify(CurieWeissIsing(; J = J, h = 0.0), SusceptibilityZZ(), Infinite(); route 
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `CurieWeissIsing`](../models/CurieWeissIsing.md) · [Quantity: `SusceptibilityZZ`](../quantities/SusceptibilityZZ.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/CurieWeissIsing_ThermalEntropy_Infinite.md
+++ b/docs/src/atlas/hubs/CurieWeissIsing_ThermalEntropy_Infinite.md
@@ -37,4 +37,5 @@ verify(CurieWeissIsing(; J = J, h = h), ThermalEntropy(), Infinite(); route = :l
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `CurieWeissIsing`](../models/CurieWeissIsing.md) · [Quantity: `ThermalEntropy`](../quantities/ThermalEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/DMIHeisenberg1D_Energy_Infinite.md
+++ b/docs/src/atlas/hubs/DMIHeisenberg1D_Energy_Infinite.md
@@ -42,4 +42,5 @@ verify(DMIHeisenberg1D(; J = J, D = 0.0), Energy(:per_site), Infinite(); route =
 - cards: 3 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `DMIHeisenberg1D`](../models/DMIHeisenberg1D.md) · [Quantity: `Energy`](../quantities/Energy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/ExtendedHubbard1D_ChargeGap_Infinite.md
+++ b/docs/src/atlas/hubs/ExtendedHubbard1D_ChargeGap_Infinite.md
@@ -32,4 +32,5 @@ verify(ExtendedHubbard1D(; t = t, U = U, V = 0.0), ChargeGap(), Infinite(); rout
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `ExtendedHubbard1D`](../models/ExtendedHubbard1D.md) · [Quantity: `ChargeGap`](../quantities/ChargeGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/FibonacciAnyons_TopologicalEntanglementEntropy_Infinite.md
+++ b/docs/src/atlas/hubs/FibonacciAnyons_TopologicalEntanglementEntropy_Infinite.md
@@ -37,4 +37,5 @@ verify(FibonacciAnyons(), TopologicalEntanglementEntropy(), Infinite(); route = 
 - cards: 2 · model ED-infeasible (frontier)
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `FibonacciAnyons`](../models/FibonacciAnyons.md) · [Quantity: `TopologicalEntanglementEntropy`](../quantities/TopologicalEntanglementEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/GrossNeveu_CentralCharge_Infinite.md
+++ b/docs/src/atlas/hubs/GrossNeveu_CentralCharge_Infinite.md
@@ -32,4 +32,5 @@ verify(GrossNeveu(; N = N, g = 0.0), CentralCharge(), Infinite(); route = :secon
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `GrossNeveu`](../models/GrossNeveu.md) · [Quantity: `CentralCharge`](../quantities/CentralCharge.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/GrossNeveu_MassGap_Infinite.md
+++ b/docs/src/atlas/hubs/GrossNeveu_MassGap_Infinite.md
@@ -32,4 +32,5 @@ verify(GrossNeveu(; N = 1, g = 1.0), MassGap(), Infinite(); route = :second_clos
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `GrossNeveu`](../models/GrossNeveu.md) · [Quantity: `MassGap`](../quantities/MassGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Heisenberg1D_EnergyLocal_OBC.md
+++ b/docs/src/atlas/hubs/Heisenberg1D_EnergyLocal_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Heisenberg1D`](../models/Heisenberg1D.md) · [Quantity: `EnergyLocal`](../quantities/EnergyLocal.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Heisenberg1D_Energy_OBC.md
+++ b/docs/src/atlas/hubs/Heisenberg1D_Energy_OBC.md
@@ -57,4 +57,5 @@ verify(Heisenberg1D(), Energy(), OBC(N); route = :delegation_invariant, fetch_kw
 - cards: 6 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Heisenberg1D`](../models/Heisenberg1D.md) · [Quantity: `Energy`](../quantities/Energy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Heisenberg1D_FreeEnergy_OBC.md
+++ b/docs/src/atlas/hubs/Heisenberg1D_FreeEnergy_OBC.md
@@ -36,4 +36,5 @@ verify(Heisenberg1D(), FreeEnergy(), OBC(N); route = :ed_finite_size, independen
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Heisenberg1D`](../models/Heisenberg1D.md) · [Quantity: `FreeEnergy`](../quantities/FreeEnergy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Heisenberg1D_GroundStateEnergyDensity_Infinite.md
+++ b/docs/src/atlas/hubs/Heisenberg1D_GroundStateEnergyDensity_Infinite.md
@@ -47,4 +47,5 @@ verify(Heisenberg1D(), GroundStateEnergyDensity(), Infinite(); route = :ed_finit
 - cards: 4 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Heisenberg1D`](../models/Heisenberg1D.md) · [Quantity: `GroundStateEnergyDensity`](../quantities/GroundStateEnergyDensity.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Heisenberg1D_LuttingerParameter_Infinite.md
+++ b/docs/src/atlas/hubs/Heisenberg1D_LuttingerParameter_Infinite.md
@@ -37,4 +37,5 @@ verify(Heisenberg1D(), LuttingerParameter(), Infinite(); route = :limiting_case,
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Heisenberg1D`](../models/Heisenberg1D.md) · [Quantity: `LuttingerParameter`](../quantities/LuttingerParameter.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Heisenberg1D_MagnetizationXLocal_OBC.md
+++ b/docs/src/atlas/hubs/Heisenberg1D_MagnetizationXLocal_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Heisenberg1D`](../models/Heisenberg1D.md) · [Quantity: `MagnetizationXLocal`](../quantities/MagnetizationXLocal.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Heisenberg1D_MagnetizationX_OBC.md
+++ b/docs/src/atlas/hubs/Heisenberg1D_MagnetizationX_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Heisenberg1D`](../models/Heisenberg1D.md) · [Quantity: `MagnetizationX`](../quantities/MagnetizationX.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Heisenberg1D_MagnetizationYLocal_OBC.md
+++ b/docs/src/atlas/hubs/Heisenberg1D_MagnetizationYLocal_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Heisenberg1D`](../models/Heisenberg1D.md) · [Quantity: `MagnetizationYLocal`](../quantities/MagnetizationYLocal.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Heisenberg1D_MagnetizationY_OBC.md
+++ b/docs/src/atlas/hubs/Heisenberg1D_MagnetizationY_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Heisenberg1D`](../models/Heisenberg1D.md) · [Quantity: `MagnetizationY`](../quantities/MagnetizationY.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Heisenberg1D_MagnetizationZLocal_OBC.md
+++ b/docs/src/atlas/hubs/Heisenberg1D_MagnetizationZLocal_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Heisenberg1D`](../models/Heisenberg1D.md) · [Quantity: `MagnetizationZLocal`](../quantities/MagnetizationZLocal.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Heisenberg1D_MagnetizationZ_OBC.md
+++ b/docs/src/atlas/hubs/Heisenberg1D_MagnetizationZ_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Heisenberg1D`](../models/Heisenberg1D.md) · [Quantity: `MagnetizationZ`](../quantities/MagnetizationZ.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Heisenberg1D_MassGap_Infinite.md
+++ b/docs/src/atlas/hubs/Heisenberg1D_MassGap_Infinite.md
@@ -32,4 +32,5 @@ verify(Heisenberg1D(), MassGap(), Infinite(); route = :second_closed_form, indep
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Heisenberg1D`](../models/Heisenberg1D.md) · [Quantity: `MassGap`](../quantities/MassGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Heisenberg1D_MassGap_OBC.md
+++ b/docs/src/atlas/hubs/Heisenberg1D_MassGap_OBC.md
@@ -32,4 +32,5 @@ verify(Heisenberg1D(), MassGap(), OBC(N); route = :second_closed_form, independe
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Heisenberg1D`](../models/Heisenberg1D.md) · [Quantity: `MassGap`](../quantities/MassGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Heisenberg1D_RenyiEntropy_OBC.md
+++ b/docs/src/atlas/hubs/Heisenberg1D_RenyiEntropy_OBC.md
@@ -31,4 +31,5 @@ verify(Heisenberg1D(), RenyiEntropy(α), OBC(N); route = :second_closed_form, in
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Heisenberg1D`](../models/Heisenberg1D.md) · [Quantity: `RenyiEntropy`](../quantities/RenyiEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Heisenberg1D_SpecificHeat_OBC.md
+++ b/docs/src/atlas/hubs/Heisenberg1D_SpecificHeat_OBC.md
@@ -41,4 +41,5 @@ verify(Heisenberg1D(), SpecificHeat(), OBC(N); route = :ed_finite_size, independ
 - cards: 3 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Heisenberg1D`](../models/Heisenberg1D.md) · [Quantity: `SpecificHeat`](../quantities/SpecificHeat.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Heisenberg1D_SusceptibilityXX_OBC.md
+++ b/docs/src/atlas/hubs/Heisenberg1D_SusceptibilityXX_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Heisenberg1D`](../models/Heisenberg1D.md) · [Quantity: `SusceptibilityXX`](../quantities/SusceptibilityXX.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Heisenberg1D_SusceptibilityYY_OBC.md
+++ b/docs/src/atlas/hubs/Heisenberg1D_SusceptibilityYY_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Heisenberg1D`](../models/Heisenberg1D.md) · [Quantity: `SusceptibilityYY`](../quantities/SusceptibilityYY.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Heisenberg1D_SusceptibilityZZ_OBC.md
+++ b/docs/src/atlas/hubs/Heisenberg1D_SusceptibilityZZ_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Heisenberg1D`](../models/Heisenberg1D.md) · [Quantity: `SusceptibilityZZ`](../quantities/SusceptibilityZZ.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Heisenberg1D_ThermalEntropy_OBC.md
+++ b/docs/src/atlas/hubs/Heisenberg1D_ThermalEntropy_OBC.md
@@ -41,4 +41,5 @@ verify(Heisenberg1D(), ThermalEntropy(), OBC(N); route = :ed_finite_size, indepe
 - cards: 3 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Heisenberg1D`](../models/Heisenberg1D.md) · [Quantity: `ThermalEntropy`](../quantities/ThermalEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Heisenberg1D_VonNeumannEntropy_OBC.md
+++ b/docs/src/atlas/hubs/Heisenberg1D_VonNeumannEntropy_OBC.md
@@ -31,4 +31,5 @@ verify(Heisenberg1D(), VonNeumannEntropy(), OBC(N); route = :second_closed_form,
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Heisenberg1D`](../models/Heisenberg1D.md) · [Quantity: `VonNeumannEntropy`](../quantities/VonNeumannEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Heisenberg1D_ZZStructureFactor_Infinite.md
+++ b/docs/src/atlas/hubs/Heisenberg1D_ZZStructureFactor_Infinite.md
@@ -37,4 +37,5 @@ verify(Heisenberg1D(), ZZStructureFactor(), Infinite(); route = :second_closed_f
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Heisenberg1D`](../models/Heisenberg1D.md) · [Quantity: `ZZStructureFactor`](../quantities/ZZStructureFactor.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/HeisenbergXYZ_Energy_Infinite.md
+++ b/docs/src/atlas/hubs/HeisenbergXYZ_Energy_Infinite.md
@@ -42,4 +42,5 @@ verify(HeisenbergXYZ(; Jx = 1.0, Jy = 1.0, Jz = -1.0), Energy(:per_site), Infini
 - cards: 3 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `HeisenbergXYZ`](../models/HeisenbergXYZ.md) · [Quantity: `Energy`](../quantities/Energy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/HeisenbergXYZ_LuttingerParameter_Infinite.md
+++ b/docs/src/atlas/hubs/HeisenbergXYZ_LuttingerParameter_Infinite.md
@@ -32,4 +32,5 @@ verify(HeisenbergXYZ(; Jx = 1.0, Jy = 1.0, Jz = 1.0), LuttingerParameter(), Infi
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `HeisenbergXYZ`](../models/HeisenbergXYZ.md) · [Quantity: `LuttingerParameter`](../quantities/LuttingerParameter.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Hubbard1D_ChargeGap_Infinite.md
+++ b/docs/src/atlas/hubs/Hubbard1D_ChargeGap_Infinite.md
@@ -37,4 +37,5 @@ verify(Hubbard1D(; t = t, U = U, μ = U / 2), ChargeGap(), Infinite(); route = :
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Hubbard1D`](../models/Hubbard1D.md) · [Quantity: `ChargeGap`](../quantities/ChargeGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Hubbard1D_GroundStateEnergyDensity_Infinite.md
+++ b/docs/src/atlas/hubs/Hubbard1D_GroundStateEnergyDensity_Infinite.md
@@ -37,4 +37,5 @@ verify(Hubbard1D(; t = t, U = U, μ = U / 2), GroundStateEnergyDensity(), Infini
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Hubbard1D`](../models/Hubbard1D.md) · [Quantity: `GroundStateEnergyDensity`](../quantities/GroundStateEnergyDensity.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Hubbard1D_LuttingerParameter_Infinite.md
+++ b/docs/src/atlas/hubs/Hubbard1D_LuttingerParameter_Infinite.md
@@ -32,4 +32,5 @@ verify(Hubbard1D(; t = t, U = 0.0, μ = 0.0), LuttingerParameter(), Infinite(); 
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Hubbard1D`](../models/Hubbard1D.md) · [Quantity: `LuttingerParameter`](../quantities/LuttingerParameter.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Hubbard1D_SpinGap_Infinite.md
+++ b/docs/src/atlas/hubs/Hubbard1D_SpinGap_Infinite.md
@@ -32,4 +32,5 @@ verify(Hubbard1D(; t = t, U = U, μ = U / 2), SpinGap(), Infinite(); route = :se
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Hubbard1D`](../models/Hubbard1D.md) · [Quantity: `SpinGap`](../quantities/SpinGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/IsingChain1D_CorrelationLength_Infinite.md
+++ b/docs/src/atlas/hubs/IsingChain1D_CorrelationLength_Infinite.md
@@ -37,4 +37,5 @@ verify(IsingChain1D(; J = J), CorrelationLength(), Infinite(); route = :second_c
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `IsingChain1D`](../models/IsingChain1D.md) · [Quantity: `CorrelationLength`](../quantities/CorrelationLength.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/IsingChain1D_CriticalTemperature_Infinite.md
+++ b/docs/src/atlas/hubs/IsingChain1D_CriticalTemperature_Infinite.md
@@ -37,4 +37,5 @@ verify(IsingChain1D(; J = J), CriticalTemperature(), Infinite(); route = :second
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `IsingChain1D`](../models/IsingChain1D.md) · [Quantity: `CriticalTemperature`](../quantities/CriticalTemperature.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/IsingChain1D_Energy_Infinite.md
+++ b/docs/src/atlas/hubs/IsingChain1D_Energy_Infinite.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `IsingChain1D`](../models/IsingChain1D.md) · [Quantity: `Energy`](../quantities/Energy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/IsingChain1D_FreeEnergy_Infinite.md
+++ b/docs/src/atlas/hubs/IsingChain1D_FreeEnergy_Infinite.md
@@ -37,4 +37,5 @@ verify(IsingChain1D(; J = J), FreeEnergy(), Infinite(); route = :second_closed_f
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `IsingChain1D`](../models/IsingChain1D.md) · [Quantity: `FreeEnergy`](../quantities/FreeEnergy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/IsingChain1D_SpecificHeat_Infinite.md
+++ b/docs/src/atlas/hubs/IsingChain1D_SpecificHeat_Infinite.md
@@ -32,4 +32,5 @@ verify(IsingChain1D(; J = J), SpecificHeat(), Infinite(); route = :second_closed
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `IsingChain1D`](../models/IsingChain1D.md) · [Quantity: `SpecificHeat`](../quantities/SpecificHeat.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/IsingChain1D_SpontaneousMagnetization_Infinite.md
+++ b/docs/src/atlas/hubs/IsingChain1D_SpontaneousMagnetization_Infinite.md
@@ -32,4 +32,5 @@ verify(IsingChain1D(; J = J), SpontaneousMagnetization(), Infinite(); route = :s
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `IsingChain1D`](../models/IsingChain1D.md) · [Quantity: `SpontaneousMagnetization`](../quantities/SpontaneousMagnetization.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/IsingChain1D_SusceptibilityZZ_Infinite.md
+++ b/docs/src/atlas/hubs/IsingChain1D_SusceptibilityZZ_Infinite.md
@@ -32,4 +32,5 @@ verify(IsingChain1D(; J = J), SusceptibilityZZ(), Infinite(); route = :second_cl
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `IsingChain1D`](../models/IsingChain1D.md) · [Quantity: `SusceptibilityZZ`](../quantities/SusceptibilityZZ.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/IsingChain1D_ThermalEntropy_Infinite.md
+++ b/docs/src/atlas/hubs/IsingChain1D_ThermalEntropy_Infinite.md
@@ -32,4 +32,5 @@ verify(IsingChain1D(; J = J), ThermalEntropy(), Infinite(); route = :second_clos
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `IsingChain1D`](../models/IsingChain1D.md) · [Quantity: `ThermalEntropy`](../quantities/ThermalEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/IsingSquare_CriticalExponents_Infinite.md
+++ b/docs/src/atlas/hubs/IsingSquare_CriticalExponents_Infinite.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `IsingSquare`](../models/IsingSquare.md) · [Quantity: `CriticalExponents`](../quantities/CriticalExponents.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/IsingSquare_CriticalTemperature_Infinite.md
+++ b/docs/src/atlas/hubs/IsingSquare_CriticalTemperature_Infinite.md
@@ -47,4 +47,5 @@ verify(IsingSquare(; J = 1.0), CriticalTemperature(), Infinite(); route = :secon
 - cards: 4 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `IsingSquare`](../models/IsingSquare.md) · [Quantity: `CriticalTemperature`](../quantities/CriticalTemperature.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/IsingSquare_Energy_Infinite.md
+++ b/docs/src/atlas/hubs/IsingSquare_Energy_Infinite.md
@@ -32,4 +32,5 @@ verify(IsingSquare(; J = 1.0), Energy(:per_site), Infinite(); route = :limiting_
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `IsingSquare`](../models/IsingSquare.md) · [Quantity: `Energy`](../quantities/Energy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/IsingSquare_Energy_PBC.md
+++ b/docs/src/atlas/hubs/IsingSquare_Energy_PBC.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `IsingSquare`](../models/IsingSquare.md) · [Quantity: `Energy`](../quantities/Energy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/IsingSquare_FreeEnergy_Infinite.md
+++ b/docs/src/atlas/hubs/IsingSquare_FreeEnergy_Infinite.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `IsingSquare`](../models/IsingSquare.md) · [Quantity: `FreeEnergy`](../quantities/FreeEnergy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/IsingSquare_FreeEnergy_PBC.md
+++ b/docs/src/atlas/hubs/IsingSquare_FreeEnergy_PBC.md
@@ -32,4 +32,5 @@ verify(IsingSquare(; Lx = L, Ly = L, J = 1.0), FreeEnergy(), PBC(0); route = :ed
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `IsingSquare`](../models/IsingSquare.md) · [Quantity: `FreeEnergy`](../quantities/FreeEnergy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/IsingSquare_PartitionFunction_PBC.md
+++ b/docs/src/atlas/hubs/IsingSquare_PartitionFunction_PBC.md
@@ -47,4 +47,5 @@ verify(IsingSquare(; Lx = L, Ly = L, J = 1.0), PartitionFunction(), PBC(0); rout
 - cards: 4 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `IsingSquare`](../models/IsingSquare.md) · [Quantity: `PartitionFunction`](../quantities/PartitionFunction.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/IsingSquare_SpecificHeat_Infinite.md
+++ b/docs/src/atlas/hubs/IsingSquare_SpecificHeat_Infinite.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `IsingSquare`](../models/IsingSquare.md) · [Quantity: `SpecificHeat`](../quantities/SpecificHeat.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/IsingSquare_SpecificHeat_PBC.md
+++ b/docs/src/atlas/hubs/IsingSquare_SpecificHeat_PBC.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `IsingSquare`](../models/IsingSquare.md) · [Quantity: `SpecificHeat`](../quantities/SpecificHeat.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/IsingSquare_SpontaneousMagnetization_Infinite.md
+++ b/docs/src/atlas/hubs/IsingSquare_SpontaneousMagnetization_Infinite.md
@@ -37,4 +37,5 @@ verify(IsingSquare(; J = J), SpontaneousMagnetization(), Infinite(); route = :se
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `IsingSquare`](../models/IsingSquare.md) · [Quantity: `SpontaneousMagnetization`](../quantities/SpontaneousMagnetization.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/IsingSquare_ThermalEntropy_Infinite.md
+++ b/docs/src/atlas/hubs/IsingSquare_ThermalEntropy_Infinite.md
@@ -32,4 +32,5 @@ verify(IsingSquare(; J = 1.0), ThermalEntropy(), Infinite(); route = :limiting_c
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `IsingSquare`](../models/IsingSquare.md) · [Quantity: `ThermalEntropy`](../quantities/ThermalEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/IsingSquare_ThermalEntropy_PBC.md
+++ b/docs/src/atlas/hubs/IsingSquare_ThermalEntropy_PBC.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `IsingSquare`](../models/IsingSquare.md) · [Quantity: `ThermalEntropy`](../quantities/ThermalEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/IsingTriangular_CriticalExponents_Infinite.md
+++ b/docs/src/atlas/hubs/IsingTriangular_CriticalExponents_Infinite.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `IsingTriangular`](../models/IsingTriangular.md) · [Quantity: `CriticalExponents`](../quantities/CriticalExponents.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/IsingTriangular_CriticalTemperature_Infinite.md
+++ b/docs/src/atlas/hubs/IsingTriangular_CriticalTemperature_Infinite.md
@@ -42,4 +42,5 @@ verify(IsingTriangular(; J = J), CriticalTemperature(), Infinite(); route = :sec
 - cards: 3 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `IsingTriangular`](../models/IsingTriangular.md) · [Quantity: `CriticalTemperature`](../quantities/CriticalTemperature.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/IsingTriangular_ResidualEntropy_Infinite.md
+++ b/docs/src/atlas/hubs/IsingTriangular_ResidualEntropy_Infinite.md
@@ -37,4 +37,5 @@ verify(IsingTriangular(; J = J), ResidualEntropy(), Infinite(); route = :second_
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `IsingTriangular`](../models/IsingTriangular.md) · [Quantity: `ResidualEntropy`](../quantities/ResidualEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/J1J2Heisenberg1D_Energy_Infinite.md
+++ b/docs/src/atlas/hubs/J1J2Heisenberg1D_Energy_Infinite.md
@@ -47,4 +47,5 @@ verify(J1J2Heisenberg1D(; J1 = 1.0, J2 = 0.5), Energy(:per_site), Infinite(); ro
 - cards: 4 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `J1J2Heisenberg1D`](../models/J1J2Heisenberg1D.md) · [Quantity: `Energy`](../quantities/Energy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/KagomeHeisenbergAFM_Energy_Infinite.md
+++ b/docs/src/atlas/hubs/KagomeHeisenbergAFM_Energy_Infinite.md
@@ -37,4 +37,5 @@ verify(KagomeHeisenbergAFM(), Energy(:per_site), Infinite(); route = :literature
 - cards: 2 · model ED-infeasible (frontier)
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `KagomeHeisenbergAFM`](../models/KagomeHeisenbergAFM.md) · [Quantity: `Energy`](../quantities/Energy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/KagomeHeisenbergAFM_MassGap_Infinite.md
+++ b/docs/src/atlas/hubs/KagomeHeisenbergAFM_MassGap_Infinite.md
@@ -37,4 +37,5 @@ verify(KagomeHeisenbergAFM(), MassGap(), Infinite(); route = :literature_value, 
 - cards: 2 · model ED-infeasible (frontier)
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `KagomeHeisenbergAFM`](../models/KagomeHeisenbergAFM.md) · [Quantity: `MassGap`](../quantities/MassGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/KagomeHeisenbergAFM_TopologicalEntanglementEntropy_Infinite.md
+++ b/docs/src/atlas/hubs/KagomeHeisenbergAFM_TopologicalEntanglementEntropy_Infinite.md
@@ -37,4 +37,5 @@ verify(KagomeHeisenbergAFM(), TopologicalEntanglementEntropy(), Infinite(); rout
 - cards: 2 · model ED-infeasible (frontier)
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `KagomeHeisenbergAFM`](../models/KagomeHeisenbergAFM.md) · [Quantity: `TopologicalEntanglementEntropy`](../quantities/TopologicalEntanglementEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Kitaev1D_CorrelationLength_Infinite.md
+++ b/docs/src/atlas/hubs/Kitaev1D_CorrelationLength_Infinite.md
@@ -42,4 +42,5 @@ verify(Kitaev1D(; μ = 3.0, t = 1.0, Δ = 1.0), CorrelationLength(), Infinite();
 - cards: 3 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Kitaev1D`](../models/Kitaev1D.md) · [Quantity: `CorrelationLength`](../quantities/CorrelationLength.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Kitaev1D_EdgeModeEnergy_OBC.md
+++ b/docs/src/atlas/hubs/Kitaev1D_EdgeModeEnergy_OBC.md
@@ -37,4 +37,5 @@ verify(Kitaev1D(; μ = 0.0, t = 1.0, Δ = 1.0), EdgeModeEnergy(), OBC(N); route 
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Kitaev1D`](../models/Kitaev1D.md) · [Quantity: `EdgeModeEnergy`](../quantities/EdgeModeEnergy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Kitaev1D_Energy_Infinite.md
+++ b/docs/src/atlas/hubs/Kitaev1D_Energy_Infinite.md
@@ -32,4 +32,5 @@ verify(Kitaev1D(; μ = 0.0, t = t, Δ = t), Energy(:per_site), Infinite(); route
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Kitaev1D`](../models/Kitaev1D.md) · [Quantity: `Energy`](../quantities/Energy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Kitaev1D_MassGap_Infinite.md
+++ b/docs/src/atlas/hubs/Kitaev1D_MassGap_Infinite.md
@@ -42,4 +42,5 @@ verify(Kitaev1D(; μ = 3.0, t = 1.0, Δ = 1.0), MassGap(), Infinite(); route = :
 - cards: 3 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Kitaev1D`](../models/Kitaev1D.md) · [Quantity: `MassGap`](../quantities/MassGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Kitaev1D_MassGap_OBC.md
+++ b/docs/src/atlas/hubs/Kitaev1D_MassGap_OBC.md
@@ -32,4 +32,5 @@ verify(Kitaev1D(; μ = 0.0, t = 1.0, Δ = 1.0), MassGap(), OBC(40); route = :sec
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Kitaev1D`](../models/Kitaev1D.md) · [Quantity: `MassGap`](../quantities/MassGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/Kitaev1D_TopologicalInvariant_Infinite.md
+++ b/docs/src/atlas/hubs/Kitaev1D_TopologicalInvariant_Infinite.md
@@ -37,4 +37,5 @@ verify(Kitaev1D(; μ = μ, t = t, Δ = Δ), TopologicalInvariant(), Infinite(); 
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `Kitaev1D`](../models/Kitaev1D.md) · [Quantity: `TopologicalInvariant`](../quantities/TopologicalInvariant.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/KitaevHeisenberg_MassGap_Infinite.md
+++ b/docs/src/atlas/hubs/KitaevHeisenberg_MassGap_Infinite.md
@@ -32,4 +32,5 @@ verify(KitaevHeisenberg(; K = K, J = 0.0, Γ = 0.0), MassGap(), Infinite(); rout
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `KitaevHeisenberg`](../models/KitaevHeisenberg.md) · [Quantity: `MassGap`](../quantities/MassGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/KitaevHoneycomb_Energy_Infinite.md
+++ b/docs/src/atlas/hubs/KitaevHoneycomb_Energy_Infinite.md
@@ -32,4 +32,5 @@ verify(KitaevHoneycomb(; Kx = 1.0, Ky = 1.0, Kz = 1.0), Energy(), Infinite(); ro
 - cards: 1 · model ED-infeasible (frontier)
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `KitaevHoneycomb`](../models/KitaevHoneycomb.md) · [Quantity: `Energy`](../quantities/Energy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/KitaevHoneycomb_Energy_OBC.md
+++ b/docs/src/atlas/hubs/KitaevHoneycomb_Energy_OBC.md
@@ -21,4 +21,5 @@ _No corroboration card._ Model is ED-infeasible — frontier (cited-only), not a
 - cards: 0 · model ED-infeasible (frontier)
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `KitaevHoneycomb`](../models/KitaevHoneycomb.md) · [Quantity: `Energy`](../quantities/Energy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/KitaevHoneycomb_Energy_PBC.md
+++ b/docs/src/atlas/hubs/KitaevHoneycomb_Energy_PBC.md
@@ -21,4 +21,5 @@ _No corroboration card._ Model is ED-infeasible — frontier (cited-only), not a
 - cards: 0 · model ED-infeasible (frontier)
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `KitaevHoneycomb`](../models/KitaevHoneycomb.md) · [Quantity: `Energy`](../quantities/Energy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/KitaevHoneycomb_FreeEnergy_Infinite.md
+++ b/docs/src/atlas/hubs/KitaevHoneycomb_FreeEnergy_Infinite.md
@@ -21,4 +21,5 @@ _No corroboration card._ Model is ED-infeasible — frontier (cited-only), not a
 - cards: 0 · model ED-infeasible (frontier)
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `KitaevHoneycomb`](../models/KitaevHoneycomb.md) · [Quantity: `FreeEnergy`](../quantities/FreeEnergy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/KitaevHoneycomb_FreeEnergy_OBC.md
+++ b/docs/src/atlas/hubs/KitaevHoneycomb_FreeEnergy_OBC.md
@@ -21,4 +21,5 @@ _No corroboration card._ Model is ED-infeasible — frontier (cited-only), not a
 - cards: 0 · model ED-infeasible (frontier)
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `KitaevHoneycomb`](../models/KitaevHoneycomb.md) · [Quantity: `FreeEnergy`](../quantities/FreeEnergy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/KitaevHoneycomb_MassGap_Infinite.md
+++ b/docs/src/atlas/hubs/KitaevHoneycomb_MassGap_Infinite.md
@@ -32,4 +32,5 @@ verify(KitaevHoneycomb(; Kx = Kx, Ky = Ky, Kz = Kz), MassGap(), Infinite(); rout
 - cards: 1 · model ED-infeasible (frontier)
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `KitaevHoneycomb`](../models/KitaevHoneycomb.md) · [Quantity: `MassGap`](../quantities/MassGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/KitaevHoneycomb_SpecificHeat_Infinite.md
+++ b/docs/src/atlas/hubs/KitaevHoneycomb_SpecificHeat_Infinite.md
@@ -37,4 +37,5 @@ verify(KitaevHoneycomb(; Kx = Kx, Ky = Ky, Kz = Kz), SpecificHeat(), Infinite();
 - cards: 2 · model ED-infeasible (frontier)
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `KitaevHoneycomb`](../models/KitaevHoneycomb.md) · [Quantity: `SpecificHeat`](../quantities/SpecificHeat.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/KitaevHoneycomb_SpecificHeat_OBC.md
+++ b/docs/src/atlas/hubs/KitaevHoneycomb_SpecificHeat_OBC.md
@@ -37,4 +37,5 @@ verify(KitaevHoneycomb(; Kx = Kx, Ky = Ky, Kz = Kz), SpecificHeat(), OBC(0); rou
 - cards: 2 · model ED-infeasible (frontier)
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `KitaevHoneycomb`](../models/KitaevHoneycomb.md) · [Quantity: `SpecificHeat`](../quantities/SpecificHeat.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/KitaevHoneycomb_ThermalEntropy_Infinite.md
+++ b/docs/src/atlas/hubs/KitaevHoneycomb_ThermalEntropy_Infinite.md
@@ -32,4 +32,5 @@ verify(KitaevHoneycomb(; Kx = Kx, Ky = Ky, Kz = Kz), ThermalEntropy(), Infinite(
 - cards: 1 · model ED-infeasible (frontier)
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `KitaevHoneycomb`](../models/KitaevHoneycomb.md) · [Quantity: `ThermalEntropy`](../quantities/ThermalEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/KitaevHoneycomb_ThermalEntropy_OBC.md
+++ b/docs/src/atlas/hubs/KitaevHoneycomb_ThermalEntropy_OBC.md
@@ -32,4 +32,5 @@ verify(KitaevHoneycomb(; Kx = Kx, Ky = Ky, Kz = Kz), ThermalEntropy(), OBC(0); r
 - cards: 1 · model ED-infeasible (frontier)
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `KitaevHoneycomb`](../models/KitaevHoneycomb.md) · [Quantity: `ThermalEntropy`](../quantities/ThermalEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/LiouvilleCFT_CentralCharge_Infinite.md
+++ b/docs/src/atlas/hubs/LiouvilleCFT_CentralCharge_Infinite.md
@@ -37,4 +37,5 @@ verify(LiouvilleCFT(; b = 2.0), CentralCharge(), Infinite(); route = :second_clo
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `LiouvilleCFT`](../models/LiouvilleCFT.md) · [Quantity: `CentralCharge`](../quantities/CentralCharge.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/LiouvilleCFT_ConformalWeights_Infinite.md
+++ b/docs/src/atlas/hubs/LiouvilleCFT_ConformalWeights_Infinite.md
@@ -32,4 +32,5 @@ verify(LiouvilleCFT(; b = 1.0), ConformalWeights(), Infinite(); route = :second_
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `LiouvilleCFT`](../models/LiouvilleCFT.md) · [Quantity: `ConformalWeights`](../quantities/ConformalWeights.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/LogarithmicCFT_CentralCharge_Infinite.md
+++ b/docs/src/atlas/hubs/LogarithmicCFT_CentralCharge_Infinite.md
@@ -37,4 +37,5 @@ verify(LogarithmicCFT(), CentralCharge(), Infinite(); route = :second_closed_for
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `LogarithmicCFT`](../models/LogarithmicCFT.md) · [Quantity: `CentralCharge`](../quantities/CentralCharge.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/LongRangeIsing1D_MassGap_Infinite.md
+++ b/docs/src/atlas/hubs/LongRangeIsing1D_MassGap_Infinite.md
@@ -32,4 +32,5 @@ verify(LongRangeIsing1D(; J = J, h = h), MassGap(), Infinite(); route = :delegat
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `LongRangeIsing1D`](../models/LongRangeIsing1D.md) · [Quantity: `MassGap`](../quantities/MassGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/LongRangeXY1D_MassGap_Infinite.md
+++ b/docs/src/atlas/hubs/LongRangeXY1D_MassGap_Infinite.md
@@ -32,4 +32,5 @@ verify(LongRangeXY1D(; h = h), MassGap(), Infinite(); route = :second_closed_for
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `LongRangeXY1D`](../models/LongRangeXY1D.md) · [Quantity: `MassGap`](../quantities/MassGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/MajumdarGhosh_GroundStateEnergyDensity_Infinite.md
+++ b/docs/src/atlas/hubs/MajumdarGhosh_GroundStateEnergyDensity_Infinite.md
@@ -37,4 +37,5 @@ verify(MajumdarGhosh(; J = J), GroundStateEnergyDensity(), Infinite(); route = :
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `MajumdarGhosh`](../models/MajumdarGhosh.md) · [Quantity: `GroundStateEnergyDensity`](../quantities/GroundStateEnergyDensity.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/MajumdarGhosh_GroundStateEnergyDensity_PBC.md
+++ b/docs/src/atlas/hubs/MajumdarGhosh_GroundStateEnergyDensity_PBC.md
@@ -37,4 +37,5 @@ verify(MajumdarGhosh(; J = J), GroundStateEnergyDensity(), PBC(N); route = :seco
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `MajumdarGhosh`](../models/MajumdarGhosh.md) · [Quantity: `GroundStateEnergyDensity`](../quantities/GroundStateEnergyDensity.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/MajumdarGhosh_MassGap_Infinite.md
+++ b/docs/src/atlas/hubs/MajumdarGhosh_MassGap_Infinite.md
@@ -37,4 +37,5 @@ verify(MajumdarGhosh(; J = J), MassGap(), Infinite(); route = :literature_value,
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `MajumdarGhosh`](../models/MajumdarGhosh.md) · [Quantity: `MassGap`](../quantities/MassGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/MajumdarGhosh_SpinGap_Infinite.md
+++ b/docs/src/atlas/hubs/MajumdarGhosh_SpinGap_Infinite.md
@@ -37,4 +37,5 @@ verify(MajumdarGhosh(; J = J), SpinGap(), Infinite(); route = :literature_value,
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `MajumdarGhosh`](../models/MajumdarGhosh.md) · [Quantity: `SpinGap`](../quantities/SpinGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/MixedFieldIsing1D_MassGap_Infinite.md
+++ b/docs/src/atlas/hubs/MixedFieldIsing1D_MassGap_Infinite.md
@@ -37,4 +37,5 @@ verify(MixedFieldIsing1D(; J = J, h_x = J, h_z = 0.0), MassGap(), Infinite(); ro
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `MixedFieldIsing1D`](../models/MixedFieldIsing1D.md) · [Quantity: `MassGap`](../quantities/MassGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/PXP1D_Energy_Infinite.md
+++ b/docs/src/atlas/hubs/PXP1D_Energy_Infinite.md
@@ -37,4 +37,5 @@ verify(PXP1D(), Energy(:per_site), Infinite(); route = :literature_value, indepe
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `PXP1D`](../models/PXP1D.md) · [Quantity: `Energy`](../quantities/Energy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/PpIp2DSC_CentralCharge_Infinite.md
+++ b/docs/src/atlas/hubs/PpIp2DSC_CentralCharge_Infinite.md
@@ -37,4 +37,5 @@ verify(PpIp2DSC(), CentralCharge(), Infinite(); route = :second_closed_form, ind
 - cards: 2 · model ED-infeasible (frontier)
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `PpIp2DSC`](../models/PpIp2DSC.md) · [Quantity: `CentralCharge`](../quantities/CentralCharge.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/PpIp2DSC_TopologicalInvariant_Infinite.md
+++ b/docs/src/atlas/hubs/PpIp2DSC_TopologicalInvariant_Infinite.md
@@ -32,4 +32,5 @@ verify(PpIp2DSC(), TopologicalInvariant(), Infinite(); route = :second_closed_fo
 - cards: 1 · model ED-infeasible (frontier)
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `PpIp2DSC`](../models/PpIp2DSC.md) · [Quantity: `TopologicalInvariant`](../quantities/TopologicalInvariant.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/RFIM_CriticalTemperature_Infinite.md
+++ b/docs/src/atlas/hubs/RFIM_CriticalTemperature_Infinite.md
@@ -32,4 +32,5 @@ verify(RFIM(; Δ = 0.5), CriticalTemperature(), Infinite(); route = :second_clos
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `RFIM`](../models/RFIM.md) · [Quantity: `CriticalTemperature`](../quantities/CriticalTemperature.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/RandomBondIsing2D_CentralCharge_Infinite.md
+++ b/docs/src/atlas/hubs/RandomBondIsing2D_CentralCharge_Infinite.md
@@ -37,4 +37,5 @@ verify(RandomBondIsing2D(), CentralCharge(), Infinite(); route = :literature_val
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `RandomBondIsing2D`](../models/RandomBondIsing2D.md) · [Quantity: `CentralCharge`](../quantities/CentralCharge.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/S1AnisotropicD1D_Energy_Infinite.md
+++ b/docs/src/atlas/hubs/S1AnisotropicD1D_Energy_Infinite.md
@@ -42,4 +42,5 @@ verify(S1AnisotropicD1D(; J = J, D = 0.0), Energy(:per_site), Infinite(); route 
 - cards: 3 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `S1AnisotropicD1D`](../models/S1AnisotropicD1D.md) · [Quantity: `Energy`](../quantities/Energy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/S1AnisotropicD1D_MassGap_Infinite.md
+++ b/docs/src/atlas/hubs/S1AnisotropicD1D_MassGap_Infinite.md
@@ -37,4 +37,5 @@ verify(S1AnisotropicD1D(; J = J, D = 0.0), MassGap(), Infinite(); route = :deleg
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `S1AnisotropicD1D`](../models/S1AnisotropicD1D.md) · [Quantity: `MassGap`](../quantities/MassGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/S1Heisenberg1D_EnergyLocal_OBC.md
+++ b/docs/src/atlas/hubs/S1Heisenberg1D_EnergyLocal_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `S1Heisenberg1D`](../models/S1Heisenberg1D.md) · [Quantity: `EnergyLocal`](../quantities/EnergyLocal.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/S1Heisenberg1D_Energy_Infinite.md
+++ b/docs/src/atlas/hubs/S1Heisenberg1D_Energy_Infinite.md
@@ -42,4 +42,5 @@ verify(S1Heisenberg1D(; J = 1.0), Energy(:per_site), Infinite(); route = :litera
 - cards: 3 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `S1Heisenberg1D`](../models/S1Heisenberg1D.md) · [Quantity: `Energy`](../quantities/Energy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/S1Heisenberg1D_Energy_OBC.md
+++ b/docs/src/atlas/hubs/S1Heisenberg1D_Energy_OBC.md
@@ -42,4 +42,5 @@ verify(S1Heisenberg1D(; J = J), Energy(:per_site), OBC(N); route = :ed_finite_si
 - cards: 3 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `S1Heisenberg1D`](../models/S1Heisenberg1D.md) · [Quantity: `Energy`](../quantities/Energy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/S1Heisenberg1D_FreeEnergy_OBC.md
+++ b/docs/src/atlas/hubs/S1Heisenberg1D_FreeEnergy_OBC.md
@@ -36,4 +36,5 @@ verify(S1Heisenberg1D(; J = J), FreeEnergy(), OBC(N); route = :ed_finite_size, i
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `S1Heisenberg1D`](../models/S1Heisenberg1D.md) · [Quantity: `FreeEnergy`](../quantities/FreeEnergy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/S1Heisenberg1D_MagnetizationXLocal_OBC.md
+++ b/docs/src/atlas/hubs/S1Heisenberg1D_MagnetizationXLocal_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `S1Heisenberg1D`](../models/S1Heisenberg1D.md) · [Quantity: `MagnetizationXLocal`](../quantities/MagnetizationXLocal.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/S1Heisenberg1D_MagnetizationX_OBC.md
+++ b/docs/src/atlas/hubs/S1Heisenberg1D_MagnetizationX_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `S1Heisenberg1D`](../models/S1Heisenberg1D.md) · [Quantity: `MagnetizationX`](../quantities/MagnetizationX.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/S1Heisenberg1D_MagnetizationY_OBC.md
+++ b/docs/src/atlas/hubs/S1Heisenberg1D_MagnetizationY_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `S1Heisenberg1D`](../models/S1Heisenberg1D.md) · [Quantity: `MagnetizationY`](../quantities/MagnetizationY.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/S1Heisenberg1D_MagnetizationZLocal_OBC.md
+++ b/docs/src/atlas/hubs/S1Heisenberg1D_MagnetizationZLocal_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `S1Heisenberg1D`](../models/S1Heisenberg1D.md) · [Quantity: `MagnetizationZLocal`](../quantities/MagnetizationZLocal.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/S1Heisenberg1D_MagnetizationZ_OBC.md
+++ b/docs/src/atlas/hubs/S1Heisenberg1D_MagnetizationZ_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `S1Heisenberg1D`](../models/S1Heisenberg1D.md) · [Quantity: `MagnetizationZ`](../quantities/MagnetizationZ.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/S1Heisenberg1D_MassGap_Infinite.md
+++ b/docs/src/atlas/hubs/S1Heisenberg1D_MassGap_Infinite.md
@@ -37,4 +37,5 @@ verify(S1Heisenberg1D(; J = 1.0), MassGap(), Infinite(); route = :literature_val
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `S1Heisenberg1D`](../models/S1Heisenberg1D.md) · [Quantity: `MassGap`](../quantities/MassGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/S1Heisenberg1D_MassGap_OBC.md
+++ b/docs/src/atlas/hubs/S1Heisenberg1D_MassGap_OBC.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `S1Heisenberg1D`](../models/S1Heisenberg1D.md) · [Quantity: `MassGap`](../quantities/MassGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/S1Heisenberg1D_RenyiEntropy_OBC.md
+++ b/docs/src/atlas/hubs/S1Heisenberg1D_RenyiEntropy_OBC.md
@@ -32,4 +32,5 @@ verify(S1Heisenberg1D(), RenyiEntropy(α), OBC(N); route = :second_closed_form, 
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `S1Heisenberg1D`](../models/S1Heisenberg1D.md) · [Quantity: `RenyiEntropy`](../quantities/RenyiEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/S1Heisenberg1D_SpecificHeat_OBC.md
+++ b/docs/src/atlas/hubs/S1Heisenberg1D_SpecificHeat_OBC.md
@@ -36,4 +36,5 @@ verify(S1Heisenberg1D(; J = J), SpecificHeat(), OBC(N); route = :ed_finite_size,
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `S1Heisenberg1D`](../models/S1Heisenberg1D.md) · [Quantity: `SpecificHeat`](../quantities/SpecificHeat.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/S1Heisenberg1D_SusceptibilityXX_OBC.md
+++ b/docs/src/atlas/hubs/S1Heisenberg1D_SusceptibilityXX_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `S1Heisenberg1D`](../models/S1Heisenberg1D.md) · [Quantity: `SusceptibilityXX`](../quantities/SusceptibilityXX.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/S1Heisenberg1D_SusceptibilityYY_OBC.md
+++ b/docs/src/atlas/hubs/S1Heisenberg1D_SusceptibilityYY_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `S1Heisenberg1D`](../models/S1Heisenberg1D.md) · [Quantity: `SusceptibilityYY`](../quantities/SusceptibilityYY.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/S1Heisenberg1D_SusceptibilityZZ_OBC.md
+++ b/docs/src/atlas/hubs/S1Heisenberg1D_SusceptibilityZZ_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `S1Heisenberg1D`](../models/S1Heisenberg1D.md) · [Quantity: `SusceptibilityZZ`](../quantities/SusceptibilityZZ.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/S1Heisenberg1D_ThermalEntropy_OBC.md
+++ b/docs/src/atlas/hubs/S1Heisenberg1D_ThermalEntropy_OBC.md
@@ -41,4 +41,5 @@ verify(S1Heisenberg1D(; J = J), ThermalEntropy(), OBC(N); route = :ed_finite_siz
 - cards: 3 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `S1Heisenberg1D`](../models/S1Heisenberg1D.md) · [Quantity: `ThermalEntropy`](../quantities/ThermalEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/S1Heisenberg1D_VonNeumannEntropy_OBC.md
+++ b/docs/src/atlas/hubs/S1Heisenberg1D_VonNeumannEntropy_OBC.md
@@ -32,4 +32,5 @@ verify(S1Heisenberg1D(), VonNeumannEntropy(), OBC(N); route = :second_closed_for
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `S1Heisenberg1D`](../models/S1Heisenberg1D.md) · [Quantity: `VonNeumannEntropy`](../quantities/VonNeumannEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/S1Heisenberg1D_XXCorrelation_OBC.md
+++ b/docs/src/atlas/hubs/S1Heisenberg1D_XXCorrelation_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `S1Heisenberg1D`](../models/S1Heisenberg1D.md) · [Quantity: `XXCorrelation`](../quantities/XXCorrelation.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/S1Heisenberg1D_YYCorrelation_OBC.md
+++ b/docs/src/atlas/hubs/S1Heisenberg1D_YYCorrelation_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `S1Heisenberg1D`](../models/S1Heisenberg1D.md) · [Quantity: `YYCorrelation`](../quantities/YYCorrelation.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/S1Heisenberg1D_ZZCorrelation_OBC.md
+++ b/docs/src/atlas/hubs/S1Heisenberg1D_ZZCorrelation_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `S1Heisenberg1D`](../models/S1Heisenberg1D.md) · [Quantity: `ZZCorrelation`](../quantities/ZZCorrelation.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/S1XXZ1D_Energy_Infinite.md
+++ b/docs/src/atlas/hubs/S1XXZ1D_Energy_Infinite.md
@@ -42,4 +42,5 @@ verify(S1XXZ1D(; J = J, Δ = 1.0), Energy(:per_site), Infinite(); route = :deleg
 - cards: 3 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `S1XXZ1D`](../models/S1XXZ1D.md) · [Quantity: `Energy`](../quantities/Energy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/S1XXZ1D_MassGap_Infinite.md
+++ b/docs/src/atlas/hubs/S1XXZ1D_MassGap_Infinite.md
@@ -37,4 +37,5 @@ verify(S1XXZ1D(; J = J, Δ = 1.0), MassGap(), Infinite(); route = :delegation_in
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `S1XXZ1D`](../models/S1XXZ1D.md) · [Quantity: `MassGap`](../quantities/MassGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/SLEkappa_CentralCharge_Infinite.md
+++ b/docs/src/atlas/hubs/SLEkappa_CentralCharge_Infinite.md
@@ -37,4 +37,5 @@ verify(SLEkappa(; κ = κ), CentralCharge(), Infinite(); route = :second_closed_
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `SLEkappa`](../models/SLEkappa.md) · [Quantity: `CentralCharge`](../quantities/CentralCharge.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/SLEkappa_FractalDimension_Infinite.md
+++ b/docs/src/atlas/hubs/SLEkappa_FractalDimension_Infinite.md
@@ -32,4 +32,5 @@ verify(SLEkappa(; κ = κ), FractalDimension(), Infinite(); route = :second_clos
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `SLEkappa`](../models/SLEkappa.md) · [Quantity: `FractalDimension`](../quantities/FractalDimension.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/SYK_ConformalWeights_Infinite.md
+++ b/docs/src/atlas/hubs/SYK_ConformalWeights_Infinite.md
@@ -37,4 +37,5 @@ verify(SYK(; q = q), ConformalWeights(), Infinite(); route = :second_closed_form
 - cards: 2 · model ED-infeasible (frontier)
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `SYK`](../models/SYK.md) · [Quantity: `ConformalWeights`](../quantities/ConformalWeights.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/SchwingerModel_ChiralCondensate_Infinite.md
+++ b/docs/src/atlas/hubs/SchwingerModel_ChiralCondensate_Infinite.md
@@ -32,4 +32,5 @@ verify(SchwingerModel(; e = e, m = 0.0), ChiralCondensate(), Infinite(); route =
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `SchwingerModel`](../models/SchwingerModel.md) · [Quantity: `ChiralCondensate`](../quantities/ChiralCondensate.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/SchwingerModel_MassGap_Infinite.md
+++ b/docs/src/atlas/hubs/SchwingerModel_MassGap_Infinite.md
@@ -32,4 +32,5 @@ verify(SchwingerModel(; e = e, m = 0.0), MassGap(), Infinite(); route = :second_
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `SchwingerModel`](../models/SchwingerModel.md) · [Quantity: `MassGap`](../quantities/MassGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/ShastrySutherland_Energy_Infinite.md
+++ b/docs/src/atlas/hubs/ShastrySutherland_Energy_Infinite.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `ShastrySutherland`](../models/ShastrySutherland.md) · [Quantity: `Energy`](../quantities/Energy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/SherringtonKirkpatrick_CriticalTemperature_Infinite.md
+++ b/docs/src/atlas/hubs/SherringtonKirkpatrick_CriticalTemperature_Infinite.md
@@ -37,4 +37,5 @@ verify(SherringtonKirkpatrick(; J = J), CriticalTemperature(), Infinite(); route
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `SherringtonKirkpatrick`](../models/SherringtonKirkpatrick.md) · [Quantity: `CriticalTemperature`](../quantities/CriticalTemperature.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/SherringtonKirkpatrick_Energy_Infinite.md
+++ b/docs/src/atlas/hubs/SherringtonKirkpatrick_Energy_Infinite.md
@@ -32,4 +32,5 @@ verify(SherringtonKirkpatrick(; J = 1.0), Energy(:per_site), Infinite(); route =
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `SherringtonKirkpatrick`](../models/SherringtonKirkpatrick.md) · [Quantity: `Energy`](../quantities/Energy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/SixVertex_FreeEnergy_Infinite.md
+++ b/docs/src/atlas/hubs/SixVertex_FreeEnergy_Infinite.md
@@ -52,4 +52,5 @@ verify(SixVertex(; a = 1.0, b = 1.0, c = 1.0), FreeEnergy(), Infinite(); route =
 - cards: 5 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `SixVertex`](../models/SixVertex.md) · [Quantity: `FreeEnergy`](../quantities/FreeEnergy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/SixVertex_ResidualEntropy_Infinite.md
+++ b/docs/src/atlas/hubs/SixVertex_ResidualEntropy_Infinite.md
@@ -37,4 +37,5 @@ verify(SixVertex(; a = 1.0, b = 1.0, c = 1.0), ResidualEntropy(), Infinite(); ro
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `SixVertex`](../models/SixVertex.md) · [Quantity: `ResidualEntropy`](../quantities/ResidualEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/SpinIce_ResidualEntropy_Infinite.md
+++ b/docs/src/atlas/hubs/SpinIce_ResidualEntropy_Infinite.md
@@ -37,4 +37,5 @@ verify(SpinIce(), ResidualEntropy(), Infinite(); route = :second_closed_form, in
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `SpinIce`](../models/SpinIce.md) · [Quantity: `ResidualEntropy`](../quantities/ResidualEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TASEP_SteadyStateCurrent_Infinite.md
+++ b/docs/src/atlas/hubs/TASEP_SteadyStateCurrent_Infinite.md
@@ -42,4 +42,5 @@ verify(TASEP(), SteadyStateCurrent(), Infinite(); route = :second_closed_form, i
 - cards: 3 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TASEP`](../models/TASEP.md) · [Quantity: `SteadyStateCurrent`](../quantities/SteadyStateCurrent.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_CentralCharge_Infinite.md
+++ b/docs/src/atlas/hubs/TFIM_CentralCharge_Infinite.md
@@ -42,4 +42,5 @@ verify(TFIM(; J = J, h = h), CentralCharge(), Infinite(); route = :second_closed
 - cards: 3 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `CentralCharge`](../quantities/CentralCharge.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_CorrelationLength_Infinite.md
+++ b/docs/src/atlas/hubs/TFIM_CorrelationLength_Infinite.md
@@ -32,4 +32,5 @@ verify(TFIM(; J = J, h = h), CorrelationLength(), Infinite(); route = :second_cl
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `CorrelationLength`](../quantities/CorrelationLength.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_CriticalExponents_Infinite.md
+++ b/docs/src/atlas/hubs/TFIM_CriticalExponents_Infinite.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `CriticalExponents`](../quantities/CriticalExponents.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_EnergyLocal_OBC.md
+++ b/docs/src/atlas/hubs/TFIM_EnergyLocal_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `EnergyLocal`](../quantities/EnergyLocal.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_Energy_Infinite.md
+++ b/docs/src/atlas/hubs/TFIM_Energy_Infinite.md
@@ -47,4 +47,5 @@ verify(TFIM(; J = J, h = J), Energy(:per_site), Infinite(); route = :second_clos
 - cards: 4 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `Energy`](../quantities/Energy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_Energy_OBC.md
+++ b/docs/src/atlas/hubs/TFIM_Energy_OBC.md
@@ -72,4 +72,5 @@ verify(TFIM(; J = J, h = h), Energy(), OBC(N); route = :ed_finite_size, independ
 - cards: 9 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `Energy`](../quantities/Energy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_Energy_PBC.md
+++ b/docs/src/atlas/hubs/TFIM_Energy_PBC.md
@@ -37,4 +37,5 @@ verify(TFIM(; J = J, h = h), Energy(:per_site), PBC(N); route = :sum_rule, fetch
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `Energy`](../quantities/Energy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_FidelitySusceptibility_Infinite.md
+++ b/docs/src/atlas/hubs/TFIM_FidelitySusceptibility_Infinite.md
@@ -37,4 +37,5 @@ verify(TFIM(; J = J, h = h), FidelitySusceptibility(), Infinite(); route = :seco
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `FidelitySusceptibility`](../quantities/FidelitySusceptibility.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_FidelitySusceptibility_OBC.md
+++ b/docs/src/atlas/hubs/TFIM_FidelitySusceptibility_OBC.md
@@ -32,4 +32,5 @@ verify(TFIM(; J = 0.0, h = h), FidelitySusceptibility(), OBC(N); route = :second
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `FidelitySusceptibility`](../quantities/FidelitySusceptibility.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_FreeEnergy_Infinite.md
+++ b/docs/src/atlas/hubs/TFIM_FreeEnergy_Infinite.md
@@ -41,4 +41,5 @@ verify(TFIM(; J = J, h = J), FreeEnergy(), Infinite(); route = :second_closed_fo
 - cards: 3 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `FreeEnergy`](../quantities/FreeEnergy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_FreeEnergy_OBC.md
+++ b/docs/src/atlas/hubs/TFIM_FreeEnergy_OBC.md
@@ -36,4 +36,5 @@ verify(TFIM(; J = J, h = 0.0), FreeEnergy(), OBC(N); route = :second_closed_form
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `FreeEnergy`](../quantities/FreeEnergy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_FreeEnergy_PBC.md
+++ b/docs/src/atlas/hubs/TFIM_FreeEnergy_PBC.md
@@ -36,4 +36,5 @@ verify(TFIM(; J = 0.0, h = h), FreeEnergy(), PBC(N); route = :second_closed_form
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `FreeEnergy`](../quantities/FreeEnergy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_GGEValue_Infinite.md
+++ b/docs/src/atlas/hubs/TFIM_GGEValue_Infinite.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `GGEValue`](../quantities/GGEValue.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_LoschmidtEcho_Infinite.md
+++ b/docs/src/atlas/hubs/TFIM_LoschmidtEcho_Infinite.md
@@ -32,4 +32,5 @@ verify(TFIM(; J = J, h = h_f), LoschmidtEcho(), Infinite(); route = :second_clos
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `LoschmidtEcho`](../quantities/LoschmidtEcho.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_LoschmidtEcho_OBC.md
+++ b/docs/src/atlas/hubs/TFIM_LoschmidtEcho_OBC.md
@@ -32,4 +32,5 @@ verify(TFIM(; J = J, h = h_f), LoschmidtEcho(), OBC(N); route = :second_closed_f
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `LoschmidtEcho`](../quantities/LoschmidtEcho.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_MagnetizationXLocal_Infinite.md
+++ b/docs/src/atlas/hubs/TFIM_MagnetizationXLocal_Infinite.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `MagnetizationXLocal`](../quantities/MagnetizationXLocal.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_MagnetizationXLocal_OBC.md
+++ b/docs/src/atlas/hubs/TFIM_MagnetizationXLocal_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `MagnetizationXLocal`](../quantities/MagnetizationXLocal.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_MagnetizationX_Infinite.md
+++ b/docs/src/atlas/hubs/TFIM_MagnetizationX_Infinite.md
@@ -36,4 +36,5 @@ verify(TFIM(; J = J, h = 0.0), MagnetizationX(), Infinite(); route = :second_clo
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `MagnetizationX`](../quantities/MagnetizationX.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_MagnetizationX_OBC.md
+++ b/docs/src/atlas/hubs/TFIM_MagnetizationX_OBC.md
@@ -36,4 +36,5 @@ verify(TFIM(; J = J, h = 0.0), MagnetizationX(), OBC(N); route = :second_closed_
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `MagnetizationX`](../quantities/MagnetizationX.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_MagnetizationX_PBC.md
+++ b/docs/src/atlas/hubs/TFIM_MagnetizationX_PBC.md
@@ -36,4 +36,5 @@ verify(TFIM(; J = J, h = 0.0), MagnetizationX(), PBC(N); route = :second_closed_
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `MagnetizationX`](../quantities/MagnetizationX.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_MagnetizationY_OBC.md
+++ b/docs/src/atlas/hubs/TFIM_MagnetizationY_OBC.md
@@ -32,4 +32,5 @@ verify(TFIM(; J = J, h = h), MagnetizationY(), OBC(6); route = :second_closed_fo
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `MagnetizationY`](../quantities/MagnetizationY.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_MagnetizationZLocal_OBC.md
+++ b/docs/src/atlas/hubs/TFIM_MagnetizationZLocal_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `MagnetizationZLocal`](../quantities/MagnetizationZLocal.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_MagnetizationZ_Infinite.md
+++ b/docs/src/atlas/hubs/TFIM_MagnetizationZ_Infinite.md
@@ -37,4 +37,5 @@ verify(TFIM(; J = J, h = h), MagnetizationZ(), Infinite(); route = :second_close
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `MagnetizationZ`](../quantities/MagnetizationZ.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_MassGap_Infinite.md
+++ b/docs/src/atlas/hubs/TFIM_MassGap_Infinite.md
@@ -82,4 +82,5 @@ verify(TFIM(; J = J, h = h), MassGap(), Infinite(); route = :second_closed_form,
 - cards: 11 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `MassGap`](../quantities/MassGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_MassGap_OBC.md
+++ b/docs/src/atlas/hubs/TFIM_MassGap_OBC.md
@@ -32,4 +32,5 @@ verify(TFIM(; J = J, h = h), MassGap(), OBC(N); route = :ed_finite_size, indepen
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `MassGap`](../quantities/MassGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_MassGap_PBC.md
+++ b/docs/src/atlas/hubs/TFIM_MassGap_PBC.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `MassGap`](../quantities/MassGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_RenyiEntropy_Infinite.md
+++ b/docs/src/atlas/hubs/TFIM_RenyiEntropy_Infinite.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `RenyiEntropy`](../quantities/RenyiEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_RenyiEntropy_OBC.md
+++ b/docs/src/atlas/hubs/TFIM_RenyiEntropy_OBC.md
@@ -42,4 +42,5 @@ verify(TFIM(; J = J, h = h), RenyiEntropy(2), OBC(N); route = :ed_finite_size, f
 - cards: 3 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `RenyiEntropy`](../quantities/RenyiEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_SpecificHeat_Infinite.md
+++ b/docs/src/atlas/hubs/TFIM_SpecificHeat_Infinite.md
@@ -36,4 +36,5 @@ verify(TFIM(; J = J, h = h), SpecificHeat(), Infinite(); route = :limiting_case,
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `SpecificHeat`](../quantities/SpecificHeat.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_SpecificHeat_OBC.md
+++ b/docs/src/atlas/hubs/TFIM_SpecificHeat_OBC.md
@@ -36,4 +36,5 @@ verify(TFIM(; J = J, h = h), SpecificHeat(), OBC(N); route = :limiting_case, ind
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `SpecificHeat`](../quantities/SpecificHeat.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_SpecificHeat_PBC.md
+++ b/docs/src/atlas/hubs/TFIM_SpecificHeat_PBC.md
@@ -31,4 +31,5 @@ verify(TFIM(; J = J, h = h), SpecificHeat(), PBC(N); route = :limiting_case, ind
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `SpecificHeat`](../quantities/SpecificHeat.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_SpontaneousMagnetization_Infinite.md
+++ b/docs/src/atlas/hubs/TFIM_SpontaneousMagnetization_Infinite.md
@@ -37,4 +37,5 @@ verify(TFIM(; J = J, h = h), SpontaneousMagnetization(), Infinite(); route = :se
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `SpontaneousMagnetization`](../quantities/SpontaneousMagnetization.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_SusceptibilityXX_Infinite.md
+++ b/docs/src/atlas/hubs/TFIM_SusceptibilityXX_Infinite.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `SusceptibilityXX`](../quantities/SusceptibilityXX.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_SusceptibilityXX_OBC.md
+++ b/docs/src/atlas/hubs/TFIM_SusceptibilityXX_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `SusceptibilityXX`](../quantities/SusceptibilityXX.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_SusceptibilityXX_PBC.md
+++ b/docs/src/atlas/hubs/TFIM_SusceptibilityXX_PBC.md
@@ -31,4 +31,5 @@ verify(TFIM(; J = J, h = h), SusceptibilityXX(), PBC(N); route = :ed_finite_size
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `SusceptibilityXX`](../quantities/SusceptibilityXX.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_SusceptibilityYY_OBC.md
+++ b/docs/src/atlas/hubs/TFIM_SusceptibilityYY_OBC.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `SusceptibilityYY`](../quantities/SusceptibilityYY.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_SusceptibilityZZ_Infinite.md
+++ b/docs/src/atlas/hubs/TFIM_SusceptibilityZZ_Infinite.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `SusceptibilityZZ`](../quantities/SusceptibilityZZ.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_SusceptibilityZZ_OBC.md
+++ b/docs/src/atlas/hubs/TFIM_SusceptibilityZZ_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `SusceptibilityZZ`](../quantities/SusceptibilityZZ.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_ThermalEntropy_Infinite.md
+++ b/docs/src/atlas/hubs/TFIM_ThermalEntropy_Infinite.md
@@ -36,4 +36,5 @@ verify(TFIM(; J = J, h = h), ThermalEntropy(), Infinite(); route = :limiting_cas
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `ThermalEntropy`](../quantities/ThermalEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_ThermalEntropy_OBC.md
+++ b/docs/src/atlas/hubs/TFIM_ThermalEntropy_OBC.md
@@ -36,4 +36,5 @@ verify(TFIM(; J = J, h = h), ThermalEntropy(), OBC(; N = N); route = :limiting_c
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `ThermalEntropy`](../quantities/ThermalEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_ThermalEntropy_PBC.md
+++ b/docs/src/atlas/hubs/TFIM_ThermalEntropy_PBC.md
@@ -31,4 +31,5 @@ verify(TFIM(; J = J, h = h), ThermalEntropy(), PBC(; N = N); route = :limiting_c
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `ThermalEntropy`](../quantities/ThermalEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_VonNeumannEntropy_Infinite.md
+++ b/docs/src/atlas/hubs/TFIM_VonNeumannEntropy_Infinite.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `VonNeumannEntropy`](../quantities/VonNeumannEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_VonNeumannEntropy_OBC.md
+++ b/docs/src/atlas/hubs/TFIM_VonNeumannEntropy_OBC.md
@@ -47,4 +47,5 @@ verify(TFIM(; J = J, h = 0.0), VonNeumannEntropy(), OBC(N); route = :second_clos
 - cards: 4 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `VonNeumannEntropy`](../quantities/VonNeumannEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_XXCorrelation_Infinite.md
+++ b/docs/src/atlas/hubs/TFIM_XXCorrelation_Infinite.md
@@ -37,4 +37,5 @@ verify(TFIM(; J = J, h = h), XXCorrelation(mode = :static), Infinite(); route = 
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `XXCorrelation`](../quantities/XXCorrelation.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_XXCorrelation_OBC.md
+++ b/docs/src/atlas/hubs/TFIM_XXCorrelation_OBC.md
@@ -31,4 +31,5 @@ verify(TFIM(; J = J, h = h), XXCorrelation(; mode = :static), OBC(N); route = :e
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `XXCorrelation`](../quantities/XXCorrelation.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_XXStructureFactor_Infinite.md
+++ b/docs/src/atlas/hubs/TFIM_XXStructureFactor_Infinite.md
@@ -32,4 +32,5 @@ verify(TFIM(; J = 1.0, h = h), XXStructureFactor(), Infinite(); route = :delegat
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `XXStructureFactor`](../quantities/XXStructureFactor.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_XXStructureFactor_OBC.md
+++ b/docs/src/atlas/hubs/TFIM_XXStructureFactor_OBC.md
@@ -32,4 +32,5 @@ verify(TFIM(; J = 1.0, h = h), XXStructureFactor(), OBC(N); route = :ed_finite_s
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `XXStructureFactor`](../quantities/XXStructureFactor.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_YYCorrelation_OBC.md
+++ b/docs/src/atlas/hubs/TFIM_YYCorrelation_OBC.md
@@ -32,4 +32,5 @@ verify(TFIM(; J = J, h = h), YYCorrelation(; mode = :static), OBC(N); route = :e
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `YYCorrelation`](../quantities/YYCorrelation.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_YYStructureFactor_Infinite.md
+++ b/docs/src/atlas/hubs/TFIM_YYStructureFactor_Infinite.md
@@ -31,4 +31,5 @@ verify(TFIM(; J = 1.0, h = h), YYStructureFactor(), Infinite(); route = :delegat
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `YYStructureFactor`](../quantities/YYStructureFactor.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_YYStructureFactor_OBC.md
+++ b/docs/src/atlas/hubs/TFIM_YYStructureFactor_OBC.md
@@ -31,4 +31,5 @@ verify(TFIM(; J = 1.0, h = h), YYStructureFactor(), OBC(N); route = :ed_finite_s
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `YYStructureFactor`](../quantities/YYStructureFactor.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_ZZCorrelation_OBC.md
+++ b/docs/src/atlas/hubs/TFIM_ZZCorrelation_OBC.md
@@ -41,4 +41,5 @@ verify(TFIM(; J = J, h = h), ZZCorrelation(; mode = :static), OBC(N); route = :e
 - cards: 3 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `ZZCorrelation`](../quantities/ZZCorrelation.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_ZZStructureFactor_Infinite.md
+++ b/docs/src/atlas/hubs/TFIM_ZZStructureFactor_Infinite.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `ZZStructureFactor`](../quantities/ZZStructureFactor.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TFIM_ZZStructureFactor_OBC.md
+++ b/docs/src/atlas/hubs/TFIM_ZZStructureFactor_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TFIM`](../models/TFIM.md) · [Quantity: `ZZStructureFactor`](../quantities/ZZStructureFactor.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TTbar_CentralCharge_Infinite.md
+++ b/docs/src/atlas/hubs/TTbar_CentralCharge_Infinite.md
@@ -42,4 +42,5 @@ verify(TTbar(), CentralCharge(), Infinite(); route = :second_closed_form, indepe
 - cards: 3 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TTbar`](../models/TTbar.md) · [Quantity: `CentralCharge`](../quantities/CentralCharge.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TightBinding1D_Energy_Infinite.md
+++ b/docs/src/atlas/hubs/TightBinding1D_Energy_Infinite.md
@@ -37,4 +37,5 @@ verify(TightBinding1D(; t = t), Energy(:per_site), Infinite(); route = :second_c
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TightBinding1D`](../models/TightBinding1D.md) · [Quantity: `Energy`](../quantities/Energy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TightBinding1D_FermiVelocity_Infinite.md
+++ b/docs/src/atlas/hubs/TightBinding1D_FermiVelocity_Infinite.md
@@ -32,4 +32,5 @@ verify(TightBinding1D(), FermiVelocity(), Infinite(); route = :second_closed_for
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TightBinding1D`](../models/TightBinding1D.md) · [Quantity: `FermiVelocity`](../quantities/FermiVelocity.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TightBinding1D_FreeEnergy_Infinite.md
+++ b/docs/src/atlas/hubs/TightBinding1D_FreeEnergy_Infinite.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TightBinding1D`](../models/TightBinding1D.md) · [Quantity: `FreeEnergy`](../quantities/FreeEnergy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TightBinding1D_MassGap_Infinite.md
+++ b/docs/src/atlas/hubs/TightBinding1D_MassGap_Infinite.md
@@ -37,4 +37,5 @@ verify(TightBinding1D(; t = 1.0, μ = 0.0), MassGap(), Infinite(); route = :seco
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TightBinding1D`](../models/TightBinding1D.md) · [Quantity: `MassGap`](../quantities/MassGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TightBinding1D_SpecificHeat_Infinite.md
+++ b/docs/src/atlas/hubs/TightBinding1D_SpecificHeat_Infinite.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TightBinding1D`](../models/TightBinding1D.md) · [Quantity: `SpecificHeat`](../quantities/SpecificHeat.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TightBinding1D_ThermalEntropy_Infinite.md
+++ b/docs/src/atlas/hubs/TightBinding1D_ThermalEntropy_Infinite.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TightBinding1D`](../models/TightBinding1D.md) · [Quantity: `ThermalEntropy`](../quantities/ThermalEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TightBindingV1D_Energy_Infinite.md
+++ b/docs/src/atlas/hubs/TightBindingV1D_Energy_Infinite.md
@@ -32,4 +32,5 @@ verify(TightBindingV1D(), Energy(), Infinite(); route = :second_closed_form, ind
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TightBindingV1D`](../models/TightBindingV1D.md) · [Quantity: `Energy`](../quantities/Energy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TightBindingV1D_FermiVelocity_Infinite.md
+++ b/docs/src/atlas/hubs/TightBindingV1D_FermiVelocity_Infinite.md
@@ -32,4 +32,5 @@ verify(TightBindingV1D(), FermiVelocity(), Infinite(); route = :second_closed_fo
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TightBindingV1D`](../models/TightBindingV1D.md) · [Quantity: `FermiVelocity`](../quantities/FermiVelocity.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TightBindingV1D_FreeEnergy_Infinite.md
+++ b/docs/src/atlas/hubs/TightBindingV1D_FreeEnergy_Infinite.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TightBindingV1D`](../models/TightBindingV1D.md) · [Quantity: `FreeEnergy`](../quantities/FreeEnergy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TightBindingV1D_MassGap_Infinite.md
+++ b/docs/src/atlas/hubs/TightBindingV1D_MassGap_Infinite.md
@@ -37,4 +37,5 @@ verify(TightBindingV1D(; μ = 3.0), MassGap(), Infinite(); route = :second_close
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TightBindingV1D`](../models/TightBindingV1D.md) · [Quantity: `MassGap`](../quantities/MassGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TightBindingV1D_SpecificHeat_Infinite.md
+++ b/docs/src/atlas/hubs/TightBindingV1D_SpecificHeat_Infinite.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TightBindingV1D`](../models/TightBindingV1D.md) · [Quantity: `SpecificHeat`](../quantities/SpecificHeat.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TightBindingV1D_ThermalEntropy_Infinite.md
+++ b/docs/src/atlas/hubs/TightBindingV1D_ThermalEntropy_Infinite.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TightBindingV1D`](../models/TightBindingV1D.md) · [Quantity: `ThermalEntropy`](../quantities/ThermalEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TodaLattice_MassGap_Infinite.md
+++ b/docs/src/atlas/hubs/TodaLattice_MassGap_Infinite.md
@@ -37,4 +37,5 @@ verify(TodaLattice(), MassGap(), Infinite(); route = :second_closed_form, indepe
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TodaLattice`](../models/TodaLattice.md) · [Quantity: `MassGap`](../quantities/MassGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/ToricCode_AnyonStatistics_Infinite.md
+++ b/docs/src/atlas/hubs/ToricCode_AnyonStatistics_Infinite.md
@@ -21,4 +21,5 @@ _No corroboration card._ Model is ED-infeasible — frontier (cited-only), not a
 - cards: 0 · model ED-infeasible (frontier)
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `ToricCode`](../models/ToricCode.md) · [Quantity: `AnyonStatistics`](../quantities/AnyonStatistics.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/ToricCode_GroundStateDegeneracy_PBC.md
+++ b/docs/src/atlas/hubs/ToricCode_GroundStateDegeneracy_PBC.md
@@ -37,4 +37,5 @@ verify(ToricCode(; J_e = J_e, J_m = J_m), GroundStateDegeneracy(), PBC(0); route
 - cards: 2 · model ED-infeasible (frontier)
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `ToricCode`](../models/ToricCode.md) · [Quantity: `GroundStateDegeneracy`](../quantities/GroundStateDegeneracy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/ToricCode_GroundStateEnergyDensity_Infinite.md
+++ b/docs/src/atlas/hubs/ToricCode_GroundStateEnergyDensity_Infinite.md
@@ -32,4 +32,5 @@ verify(ToricCode(; J_e = 1.0, J_m = 1.0), GroundStateEnergyDensity(), Infinite()
 - cards: 1 · model ED-infeasible (frontier)
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `ToricCode`](../models/ToricCode.md) · [Quantity: `GroundStateEnergyDensity`](../quantities/GroundStateEnergyDensity.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/ToricCode_MassGap_Infinite.md
+++ b/docs/src/atlas/hubs/ToricCode_MassGap_Infinite.md
@@ -32,4 +32,5 @@ verify(ToricCode(; J_e = 1.0, J_m = 1.0), MassGap(), Infinite(); route = :second
 - cards: 1 · model ED-infeasible (frontier)
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `ToricCode`](../models/ToricCode.md) · [Quantity: `MassGap`](../quantities/MassGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/ToricCode_TopologicalEntanglementEntropy_Infinite.md
+++ b/docs/src/atlas/hubs/ToricCode_TopologicalEntanglementEntropy_Infinite.md
@@ -32,4 +32,5 @@ verify(ToricCode(; J_e = 1.0, J_m = 1.0), TopologicalEntanglementEntropy(), Infi
 - cards: 1 · model ED-infeasible (frontier)
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `ToricCode`](../models/ToricCode.md) · [Quantity: `TopologicalEntanglementEntropy`](../quantities/TopologicalEntanglementEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TricriticalIsing_CentralCharge_Infinite.md
+++ b/docs/src/atlas/hubs/TricriticalIsing_CentralCharge_Infinite.md
@@ -32,4 +32,5 @@ verify(TricriticalIsing(), CentralCharge(), Infinite(); route = :second_closed_f
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TricriticalIsing`](../models/TricriticalIsing.md) · [Quantity: `CentralCharge`](../quantities/CentralCharge.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TricriticalIsing_ConformalWeights_Infinite.md
+++ b/docs/src/atlas/hubs/TricriticalIsing_ConformalWeights_Infinite.md
@@ -32,4 +32,5 @@ verify(TricriticalIsing(), ConformalWeights(), Infinite(); route = :second_close
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TricriticalIsing`](../models/TricriticalIsing.md) · [Quantity: `ConformalWeights`](../quantities/ConformalWeights.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TricriticalIsing_PrimaryFields_Infinite.md
+++ b/docs/src/atlas/hubs/TricriticalIsing_PrimaryFields_Infinite.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TricriticalIsing`](../models/TricriticalIsing.md) · [Quantity: `PrimaryFields`](../quantities/PrimaryFields.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TricriticalPotts3_CentralCharge_Infinite.md
+++ b/docs/src/atlas/hubs/TricriticalPotts3_CentralCharge_Infinite.md
@@ -32,4 +32,5 @@ verify(TricriticalPotts3(), CentralCharge(), Infinite(); route = :second_closed_
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TricriticalPotts3`](../models/TricriticalPotts3.md) · [Quantity: `CentralCharge`](../quantities/CentralCharge.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TricriticalPotts3_ConformalWeights_Infinite.md
+++ b/docs/src/atlas/hubs/TricriticalPotts3_ConformalWeights_Infinite.md
@@ -32,4 +32,5 @@ verify(TricriticalPotts3(), ConformalWeights(), Infinite(); route = :second_clos
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TricriticalPotts3`](../models/TricriticalPotts3.md) · [Quantity: `ConformalWeights`](../quantities/ConformalWeights.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/TricriticalPotts3_PrimaryFields_Infinite.md
+++ b/docs/src/atlas/hubs/TricriticalPotts3_PrimaryFields_Infinite.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `TricriticalPotts3`](../models/TricriticalPotts3.md) · [Quantity: `PrimaryFields`](../quantities/PrimaryFields.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/XCube_GroundStateDegeneracy_PBC.md
+++ b/docs/src/atlas/hubs/XCube_GroundStateDegeneracy_PBC.md
@@ -32,4 +32,5 @@ verify(XCube(), GroundStateDegeneracy(), PBC(); route = :second_closed_form, fet
 - cards: 1 · model ED-infeasible (frontier)
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `XCube`](../models/XCube.md) · [Quantity: `GroundStateDegeneracy`](../quantities/GroundStateDegeneracy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/XXZ1D_CentralCharge_Infinite.md
+++ b/docs/src/atlas/hubs/XXZ1D_CentralCharge_Infinite.md
@@ -32,4 +32,5 @@ verify(XXZ1D(; J = 1.0, Δ = 0.0), CentralCharge(), Infinite(); route = :second_
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `XXZ1D`](../models/XXZ1D.md) · [Quantity: `CentralCharge`](../quantities/CentralCharge.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/XXZ1D_EnergyLocal_OBC.md
+++ b/docs/src/atlas/hubs/XXZ1D_EnergyLocal_OBC.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `XXZ1D`](../models/XXZ1D.md) · [Quantity: `EnergyLocal`](../quantities/EnergyLocal.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/XXZ1D_Energy_Infinite.md
+++ b/docs/src/atlas/hubs/XXZ1D_Energy_Infinite.md
@@ -82,4 +82,5 @@ verify(XXZ1D(; J = 1.0, Δ = 1.0), Energy(), Infinite(); route = :ed_finite_size
 - cards: 11 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `XXZ1D`](../models/XXZ1D.md) · [Quantity: `Energy`](../quantities/Energy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/XXZ1D_Energy_OBC.md
+++ b/docs/src/atlas/hubs/XXZ1D_Energy_OBC.md
@@ -47,4 +47,5 @@ verify(XXZ1D(; J = J, Δ = dz), Energy(:per_site), OBC(N); route = :ed_finite_si
 - cards: 4 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `XXZ1D`](../models/XXZ1D.md) · [Quantity: `Energy`](../quantities/Energy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/XXZ1D_FreeEnergy_Infinite.md
+++ b/docs/src/atlas/hubs/XXZ1D_FreeEnergy_Infinite.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `XXZ1D`](../models/XXZ1D.md) · [Quantity: `FreeEnergy`](../quantities/FreeEnergy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/XXZ1D_FreeEnergy_OBC.md
+++ b/docs/src/atlas/hubs/XXZ1D_FreeEnergy_OBC.md
@@ -36,4 +36,5 @@ verify(XXZ1D(; J = J, Δ = dz), FreeEnergy(), OBC(N); route = :ed_finite_size, i
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `XXZ1D`](../models/XXZ1D.md) · [Quantity: `FreeEnergy`](../quantities/FreeEnergy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/XXZ1D_LoschmidtEcho_Infinite.md
+++ b/docs/src/atlas/hubs/XXZ1D_LoschmidtEcho_Infinite.md
@@ -37,4 +37,5 @@ verify(XXZ1D(; J = 1.0, Δ = 0.0), LoschmidtEcho(; mode = :rate), Infinite(); ro
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `XXZ1D`](../models/XXZ1D.md) · [Quantity: `LoschmidtEcho`](../quantities/LoschmidtEcho.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/XXZ1D_LuttingerParameter_Infinite.md
+++ b/docs/src/atlas/hubs/XXZ1D_LuttingerParameter_Infinite.md
@@ -47,4 +47,5 @@ verify(XXZ1D(; J = 1.0, Δ = Δ), LuttingerParameter(), Infinite(); route = :sec
 - cards: 4 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `XXZ1D`](../models/XXZ1D.md) · [Quantity: `LuttingerParameter`](../quantities/LuttingerParameter.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/XXZ1D_LuttingerVelocity_Infinite.md
+++ b/docs/src/atlas/hubs/XXZ1D_LuttingerVelocity_Infinite.md
@@ -37,4 +37,5 @@ verify(XXZ1D(; J = 1.0, Δ = 1.0), LuttingerVelocity(), Infinite(); route = :lim
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `XXZ1D`](../models/XXZ1D.md) · [Quantity: `LuttingerVelocity`](../quantities/LuttingerVelocity.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/XXZ1D_MagnetizationXLocal_OBC.md
+++ b/docs/src/atlas/hubs/XXZ1D_MagnetizationXLocal_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `XXZ1D`](../models/XXZ1D.md) · [Quantity: `MagnetizationXLocal`](../quantities/MagnetizationXLocal.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/XXZ1D_MagnetizationX_OBC.md
+++ b/docs/src/atlas/hubs/XXZ1D_MagnetizationX_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `XXZ1D`](../models/XXZ1D.md) · [Quantity: `MagnetizationX`](../quantities/MagnetizationX.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/XXZ1D_MagnetizationYLocal_OBC.md
+++ b/docs/src/atlas/hubs/XXZ1D_MagnetizationYLocal_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `XXZ1D`](../models/XXZ1D.md) · [Quantity: `MagnetizationYLocal`](../quantities/MagnetizationYLocal.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/XXZ1D_MagnetizationY_OBC.md
+++ b/docs/src/atlas/hubs/XXZ1D_MagnetizationY_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `XXZ1D`](../models/XXZ1D.md) · [Quantity: `MagnetizationY`](../quantities/MagnetizationY.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/XXZ1D_MagnetizationZLocal_OBC.md
+++ b/docs/src/atlas/hubs/XXZ1D_MagnetizationZLocal_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `XXZ1D`](../models/XXZ1D.md) · [Quantity: `MagnetizationZLocal`](../quantities/MagnetizationZLocal.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/XXZ1D_MagnetizationZ_OBC.md
+++ b/docs/src/atlas/hubs/XXZ1D_MagnetizationZ_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `XXZ1D`](../models/XXZ1D.md) · [Quantity: `MagnetizationZ`](../quantities/MagnetizationZ.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/XXZ1D_MassGap_Infinite.md
+++ b/docs/src/atlas/hubs/XXZ1D_MassGap_Infinite.md
@@ -32,4 +32,5 @@ verify(XXZ1D(; J = 1.0, Δ = 0.5), MassGap(), Infinite(); route = :second_closed
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `XXZ1D`](../models/XXZ1D.md) · [Quantity: `MassGap`](../quantities/MassGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/XXZ1D_MassGap_OBC.md
+++ b/docs/src/atlas/hubs/XXZ1D_MassGap_OBC.md
@@ -32,4 +32,5 @@ verify(XXZ1D(), MassGap(), OBC(N); route = :second_closed_form, independent = 0.
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `XXZ1D`](../models/XXZ1D.md) · [Quantity: `MassGap`](../quantities/MassGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/XXZ1D_RenyiEntropy_OBC.md
+++ b/docs/src/atlas/hubs/XXZ1D_RenyiEntropy_OBC.md
@@ -32,4 +32,5 @@ verify(XXZ1D(), RenyiEntropy(α), OBC(N); route = :second_closed_form, independe
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `XXZ1D`](../models/XXZ1D.md) · [Quantity: `RenyiEntropy`](../quantities/RenyiEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/XXZ1D_SpecificHeat_Infinite.md
+++ b/docs/src/atlas/hubs/XXZ1D_SpecificHeat_Infinite.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `XXZ1D`](../models/XXZ1D.md) · [Quantity: `SpecificHeat`](../quantities/SpecificHeat.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/XXZ1D_SpecificHeat_OBC.md
+++ b/docs/src/atlas/hubs/XXZ1D_SpecificHeat_OBC.md
@@ -41,4 +41,5 @@ verify(XXZ1D(; J = J, Δ = dz), SpecificHeat(), OBC(N); route = :ed_finite_size,
 - cards: 3 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `XXZ1D`](../models/XXZ1D.md) · [Quantity: `SpecificHeat`](../quantities/SpecificHeat.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/XXZ1D_SusceptibilityXX_OBC.md
+++ b/docs/src/atlas/hubs/XXZ1D_SusceptibilityXX_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `XXZ1D`](../models/XXZ1D.md) · [Quantity: `SusceptibilityXX`](../quantities/SusceptibilityXX.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/XXZ1D_SusceptibilityYY_OBC.md
+++ b/docs/src/atlas/hubs/XXZ1D_SusceptibilityYY_OBC.md
@@ -20,4 +20,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `XXZ1D`](../models/XXZ1D.md) · [Quantity: `SusceptibilityYY`](../quantities/SusceptibilityYY.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/XXZ1D_SusceptibilityZZ_OBC.md
+++ b/docs/src/atlas/hubs/XXZ1D_SusceptibilityZZ_OBC.md
@@ -41,4 +41,5 @@ verify(XXZ1D(), SusceptibilityZZ(), OBC(N); route = :second_closed_form, indepen
 - cards: 3 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `XXZ1D`](../models/XXZ1D.md) · [Quantity: `SusceptibilityZZ`](../quantities/SusceptibilityZZ.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/XXZ1D_ThermalEntropy_Infinite.md
+++ b/docs/src/atlas/hubs/XXZ1D_ThermalEntropy_Infinite.md
@@ -21,4 +21,5 @@ _No corroboration card._ Flagged by the R1 risk-linter (`src` claims this hub, E
 - cards: 0 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `XXZ1D`](../models/XXZ1D.md) · [Quantity: `ThermalEntropy`](../quantities/ThermalEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/XXZ1D_ThermalEntropy_OBC.md
+++ b/docs/src/atlas/hubs/XXZ1D_ThermalEntropy_OBC.md
@@ -41,4 +41,5 @@ verify(XXZ1D(; J = J, Δ = dz), ThermalEntropy(), OBC(N); route = :ed_finite_siz
 - cards: 3 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `XXZ1D`](../models/XXZ1D.md) · [Quantity: `ThermalEntropy`](../quantities/ThermalEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/XXZ1D_VonNeumannEntropy_OBC.md
+++ b/docs/src/atlas/hubs/XXZ1D_VonNeumannEntropy_OBC.md
@@ -32,4 +32,5 @@ verify(XXZ1D(), VonNeumannEntropy(), OBC(N); route = :second_closed_form, indepe
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `XXZ1D`](../models/XXZ1D.md) · [Quantity: `VonNeumannEntropy`](../quantities/VonNeumannEntropy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/XYh1D_Energy_Infinite.md
+++ b/docs/src/atlas/hubs/XYh1D_Energy_Infinite.md
@@ -37,4 +37,5 @@ verify(XYh1D(; h = 0.0), Energy(:per_site), Infinite(); route = :second_closed_f
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `XYh1D`](../models/XYh1D.md) · [Quantity: `Energy`](../quantities/Energy.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/XYh1D_MassGap_Infinite.md
+++ b/docs/src/atlas/hubs/XYh1D_MassGap_Infinite.md
@@ -42,4 +42,5 @@ verify(XYh1D(; h = 0.5), MassGap(), Infinite(); route = :second_closed_form, ind
 - cards: 3 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `XYh1D`](../models/XYh1D.md) · [Quantity: `MassGap`](../quantities/MassGap.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/YangLee_CentralCharge_Infinite.md
+++ b/docs/src/atlas/hubs/YangLee_CentralCharge_Infinite.md
@@ -37,4 +37,5 @@ verify(YangLee(), CentralCharge(), Infinite(); route = :second_closed_form, inde
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `YangLee`](../models/YangLee.md) · [Quantity: `CentralCharge`](../quantities/CentralCharge.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/YangLee_ConformalWeights_Infinite.md
+++ b/docs/src/atlas/hubs/YangLee_ConformalWeights_Infinite.md
@@ -32,4 +32,5 @@ verify(YangLee(), ConformalWeights(), Infinite(); route = :literature_value, fet
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `YangLee`](../models/YangLee.md) · [Quantity: `ConformalWeights`](../quantities/ConformalWeights.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/ZnClock_CentralCharge_Infinite.md
+++ b/docs/src/atlas/hubs/ZnClock_CentralCharge_Infinite.md
@@ -37,4 +37,5 @@ verify(ZnClock(; n = 3), CentralCharge(), Infinite(); route = :second_closed_for
 - cards: 2 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `ZnClock`](../models/ZnClock.md) · [Quantity: `CentralCharge`](../quantities/CentralCharge.md) · [Atlas index](../index.md)

--- a/docs/src/atlas/hubs/ZnParafermion_CentralCharge_Infinite.md
+++ b/docs/src/atlas/hubs/ZnParafermion_CentralCharge_Infinite.md
@@ -32,4 +32,5 @@ verify(ZnParafermion(; n = n), CentralCharge(), Infinite(); route = :second_clos
 - cards: 1 · model ED-feasible
 - RES not wired — measured residuals / confidence are not shown yet.
 
+
 [← Model: `ZnParafermion`](../models/ZnParafermion.md) · [Quantity: `CentralCharge`](../quantities/CentralCharge.md) · [Atlas index](../index.md)


### PR DESCRIPTION
Stacked on #478.  Pure refactor (hoist TIER-1 EXT HELPERS above per-hub render to fix top-level execution order) + injection of the per-hub Derivation-note section that was deferred in #478.  Currently 0 hubs match the strict (model+quantity) heuristic against existing calc/*.md filenames; the section is empty-guarded.  Future calc notes adopting quantity-named filenames (e.g. tfim-massgap.md) will auto-link from the relevant hub.  Guards: 2/2 + 179/179.  Project.toml 0.22.8 -> 0.22.9.