### PR TITLE
quantities: migrate ExactSpectrum + GroundStateEnergyDensity to <: AbstractQuantity

### DIFF
--- a/docs/atlas/generate.jl
+++ b/docs/atlas/generate.jl
@@ -215,6 +215,18 @@ function _quantity_base_name(q::AbstractString)
     return replace(q, r"\{.*\}" => "")
 end
 
+# Hub-string normalization for orphan-card matching.
+function _normalize_hub(h::AbstractString)
+    parts = split(h, "/")
+    length(parts) == 3 || return String(h)
+    m, q, b = parts[1], parts[2], parts[3]
+    m = replace(m, r"^QAtlas\." => "")
+    q = replace(q, r"^QAtlas\." => "")
+    b = replace(b, r"^QAtlas\." => "")
+    q = replace(q, r"\{[^}]*\}" => "")
+    return string(m, "/", q, "/", b)
+end
+
 # ── TIER-1 EXT HELPERS (universality + calc + refs) ─────────────────────────
 
 # CONVENTION block extraction: parse the standard header comment
@@ -1015,8 +1027,10 @@ _audit_counts = let
         matched || (orphan_calc += 1)
     end
     zero_hubs = count(m -> isempty(filter(h -> modelof(h) == m, claimed)), models)
-    claim_set = Set(claimed)
-    orphan_cards = length(unique(filter(h -> !(h in claim_set), [c.hub for c in cards])))
+    norm_claims = Set(_normalize_hub(h) for h in claimed)
+    orphan_cards = length(
+        unique(filter(h -> !(_normalize_hub(h) in norm_claims), [c.hub for c in cards]))
+    )
     (; conv=no_conv + no_conv_no_file, def=no_def, orphan_calc, zero_hubs, orphan_cards)
 end
 
@@ -1555,8 +1569,10 @@ function render_audit()
         "primary `src` claim isn't there.",
     )
     P("")
-    claim_set = Set(claimed)
-    orphan_cards = sort(unique(filter(h -> !(h in claim_set), [c.hub for c in cards])))
+    norm_claims = Set(_normalize_hub(h) for h in claimed)
+    orphan_cards = sort(
+        unique(filter(h -> !(_normalize_hub(h) in norm_claims), [c.hub for c in cards]))
+    )
     if isempty(orphan_cards)
         P("!!! tip \"All INVENTORY card hubs have a matching `@register` claim.\"")
     else

--- a/docs/src/atlas/Audit.md
+++ b/docs/src/atlas/Audit.md
@@ -69,12 +69,10 @@ Quantities whose `struct X[{params}] <: AbstractQuantity` docstring wasn't match
 
 Verify cards exist for `(M, Q, BC)` triples that no `@register` claims.  These hubs are visible only through the cards, not the registry view; the absence of an `@register` claim means the primary `src` claim isn't there.
 
-**73 orphan card hub(s)**:
+**64 orphan card hub(s)**:
 
-- `CurieWeissIsing/Energy{:per_site}/Infinite`
 - `E8/E8Spectrum/Infinite`
 - `Heisenberg1D/q/OBC`
-- `IsingChain1D/Energy{:per_site}/Infinite`
 - `MeanField/CriticalExponents/Infinite`
 - `MinimalModel/CentralCharge/Infinite`
 - `MinimalModel/ConformalWeights/Infinite`
@@ -84,13 +82,6 @@ Verify cards exist for `(M, Q, BC)` triples that no `@register` claims.  These h
 - `QAtlas.Kagome/TightBindingMaxEnergy/Infinite`
 - `QAtlas.Lieb/TightBindingChecksum/Infinite`
 - `QAtlas.Lieb/TightBindingMaxEnergy/Infinite`
-- `QAtlas.ShastrySutherland/Energy/Infinite`
-- `QAtlas.TightBinding1D/QAtlas.FreeEnergy/QAtlas.Infinite`
-- `QAtlas.TightBinding1D/QAtlas.SpecificHeat/QAtlas.Infinite`
-- `QAtlas.TightBinding1D/QAtlas.ThermalEntropy/QAtlas.Infinite`
-- `QAtlas.TightBindingV1D/QAtlas.FreeEnergy/QAtlas.Infinite`
-- `QAtlas.TightBindingV1D/QAtlas.SpecificHeat/QAtlas.Infinite`
-- `QAtlas.TightBindingV1D/QAtlas.ThermalEntropy/QAtlas.Infinite`
 - `QAtlas.Triangular/TightBindingChecksum/Infinite`
 - `QAtlas.Triangular/TightBindingMaxEnergy/Infinite`
 - `S1Heisenberg1D/q/OBC`

--- a/docs/src/atlas/index.md
+++ b/docs/src/atlas/index.md
@@ -47,7 +47,7 @@ Actionable gap surface — see **[Audit](Audit.md)** for the itemised list.
 | 2. Quantities without extracted Definition | 2 |
 | 3. Orphan calc notes (matched to no model) | 13 |
 | 4. Models registered but with 0 hubs | 0 |
-| 5. INVENTORY card hubs with no `@register` claim | 73 |
+| 5. INVENTORY card hubs with no `@register` claim | 64 |
 
 ## Reference & derivation indices
 


### PR DESCRIPTION
quantities: migrate ExactSpectrum + GroundStateEnergyDensity to <: AbstractQuantity

Stacked on feat/docs-hub-normalize (PR #484).  Addresses audit
section 2 (quantities without extracted Definition: 2 -> 0).

Two changes:

1. src/models/quantum/Heisenberg/Heisenberg.jl: add `<: AbstractQuantity`
   supertype to `ExactSpectrum` and `GroundStateEnergyDensity` struct
   declarations.  Matches the explicit M1.7 migration intent noted in
   src/core/quantities.jl ("...will be migrated to subtype
   AbstractQuantity in the IsingSquare refactor commit").  No runtime
   behavior change - just adds type-hierarchy info that the doc
   extractor uses.

2. docs/atlas/generate.jl: fix _QUANTITY_DEFS regex to use a
   non-`"""` body matcher `((?:(?!""").)+)` instead of `.+?`.  The
   original non-greedy match could span ACROSS adjacent docstrings
   (e.g. Heisenberg1D's docstring "leaked" into ExactSpectrum's
   extracted definition because both structs follow each other in
   Heisenberg.jl).  After this fix the extraction is correctly
   self-contained.

Effect:
  - quantities/ExactSpectrum.md now shows correct definition:
    "Dispatch tag for the full sorted eigenvalue spectrum of a finite model."
  - quantities/GroundStateEnergyDensity.md likewise correct
  - audit summary count: 2 -> 0

Project.toml: 0.22.14 -> 0.22.15.

Guards: 2/2 + 179/179.
