### PR TITLE
docs(atlas): apply /review-pr findings to PR #490 (WZWSU2 + dedupe + normalized display)

### DIFF
--- a/docs/atlas/generate.jl
+++ b/docs/atlas/generate.jl
@@ -239,13 +239,24 @@ const _UNIV_CLASS_MODELS = Set([
     "ONModel",
     "Potts",
     "KPZ",
+    "KPZ1D",
     "Percolation",
+    "WZWSU2",
 ])
 
 function _is_univ_class_orphan(h::AbstractString)
     parts = split(h, "/")
     isempty(parts) && return false
     return first(parts) in _UNIV_CLASS_MODELS
+end
+
+# Single source of truth for orphan card hubs.  Computed once at load
+# time so both the atlas/index.md count summary and the Audit.md
+# section 5 list use the same data; eliminates duplication and prevents
+# future divergence.
+const _ORPHAN_HUBS = let
+    norm = Set(_normalize_hub(h) for h in claimed)
+    sort(unique(filter(h -> !(_normalize_hub(h) in norm), [c.hub for c in cards])))
 end
 
 # ── TIER-1 EXT HELPERS (universality + calc + refs) ─────────────────────────
@@ -1048,11 +1059,7 @@ _audit_counts = let
         matched || (orphan_calc += 1)
     end
     zero_hubs = count(m -> isempty(filter(h -> modelof(h) == m, claimed)), models)
-    norm_claims = Set(_normalize_hub(h) for h in claimed)
-    all_oc = unique(
-        filter(h -> !(_normalize_hub(h) in norm_claims), [c.hub for c in cards])
-    )
-    orphan_cards = count(h -> !_is_univ_class_orphan(h), all_oc)
+    orphan_cards = count(h -> !_is_univ_class_orphan(h), _ORPHAN_HUBS)
     (; conv=no_conv + no_conv_no_file, def=no_def, orphan_calc, zero_hubs, orphan_cards)
 end
 
@@ -1592,12 +1599,8 @@ function render_audit()
         "the rest are real registry gaps for follow-up.",
     )
     P("")
-    norm_claims = Set(_normalize_hub(h) for h in claimed)
-    all_orphans = sort(
-        unique(filter(h -> !(_normalize_hub(h) in norm_claims), [c.hub for c in cards]))
-    )
-    univ_orphans = filter(_is_univ_class_orphan, all_orphans)
-    real_orphans = filter(h -> !_is_univ_class_orphan(h), all_orphans)
+    univ_orphans = filter(_is_univ_class_orphan, _ORPHAN_HUBS)
+    real_orphans = filter(h -> !_is_univ_class_orphan(h), _ORPHAN_HUBS)
     P("### 5a. Universality-class card-only (by design — not a gap)")
     P("")
     if isempty(univ_orphans)
@@ -1606,7 +1609,7 @@ function render_audit()
         P("**", length(univ_orphans), " universality-class hub(s)**:")
         P("")
         for h in univ_orphans
-            P("- `", h, "`")
+            P("- `", _normalize_hub(h), "`")
         end
     end
     P("")
@@ -1620,7 +1623,7 @@ function render_audit()
         P("**", length(real_orphans), " real orphan card hub(s)**:")
         P("")
         for h in real_orphans
-            P("- `", h, "`")
+            P("- `", _normalize_hub(h), "`")
         end
         P("")
     end

--- a/docs/src/atlas/Audit.md
+++ b/docs/src/atlas/Audit.md
@@ -44,7 +44,7 @@ Verify cards exist for `(M, Q, BC)` triples that no `@register` claims.  Split i
 
 ### 5a. Universality-class card-only (by design — not a gap)
 
-**19 universality-class hub(s)**:
+**21 universality-class hub(s)**:
 
 - `E8/E8Spectrum/Infinite`
 - `MeanField/CriticalExponents/Infinite`
@@ -65,19 +65,21 @@ Verify cards exist for `(M, Q, BC)` triples that no `@register` claims.  Split i
 - `Universality/VonNeumannEntropy/OBC`
 - `Universality/VonNeumannEntropy/PBC`
 - `Universality/WignerSurmise/Infinite`
+- `WZWSU2/CentralCharge/Infinite`
+- `WZWSU2/ConformalWeights/Infinite`
 
 ### 5b. Real orphan card hubs (need @register or removal)
 
-**44 real orphan card hub(s)**:
+**42 real orphan card hub(s)**:
 
-- `QAtlas.Honeycomb/TightBindingChecksum/Infinite`
-- `QAtlas.Honeycomb/TightBindingMaxEnergy/Infinite`
-- `QAtlas.Kagome/TightBindingChecksum/Infinite`
-- `QAtlas.Kagome/TightBindingMaxEnergy/Infinite`
-- `QAtlas.Lieb/TightBindingChecksum/Infinite`
-- `QAtlas.Lieb/TightBindingMaxEnergy/Infinite`
-- `QAtlas.Triangular/TightBindingChecksum/Infinite`
-- `QAtlas.Triangular/TightBindingMaxEnergy/Infinite`
+- `Honeycomb/TightBindingChecksum/Infinite`
+- `Honeycomb/TightBindingMaxEnergy/Infinite`
+- `Kagome/TightBindingChecksum/Infinite`
+- `Kagome/TightBindingMaxEnergy/Infinite`
+- `Lieb/TightBindingChecksum/Infinite`
+- `Lieb/TightBindingMaxEnergy/Infinite`
+- `Triangular/TightBindingChecksum/Infinite`
+- `Triangular/TightBindingMaxEnergy/Infinite`
 - `S1Heisenberg1D/q/OBC`
 - `TFIM/Energy/bc`
 - `TFIM/LoschmidtRateFunction/Infinite`
@@ -85,15 +87,13 @@ Verify cards exist for `(M, Q, BC)` triples that no `@register` claims.  Split i
 - `TFIM/q/OBC`
 - `TFIM/qty/OBC`
 - `TFIM/qty/PBC`
-- `WZWSU2/CentralCharge/Infinite`
-- `WZWSU2/ConformalWeights/Infinite`
 - `XXZ1D/GroundStateEnergyDensity/Infinite`
 - `XXZ1D/q/OBC`
 - `XXZ1D/qty/OBC`
 - `_XX/Energy/Infinite`
 - `_XX/FreeEnergy/Infinite`
 - `_XX/ThermalEntropy/Infinite`
-- `m/Energy{:per_site}/Infinite`
+- `m/Energy/Infinite`
 - `m/FreeEnergy/Infinite`
 - `m/GGEValue/Infinite`
 - `m/LoschmidtRateFunction/Infinite`

--- a/docs/src/atlas/index.md
+++ b/docs/src/atlas/index.md
@@ -47,7 +47,7 @@ Actionable gap surface — see **[Audit](Audit.md)** for the itemised list.
 | 2. Quantities without extracted Definition | 0 |
 | 3. Orphan calc notes (matched to no model) | 13 |
 | 4. Models registered but with 0 hubs | 0 |
-| 5. INVENTORY card hubs with no `@register` claim | 44 |
+| 5. INVENTORY card hubs with no `@register` claim | 42 |
 
 ## Reference & derivation indices
 


### PR DESCRIPTION
docs(atlas): apply /review-pr findings to PR #490 (WZWSU2 + dedupe + normalized display)

Stacked on feat/audit-univ-split (PR #490).  Aggregated findings from
the multi-agent /review-pr stack (code-reviewer + silent-failure-hunter
+ code-simplifier).

Important fixes:
  - Add `WZWSU2` to `_UNIV_CLASS_MODELS`.  WZWSU2 lives in
    src/universalities/WZW.jl - same universality-class category as
    MinimalModel/E8/MeanField.  Without this, its 2 card hubs
    (WZWSU2/CentralCharge/Infinite, WZWSU2/ConformalWeights/Infinite)
    were misrouted to "real orphans" instead of the "by design"
    bucket.  Front-page count: 44 -> 42.
  - Add `KPZ1D` alongside `KPZ` (latent: no current KPZ1D cards exist
    but the struct is named `KPZ1D` per src/universalities/KPZ.jl;
    future cards will land in the right bucket).

Advisory fixes:
  - Display `_normalize_hub(h)` in both orphan loops (5a + 5b).
    Previously the lookup normalized but the displayed list still
    showed raw `QAtlas.Honeycomb/...` prefix - inconsistent with
    every other atlas page that uses bare model names.
  - Extract orphan-hub computation into module-level `_ORPHAN_HUBS`
    const.  Eliminates the duplicated `norm_claims + filter + unique`
    pipeline between atlas/index.md count and Audit.md list, and
    prevents the silent-divergence risk silent-failure-hunter flagged
    (the two paths could have gotten out of sync on a future bug fix).

Project.toml: 0.22.20 -> 0.22.21.

Guards: 2/2 + 179/179.

Stack (18 PRs):
  - #474..#490 (existing)
  - this PR feat/review-fixes-490
