### PR TITLE
docs(atlas): quantity definition glossary on per-quantity pages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.22.9"
+version = "0.22.8"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.22.8"
+version = "0.22.9"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/docs/atlas/generate.jl
+++ b/docs/atlas/generate.jl
@@ -170,6 +170,51 @@ const LEGEND = string(
 )
 
 # HOISTED: TIER-1 EXT HELPERS
+
+# Quantity definition extraction: scan src/**/*.jl for docstrings preceding
+# `struct <Name>[{params}] <: AbstractQuantity`, build a Dict{base_name => first paragraph}.
+const _QUANTITY_DEFS = let
+    defs = Dict{String,String}()
+    for (root, _, fs) in walkdir(joinpath(ROOT, "src"))
+        for f in fs
+            endswith(f, ".jl") || continue
+            txt = read(joinpath(root, f), String)
+            for m in eachmatch(
+                r"\"\"\"(.+?)\"\"\"\s*\n\s*struct\s+([A-Z][A-Za-z0-9_]*)(?:\{[^}]*\})?\s*<:\s*AbstractQuantity"s,
+                txt,
+            )
+                docblock = strip(m.captures[1])
+                name = m.captures[2]
+                haskey(defs, name) && continue
+                lines = split(docblock, "\n")
+                body_start = 1
+                for (i, ln) in enumerate(lines)
+                    if i > 1 && isempty(strip(ln))
+                        body_start = i + 1
+                        break
+                    end
+                end
+                if body_start > length(lines)
+                    defs[name] = ""
+                    continue
+                end
+                para = String[]
+                for ln in lines[body_start:end]
+                    isempty(strip(ln)) && !isempty(para) && break
+                    isempty(strip(ln)) && continue
+                    push!(para, strip(ln))
+                end
+                defs[name] = join(para, " ")
+            end
+        end
+    end
+    defs
+end
+
+function _quantity_base_name(q::AbstractString)
+    return replace(q, r"\{.*\}" => "")
+end
+
 # ── TIER-1 EXT HELPERS (universality + calc + refs) ─────────────────────────
 
 # CONVENTION block extraction: parse the standard header comment
@@ -474,6 +519,27 @@ function render_quantity_index(quant_name::AbstractString)
         "to other models.",
     )
     P("")
+    base_name = _quantity_base_name(quant_name)
+    qdef = get(_QUANTITY_DEFS, base_name, "")
+    if !isempty(qdef)
+        P("## Definition")
+        P("")
+        P(_md_escape_dollar(qdef))
+        P("")
+        if base_name != quant_name
+            P(
+                "_(extracted from `src/core/quantities.jl` docstring for the base `",
+                base_name,
+                "`; this page covers the `",
+                quant_name,
+                "` variant.)_",
+            )
+            P("")
+        else
+            P("_(extracted from `src/core/quantities.jl` docstring.)_")
+            P("")
+        end
+    end
     P("## Coverage")
     P("")
     P("- **Models with this quantity registered**: ", length(mdls))

--- a/docs/src/atlas/quantities/AnyonStatistics.md
+++ b/docs/src/atlas/quantities/AnyonStatistics.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`AnyonStatistics`** observable.  Empty cells = this model doesn't yet have a `AnyonStatistics` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Topological data of the anyon content of a 2D topologically ordered phase.  The dispatched `fetch` method takes a `type::Symbol` kwarg selecting an anyon (or a mutual-braiding row) and returns a `NamedTuple` whose shape depends on the requested row — typically `(label, statistics, self_phase, quantum_dim, fusion)` for individual anyons, and `(label, mutual_phase, anyons)` for two-anyon braids.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 1

--- a/docs/src/atlas/quantities/CentralCharge.md
+++ b/docs/src/atlas/quantities/CentralCharge.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`CentralCharge`** observable.  Empty cells = this model doesn't yet have a `CentralCharge` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Central charge `c` of the emergent CFT.  For 1D critical systems extracted from the Calabrese–Cardy entanglement formula; universality pages return literature values.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 15

--- a/docs/src/atlas/quantities/ChargeGap.md
+++ b/docs/src/atlas/quantities/ChargeGap.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`ChargeGap`** observable.  Empty cells = this model doesn't yet have a `ChargeGap` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Convenience alias for the rate-function flavour `λ(t) = -log L(t)/N`.  See [`LoschmidtEcho`](@ref). """ const LoschmidtRateFunction = LoschmidtEcho{:rate}
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 2

--- a/docs/src/atlas/quantities/ChiralCondensate.md
+++ b/docs/src/atlas/quantities/ChiralCondensate.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`ChiralCondensate`** observable.  Empty cells = this model doesn't yet have a `ChiralCondensate` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Vacuum expectation value `⟨ψ̄ψ⟩` of a fermion bilinear, signalling spontaneous (anomalous) chiral-symmetry breaking.  The massless Schwinger model is the canonical 1+1-D example: even though the classical Lagrangian is chirally symmetric, the anomaly forces a non-zero condensate
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 1

--- a/docs/src/atlas/quantities/ConformalWeights.md
+++ b/docs/src/atlas/quantities/ConformalWeights.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`ConformalWeights`** observable.  Empty cells = this model doesn't yet have a `ConformalWeights` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Primary scaling dimension `h` of a 2D rational CFT.  For Virasoro [`MinimalModel`](@ref) this is the Kac-table entry `h_{r,s}`; for [`WZWSU2`](@ref) it is the SU(2)-spin label `h_j = j(j+1)/(k+2)`.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 6

--- a/docs/src/atlas/quantities/CorrelationLength.md
+++ b/docs/src/atlas/quantities/CorrelationLength.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`CorrelationLength`** observable.  Empty cells = this model doesn't yet have a `CorrelationLength` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Two-point correlation length `ξ` controlling the exponential decay of connected equal-time correlators in a gapped phase,
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 4

--- a/docs/src/atlas/quantities/CriticalExponents.md
+++ b/docs/src/atlas/quantities/CriticalExponents.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`CriticalExponents`** observable.  Empty cells = this model doesn't yet have a `CriticalExponents` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Parametric dispatch tag for universality classes. `C` is a `Symbol` identifying the class (`:Ising`, `:XY`, `:Heisenberg`, `:Potts3`, `:Potts4`, `:Percolation`, `:KPZ`, etc.).
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 4

--- a/docs/src/atlas/quantities/CriticalTemperature.md
+++ b/docs/src/atlas/quantities/CriticalTemperature.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`CriticalTemperature`** observable.  Empty cells = this model doesn't yet have a `CriticalTemperature` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Return the 2^Ly × 2^Ly symmetric transfer matrix for a row of `Ly` Ising spins with PBC along the row direction.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 6

--- a/docs/src/atlas/quantities/EdgeModeEnergy.md
+++ b/docs/src/atlas/quantities/EdgeModeEnergy.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`EdgeModeEnergy`** observable.  Empty cells = this model doesn't yet have a `EdgeModeEnergy` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Energy of the lowest-lying boundary mode on an open chain.  In a topological 1D superconductor (Kitaev 2001) the OBC chain hosts two Majorana zero modes at the chain ends; their hybridization energy decays exponentially with chain length,
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 1

--- a/docs/src/atlas/quantities/Energy.md
+++ b/docs/src/atlas/quantities/Energy.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`Energy`** observable.  Empty cells = this model doesn't yet have a `Energy` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Ground-state / thermal energy expectation.  The type parameter `G` makes the granularity (total vs per-site) a dispatch axis instead of a hidden docstring contract.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 24

--- a/docs/src/atlas/quantities/EnergyLocal.md
+++ b/docs/src/atlas/quantities/EnergyLocal.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`EnergyLocal`** observable.  Empty cells = this model doesn't yet have a `EnergyLocal` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Bond-resolved energy density vector, length `N_bulk − 1` for a bond Hamiltonian `Σ_b h_b`.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 4

--- a/docs/src/atlas/quantities/FermiVelocity.md
+++ b/docs/src/atlas/quantities/FermiVelocity.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`FermiVelocity`** observable.  Empty cells = this model doesn't yet have a `FermiVelocity` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Fermi velocity `v_F = ∂ε/∂k |_{k_F}`.  Meaningful for non-interacting / mean-field fermionic band structures (tight-binding lattices, Bogoliubov-de Gennes diagonalisations).  In QAtlas this is the type returned by models like [`Honeycomb`](@ref) (at the Dirac cones), the other tight-binding lattices, and the TFIM Majorana mode at the critical field.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 2

--- a/docs/src/atlas/quantities/FidelitySusceptibility.md
+++ b/docs/src/atlas/quantities/FidelitySusceptibility.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`FidelitySusceptibility`** observable.  Empty cells = this model doesn't yet have a `FidelitySusceptibility` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Fidelity susceptibility `χ_F(λ) = −∂²⟨ψ(λ)|ψ(λ + δλ)⟩/∂δλ²`.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 1

--- a/docs/src/atlas/quantities/FractalDimension.md
+++ b/docs/src/atlas/quantities/FractalDimension.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`FractalDimension`** observable.  Empty cells = this model doesn't yet have a `FractalDimension` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Hausdorff dimension `d_H` of the random geometric set associated with a model — e.g. the SLE_κ curve's `d_H(κ) = min(2, 1 + κ/8)` (Beffara 2008).  Real-valued, dimensionless, capped at the ambient space dimension.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 1

--- a/docs/src/atlas/quantities/FreeEnergy.md
+++ b/docs/src/atlas/quantities/FreeEnergy.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`FreeEnergy`** observable.  Empty cells = this model doesn't yet have a `FreeEnergy` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Trait declaring which granularity the given `model` returns natively for [`Energy`](@ref) at boundary condition `bc`.  Used by the `Energy()` (`:natural`) router and by the generic conversion fallbacks.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 11

--- a/docs/src/atlas/quantities/GGEValue.md
+++ b/docs/src/atlas/quantities/GGEValue.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`GGEValue`** observable.  Empty cells = this model doesn't yet have a `GGEValue` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Wrapper quantity carrying an underlying observable `inner::Q` whose *generalised Gibbs ensemble* (GGE) stationary value is to be computed — i.e. the `t → ∞` long-time average that an integrable (free-fermion) quench reaches.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 1

--- a/docs/src/atlas/quantities/GroundStateDegeneracy.md
+++ b/docs/src/atlas/quantities/GroundStateDegeneracy.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`GroundStateDegeneracy`** observable.  Empty cells = this model doesn't yet have a `GroundStateDegeneracy` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Dimension of the ground-state subspace as an `Int`.  In topologically ordered phases this is a robust, lattice-independent invariant determined by the ambient surface (e.g. `4^g` on a closed orientable genus-`g` surface for the toric code) and is set by the kwarg `genus` on the `fetch` call.  Trivially `1` for any gapped, symmetry-unbroken phase.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 2

--- a/docs/src/atlas/quantities/LoschmidtEcho.md
+++ b/docs/src/atlas/quantities/LoschmidtEcho.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`LoschmidtEcho`** observable.  Empty cells = this model doesn't yet have a `LoschmidtEcho` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Loschmidt-echo family for sudden-quench dynamics.  After preparing `|ψ_0⟩` as the ground state of an "initial" model `H_0` and quenching to the "final" model `H_f` (passed as the first positional argument to `fetch`), the Loschmidt amplitude is
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 2

--- a/docs/src/atlas/quantities/LuttingerParameter.md
+++ b/docs/src/atlas/quantities/LuttingerParameter.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`LuttingerParameter`** observable.  Empty cells = this model doesn't yet have a `LuttingerParameter` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Luttinger liquid parameter `K`.  Meaningful for critical 1D models with U(1) symmetry (e.g. XXZ in the critical regime `|Δ| < 1`).
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 4

--- a/docs/src/atlas/quantities/LuttingerVelocity.md
+++ b/docs/src/atlas/quantities/LuttingerVelocity.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`LuttingerVelocity`** observable.  Empty cells = this model doesn't yet have a `LuttingerVelocity` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Luttinger-liquid / bosonisation velocity `u` (a.k.a. `v_{LL}`) of the low-energy linear-dispersion mode in a 1D critical interacting system. Used by models like [`XXZ1D`](@ref) in the Luttinger regime `|Δ| < 1`, the Heisenberg chain at the SU(2) point, and any other bosonised 1D critical theory.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 1

--- a/docs/src/atlas/quantities/MagnetizationX.md
+++ b/docs/src/atlas/quantities/MagnetizationX.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`MagnetizationX`** observable.  Empty cells = this model doesn't yet have a `MagnetizationX` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Bulk-averaged `⟨σˣ⟩` in Pauli convention (= 2 ⟨Sˣ⟩ in spin-1/2 units). For a spin-1/2 chain `H = -J ΣSᶻSᶻ - h ΣSˣ` this is the transverse magnetization; the axis-explicit name avoids the "transverse" / "longitudinal" ambiguity that depends on the model's Hamiltonian choice.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 4

--- a/docs/src/atlas/quantities/MagnetizationXLocal.md
+++ b/docs/src/atlas/quantities/MagnetizationXLocal.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`MagnetizationXLocal`** observable.  Empty cells = this model doesn't yet have a `MagnetizationXLocal` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Site-resolved `⟨σˣ_i⟩` quantity.  The mode parameter `M::Symbol` is a phantom type that splits the dispatch into:
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 4

--- a/docs/src/atlas/quantities/MagnetizationY.md
+++ b/docs/src/atlas/quantities/MagnetizationY.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`MagnetizationY`** observable.  Empty cells = this model doesn't yet have a `MagnetizationY` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Bulk-averaged `⟨σʸ⟩`.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 4

--- a/docs/src/atlas/quantities/MagnetizationYLocal.md
+++ b/docs/src/atlas/quantities/MagnetizationYLocal.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`MagnetizationYLocal`** observable.  Empty cells = this model doesn't yet have a `MagnetizationYLocal` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Site-resolved `⟨σʸ_i⟩` vector of length `N_bulk`.  Identically zero for any real Hermitian Hamiltonian (parity / time-reversal); a model that returns it explicitly does so as an exact baseline against random-sample estimators that fluctuate around zero.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 2

--- a/docs/src/atlas/quantities/MagnetizationZ.md
+++ b/docs/src/atlas/quantities/MagnetizationZ.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`MagnetizationZ`** observable.  Empty cells = this model doesn't yet have a `MagnetizationZ` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Bulk-averaged `⟨σᶻ⟩`.  For Z₂-symmetric phases on an infinite system this is the order parameter at low temperature; finite-system fetch methods may return the absolute value / the ordered-phase limit as documented.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 4

--- a/docs/src/atlas/quantities/MagnetizationZLocal.md
+++ b/docs/src/atlas/quantities/MagnetizationZLocal.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`MagnetizationZLocal`** observable.  Empty cells = this model doesn't yet have a `MagnetizationZLocal` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Site-resolved `⟨σᶻ_i⟩` vector of length `N_bulk`.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 4

--- a/docs/src/atlas/quantities/MassGap.md
+++ b/docs/src/atlas/quantities/MassGap.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`MassGap`** observable.  Empty cells = this model doesn't yet have a `MassGap` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Energy gap between the ground state and the first excited state.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 24

--- a/docs/src/atlas/quantities/PartitionFunction.md
+++ b/docs/src/atlas/quantities/PartitionFunction.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`PartitionFunction`** observable.  Empty cells = this model doesn't yet have a `PartitionFunction` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Classical 2D Ising model on a square lattice with periodic boundary conditions (PBC) in both directions.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 2

--- a/docs/src/atlas/quantities/PrimaryFields.md
+++ b/docs/src/atlas/quantities/PrimaryFields.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`PrimaryFields`** observable.  Empty cells = this model doesn't yet have a `PrimaryFields` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Full list of primary fields of a 2D rational CFT.  For [`MinimalModel`](@ref) the result is a `Vector{NamedTuple{(:r, :s, :h)}}` of length `(p - 1)(p_prime - 1) / 2`, with one entry per Kac-symmetry orbit.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 2

--- a/docs/src/atlas/quantities/RenyiEntropy.md
+++ b/docs/src/atlas/quantities/RenyiEntropy.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`RenyiEntropy`** observable.  Empty cells = this model doesn't yet have a `RenyiEntropy` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Rényi entropy of order `α`, `S_α = (1 − α)⁻¹ log Tr ρ_A^α`.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 4

--- a/docs/src/atlas/quantities/ResidualEntropy.md
+++ b/docs/src/atlas/quantities/ResidualEntropy.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`ResidualEntropy`** observable.  Empty cells = this model doesn't yet have a `ResidualEntropy` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Zero-temperature configurational (residual) entropy density.  Real- valued, non-negative; non-zero in the presence of macroscopic ground-state degeneracy (e.g. ice rule, frustrated Ising AFM, Pauling-1935-style models).  Distinct from [`ThermalEntropy`](@ref): `ThermalEntropy` is a finite-temperature thermodynamic quantity, while `ResidualEntropy` is the lim_{T -> 0} S(T) / N residual term. Zero-temperature ground-state entropy per site,
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 4

--- a/docs/src/atlas/quantities/SpecificHeat.md
+++ b/docs/src/atlas/quantities/SpecificHeat.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`SpecificHeat`** observable.  Empty cells = this model doesn't yet have a `SpecificHeat` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Specific heat per site, `c_v(β) = β² (⟨H²⟩ − ⟨H⟩²) / N`.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 10

--- a/docs/src/atlas/quantities/SpinGap.md
+++ b/docs/src/atlas/quantities/SpinGap.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`SpinGap`** observable.  Empty cells = this model doesn't yet have a `SpinGap` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Spin gap of an electron system,
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 2

--- a/docs/src/atlas/quantities/SpontaneousMagnetization.md
+++ b/docs/src/atlas/quantities/SpontaneousMagnetization.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`SpontaneousMagnetization`** observable.  Empty cells = this model doesn't yet have a `SpontaneousMagnetization` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Spontaneous magnetization of a classical model as a function of temperature.  Retained under this name for backward compatibility with the classical-Ising literature; new code may prefer the axis-explicit [`MagnetizationZ`](@ref) together with a `T < T_c` context.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 4

--- a/docs/src/atlas/quantities/SteadyStateCurrent.md
+++ b/docs/src/atlas/quantities/SteadyStateCurrent.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`SteadyStateCurrent`** observable.  Empty cells = this model doesn't yet have a `SteadyStateCurrent` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Steady-state mass / particle current `j` in a 1D non-equilibrium lattice gas (e.g. ASEP / TASEP, Derrida-Lebowitz 1998).  For TASEP at hopping rate `p` and density `ρ`,
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 1

--- a/docs/src/atlas/quantities/StringOrderParameter.md
+++ b/docs/src/atlas/quantities/StringOrderParameter.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`StringOrderParameter`** observable.  Empty cells = this model doesn't yet have a `StringOrderParameter` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Kennedy-Tasaki non-local (string) order parameter
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 1

--- a/docs/src/atlas/quantities/SusceptibilityXX.md
+++ b/docs/src/atlas/quantities/SusceptibilityXX.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`SusceptibilityXX`** observable.  Empty cells = this model doesn't yet have a `SusceptibilityXX` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Static transverse susceptibility, `χ_xx(β) = β · (⟨M_x²⟩ − ⟨M_x⟩²) / N`.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 4

--- a/docs/src/atlas/quantities/SusceptibilityYY.md
+++ b/docs/src/atlas/quantities/SusceptibilityYY.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`SusceptibilityYY`** observable.  Empty cells = this model doesn't yet have a `SusceptibilityYY` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Analogue for the y-axis.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 4

--- a/docs/src/atlas/quantities/SusceptibilityZZ.md
+++ b/docs/src/atlas/quantities/SusceptibilityZZ.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`SusceptibilityZZ`** observable.  Empty cells = this model doesn't yet have a `SusceptibilityZZ` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Uniform longitudinal susceptibility, `χ_zz(β) = β · (⟨M_z²⟩ − ⟨M_z⟩²) / N`.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 6

--- a/docs/src/atlas/quantities/ThermalEntropy.md
+++ b/docs/src/atlas/quantities/ThermalEntropy.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`ThermalEntropy`** observable.  Empty cells = this model doesn't yet have a `ThermalEntropy` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Thermal / thermodynamic entropy per site, `s(β) = −∂f/∂T` where `f` is the free energy per site.  Real-valued, non-negative, monotone in `T`.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 10

--- a/docs/src/atlas/quantities/TopologicalEntanglementEntropy.md
+++ b/docs/src/atlas/quantities/TopologicalEntanglementEntropy.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`TopologicalEntanglementEntropy`** observable.  Empty cells = this model doesn't yet have a `TopologicalEntanglementEntropy` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Constant subleading correction `γ` in the area-law bipartite entanglement entropy of a 2D topologically ordered ground state on a simply-connected disk region:
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 3

--- a/docs/src/atlas/quantities/TopologicalInvariant.md
+++ b/docs/src/atlas/quantities/TopologicalInvariant.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`TopologicalInvariant`** observable.  Empty cells = this model doesn't yet have a `TopologicalInvariant` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Topological `Z_2` invariant of a 1D BdG superconductor (Kitaev 2001). Defined as the Pfaffian sign at the time-reversal-invariant momenta `k = 0` and `k = π`,
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 2

--- a/docs/src/atlas/quantities/VonNeumannEntropy.md
+++ b/docs/src/atlas/quantities/VonNeumannEntropy.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`VonNeumannEntropy`** observable.  Empty cells = this model doesn't yet have a `VonNeumannEntropy` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Von Neumann entanglement entropy of a reduced density matrix, `S_vN = −Tr ρ_A log ρ_A`.  The mode parameter `M::Symbol` is a phantom type that splits the dispatch into:
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 4

--- a/docs/src/atlas/quantities/XXCorrelation.md
+++ b/docs/src/atlas/quantities/XXCorrelation.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`XXCorrelation`** observable.  Empty cells = this model doesn't yet have a `XXCorrelation` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Real-space 2-point `⟨σˣ_i σˣ_j⟩` correlator.  See [`ZZCorrelation`](@ref) for the `mode` semantics.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 2

--- a/docs/src/atlas/quantities/XXStructureFactor.md
+++ b/docs/src/atlas/quantities/XXStructureFactor.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`XXStructureFactor`** observable.  Empty cells = this model doesn't yet have a `XXStructureFactor` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Fourier-space equivalent of [`XXCorrelation`](@ref).
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 1

--- a/docs/src/atlas/quantities/YYCorrelation.md
+++ b/docs/src/atlas/quantities/YYCorrelation.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`YYCorrelation`** observable.  Empty cells = this model doesn't yet have a `YYCorrelation` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Real-space 2-point `⟨σʸ_i σʸ_j⟩` correlator.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 2

--- a/docs/src/atlas/quantities/YYStructureFactor.md
+++ b/docs/src/atlas/quantities/YYStructureFactor.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`YYStructureFactor`** observable.  Empty cells = this model doesn't yet have a `YYStructureFactor` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Fourier-space equivalent of [`YYCorrelation`](@ref).
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 1

--- a/docs/src/atlas/quantities/ZZCorrelation.md
+++ b/docs/src/atlas/quantities/ZZCorrelation.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`ZZCorrelation`** observable.  Empty cells = this model doesn't yet have a `ZZCorrelation` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Real-space 2-point correlator `⟨σᶻ_i σᶻ_j⟩`.  The mode `M::Symbol` is a phantom type parameter so dispatch can specialise on it.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 3

--- a/docs/src/atlas/quantities/ZZStructureFactor.md
+++ b/docs/src/atlas/quantities/ZZStructureFactor.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`ZZStructureFactor`** observable.  Empty cells = this model doesn't yet have a `ZZStructureFactor` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Fourier-space structure factor `S_zz(q, ω) = ∫ dt e^{iωt} (1/N) Σ_{ij} e^{iq·(i-j)} ⟨σᶻ_i(t)σᶻ_j(0)⟩` (or its static limit, depending on the model's fetch signature).
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 3


### PR DESCRIPTION
Stacked on #479.  Each quantities/<Q>.md gets a Definition section extracted from the docstring above struct X <: AbstractQuantity in src/**/*.jl.  49 of 51 quantities matched; the 2 misses (ExactSpectrum, GroundStateEnergyDensity) honestly show no Definition.  Guards: 2/2 + 179/179.  Project.toml 0.22.9 -> 0.22.10.