### PR TITLE
quantities: migrate ExactSpectrum + GroundStateEnergyDensity to <: AbstractQuantity (re-merge of #485)

### DIFF
--- a/docs/atlas/generate.jl
+++ b/docs/atlas/generate.jl
@@ -180,7 +180,7 @@ const _QUANTITY_DEFS = let
             endswith(f, ".jl") || continue
             txt = read(joinpath(root, f), String)
             for m in eachmatch(
-                r"\"\"\"(.+?)\"\"\"\s*\n\s*struct\s+([A-Z][A-Za-z0-9_]*)(?:\{[^}]*\})?\s*<:\s*AbstractQuantity"s,
+                r"\"\"\"((?:(?!\"\"\").)+)\"\"\"\s*\n\s*struct\s+([A-Z][A-Za-z0-9_]*)(?:\{[^}]*\})?\s*<:\s*AbstractQuantity"s,
                 txt,
             )
                 docblock = strip(m.captures[1])

--- a/docs/src/atlas/Audit.md
+++ b/docs/src/atlas/Audit.md
@@ -37,11 +37,7 @@ The CI lint enforces `# CONVENTION` headers on new model files, but older files 
 
 Quantities whose `struct X[{params}] <: AbstractQuantity` docstring wasn't matched by the regex extractor (likely defined as bare `struct X end` without `<: AbstractQuantity`, or with alternate formatting).  Adding the supertype + docstring makes them appear on the per-quantity page automatically.
 
-**2 quantities**:
-
-- [`ExactSpectrum`](quantities/ExactSpectrum.md)
-- [`GroundStateEnergyDensity`](quantities/GroundStateEnergyDensity.md)
-
+!!! tip "All quantities have an extracted Definition."
 ## 3. Orphan calc notes (matched to no model)
 
 `docs/src/calc/*.md` whose filename doesn't substring-match any registered model.  Likely true derivation notes that describe a method (e.g. `calabrese-cardy-obc-vs-pbc.md`, `ad-thermodynamics-from-z.md`) rather than a model, but worth scanning to confirm.

--- a/docs/src/atlas/index.md
+++ b/docs/src/atlas/index.md
@@ -44,7 +44,7 @@ Actionable gap surface — see **[Audit](Audit.md)** for the itemised list.
 | Section | Count |
 |---|---|
 | 1. Models without CONVENTION header | 21 |
-| 2. Quantities without extracted Definition | 2 |
+| 2. Quantities without extracted Definition | 0 |
 | 3. Orphan calc notes (matched to no model) | 13 |
 | 4. Models registered but with 0 hubs | 0 |
 | 5. INVENTORY card hubs with no `@register` claim | 64 |

--- a/docs/src/atlas/quantities/ChargeGap.md
+++ b/docs/src/atlas/quantities/ChargeGap.md
@@ -7,7 +7,7 @@ All `(Model, BC)` hubs `src` claims for the **`ChargeGap`** observable.  Empty c
 
 ## Definition
 
-Convenience alias for the rate-function flavour `λ(t) = -log L(t)/N`.  See [`LoschmidtEcho`](@ref). """ const LoschmidtRateFunction = LoschmidtEcho{:rate}
+Charge (Mott) gap of an electron system,
 
 _(extracted from `src/core/quantities.jl` docstring.)_
 

--- a/docs/src/atlas/quantities/CriticalExponents.md
+++ b/docs/src/atlas/quantities/CriticalExponents.md
@@ -7,7 +7,7 @@ All `(Model, BC)` hubs `src` claims for the **`CriticalExponents`** observable. 
 
 ## Definition
 
-Parametric dispatch tag for universality classes. `C` is a `Symbol` identifying the class (`:Ising`, `:XY`, `:Heisenberg`, `:Potts3`, `:Potts4`, `:Percolation`, `:KPZ`, etc.).
+Standard set of equilibrium critical exponents {α, β, γ, δ, ν, η} of a universality class. Returns a `NamedTuple`.
 
 _(extracted from `src/core/quantities.jl` docstring.)_
 

--- a/docs/src/atlas/quantities/CriticalTemperature.md
+++ b/docs/src/atlas/quantities/CriticalTemperature.md
@@ -7,7 +7,7 @@ All `(Model, BC)` hubs `src` claims for the **`CriticalTemperature`** observable
 
 ## Definition
 
-Return the 2^Ly × 2^Ly symmetric transfer matrix for a row of `Ly` Ising spins with PBC along the row direction.
+Exact critical temperature of a classical model.
 
 _(extracted from `src/core/quantities.jl` docstring.)_
 

--- a/docs/src/atlas/quantities/ExactSpectrum.md
+++ b/docs/src/atlas/quantities/ExactSpectrum.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`ExactSpectrum`** observable.  Empty cells = this model doesn't yet have a `ExactSpectrum` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Dispatch tag for the full sorted eigenvalue spectrum of a finite model.
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 1

--- a/docs/src/atlas/quantities/FreeEnergy.md
+++ b/docs/src/atlas/quantities/FreeEnergy.md
@@ -7,7 +7,7 @@ All `(Model, BC)` hubs `src` claims for the **`FreeEnergy`** observable.  Empty 
 
 ## Definition
 
-Trait declaring which granularity the given `model` returns natively for [`Energy`](@ref) at boundary condition `bc`.  Used by the `Energy()` (`:natural`) router and by the generic conversion fallbacks.
+Helmholtz free energy per site, `f = -β⁻¹ log Z / N`.
 
 _(extracted from `src/core/quantities.jl` docstring.)_
 

--- a/docs/src/atlas/quantities/GroundStateEnergyDensity.md
+++ b/docs/src/atlas/quantities/GroundStateEnergyDensity.md
@@ -5,6 +5,12 @@
 
 All `(Model, BC)` hubs `src` claims for the **`GroundStateEnergyDensity`** observable.  Empty cells = this model doesn't yet have a `GroundStateEnergyDensity` registered at that BC — i.e. where this quantity could be added to other models.
 
+## Definition
+
+Dispatch tag for the ground-state energy per site in the thermodynamic limit (N → ∞).
+
+_(extracted from `src/core/quantities.jl` docstring.)_
+
 ## Coverage
 
 - **Models with this quantity registered**: 5

--- a/docs/src/atlas/quantities/PartitionFunction.md
+++ b/docs/src/atlas/quantities/PartitionFunction.md
@@ -7,7 +7,7 @@ All `(Model, BC)` hubs `src` claims for the **`PartitionFunction`** observable. 
 
 ## Definition
 
-Classical 2D Ising model on a square lattice with periodic boundary conditions (PBC) in both directions.
+Canonical partition function `Z = Σ_σ exp(-β H(σ))`.
 
 _(extracted from `src/core/quantities.jl` docstring.)_
 

--- a/src/models/quantum/Heisenberg/Heisenberg.jl
+++ b/src/models/quantum/Heisenberg/Heisenberg.jl
@@ -47,7 +47,7 @@ struct Heisenberg1D <: AbstractQAtlasModel end
 
 Dispatch tag for the full sorted eigenvalue spectrum of a finite model.
 """
-struct ExactSpectrum end
+struct ExactSpectrum <: AbstractQuantity end
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # fetch: exact spectrum for small N
@@ -118,7 +118,7 @@ end
 Dispatch tag for the ground-state energy per site in the thermodynamic
 limit (N → ∞).
 """
-struct GroundStateEnergyDensity end
+struct GroundStateEnergyDensity <: AbstractQuantity end
 
 """
     fetch(::Heisenberg1D, ::GroundStateEnergyDensity; J=1.0) -> Float64


### PR DESCRIPTION
Re-merge of PR #485 content (commit b09ff2f1) which got merged into the wrong base during the stack collapse. Adds <: AbstractQuantity supertype to ExactSpectrum and GroundStateEnergyDensity structs.\n\nVersion stays at 0.22.8 (no Julia registry trigger).