### PR TITLE
docs(atlas): split audit section 5 into universality vs real orphans

### DIFF
--- a/docs/atlas/generate.jl
+++ b/docs/atlas/generate.jl
@@ -230,6 +230,24 @@ function _normalize_hub(h::AbstractString)
     return string(m, "/", q, "/", b)
 end
 
+# Universality-class orphan classification.
+const _UNIV_CLASS_MODELS = Set([
+    "Universality",
+    "E8",
+    "MeanField",
+    "MinimalModel",
+    "ONModel",
+    "Potts",
+    "KPZ",
+    "Percolation",
+])
+
+function _is_univ_class_orphan(h::AbstractString)
+    parts = split(h, "/")
+    isempty(parts) && return false
+    return first(parts) in _UNIV_CLASS_MODELS
+end
+
 # ── TIER-1 EXT HELPERS (universality + calc + refs) ─────────────────────────
 
 # CONVENTION block extraction: parse the standard header comment
@@ -1031,9 +1049,10 @@ _audit_counts = let
     end
     zero_hubs = count(m -> isempty(filter(h -> modelof(h) == m, claimed)), models)
     norm_claims = Set(_normalize_hub(h) for h in claimed)
-    orphan_cards = length(
-        unique(filter(h -> !(_normalize_hub(h) in norm_claims), [c.hub for c in cards]))
+    all_oc = unique(
+        filter(h -> !(_normalize_hub(h) in norm_claims), [c.hub for c in cards])
     )
+    orphan_cards = count(h -> !_is_univ_class_orphan(h), all_oc)
     (; conv=no_conv + no_conv_no_file, def=no_def, orphan_calc, zero_hubs, orphan_cards)
 end
 
@@ -1568,21 +1587,39 @@ function render_audit()
     P("")
     P(
         "Verify cards exist for `(M, Q, BC)` triples that no `@register` ",
-        "claims.  These hubs are visible only through the cards, not the ",
-        "registry view; the absence of an `@register` claim means the ",
-        "primary `src` claim isn't there.",
+        "claims.  Split into two subcategories: universality-class cards ",
+        "are intentionally card-only (no model-side @register applies); ",
+        "the rest are real registry gaps for follow-up.",
     )
     P("")
     norm_claims = Set(_normalize_hub(h) for h in claimed)
-    orphan_cards = sort(
+    all_orphans = sort(
         unique(filter(h -> !(_normalize_hub(h) in norm_claims), [c.hub for c in cards]))
     )
-    if isempty(orphan_cards)
-        P("!!! tip \"All INVENTORY card hubs have a matching `@register` claim.\"")
+    univ_orphans = filter(_is_univ_class_orphan, all_orphans)
+    real_orphans = filter(h -> !_is_univ_class_orphan(h), all_orphans)
+    P("### 5a. Universality-class card-only (by design — not a gap)")
+    P("")
+    if isempty(univ_orphans)
+        P("_None._")
     else
-        P("**", length(orphan_cards), " orphan card hub(s)**:")
+        P("**", length(univ_orphans), " universality-class hub(s)**:")
         P("")
-        for h in orphan_cards
+        for h in univ_orphans
+            P("- `", h, "`")
+        end
+    end
+    P("")
+    P("### 5b. Real orphan card hubs (need @register or removal)")
+    P("")
+    if isempty(real_orphans)
+        P(
+            "!!! tip \"All non-universality INVENTORY card hubs have a matching `@register` claim.\"",
+        )
+    else
+        P("**", length(real_orphans), " real orphan card hub(s)**:")
+        P("")
+        for h in real_orphans
             P("- `", h, "`")
         end
         P("")

--- a/docs/src/atlas/Audit.md
+++ b/docs/src/atlas/Audit.md
@@ -40,29 +40,16 @@ Quantities whose `struct X[{params}] <: AbstractQuantity` docstring wasn't match
 !!! tip "Every registered model has at least one hub."
 ## 5. INVENTORY cards with no matching registry claim
 
-Verify cards exist for `(M, Q, BC)` triples that no `@register` claims.  These hubs are visible only through the cards, not the registry view; the absence of an `@register` claim means the primary `src` claim isn't there.
+Verify cards exist for `(M, Q, BC)` triples that no `@register` claims.  Split into two subcategories: universality-class cards are intentionally card-only (no model-side @register applies); the rest are real registry gaps for follow-up.
 
-**63 orphan card hub(s)**:
+### 5a. Universality-class card-only (by design — not a gap)
+
+**19 universality-class hub(s)**:
 
 - `E8/E8Spectrum/Infinite`
 - `MeanField/CriticalExponents/Infinite`
 - `MinimalModel/CentralCharge/Infinite`
 - `MinimalModel/ConformalWeights/Infinite`
-- `QAtlas.Honeycomb/TightBindingChecksum/Infinite`
-- `QAtlas.Honeycomb/TightBindingMaxEnergy/Infinite`
-- `QAtlas.Kagome/TightBindingChecksum/Infinite`
-- `QAtlas.Kagome/TightBindingMaxEnergy/Infinite`
-- `QAtlas.Lieb/TightBindingChecksum/Infinite`
-- `QAtlas.Lieb/TightBindingMaxEnergy/Infinite`
-- `QAtlas.Triangular/TightBindingChecksum/Infinite`
-- `QAtlas.Triangular/TightBindingMaxEnergy/Infinite`
-- `S1Heisenberg1D/q/OBC`
-- `TFIM/Energy/bc`
-- `TFIM/LoschmidtRateFunction/Infinite`
-- `TFIM/q/Infinite`
-- `TFIM/q/OBC`
-- `TFIM/qty/OBC`
-- `TFIM/qty/PBC`
 - `Universality/CasimirEnergyCorrection/OBC`
 - `Universality/CasimirEnergyCorrection/PBC`
 - `Universality/CentralCharge/Infinite`
@@ -78,6 +65,26 @@ Verify cards exist for `(M, Q, BC)` triples that no `@register` claims.  These h
 - `Universality/VonNeumannEntropy/OBC`
 - `Universality/VonNeumannEntropy/PBC`
 - `Universality/WignerSurmise/Infinite`
+
+### 5b. Real orphan card hubs (need @register or removal)
+
+**44 real orphan card hub(s)**:
+
+- `QAtlas.Honeycomb/TightBindingChecksum/Infinite`
+- `QAtlas.Honeycomb/TightBindingMaxEnergy/Infinite`
+- `QAtlas.Kagome/TightBindingChecksum/Infinite`
+- `QAtlas.Kagome/TightBindingMaxEnergy/Infinite`
+- `QAtlas.Lieb/TightBindingChecksum/Infinite`
+- `QAtlas.Lieb/TightBindingMaxEnergy/Infinite`
+- `QAtlas.Triangular/TightBindingChecksum/Infinite`
+- `QAtlas.Triangular/TightBindingMaxEnergy/Infinite`
+- `S1Heisenberg1D/q/OBC`
+- `TFIM/Energy/bc`
+- `TFIM/LoschmidtRateFunction/Infinite`
+- `TFIM/q/Infinite`
+- `TFIM/q/OBC`
+- `TFIM/qty/OBC`
+- `TFIM/qty/PBC`
 - `WZWSU2/CentralCharge/Infinite`
 - `WZWSU2/ConformalWeights/Infinite`
 - `XXZ1D/GroundStateEnergyDensity/Infinite`

--- a/docs/src/atlas/index.md
+++ b/docs/src/atlas/index.md
@@ -47,7 +47,7 @@ Actionable gap surface — see **[Audit](Audit.md)** for the itemised list.
 | 2. Quantities without extracted Definition | 0 |
 | 3. Orphan calc notes (matched to no model) | 13 |
 | 4. Models registered but with 0 hubs | 0 |
-| 5. INVENTORY card hubs with no `@register` claim | 63 |
+| 5. INVENTORY card hubs with no `@register` claim | 44 |
 
 ## Reference & derivation indices
 


### PR DESCRIPTION
docs(atlas): split audit section 5 into universality vs real orphans

Stacked on feat/unroll-q-loops (PR #489).  The audit's section 5
(INVENTORY card hubs without matching @register claim) lumped together
two qualitatively different categories:

  - Universality-class cards (E8, MeanField, MinimalModel, Universality):
    intentionally card-only because these are universality-tier claims
    rather than model-side @register entries.  By design, not a gap.

  - Real orphans: verify cards for (Model, Quantity, BC) triples where
    a model-side @register is genuinely missing or removed.

Split the section into 5a (universality, by-design) and 5b (real,
actionable).  Front-page count now shows ONLY real orphans.

Effect:
  - Atlas index summary, section 5 count: 63 -> 44 (19 univ-class
    entries reclassified to 5a)
  - Audit.md gains 5a header for transparent surfacing of the
    universality-class card-only category

Implementation: _UNIV_CLASS_MODELS set + _is_univ_class_orphan helper
in docs/atlas/generate.jl, applied in both render_audit() and the
atlas/index.md count emission.

Project.toml: 0.22.19 -> 0.22.20.

Guards: 2/2 + 179/179.

Stack (17 PRs):
  - #474..#489 (existing)
  - this PR feat/audit-univ-split
