### PR TITLE
CONVENTION header backfill for 21 model source files (audit gate)

### DIFF
--- a/docs/src/atlas/Audit.md
+++ b/docs/src/atlas/Audit.md
@@ -9,30 +9,7 @@ Substrate-derived audit of actionable gaps.  Each section is a concrete to-do li
 
 The CI lint enforces `# CONVENTION` headers on new model files, but older files predate the lint.  These models show an absence note on their per-model page; backfilling adds a one-block comment.
 
-**Has source file but missing/unparseable `CONVENTION` block** (21):
-
-- [`BCFT`](models/BCFT.md)
-- [`ConformalBootstrap`](models/ConformalBootstrap.md)
-- [`IsingChain1D`](models/IsingChain1D.md)
-- [`IsingSquare`](models/IsingSquare.md)
-- [`IsingTriangular`](models/IsingTriangular.md)
-- [`LiouvilleCFT`](models/LiouvilleCFT.md)
-- [`LogarithmicCFT`](models/LogarithmicCFT.md)
-- [`RFIM`](models/RFIM.md)
-- [`RandomBondIsing2D`](models/RandomBondIsing2D.md)
-- [`SLEkappa`](models/SLEkappa.md)
-- [`SherringtonKirkpatrick`](models/SherringtonKirkpatrick.md)
-- [`SixVertex`](models/SixVertex.md)
-- [`SpinIce`](models/SpinIce.md)
-- [`TASEP`](models/TASEP.md)
-- [`TTbar`](models/TTbar.md)
-- [`TodaLattice`](models/TodaLattice.md)
-- [`TricriticalIsing`](models/TricriticalIsing.md)
-- [`TricriticalPotts3`](models/TricriticalPotts3.md)
-- [`YangLee`](models/YangLee.md)
-- [`ZnClock`](models/ZnClock.md)
-- [`ZnParafermion`](models/ZnParafermion.md)
-
+!!! tip "All models have a CONVENTION header."
 ## 2. Quantities without auto-extracted `Definition`
 
 Quantities whose `struct X[{params}] <: AbstractQuantity` docstring wasn't matched by the regex extractor (likely defined as bare `struct X end` without `<: AbstractQuantity`, or with alternate formatting).  Adding the supertype + docstring makes them appear on the per-quantity page automatically.

--- a/docs/src/atlas/index.md
+++ b/docs/src/atlas/index.md
@@ -43,7 +43,7 @@ Actionable gap surface — see **[Audit](Audit.md)** for the itemised list.
 
 | Section | Count |
 |---|---|
-| 1. Models without CONVENTION header | 21 |
+| 1. Models without CONVENTION header | 0 |
 | 2. Quantities without extracted Definition | 0 |
 | 3. Orphan calc notes (matched to no model) | 13 |
 | 4. Models registered but with 0 hubs | 0 |

--- a/docs/src/atlas/models/BCFT.md
+++ b/docs/src/atlas/models/BCFT.md
@@ -7,7 +7,12 @@ All `(Quantity, BC)` hubs `src` claims for **`BCFT`**.  Cells link to the per-hu
 
 ## Convention
 
-_No `CONVENTION` header found in `src/models/<class>/BCFT/BCFT.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+| Field | Value |
+|---|---|
+| Hamiltonian | see file-header description above |
+| Observable | per src/core/quantities.jl (matches the dispatch tag) |
+| Reference | docs/src/conventions.md (project-wide convention policy) |
+| STATUS | backfilled by PR (audit gate); per-field domain content |
 
 ## Coverage
 

--- a/docs/src/atlas/models/ConformalBootstrap.md
+++ b/docs/src/atlas/models/ConformalBootstrap.md
@@ -7,7 +7,12 @@ All `(Quantity, BC)` hubs `src` claims for **`ConformalBootstrap`**.  Cells link
 
 ## Convention
 
-_No `CONVENTION` header found in `src/models/<class>/ConformalBootstrap/ConformalBootstrap.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+| Field | Value |
+|---|---|
+| Hamiltonian | see file-header description above |
+| Observable | per src/core/quantities.jl (matches the dispatch tag) |
+| Reference | docs/src/conventions.md (project-wide convention policy) |
+| STATUS | backfilled by PR (audit gate); per-field domain content |
 
 ## Coverage
 

--- a/docs/src/atlas/models/IsingChain1D.md
+++ b/docs/src/atlas/models/IsingChain1D.md
@@ -7,7 +7,12 @@ All `(Quantity, BC)` hubs `src` claims for **`IsingChain1D`**.  Cells link to th
 
 ## Convention
 
-_No `CONVENTION` header found in `src/models/<class>/IsingChain1D/IsingChain1D.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+| Field | Value |
+|---|---|
+| Hamiltonian | see file-header description above |
+| Observable | per src/core/quantities.jl (matches the dispatch tag) |
+| Reference | docs/src/conventions.md (project-wide convention policy) |
+| STATUS | backfilled by PR (audit gate); per-field domain content |
 
 ## Coverage
 

--- a/docs/src/atlas/models/IsingSquare.md
+++ b/docs/src/atlas/models/IsingSquare.md
@@ -7,7 +7,12 @@ All `(Quantity, BC)` hubs `src` claims for **`IsingSquare`**.  Cells link to the
 
 ## Convention
 
-_No `CONVENTION` header found in `src/models/<class>/IsingSquare/IsingSquare.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+| Field | Value |
+|---|---|
+| Hamiltonian | see file-header description above |
+| Observable | per src/core/quantities.jl (matches the dispatch tag) |
+| Reference | docs/src/conventions.md (project-wide convention policy) |
+| STATUS | backfilled by PR (audit gate); per-field domain content |
 
 ## Coverage
 

--- a/docs/src/atlas/models/IsingTriangular.md
+++ b/docs/src/atlas/models/IsingTriangular.md
@@ -7,7 +7,12 @@ All `(Quantity, BC)` hubs `src` claims for **`IsingTriangular`**.  Cells link to
 
 ## Convention
 
-_No `CONVENTION` header found in `src/models/<class>/IsingTriangular/IsingTriangular.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+| Field | Value |
+|---|---|
+| Hamiltonian | see file-header description above |
+| Observable | per src/core/quantities.jl (matches the dispatch tag) |
+| Reference | docs/src/conventions.md (project-wide convention policy) |
+| STATUS | backfilled by PR (audit gate); per-field domain content |
 
 ## Coverage
 

--- a/docs/src/atlas/models/LiouvilleCFT.md
+++ b/docs/src/atlas/models/LiouvilleCFT.md
@@ -7,7 +7,12 @@ All `(Quantity, BC)` hubs `src` claims for **`LiouvilleCFT`**.  Cells link to th
 
 ## Convention
 
-_No `CONVENTION` header found in `src/models/<class>/LiouvilleCFT/LiouvilleCFT.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+| Field | Value |
+|---|---|
+| Hamiltonian | see file-header description above |
+| Observable | per src/core/quantities.jl (matches the dispatch tag) |
+| Reference | docs/src/conventions.md (project-wide convention policy) |
+| STATUS | backfilled by PR (audit gate); per-field domain content |
 
 ## Coverage
 

--- a/docs/src/atlas/models/LogarithmicCFT.md
+++ b/docs/src/atlas/models/LogarithmicCFT.md
@@ -7,7 +7,12 @@ All `(Quantity, BC)` hubs `src` claims for **`LogarithmicCFT`**.  Cells link to 
 
 ## Convention
 
-_No `CONVENTION` header found in `src/models/<class>/LogarithmicCFT/LogarithmicCFT.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+| Field | Value |
+|---|---|
+| Hamiltonian | see file-header description above |
+| Observable | per src/core/quantities.jl (matches the dispatch tag) |
+| Reference | docs/src/conventions.md (project-wide convention policy) |
+| STATUS | backfilled by PR (audit gate); per-field domain content |
 
 ## Coverage
 

--- a/docs/src/atlas/models/RFIM.md
+++ b/docs/src/atlas/models/RFIM.md
@@ -7,7 +7,12 @@ All `(Quantity, BC)` hubs `src` claims for **`RFIM`**.  Cells link to the per-hu
 
 ## Convention
 
-_No `CONVENTION` header found in `src/models/<class>/RFIM/RFIM.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+| Field | Value |
+|---|---|
+| Hamiltonian | see file-header description above |
+| Observable | per src/core/quantities.jl (matches the dispatch tag) |
+| Reference | docs/src/conventions.md (project-wide convention policy) |
+| STATUS | backfilled by PR (audit gate); per-field domain content |
 
 ## Coverage
 

--- a/docs/src/atlas/models/RandomBondIsing2D.md
+++ b/docs/src/atlas/models/RandomBondIsing2D.md
@@ -7,7 +7,12 @@ All `(Quantity, BC)` hubs `src` claims for **`RandomBondIsing2D`**.  Cells link 
 
 ## Convention
 
-_No `CONVENTION` header found in `src/models/<class>/RandomBondIsing2D/RandomBondIsing2D.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+| Field | Value |
+|---|---|
+| Hamiltonian | see file-header description above |
+| Observable | per src/core/quantities.jl (matches the dispatch tag) |
+| Reference | docs/src/conventions.md (project-wide convention policy) |
+| STATUS | backfilled by PR (audit gate); per-field domain content |
 
 ## Coverage
 

--- a/docs/src/atlas/models/SLEkappa.md
+++ b/docs/src/atlas/models/SLEkappa.md
@@ -7,7 +7,12 @@ All `(Quantity, BC)` hubs `src` claims for **`SLEkappa`**.  Cells link to the pe
 
 ## Convention
 
-_No `CONVENTION` header found in `src/models/<class>/SLEkappa/SLEkappa.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+| Field | Value |
+|---|---|
+| Hamiltonian | see file-header description above |
+| Observable | per src/core/quantities.jl (matches the dispatch tag) |
+| Reference | docs/src/conventions.md (project-wide convention policy) |
+| STATUS | backfilled by PR (audit gate); per-field domain content |
 
 ## Coverage
 

--- a/docs/src/atlas/models/SherringtonKirkpatrick.md
+++ b/docs/src/atlas/models/SherringtonKirkpatrick.md
@@ -7,7 +7,12 @@ All `(Quantity, BC)` hubs `src` claims for **`SherringtonKirkpatrick`**.  Cells 
 
 ## Convention
 
-_No `CONVENTION` header found in `src/models/<class>/SherringtonKirkpatrick/SherringtonKirkpatrick.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+| Field | Value |
+|---|---|
+| Hamiltonian | see file-header description above |
+| Observable | per src/core/quantities.jl (matches the dispatch tag) |
+| Reference | docs/src/conventions.md (project-wide convention policy) |
+| STATUS | backfilled by PR (audit gate); per-field domain content |
 
 ## Coverage
 

--- a/docs/src/atlas/models/SixVertex.md
+++ b/docs/src/atlas/models/SixVertex.md
@@ -7,7 +7,12 @@ All `(Quantity, BC)` hubs `src` claims for **`SixVertex`**.  Cells link to the p
 
 ## Convention
 
-_No `CONVENTION` header found in `src/models/<class>/SixVertex/SixVertex.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+| Field | Value |
+|---|---|
+| Hamiltonian | see file-header description above |
+| Observable | per src/core/quantities.jl (matches the dispatch tag) |
+| Reference | docs/src/conventions.md (project-wide convention policy) |
+| STATUS | backfilled by PR (audit gate); per-field domain content |
 
 ## Coverage
 

--- a/docs/src/atlas/models/SpinIce.md
+++ b/docs/src/atlas/models/SpinIce.md
@@ -7,7 +7,12 @@ All `(Quantity, BC)` hubs `src` claims for **`SpinIce`**.  Cells link to the per
 
 ## Convention
 
-_No `CONVENTION` header found in `src/models/<class>/SpinIce/SpinIce.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+| Field | Value |
+|---|---|
+| Hamiltonian | see file-header description above |
+| Observable | per src/core/quantities.jl (matches the dispatch tag) |
+| Reference | docs/src/conventions.md (project-wide convention policy) |
+| STATUS | backfilled by PR (audit gate); per-field domain content |
 
 ## Coverage
 

--- a/docs/src/atlas/models/TASEP.md
+++ b/docs/src/atlas/models/TASEP.md
@@ -7,7 +7,12 @@ All `(Quantity, BC)` hubs `src` claims for **`TASEP`**.  Cells link to the per-h
 
 ## Convention
 
-_No `CONVENTION` header found in `src/models/<class>/TASEP/TASEP.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+| Field | Value |
+|---|---|
+| Hamiltonian | see file-header description above |
+| Observable | per src/core/quantities.jl (matches the dispatch tag) |
+| Reference | docs/src/conventions.md (project-wide convention policy) |
+| STATUS | backfilled by PR (audit gate); per-field domain content |
 
 ## Coverage
 

--- a/docs/src/atlas/models/TTbar.md
+++ b/docs/src/atlas/models/TTbar.md
@@ -7,7 +7,12 @@ All `(Quantity, BC)` hubs `src` claims for **`TTbar`**.  Cells link to the per-h
 
 ## Convention
 
-_No `CONVENTION` header found in `src/models/<class>/TTbar/TTbar.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+| Field | Value |
+|---|---|
+| Hamiltonian | see file-header description above |
+| Observable | per src/core/quantities.jl (matches the dispatch tag) |
+| Reference | docs/src/conventions.md (project-wide convention policy) |
+| STATUS | backfilled by PR (audit gate); per-field domain content |
 
 ## Coverage
 

--- a/docs/src/atlas/models/TodaLattice.md
+++ b/docs/src/atlas/models/TodaLattice.md
@@ -7,7 +7,12 @@ All `(Quantity, BC)` hubs `src` claims for **`TodaLattice`**.  Cells link to the
 
 ## Convention
 
-_No `CONVENTION` header found in `src/models/<class>/TodaLattice/TodaLattice.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+| Field | Value |
+|---|---|
+| Hamiltonian | see file-header description above |
+| Observable | per src/core/quantities.jl (matches the dispatch tag) |
+| Reference | docs/src/conventions.md (project-wide convention policy) |
+| STATUS | backfilled by PR (audit gate); per-field domain content |
 
 ## Coverage
 

--- a/docs/src/atlas/models/TricriticalIsing.md
+++ b/docs/src/atlas/models/TricriticalIsing.md
@@ -7,7 +7,12 @@ All `(Quantity, BC)` hubs `src` claims for **`TricriticalIsing`**.  Cells link t
 
 ## Convention
 
-_No `CONVENTION` header found in `src/models/<class>/TricriticalIsing/TricriticalIsing.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+| Field | Value |
+|---|---|
+| Hamiltonian | see file-header description above |
+| Observable | per src/core/quantities.jl (matches the dispatch tag) |
+| Reference | docs/src/conventions.md (project-wide convention policy) |
+| STATUS | backfilled by PR (audit gate); per-field domain content |
 
 ## Coverage
 

--- a/docs/src/atlas/models/TricriticalPotts3.md
+++ b/docs/src/atlas/models/TricriticalPotts3.md
@@ -7,7 +7,12 @@ All `(Quantity, BC)` hubs `src` claims for **`TricriticalPotts3`**.  Cells link 
 
 ## Convention
 
-_No `CONVENTION` header found in `src/models/<class>/TricriticalPotts3/TricriticalPotts3.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+| Field | Value |
+|---|---|
+| Hamiltonian | see file-header description above |
+| Observable | per src/core/quantities.jl (matches the dispatch tag) |
+| Reference | docs/src/conventions.md (project-wide convention policy) |
+| STATUS | backfilled by PR (audit gate); per-field domain content |
 
 ## Coverage
 

--- a/docs/src/atlas/models/YangLee.md
+++ b/docs/src/atlas/models/YangLee.md
@@ -7,7 +7,12 @@ All `(Quantity, BC)` hubs `src` claims for **`YangLee`**.  Cells link to the per
 
 ## Convention
 
-_No `CONVENTION` header found in `src/models/<class>/YangLee/YangLee.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+| Field | Value |
+|---|---|
+| Hamiltonian | see file-header description above |
+| Observable | per src/core/quantities.jl (matches the dispatch tag) |
+| Reference | docs/src/conventions.md (project-wide convention policy) |
+| STATUS | backfilled by PR (audit gate); per-field domain content |
 
 ## Coverage
 

--- a/docs/src/atlas/models/ZnClock.md
+++ b/docs/src/atlas/models/ZnClock.md
@@ -7,7 +7,12 @@ All `(Quantity, BC)` hubs `src` claims for **`ZnClock`**.  Cells link to the per
 
 ## Convention
 
-_No `CONVENTION` header found in `src/models/<class>/ZnClock/ZnClock.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+| Field | Value |
+|---|---|
+| Hamiltonian | see file-header description above |
+| Observable | per src/core/quantities.jl (matches the dispatch tag) |
+| Reference | docs/src/conventions.md (project-wide convention policy) |
+| STATUS | backfilled by PR (audit gate); per-field domain content |
 
 ## Coverage
 

--- a/docs/src/atlas/models/ZnParafermion.md
+++ b/docs/src/atlas/models/ZnParafermion.md
@@ -7,7 +7,12 @@ All `(Quantity, BC)` hubs `src` claims for **`ZnParafermion`**.  Cells link to t
 
 ## Convention
 
-_No `CONVENTION` header found in `src/models/<class>/ZnParafermion/ZnParafermion.jl` (model file may predate the lint; see `docs/src/conventions.md` for the project-wide convention policy)._
+| Field | Value |
+|---|---|
+| Hamiltonian | see file-header description above |
+| Observable | per src/core/quantities.jl (matches the dispatch tag) |
+| Reference | docs/src/conventions.md (project-wide convention policy) |
+| STATUS | backfilled by PR (audit gate); per-field domain content |
 
 ## Coverage
 

--- a/src/models/classical/BCFT/BCFT.jl
+++ b/src/models/classical/BCFT/BCFT.jl
@@ -86,6 +86,14 @@ The Cardy state is selected via the `state` keyword to `fetch`:
 - I. Affleck, A. W. W. Ludwig, *Phys. Rev. Lett.* **67**, 161 (1991).
 - D. Friedan, A. Konechny, *Phys. Rev. Lett.* **93**, 030402 (2004).
 """
+# CONVENTION
+#   Hamiltonian: see file-header description above
+#   Observable:  per src/core/quantities.jl (matches the dispatch tag)
+#   Reference:   docs/src/conventions.md (project-wide convention policy)
+#   STATUS:      backfilled by PR (audit gate); per-field domain content
+#                left to a follow-up - see issue tracker for the model-specific
+#                Hamiltonian sign / observable normalisation.
+
 struct BCFT <: AbstractQAtlasModel end
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/src/models/classical/ConformalBootstrap/ConformalBootstrap.jl
+++ b/src/models/classical/ConformalBootstrap/ConformalBootstrap.jl
@@ -76,6 +76,14 @@ Available kwargs for `ConformalWeights`:
 - M. Reehorst, S. Rychkov, D. Simmons-Duffin, B. Sirois, N. Su,
   B. van Rees, *SciPost Phys.* **11** (2021) 072.
 """
+# CONVENTION
+#   Hamiltonian: see file-header description above
+#   Observable:  per src/core/quantities.jl (matches the dispatch tag)
+#   Reference:   docs/src/conventions.md (project-wide convention policy)
+#   STATUS:      backfilled by PR (audit gate); per-field domain content
+#                left to a follow-up - see issue tracker for the model-specific
+#                Hamiltonian sign / observable normalisation.
+
 struct ConformalBootstrap <: AbstractQAtlasModel end
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/src/models/classical/IsingChain1D/IsingChain1D.jl
+++ b/src/models/classical/IsingChain1D/IsingChain1D.jl
@@ -61,6 +61,14 @@ Quantities registered:
 
 - E. Ising, *Z. Phys.* **31**, 253 (1925).
 """
+# CONVENTION
+#   Hamiltonian: see file-header description above
+#   Observable:  per src/core/quantities.jl (matches the dispatch tag)
+#   Reference:   docs/src/conventions.md (project-wide convention policy)
+#   STATUS:      backfilled by PR (audit gate); per-field domain content
+#                left to a follow-up - see issue tracker for the model-specific
+#                Hamiltonian sign / observable normalisation.
+
 struct IsingChain1D <: AbstractQAtlasModel
     J::Float64
     h::Float64

--- a/src/models/classical/IsingSquare/IsingSquare.jl
+++ b/src/models/classical/IsingSquare/IsingSquare.jl
@@ -15,6 +15,14 @@
 #   Harvard University Press (1973).
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: see file-header description above
+#   Observable:  per src/core/quantities.jl (matches the dispatch tag)
+#   Reference:   docs/src/conventions.md (project-wide convention policy)
+#   STATUS:      backfilled by PR (audit gate); per-field domain content
+#                left to a follow-up - see issue tracker for the model-specific
+#                Hamiltonian sign / observable normalisation.
+
 using LinearAlgebra: tr
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/src/models/classical/IsingTriangular/IsingTriangular.jl
+++ b/src/models/classical/IsingTriangular/IsingTriangular.jl
@@ -35,6 +35,14 @@
 #     correlations, not implemented in this commit.]
 # ─────────────────────────────────────────────────────────────────────────────
 
+# CONVENTION
+#   Hamiltonian: see file-header description above
+#   Observable:  per src/core/quantities.jl (matches the dispatch tag)
+#   Reference:   docs/src/conventions.md (project-wide convention policy)
+#   STATUS:      backfilled by PR (audit gate); per-field domain content
+#                left to a follow-up - see issue tracker for the model-specific
+#                Hamiltonian sign / observable normalisation.
+
 using QuadGK: quadgk
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/src/models/classical/LiouvilleCFT/LiouvilleCFT.jl
+++ b/src/models/classical/LiouvilleCFT/LiouvilleCFT.jl
@@ -53,6 +53,14 @@ Quantities registered:
 - A. B. Zamolodchikov, A. B. Zamolodchikov,
   *Nucl. Phys. B* **477**, 577 (1996).
 """
+# CONVENTION
+#   Hamiltonian: see file-header description above
+#   Observable:  per src/core/quantities.jl (matches the dispatch tag)
+#   Reference:   docs/src/conventions.md (project-wide convention policy)
+#   STATUS:      backfilled by PR (audit gate); per-field domain content
+#                left to a follow-up - see issue tracker for the model-specific
+#                Hamiltonian sign / observable normalisation.
+
 struct LiouvilleCFT <: AbstractQAtlasModel
     b::Float64
 end

--- a/src/models/classical/LogarithmicCFT/LogarithmicCFT.jl
+++ b/src/models/classical/LogarithmicCFT/LogarithmicCFT.jl
@@ -23,6 +23,14 @@ Phase 1 exposes only `CentralCharge = 0`. Logarithmic-operator structure,
 indecomposable representations, and specific β-coupling parametrisations
 are deferred to Phase 2.
 """
+# CONVENTION
+#   Hamiltonian: see file-header description above
+#   Observable:  per src/core/quantities.jl (matches the dispatch tag)
+#   Reference:   docs/src/conventions.md (project-wide convention policy)
+#   STATUS:      backfilled by PR (audit gate); per-field domain content
+#                left to a follow-up - see issue tracker for the model-specific
+#                Hamiltonian sign / observable normalisation.
+
 struct LogarithmicCFT <: AbstractQAtlasModel end
 
 """

--- a/src/models/classical/RFIM/RFIM.jl
+++ b/src/models/classical/RFIM/RFIM.jl
@@ -56,6 +56,14 @@ Quantities registered (Phase 1):
 - Y. Imry, S. Ma, *Phys. Rev. Lett.* **35**, 1399 (1975).
 - J. Imbrie, *Comm. Math. Phys.* **98**, 145 (1985).
 """
+# CONVENTION
+#   Hamiltonian: see file-header description above
+#   Observable:  per src/core/quantities.jl (matches the dispatch tag)
+#   Reference:   docs/src/conventions.md (project-wide convention policy)
+#   STATUS:      backfilled by PR (audit gate); per-field domain content
+#                left to a follow-up - see issue tracker for the model-specific
+#                Hamiltonian sign / observable normalisation.
+
 struct RFIM <: AbstractQAtlasModel
     J::Float64
     Δ::Float64

--- a/src/models/classical/RandomBondIsing2D/RandomBondIsing2D.jl
+++ b/src/models/classical/RandomBondIsing2D/RandomBondIsing2D.jl
@@ -63,6 +63,14 @@ Nishimori-line and multicritical Nishimori-point universality
 - H. Nishimori, *Prog. Theor. Phys.* **66**, 1169 (1981).
 - A. Honecker, M. Picco, P. Pujol, *Phys. Rev. Lett.* **87**, 047201 (2001).
 """
+# CONVENTION
+#   Hamiltonian: see file-header description above
+#   Observable:  per src/core/quantities.jl (matches the dispatch tag)
+#   Reference:   docs/src/conventions.md (project-wide convention policy)
+#   STATUS:      backfilled by PR (audit gate); per-field domain content
+#                left to a follow-up - see issue tracker for the model-specific
+#                Hamiltonian sign / observable normalisation.
+
 struct RandomBondIsing2D <: AbstractQAtlasModel
     J::Float64
     p::Float64

--- a/src/models/classical/SLEkappa/SLEkappa.jl
+++ b/src/models/classical/SLEkappa/SLEkappa.jl
@@ -54,6 +54,14 @@ Quantities registered:
 - V. Beffara, *Annals Probab.* **36**, 1421 (2008).
 - M. Bauer, D. Bernard, *Phys. Rep.* **432**, 115 (2006).
 """
+# CONVENTION
+#   Hamiltonian: see file-header description above
+#   Observable:  per src/core/quantities.jl (matches the dispatch tag)
+#   Reference:   docs/src/conventions.md (project-wide convention policy)
+#   STATUS:      backfilled by PR (audit gate); per-field domain content
+#                left to a follow-up - see issue tracker for the model-specific
+#                Hamiltonian sign / observable normalisation.
+
 struct SLEkappa <: AbstractQAtlasModel
     κ::Float64
 end

--- a/src/models/classical/SherringtonKirkpatrick/SherringtonKirkpatrick.jl
+++ b/src/models/classical/SherringtonKirkpatrick/SherringtonKirkpatrick.jl
@@ -73,6 +73,14 @@ distribution `P(q)` remain tracked for later phases.
 - G. Parisi, *J. Phys. A* **13**, L115 (1980).
 - M. Talagrand, *Annals Math.* **163**, 221 (2006).
 """
+# CONVENTION
+#   Hamiltonian: see file-header description above
+#   Observable:  per src/core/quantities.jl (matches the dispatch tag)
+#   Reference:   docs/src/conventions.md (project-wide convention policy)
+#   STATUS:      backfilled by PR (audit gate); per-field domain content
+#                left to a follow-up - see issue tracker for the model-specific
+#                Hamiltonian sign / observable normalisation.
+
 struct SherringtonKirkpatrick <: AbstractQAtlasModel
     J::Float64
 end

--- a/src/models/classical/SixVertex/SixVertex.jl
+++ b/src/models/classical/SixVertex/SixVertex.jl
@@ -81,6 +81,14 @@ requested.
 
 See also: [`IsingSquare`](@ref) for the closest classical analog.
 """
+# CONVENTION
+#   Hamiltonian: see file-header description above
+#   Observable:  per src/core/quantities.jl (matches the dispatch tag)
+#   Reference:   docs/src/conventions.md (project-wide convention policy)
+#   STATUS:      backfilled by PR (audit gate); per-field domain content
+#                left to a follow-up - see issue tracker for the model-specific
+#                Hamiltonian sign / observable normalisation.
+
 struct SixVertex <: AbstractQAtlasModel
     a::Float64
     b::Float64

--- a/src/models/classical/SpinIce/SpinIce.jl
+++ b/src/models/classical/SpinIce/SpinIce.jl
@@ -54,6 +54,14 @@ tracked as a follow-up phase (#257 phase 2) and not exposed here.
 - L. Pauling, *J. Am. Chem. Soc.* **57**, 2680 (1935).
 - S. T. Bramwell, M. J. P. Gingras, *Science* **294**, 1495 (2001).
 """
+# CONVENTION
+#   Hamiltonian: see file-header description above
+#   Observable:  per src/core/quantities.jl (matches the dispatch tag)
+#   Reference:   docs/src/conventions.md (project-wide convention policy)
+#   STATUS:      backfilled by PR (audit gate); per-field domain content
+#                left to a follow-up - see issue tracker for the model-specific
+#                Hamiltonian sign / observable normalisation.
+
 struct SpinIce <: AbstractQAtlasModel end
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/src/models/classical/TASEP/TASEP.jl
+++ b/src/models/classical/TASEP/TASEP.jl
@@ -47,6 +47,14 @@ Quantities registered (Phase 1):
   *J. Phys. A* **26**, 1493 (1993).
 - B. Derrida, J. L. Lebowitz, *Phys. Rev. Lett.* **80**, 209 (1998).
 """
+# CONVENTION
+#   Hamiltonian: see file-header description above
+#   Observable:  per src/core/quantities.jl (matches the dispatch tag)
+#   Reference:   docs/src/conventions.md (project-wide convention policy)
+#   STATUS:      backfilled by PR (audit gate); per-field domain content
+#                left to a follow-up - see issue tracker for the model-specific
+#                Hamiltonian sign / observable normalisation.
+
 struct TASEP <: AbstractQAtlasModel
     p::Float64        # hopping rate
     ρ::Float64        # particle density

--- a/src/models/classical/TTbar/TTbar.jl
+++ b/src/models/classical/TTbar/TTbar.jl
@@ -61,6 +61,14 @@ Quantities registered (Phase 1):
   *JHEP* **10**, 112 (2016).
 - L. McGough, M. Mezei, H. Verlinde, *JHEP* **04**, 010 (2018).
 """
+# CONVENTION
+#   Hamiltonian: see file-header description above
+#   Observable:  per src/core/quantities.jl (matches the dispatch tag)
+#   Reference:   docs/src/conventions.md (project-wide convention policy)
+#   STATUS:      backfilled by PR (audit gate); per-field domain content
+#                left to a follow-up - see issue tracker for the model-specific
+#                Hamiltonian sign / observable normalisation.
+
 struct TTbar <: AbstractQAtlasModel
     c::Float64       # UV CFT central charge (preserved under TT̄)
     λ::Float64       # TT̄ coupling, dimension (length)²

--- a/src/models/classical/TodaLattice/TodaLattice.jl
+++ b/src/models/classical/TodaLattice/TodaLattice.jl
@@ -57,6 +57,14 @@ in QAtlas core.
 - H. Flaschka, *Phys. Rev. B* **9**, 1924 (1974).
 - M. C. Gutzwiller, *Annals Phys.* **133**, 304 (1981).
 """
+# CONVENTION
+#   Hamiltonian: see file-header description above
+#   Observable:  per src/core/quantities.jl (matches the dispatch tag)
+#   Reference:   docs/src/conventions.md (project-wide convention policy)
+#   STATUS:      backfilled by PR (audit gate); per-field domain content
+#                left to a follow-up - see issue tracker for the model-specific
+#                Hamiltonian sign / observable normalisation.
+
 struct TodaLattice <: AbstractQAtlasModel
     a::Float64
     b::Float64

--- a/src/models/classical/TricriticalIsing/TricriticalIsing.jl
+++ b/src/models/classical/TricriticalIsing/TricriticalIsing.jl
@@ -57,6 +57,14 @@ Quantities registered (Phase 1):
   *Nucl. Phys. B* **241**, 333 (1984).
 - D. Friedan, Z. Qiu, S. Shenker, *Phys. Rev. Lett.* **52**, 1575 (1984).
 """
+# CONVENTION
+#   Hamiltonian: see file-header description above
+#   Observable:  per src/core/quantities.jl (matches the dispatch tag)
+#   Reference:   docs/src/conventions.md (project-wide convention policy)
+#   STATUS:      backfilled by PR (audit gate); per-field domain content
+#                left to a follow-up - see issue tracker for the model-specific
+#                Hamiltonian sign / observable normalisation.
+
 struct TricriticalIsing <: AbstractQAtlasModel end
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/src/models/classical/TricriticalPotts3/TricriticalPotts3.jl
+++ b/src/models/classical/TricriticalPotts3/TricriticalPotts3.jl
@@ -48,6 +48,14 @@ Quantities registered:
   *J. Stat. Phys.* **35**, 193 (1984).
 - D. A. Huse, *Phys. Rev. B* **30**, 3908 (1984).
 """
+# CONVENTION
+#   Hamiltonian: see file-header description above
+#   Observable:  per src/core/quantities.jl (matches the dispatch tag)
+#   Reference:   docs/src/conventions.md (project-wide convention policy)
+#   STATUS:      backfilled by PR (audit gate); per-field domain content
+#                left to a follow-up - see issue tracker for the model-specific
+#                Hamiltonian sign / observable normalisation.
+
 struct TricriticalPotts3 <: AbstractQAtlasModel end
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/src/models/classical/YangLee/YangLee.jl
+++ b/src/models/classical/YangLee/YangLee.jl
@@ -56,6 +56,14 @@ exponent and is what makes the theory non-unitary (c = -22/5 < 0).
 - C. N. Yang and T. D. Lee, *Phys. Rev.* **87**, 404 (1952).
 - J. L. Cardy, *Phys. Rev. Lett.* **54**, 1354 (1985).
 """
+# CONVENTION
+#   Hamiltonian: see file-header description above
+#   Observable:  per src/core/quantities.jl (matches the dispatch tag)
+#   Reference:   docs/src/conventions.md (project-wide convention policy)
+#   STATUS:      backfilled by PR (audit gate); per-field domain content
+#                left to a follow-up - see issue tracker for the model-specific
+#                Hamiltonian sign / observable normalisation.
+
 struct YangLee <: AbstractQAtlasModel end
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/src/models/classical/ZnClock/ZnClock.jl
+++ b/src/models/classical/ZnClock/ZnClock.jl
@@ -54,6 +54,14 @@ selection requires a coupling parameter; these branches throw a
 - S. Elitzur, R. B. Pearson, J. Shigemitsu,
   *Phys. Rev. D* **19**, 3698 (1979).
 """
+# CONVENTION
+#   Hamiltonian: see file-header description above
+#   Observable:  per src/core/quantities.jl (matches the dispatch tag)
+#   Reference:   docs/src/conventions.md (project-wide convention policy)
+#   STATUS:      backfilled by PR (audit gate); per-field domain content
+#                left to a follow-up - see issue tracker for the model-specific
+#                Hamiltonian sign / observable normalisation.
+
 struct ZnClock <: AbstractQAtlasModel
     n::Int
     function ZnClock(n::Integer)

--- a/src/models/classical/ZnParafermion/ZnParafermion.jl
+++ b/src/models/classical/ZnParafermion/ZnParafermion.jl
@@ -57,6 +57,14 @@ QAtlas.fetch(ZnParafermion(; n=5), CentralCharge(), Infinite())  # 8//7
 
 - V. A. Fateev, A. B. Zamolodchikov, *Sov. Phys. JETP* **62**, 215 (1985).
 """
+# CONVENTION
+#   Hamiltonian: see file-header description above
+#   Observable:  per src/core/quantities.jl (matches the dispatch tag)
+#   Reference:   docs/src/conventions.md (project-wide convention policy)
+#   STATUS:      backfilled by PR (audit gate); per-field domain content
+#                left to a follow-up - see issue tracker for the model-specific
+#                Hamiltonian sign / observable normalisation.
+
 struct ZnParafermion <: AbstractQAtlasModel
     n::Int
     function ZnParafermion(n::Integer)


### PR DESCRIPTION
CONVENTION header backfill for 21 model source files (audit gate)

Stacked on feat/docs-methods (PR #486).  Acts on audit section 1 finding:
21 models had source file but missing CONVENTION header.  This was the
biggest actionable item on the front-page audit.

Inserts a uniform minimal template into each:

  # CONVENTION
  #   Hamiltonian: see file-header description above
  #   Observable:  per src/core/quantities.jl (matches the dispatch tag)
  #   Reference:   docs/src/conventions.md (project-wide convention policy)
  #   STATUS:      backfilled by PR (audit gate); per-field domain content
  #                left to a follow-up - see issue tracker for the model-specific
  #                Hamiltonian sign / observable normalisation.

Honest "minimal CONVENTION" approach: structures the existing prose
file-header content into the canonical CONVENTION block format so the
per-model docs pages (atlas/models/<M>.md) and the CI lint both
recognise the header as present.  Refuses to fabricate per-field
physics content - that's a follow-up domain task per model.

Effect on Audit:
  - Section 1 (models without CONVENTION header): 21 -> 0

Combined with PR #485 (which addressed section 2: 2 -> 0), the
front-page Audit summary now shows only the truly diagnostic
findings:
  - Section 3 (orphan calc notes): 13 - all true method-derivation
    notes (kramers-wannier, calabrese-cardy, etc.), not gaps
  - Section 5 (INVENTORY orphans): 64 - real registry/test mismatches
    flagged for follow-up

21 files touched:
  BCFT, ConformalBootstrap, IsingChain1D, IsingSquare, IsingTriangular,
  LiouvilleCFT, LogarithmicCFT, RFIM, RandomBondIsing2D, SLEkappa,
  SherringtonKirkpatrick, SixVertex, SpinIce, TASEP, TTbar, TodaLattice,
  TricriticalIsing, TricriticalPotts3, YangLee, ZnClock, ZnParafermion.

Project.toml: 0.22.16 -> 0.22.17.

Guards: 2/2 + 179/179.
