### PR TITLE
docs(atlas): _convention_path struct-search fallback

### DIFF
--- a/docs/atlas/generate.jl
+++ b/docs/atlas/generate.jl
@@ -225,12 +225,34 @@ end
 # from src/models/<class>/<Model>/<Model>.jl.  The block is enforced by
 # the CI lint (`test/lint/`) on new model files; older files (e.g.
 # IsingSquare) may not have it — return an empty list in that case.
+const _STRUCT_PATH_CACHE = Dict{String,String}()
+const _STRUCT_CACHE_BUILT = Ref(false)
+
+function _build_struct_path_cache()
+    _STRUCT_CACHE_BUILT[] && return nothing
+    for (root, _, fs) in walkdir(joinpath(ROOT, "src", "models"))
+        for f in fs
+            endswith(f, ".jl") || continue
+            endswith(f, "_registry.jl") && continue
+            p = joinpath(root, f)
+            txt = read(p, String)
+            for m in eachmatch(r"^struct\s+([A-Z][A-Za-z0-9_]*)(?:\{[^}]*\})?\s*<:"m, txt)
+                name = m.captures[1]
+                haskey(_STRUCT_PATH_CACHE, name) || (_STRUCT_PATH_CACHE[name] = p)
+            end
+        end
+    end
+    _STRUCT_CACHE_BUILT[] = true
+    return nothing
+end
+
 function _convention_path(model_name::AbstractString)
     for class in ("classical", "quantum")
         p = joinpath(ROOT, "src", "models", class, model_name, model_name * ".jl")
         isfile(p) && return p
     end
-    return ""
+    _build_struct_path_cache()
+    return get(_STRUCT_PATH_CACHE, model_name, "")
 end
 
 function _parse_convention(model_name::AbstractString)

--- a/docs/src/atlas/Audit.md
+++ b/docs/src/atlas/Audit.md
@@ -33,13 +33,6 @@ The CI lint enforces `# CONVENTION` headers on new model files, but older files 
 - [`ZnClock`](models/ZnClock.md)
 - [`ZnParafermion`](models/ZnParafermion.md)
 
-**Source file not found at `src/models/<class>/<Model>/<Model>.jl`** (4) — model may live elsewhere or be defined inline:
-
-- [`AKLT1D`](models/AKLT1D.md)
-- [`Heisenberg1D`](models/Heisenberg1D.md)
-- [`S1Heisenberg1D`](models/S1Heisenberg1D.md)
-- [`XXZ1D`](models/XXZ1D.md)
-
 ## 2. Quantities without auto-extracted `Definition`
 
 Quantities whose `struct X[{params}] <: AbstractQuantity` docstring wasn't matched by the regex extractor (likely defined as bare `struct X end` without `<: AbstractQuantity`, or with alternate formatting).  Adding the supertype + docstring makes them appear on the per-quantity page automatically.

--- a/docs/src/atlas/models/AKLT1D.md
+++ b/docs/src/atlas/models/AKLT1D.md
@@ -7,7 +7,10 @@ All `(Quantity, BC)` hubs `src` claims for **`AKLT1D`**.  Cells link to the per-
 
 ## Convention
 
-_No `CONVENTION` header found in `src/models/<class>/AKLT1D/AKLT1D.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+| Field | Value |
+|---|---|
+| Hamiltonian | Spin S (this file) |
+| Observable | Spin S         (QAtlas-wide spin convention; see docs/src/conventions.md) |
 
 ## Coverage
 

--- a/docs/src/atlas/models/Heisenberg1D.md
+++ b/docs/src/atlas/models/Heisenberg1D.md
@@ -7,7 +7,10 @@ All `(Quantity, BC)` hubs `src` claims for **`Heisenberg1D`**.  Cells link to th
 
 ## Convention
 
-_No `CONVENTION` header found in `src/models/<class>/Heisenberg1D/Heisenberg1D.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+| Field | Value |
+|---|---|
+| Hamiltonian | Spin S (this file) |
+| Observable | Spin S         (QAtlas-wide spin convention; see docs/src/conventions.md) |
 
 ## Coverage
 

--- a/docs/src/atlas/models/S1Heisenberg1D.md
+++ b/docs/src/atlas/models/S1Heisenberg1D.md
@@ -7,7 +7,10 @@ All `(Quantity, BC)` hubs `src` claims for **`S1Heisenberg1D`**.  Cells link to 
 
 ## Convention
 
-_No `CONVENTION` header found in `src/models/<class>/S1Heisenberg1D/S1Heisenberg1D.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+| Field | Value |
+|---|---|
+| Hamiltonian | Spin S (this file) |
+| Observable | Spin S         (QAtlas-wide spin convention; see docs/src/conventions.md) |
 
 ## Coverage
 

--- a/docs/src/atlas/models/XXZ1D.md
+++ b/docs/src/atlas/models/XXZ1D.md
@@ -7,7 +7,10 @@ All `(Quantity, BC)` hubs `src` claims for **`XXZ1D`**.  Cells link to the per-h
 
 ## Convention
 
-_No `CONVENTION` header found in `src/models/<class>/XXZ1D/XXZ1D.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+| Field | Value |
+|---|---|
+| Hamiltonian | Spin S (this file) |
+| Observable | Spin S         (QAtlas-wide spin convention; see docs/src/conventions.md) |
 
 ## Coverage
 


### PR DESCRIPTION
Stacked on #481.  Acts on Audit finding: 4 models had source file not found at canonical path.  Adds struct-name regex search fallback across src/models/.  Source-file-not-found: 4 -> 0; AKLT1D / Heisenberg1D / S1Heisenberg1D now show real CONVENTION block.  Guards: 2/2 + 179/179.  Project.toml 0.22.11 -> 0.22.12.