### PR TITLE
docs(atlas): strip Documenter @ref cross-references in docstring extraction

### DIFF
--- a/docs/atlas/generate.jl
+++ b/docs/atlas/generate.jl
@@ -61,7 +61,10 @@ quantof(h) = (p=split(h, "/"); length(p) >= 2 ? p[2] : "?")
 bcof(h) = (p=split(h, "/"); length(p) >= 3 ? p[3] : "?")
 slugof(h) = replace(h, r"[^A-Za-z0-9]" => "_")
 _quant_slugof(q::AbstractString) = replace(q, r"[^A-Za-z0-9]" => "_")
-_md_escape_dollar(s::AbstractString) = replace(s, r"(?<!\\)\$" => "\\\$")
+function _md_escape_dollar(s::AbstractString)
+    s = replace(s, r"\[([^\]]+)\]\(@ref[^\)]*\)" => s"`\1`")
+    return replace(s, r"(?<!\\)\$" => "\\\$")
+end
 
 # ── R1 taxonomy (single source of truth lives in AtlasInventory) ─────
 # generate.jl is now a thin TYPED consumer of AtlasInventory's

--- a/docs/src/atlas/quantities/ConformalWeights.md
+++ b/docs/src/atlas/quantities/ConformalWeights.md
@@ -7,7 +7,7 @@ All `(Model, BC)` hubs `src` claims for the **`ConformalWeights`** observable.  
 
 ## Definition
 
-Primary scaling dimension `h` of a 2D rational CFT.  For Virasoro [`MinimalModel`](@ref) this is the Kac-table entry `h_{r,s}`; for [`WZWSU2`](@ref) it is the SU(2)-spin label `h_j = j(j+1)/(k+2)`.
+Primary scaling dimension `h` of a 2D rational CFT.  For Virasoro ``MinimalModel`` this is the Kac-table entry `h_{r,s}`; for ``WZWSU2`` it is the SU(2)-spin label `h_j = j(j+1)/(k+2)`.
 
 _(extracted from `src/core/quantities.jl` docstring.)_
 

--- a/docs/src/atlas/quantities/FermiVelocity.md
+++ b/docs/src/atlas/quantities/FermiVelocity.md
@@ -7,7 +7,7 @@ All `(Model, BC)` hubs `src` claims for the **`FermiVelocity`** observable.  Emp
 
 ## Definition
 
-Fermi velocity `v_F = ∂ε/∂k |_{k_F}`.  Meaningful for non-interacting / mean-field fermionic band structures (tight-binding lattices, Bogoliubov-de Gennes diagonalisations).  In QAtlas this is the type returned by models like [`Honeycomb`](@ref) (at the Dirac cones), the other tight-binding lattices, and the TFIM Majorana mode at the critical field.
+Fermi velocity `v_F = ∂ε/∂k |_{k_F}`.  Meaningful for non-interacting / mean-field fermionic band structures (tight-binding lattices, Bogoliubov-de Gennes diagonalisations).  In QAtlas this is the type returned by models like ``Honeycomb`` (at the Dirac cones), the other tight-binding lattices, and the TFIM Majorana mode at the critical field.
 
 _(extracted from `src/core/quantities.jl` docstring.)_
 

--- a/docs/src/atlas/quantities/LuttingerVelocity.md
+++ b/docs/src/atlas/quantities/LuttingerVelocity.md
@@ -7,7 +7,7 @@ All `(Model, BC)` hubs `src` claims for the **`LuttingerVelocity`** observable. 
 
 ## Definition
 
-Luttinger-liquid / bosonisation velocity `u` (a.k.a. `v_{LL}`) of the low-energy linear-dispersion mode in a 1D critical interacting system. Used by models like [`XXZ1D`](@ref) in the Luttinger regime `|Δ| < 1`, the Heisenberg chain at the SU(2) point, and any other bosonised 1D critical theory.
+Luttinger-liquid / bosonisation velocity `u` (a.k.a. `v_{LL}`) of the low-energy linear-dispersion mode in a 1D critical interacting system. Used by models like ``XXZ1D`` in the Luttinger regime `|Δ| < 1`, the Heisenberg chain at the SU(2) point, and any other bosonised 1D critical theory.
 
 _(extracted from `src/core/quantities.jl` docstring.)_
 

--- a/docs/src/atlas/quantities/PrimaryFields.md
+++ b/docs/src/atlas/quantities/PrimaryFields.md
@@ -7,7 +7,7 @@ All `(Model, BC)` hubs `src` claims for the **`PrimaryFields`** observable.  Emp
 
 ## Definition
 
-Full list of primary fields of a 2D rational CFT.  For [`MinimalModel`](@ref) the result is a `Vector{NamedTuple{(:r, :s, :h)}}` of length `(p - 1)(p_prime - 1) / 2`, with one entry per Kac-symmetry orbit.
+Full list of primary fields of a 2D rational CFT.  For ``MinimalModel`` the result is a `Vector{NamedTuple{(:r, :s, :h)}}` of length `(p - 1)(p_prime - 1) / 2`, with one entry per Kac-symmetry orbit.
 
 _(extracted from `src/core/quantities.jl` docstring.)_
 

--- a/docs/src/atlas/quantities/ResidualEntropy.md
+++ b/docs/src/atlas/quantities/ResidualEntropy.md
@@ -7,7 +7,7 @@ All `(Model, BC)` hubs `src` claims for the **`ResidualEntropy`** observable.  E
 
 ## Definition
 
-Zero-temperature configurational (residual) entropy density.  Real- valued, non-negative; non-zero in the presence of macroscopic ground-state degeneracy (e.g. ice rule, frustrated Ising AFM, Pauling-1935-style models).  Distinct from [`ThermalEntropy`](@ref): `ThermalEntropy` is a finite-temperature thermodynamic quantity, while `ResidualEntropy` is the lim_{T -> 0} S(T) / N residual term. Zero-temperature ground-state entropy per site,
+Zero-temperature configurational (residual) entropy density.  Real- valued, non-negative; non-zero in the presence of macroscopic ground-state degeneracy (e.g. ice rule, frustrated Ising AFM, Pauling-1935-style models).  Distinct from ``ThermalEntropy``: `ThermalEntropy` is a finite-temperature thermodynamic quantity, while `ResidualEntropy` is the lim_{T -> 0} S(T) / N residual term. Zero-temperature ground-state entropy per site,
 
 _(extracted from `src/core/quantities.jl` docstring.)_
 

--- a/docs/src/atlas/quantities/SpontaneousMagnetization.md
+++ b/docs/src/atlas/quantities/SpontaneousMagnetization.md
@@ -7,7 +7,7 @@ All `(Model, BC)` hubs `src` claims for the **`SpontaneousMagnetization`** obser
 
 ## Definition
 
-Spontaneous magnetization of a classical model as a function of temperature.  Retained under this name for backward compatibility with the classical-Ising literature; new code may prefer the axis-explicit [`MagnetizationZ`](@ref) together with a `T < T_c` context.
+Spontaneous magnetization of a classical model as a function of temperature.  Retained under this name for backward compatibility with the classical-Ising literature; new code may prefer the axis-explicit ``MagnetizationZ`` together with a `T < T_c` context.
 
 _(extracted from `src/core/quantities.jl` docstring.)_
 

--- a/docs/src/atlas/quantities/XXCorrelation.md
+++ b/docs/src/atlas/quantities/XXCorrelation.md
@@ -7,7 +7,7 @@ All `(Model, BC)` hubs `src` claims for the **`XXCorrelation`** observable.  Emp
 
 ## Definition
 
-Real-space 2-point `⟨σˣ_i σˣ_j⟩` correlator.  See [`ZZCorrelation`](@ref) for the `mode` semantics.
+Real-space 2-point `⟨σˣ_i σˣ_j⟩` correlator.  See ``ZZCorrelation`` for the `mode` semantics.
 
 _(extracted from `src/core/quantities.jl` docstring.)_
 

--- a/docs/src/atlas/quantities/XXStructureFactor.md
+++ b/docs/src/atlas/quantities/XXStructureFactor.md
@@ -7,7 +7,7 @@ All `(Model, BC)` hubs `src` claims for the **`XXStructureFactor`** observable. 
 
 ## Definition
 
-Fourier-space equivalent of [`XXCorrelation`](@ref).
+Fourier-space equivalent of ``XXCorrelation``.
 
 _(extracted from `src/core/quantities.jl` docstring.)_
 

--- a/docs/src/atlas/quantities/YYStructureFactor.md
+++ b/docs/src/atlas/quantities/YYStructureFactor.md
@@ -7,7 +7,7 @@ All `(Model, BC)` hubs `src` claims for the **`YYStructureFactor`** observable. 
 
 ## Definition
 
-Fourier-space equivalent of [`YYCorrelation`](@ref).
+Fourier-space equivalent of ``YYCorrelation``.
 
 _(extracted from `src/core/quantities.jl` docstring.)_
 


### PR DESCRIPTION
docs(atlas): strip Documenter @ref cross-references from extracted docstrings

Stacked on feat/convention-backfill (PR #487).  Fixes the Documenter
docs build which started failing on the stack after PR #480 introduced
the quantity-Definition extraction:

  Error: Cannot resolve @ref for md"[`Honeycomb`](@ref)" in
  docs/src/atlas/quantities/FermiVelocity.md.
  ERROR: `makedocs` encountered an error [:cross_references]

Root cause: src/core/quantities.jl docstrings for FermiVelocity (and 8
other quantities) contain `[X](@ref)` Documenter cross-references.
PR #480's _QUANTITY_DEFS extractor pulls these docstrings verbatim
into the auto-gen atlas/quantities/<Q>.md pages.  The atlas/ pages
don't share the autodocs cross-reference scope, so Documenter cannot
resolve [Honeycomb](@ref), and the build aborts.

Fix: extend _md_escape_dollar to first strip Documenter @ref links,
mapping `[X](@ref)` and `[X](@ref label)` to `` `X` `` (code-formatted
text, no link).  Keeps the symbol visible without an unresolvable link.

Effect:
  - 9 quantities/<Q>.md files now have @ref-free Definition sections
  - docs build completes (only the pre-existing size_threshold warnings
    remain, which are non-blocking)

The fix lives in _md_escape_dollar so all auto-gen pages benefit
(future docstring extractions are also safe).

Project.toml: 0.22.17 -> 0.22.18.

Guards: 2/2 + 179/179.

Stack (15 PRs):
  - #474..#487 (existing)
  - this PR feat/docs-strip-atref
