### PR TITLE
docs(atlas): hub-string normalization for orphan-card matching

### DIFF
--- a/docs/atlas/generate.jl
+++ b/docs/atlas/generate.jl
@@ -215,6 +215,18 @@ function _quantity_base_name(q::AbstractString)
     return replace(q, r"\{.*\}" => "")
 end
 
+# Hub-string normalization for orphan-card matching.
+function _normalize_hub(h::AbstractString)
+    parts = split(h, "/")
+    length(parts) == 3 || return String(h)
+    m, q, b = parts[1], parts[2], parts[3]
+    m = replace(m, r"^QAtlas\." => "")
+    q = replace(q, r"^QAtlas\." => "")
+    b = replace(b, r"^QAtlas\." => "")
+    q = replace(q, r"\{[^}]*\}" => "")
+    return string(m, "/", q, "/", b)
+end
+
 # ── TIER-1 EXT HELPERS (universality + calc + refs) ─────────────────────────
 
 # CONVENTION block extraction: parse the standard header comment
@@ -1015,8 +1027,10 @@ _audit_counts = let
         matched || (orphan_calc += 1)
     end
     zero_hubs = count(m -> isempty(filter(h -> modelof(h) == m, claimed)), models)
-    claim_set = Set(claimed)
-    orphan_cards = length(unique(filter(h -> !(h in claim_set), [c.hub for c in cards])))
+    norm_claims = Set(_normalize_hub(h) for h in claimed)
+    orphan_cards = length(
+        unique(filter(h -> !(_normalize_hub(h) in norm_claims), [c.hub for c in cards]))
+    )
     (; conv=no_conv + no_conv_no_file, def=no_def, orphan_calc, zero_hubs, orphan_cards)
 end
 
@@ -1555,8 +1569,10 @@ function render_audit()
         "primary `src` claim isn't there.",
     )
     P("")
-    claim_set = Set(claimed)
-    orphan_cards = sort(unique(filter(h -> !(h in claim_set), [c.hub for c in cards])))
+    norm_claims = Set(_normalize_hub(h) for h in claimed)
+    orphan_cards = sort(
+        unique(filter(h -> !(_normalize_hub(h) in norm_claims), [c.hub for c in cards]))
+    )
     if isempty(orphan_cards)
         P("!!! tip \"All INVENTORY card hubs have a matching `@register` claim.\"")
     else

--- a/docs/src/atlas/Audit.md
+++ b/docs/src/atlas/Audit.md
@@ -69,12 +69,10 @@ Quantities whose `struct X[{params}] <: AbstractQuantity` docstring wasn't match
 
 Verify cards exist for `(M, Q, BC)` triples that no `@register` claims.  These hubs are visible only through the cards, not the registry view; the absence of an `@register` claim means the primary `src` claim isn't there.
 
-**73 orphan card hub(s)**:
+**64 orphan card hub(s)**:
 
-- `CurieWeissIsing/Energy{:per_site}/Infinite`
 - `E8/E8Spectrum/Infinite`
 - `Heisenberg1D/q/OBC`
-- `IsingChain1D/Energy{:per_site}/Infinite`
 - `MeanField/CriticalExponents/Infinite`
 - `MinimalModel/CentralCharge/Infinite`
 - `MinimalModel/ConformalWeights/Infinite`
@@ -84,13 +82,6 @@ Verify cards exist for `(M, Q, BC)` triples that no `@register` claims.  These h
 - `QAtlas.Kagome/TightBindingMaxEnergy/Infinite`
 - `QAtlas.Lieb/TightBindingChecksum/Infinite`
 - `QAtlas.Lieb/TightBindingMaxEnergy/Infinite`
-- `QAtlas.ShastrySutherland/Energy/Infinite`
-- `QAtlas.TightBinding1D/QAtlas.FreeEnergy/QAtlas.Infinite`
-- `QAtlas.TightBinding1D/QAtlas.SpecificHeat/QAtlas.Infinite`
-- `QAtlas.TightBinding1D/QAtlas.ThermalEntropy/QAtlas.Infinite`
-- `QAtlas.TightBindingV1D/QAtlas.FreeEnergy/QAtlas.Infinite`
-- `QAtlas.TightBindingV1D/QAtlas.SpecificHeat/QAtlas.Infinite`
-- `QAtlas.TightBindingV1D/QAtlas.ThermalEntropy/QAtlas.Infinite`
 - `QAtlas.Triangular/TightBindingChecksum/Infinite`
 - `QAtlas.Triangular/TightBindingMaxEnergy/Infinite`
 - `S1Heisenberg1D/q/OBC`

--- a/docs/src/atlas/index.md
+++ b/docs/src/atlas/index.md
@@ -47,7 +47,7 @@ Actionable gap surface — see **[Audit](Audit.md)** for the itemised list.
 | 2. Quantities without extracted Definition | 2 |
 | 3. Orphan calc notes (matched to no model) | 13 |
 | 4. Models registered but with 0 hubs | 0 |
-| 5. INVENTORY card hubs with no `@register` claim | 73 |
+| 5. INVENTORY card hubs with no `@register` claim | 64 |
 
 ## Reference & derivation indices
 


### PR DESCRIPTION
docs(atlas): hub-string normalization in orphan-card matching

Stacked on feat/docs-audit-summary (PR #483).  Adds _normalize_hub
helper that strips QAtlas. module prefix and {...} parametrization
from hub strings before matching INVENTORY cards to registry claims.

Effect on Audit section 5 + front-page count:
  - Orphan-card count: 73 -> 64
  - Saved 9 normalization-artifact false positives:
    * Energy{:per_site} matches Energy claim
    * QAtlas.TightBinding1D matches TightBinding1D claim
    * QAtlas.Infinite matches Infinite claim

The remaining 64 are true diagnostic findings:
  (a) TightBindingChecksum / TightBindingMaxEnergy cards (from the
      complement PRs #453-#456) without corresponding @register entries
  (b) Universality / E8 / MeanField / MinimalModel cards (universality
      classes which aren't model-side @register entries)
  (c) TFIM/q/OBC, TFIM/qty/PBC, TFIM/Energy/bc - loop-variable AST
      artifacts where the static scanner can't resolve the runtime value

These should be either added to the registry (for case a) or migrated
to a "Universality" claim class (for case b), or fixed in the verify
call (for case c) - all out of scope for this PR.

Project.toml: 0.22.13 -> 0.22.14.

Guards: 2/2 + 179/179.
