### PR TITLE
docs(atlas): cross-model binding for general-method calc notes (orphan 10->0)

### DIFF
--- a/docs/atlas/generate.jl
+++ b/docs/atlas/generate.jl
@@ -370,12 +370,53 @@ function _model_calc_aliases(model_name::AbstractString)
     return unique(aliases)
 end
 
+# Cross-cutting calc notes whose filename does not substring-match a single
+# model name (general CFT, duality, transfer-matrix, scaling concepts).
+# Each entry binds the note to the list of models on whose page it should
+# appear, and removes it from the orphan-calc bookkeeping.  Hub-level (model
+# + quantity) matching is unchanged (still substring), so cross-listing here
+# does not auto-inject the note into every hub card.
+const _CALC_BIND_OVERRIDES = Dict{String,Vector{String}}(
+    "ad-thermodynamics-from-z.md" => [
+        "IsingChain1D", "IsingSquare", "IsingTriangular", "CurieWeissIsing",
+        "TFIM", "XXZ1D", "Heisenberg1D", "Hubbard1D",
+    ],
+    "calabrese-cardy-obc-vs-pbc.md" => [
+        "TFIM", "XXZ1D", "Heisenberg1D", "Universality", "MinimalModel",
+    ],
+    "e8-mass-spectrum-derivation.md" => ["TFIM", "E8", "Universality"],
+    "ising-cft-magnetic-perturbation.md" => [
+        "TFIM", "IsingSquare", "IsingChain1D", "IsingTriangular",
+        "MinimalModel", "Universality",
+    ],
+    "ising-cft-primary-operators.md" => [
+        "TFIM", "IsingSquare", "IsingChain1D", "IsingTriangular",
+        "MinimalModel", "Universality",
+    ],
+    "ising-scaling-relations.md" => [
+        "TFIM", "IsingSquare", "IsingChain1D", "IsingTriangular",
+        "MinimalModel", "Universality",
+    ],
+    "kramers-wannier-duality.md" => ["TFIM", "IsingChain1D", "IsingSquare"],
+    "transfer-matrix-symmetric-split.md" => [
+        "IsingChain1D", "TFIM", "IsingSquare",
+    ],
+    "xx-quench.md" => ["XXZ1D", "TFIM", "Heisenberg1D"],
+    "yang-magnetization-toeplitz.md" => [
+        "XXZ1D", "Heisenberg1D", "TFIM",
+    ],
+)
+
 function _calc_files_for_model(model_name::AbstractString)
     aliases = _model_calc_aliases(model_name)
     out = String[]
     for f in _CALC_FILES
         flo = lowercase(f)
-        any(a -> length(a) >= 3 && occursin(a, flo), aliases) || continue
+        matched = any(a -> length(a) >= 3 && occursin(a, flo), aliases)
+        if !matched
+            matched = model_name in get(_CALC_BIND_OVERRIDES, f, String[])
+        end
+        matched || continue
         push!(out, f)
     end
     return out

--- a/docs/src/atlas/Audit.md
+++ b/docs/src/atlas/Audit.md
@@ -19,19 +19,7 @@ Quantities whose `struct X[{params}] <: AbstractQuantity` docstring wasn't match
 
 `docs/src/calc/*.md` whose filename doesn't substring-match any registered model.  Likely true derivation notes that describe a method (e.g. `calabrese-cardy-obc-vs-pbc.md`, `ad-thermodynamics-from-z.md`) rather than a model, but worth scanning to confirm.
 
-**10 orphan calc note(s)**:
-
-- [`ad-thermodynamics-from-z.md`](../calc/ad-thermodynamics-from-z.md)
-- [`calabrese-cardy-obc-vs-pbc.md`](../calc/calabrese-cardy-obc-vs-pbc.md)
-- [`e8-mass-spectrum-derivation.md`](../calc/e8-mass-spectrum-derivation.md)
-- [`ising-cft-magnetic-perturbation.md`](../calc/ising-cft-magnetic-perturbation.md)
-- [`ising-cft-primary-operators.md`](../calc/ising-cft-primary-operators.md)
-- [`ising-scaling-relations.md`](../calc/ising-scaling-relations.md)
-- [`kramers-wannier-duality.md`](../calc/kramers-wannier-duality.md)
-- [`transfer-matrix-symmetric-split.md`](../calc/transfer-matrix-symmetric-split.md)
-- [`xx-quench.md`](../calc/xx-quench.md)
-- [`yang-magnetization-toeplitz.md`](../calc/yang-magnetization-toeplitz.md)
-
+!!! tip "All calc notes match at least one model."
 ## 4. Models registered but with 0 hubs
 
 !!! tip "Every registered model has at least one hub."

--- a/docs/src/atlas/CalcIndex.md
+++ b/docs/src/atlas/CalcIndex.md
@@ -7,27 +7,27 @@ All 22 step-by-step derivation notes under `docs/src/calc/`, with the model(s) e
 
 | Derivation note | Models matched |
 |---|---|
-| [`ad-thermodynamics-from-z.md`](../calc/ad-thermodynamics-from-z.md) | — |
+| [`ad-thermodynamics-from-z.md`](../calc/ad-thermodynamics-from-z.md) | [`CurieWeissIsing`](models/CurieWeissIsing.md), [`Heisenberg1D`](models/Heisenberg1D.md), [`Hubbard1D`](models/Hubbard1D.md), [`IsingChain1D`](models/IsingChain1D.md), [`IsingSquare`](models/IsingSquare.md), [`IsingTriangular`](models/IsingTriangular.md), [`TFIM`](models/TFIM.md), [`XXZ1D`](models/XXZ1D.md) |
 | [`bethe-ansatz-heisenberg-e0.md`](../calc/bethe-ansatz-heisenberg-e0.md) | [`Heisenberg1D`](models/Heisenberg1D.md), [`S1Heisenberg1D`](models/S1Heisenberg1D.md) |
 | [`bloch-honeycomb-dispersion.md`](../calc/bloch-honeycomb-dispersion.md) | [`Honeycomb`](models/Honeycomb.md) |
 | [`bloch-kagome-flat-band.md`](../calc/bloch-kagome-flat-band.md) | [`Kagome`](models/Kagome.md) |
 | [`bloch-lieb-flat-band.md`](../calc/bloch-lieb-flat-band.md) | [`Lieb`](models/Lieb.md) |
-| [`calabrese-cardy-obc-vs-pbc.md`](../calc/calabrese-cardy-obc-vs-pbc.md) | — |
-| [`e8-mass-spectrum-derivation.md`](../calc/e8-mass-spectrum-derivation.md) | — |
+| [`calabrese-cardy-obc-vs-pbc.md`](../calc/calabrese-cardy-obc-vs-pbc.md) | [`Heisenberg1D`](models/Heisenberg1D.md), [`TFIM`](models/TFIM.md), [`XXZ1D`](models/XXZ1D.md) |
+| [`e8-mass-spectrum-derivation.md`](../calc/e8-mass-spectrum-derivation.md) | [`TFIM`](models/TFIM.md) |
 | [`heisenberg-dimer-singlet-triplet.md`](../calc/heisenberg-dimer-singlet-triplet.md) | [`Heisenberg1D`](models/Heisenberg1D.md), [`S1Heisenberg1D`](models/S1Heisenberg1D.md) |
 | [`heisenberg-spinons.md`](../calc/heisenberg-spinons.md) | [`Heisenberg1D`](models/Heisenberg1D.md), [`S1Heisenberg1D`](models/S1Heisenberg1D.md) |
-| [`ising-cft-magnetic-perturbation.md`](../calc/ising-cft-magnetic-perturbation.md) | — |
-| [`ising-cft-primary-operators.md`](../calc/ising-cft-primary-operators.md) | — |
-| [`ising-scaling-relations.md`](../calc/ising-scaling-relations.md) | — |
+| [`ising-cft-magnetic-perturbation.md`](../calc/ising-cft-magnetic-perturbation.md) | [`IsingChain1D`](models/IsingChain1D.md), [`IsingSquare`](models/IsingSquare.md), [`IsingTriangular`](models/IsingTriangular.md), [`TFIM`](models/TFIM.md) |
+| [`ising-cft-primary-operators.md`](../calc/ising-cft-primary-operators.md) | [`IsingChain1D`](models/IsingChain1D.md), [`IsingSquare`](models/IsingSquare.md), [`IsingTriangular`](models/IsingTriangular.md), [`TFIM`](models/TFIM.md) |
+| [`ising-scaling-relations.md`](../calc/ising-scaling-relations.md) | [`IsingChain1D`](models/IsingChain1D.md), [`IsingSquare`](models/IsingSquare.md), [`IsingTriangular`](models/IsingTriangular.md), [`TFIM`](models/TFIM.md) |
 | [`jw-tfim-bdg.md`](../calc/jw-tfim-bdg.md) | [`TFIM`](models/TFIM.md) |
-| [`kramers-wannier-duality.md`](../calc/kramers-wannier-duality.md) | — |
+| [`kramers-wannier-duality.md`](../calc/kramers-wannier-duality.md) | [`IsingChain1D`](models/IsingChain1D.md), [`IsingSquare`](models/IsingSquare.md), [`TFIM`](models/TFIM.md) |
 | [`tfim-entanglement-peschel.md`](../calc/tfim-entanglement-peschel.md) | [`TFIM`](models/TFIM.md) |
 | [`tfim-gge.md`](../calc/tfim-gge.md) | [`TFIM`](models/TFIM.md) |
 | [`tfim-loschmidt.md`](../calc/tfim-loschmidt.md) | [`TFIM`](models/TFIM.md) |
 | [`tfim-sigma-x-quench.md`](../calc/tfim-sigma-x-quench.md) | [`TFIM`](models/TFIM.md) |
-| [`transfer-matrix-symmetric-split.md`](../calc/transfer-matrix-symmetric-split.md) | — |
-| [`xx-quench.md`](../calc/xx-quench.md) | — |
+| [`transfer-matrix-symmetric-split.md`](../calc/transfer-matrix-symmetric-split.md) | [`IsingChain1D`](models/IsingChain1D.md), [`IsingSquare`](models/IsingSquare.md), [`TFIM`](models/TFIM.md) |
+| [`xx-quench.md`](../calc/xx-quench.md) | [`Heisenberg1D`](models/Heisenberg1D.md), [`TFIM`](models/TFIM.md), [`XXZ1D`](models/XXZ1D.md) |
 | [`xxz-luttinger-parameters.md`](../calc/xxz-luttinger-parameters.md) | [`S1XXZ1D`](models/S1XXZ1D.md), [`XXZ1D`](models/XXZ1D.md) |
-| [`yang-magnetization-toeplitz.md`](../calc/yang-magnetization-toeplitz.md) | — |
+| [`yang-magnetization-toeplitz.md`](../calc/yang-magnetization-toeplitz.md) | [`Heisenberg1D`](models/Heisenberg1D.md), [`TFIM`](models/TFIM.md), [`XXZ1D`](models/XXZ1D.md) |
 
 [← back to the Atlas index](index.md)

--- a/docs/src/atlas/index.md
+++ b/docs/src/atlas/index.md
@@ -45,7 +45,7 @@ Actionable gap surface — see **[Audit](Audit.md)** for the itemised list.
 |---|---|
 | 1. Models without CONVENTION header | 0 |
 | 2. Quantities without extracted Definition | 0 |
-| 3. Orphan calc notes (matched to no model) | 10 |
+| 3. Orphan calc notes (matched to no model) | 0 |
 | 4. Models registered but with 0 hubs | 0 |
 | 5. INVENTORY card hubs with no `@register` claim | 2 |
 

--- a/docs/src/atlas/models/CurieWeissIsing.md
+++ b/docs/src/atlas/models/CurieWeissIsing.md
@@ -43,4 +43,10 @@ All `(Quantity, BC)` hubs `src` claims for **`CurieWeissIsing`**.  Cells link to
 | [`SusceptibilityZZ`](../quantities/SusceptibilityZZ.md) | 🟢 [hub](../hubs/CurieWeissIsing_SusceptibilityZZ_Infinite.md) |
 | [`ThermalEntropy`](../quantities/ThermalEntropy.md) | 🟢 [hub](../hubs/CurieWeissIsing_ThermalEntropy_Infinite.md) |
 
+## Derivation notes
+
+Matched by filename substring (no annotation; substrate-derived):
+
+- [`ad-thermodynamics-from-z.md`](../../calc/ad-thermodynamics-from-z.md)
+
 [← Atlas index](../index.md) · [Model list →](../ModelList.md)

--- a/docs/src/atlas/models/Heisenberg1D.md
+++ b/docs/src/atlas/models/Heisenberg1D.md
@@ -59,8 +59,12 @@ All `(Quantity, BC)` hubs `src` claims for **`Heisenberg1D`**.  Cells link to th
 
 Matched by filename substring (no annotation; substrate-derived):
 
+- [`ad-thermodynamics-from-z.md`](../../calc/ad-thermodynamics-from-z.md)
 - [`bethe-ansatz-heisenberg-e0.md`](../../calc/bethe-ansatz-heisenberg-e0.md)
+- [`calabrese-cardy-obc-vs-pbc.md`](../../calc/calabrese-cardy-obc-vs-pbc.md)
 - [`heisenberg-dimer-singlet-triplet.md`](../../calc/heisenberg-dimer-singlet-triplet.md)
 - [`heisenberg-spinons.md`](../../calc/heisenberg-spinons.md)
+- [`xx-quench.md`](../../calc/xx-quench.md)
+- [`yang-magnetization-toeplitz.md`](../../calc/yang-magnetization-toeplitz.md)
 
 [← Atlas index](../index.md) · [Model list →](../ModelList.md)

--- a/docs/src/atlas/models/Hubbard1D.md
+++ b/docs/src/atlas/models/Hubbard1D.md
@@ -40,4 +40,10 @@ All `(Quantity, BC)` hubs `src` claims for **`Hubbard1D`**.  Cells link to the p
 | [`LuttingerParameter`](../quantities/LuttingerParameter.md) | 🟢 [hub](../hubs/Hubbard1D_LuttingerParameter_Infinite.md) |
 | [`SpinGap`](../quantities/SpinGap.md) | 🟢 [hub](../hubs/Hubbard1D_SpinGap_Infinite.md) |
 
+## Derivation notes
+
+Matched by filename substring (no annotation; substrate-derived):
+
+- [`ad-thermodynamics-from-z.md`](../../calc/ad-thermodynamics-from-z.md)
+
 [← Atlas index](../index.md) · [Model list →](../ModelList.md)

--- a/docs/src/atlas/models/IsingChain1D.md
+++ b/docs/src/atlas/models/IsingChain1D.md
@@ -44,4 +44,15 @@ All `(Quantity, BC)` hubs `src` claims for **`IsingChain1D`**.  Cells link to th
 | [`SusceptibilityZZ`](../quantities/SusceptibilityZZ.md) | 🟢 [hub](../hubs/IsingChain1D_SusceptibilityZZ_Infinite.md) |
 | [`ThermalEntropy`](../quantities/ThermalEntropy.md) | 🟢 [hub](../hubs/IsingChain1D_ThermalEntropy_Infinite.md) |
 
+## Derivation notes
+
+Matched by filename substring (no annotation; substrate-derived):
+
+- [`ad-thermodynamics-from-z.md`](../../calc/ad-thermodynamics-from-z.md)
+- [`ising-cft-magnetic-perturbation.md`](../../calc/ising-cft-magnetic-perturbation.md)
+- [`ising-cft-primary-operators.md`](../../calc/ising-cft-primary-operators.md)
+- [`ising-scaling-relations.md`](../../calc/ising-scaling-relations.md)
+- [`kramers-wannier-duality.md`](../../calc/kramers-wannier-duality.md)
+- [`transfer-matrix-symmetric-split.md`](../../calc/transfer-matrix-symmetric-split.md)
+
 [← Atlas index](../index.md) · [Model list →](../ModelList.md)

--- a/docs/src/atlas/models/IsingSquare.md
+++ b/docs/src/atlas/models/IsingSquare.md
@@ -44,4 +44,15 @@ All `(Quantity, BC)` hubs `src` claims for **`IsingSquare`**.  Cells link to the
 | [`SpontaneousMagnetization`](../quantities/SpontaneousMagnetization.md) | — | 🟢 [hub](../hubs/IsingSquare_SpontaneousMagnetization_Infinite.md) |
 | [`ThermalEntropy`](../quantities/ThermalEntropy.md) | 🟢 [hub](../hubs/IsingSquare_ThermalEntropy_PBC.md) | 🔵 [hub](../hubs/IsingSquare_ThermalEntropy_Infinite.md) |
 
+## Derivation notes
+
+Matched by filename substring (no annotation; substrate-derived):
+
+- [`ad-thermodynamics-from-z.md`](../../calc/ad-thermodynamics-from-z.md)
+- [`ising-cft-magnetic-perturbation.md`](../../calc/ising-cft-magnetic-perturbation.md)
+- [`ising-cft-primary-operators.md`](../../calc/ising-cft-primary-operators.md)
+- [`ising-scaling-relations.md`](../../calc/ising-scaling-relations.md)
+- [`kramers-wannier-duality.md`](../../calc/kramers-wannier-duality.md)
+- [`transfer-matrix-symmetric-split.md`](../../calc/transfer-matrix-symmetric-split.md)
+
 [← Atlas index](../index.md) · [Model list →](../ModelList.md)

--- a/docs/src/atlas/models/IsingTriangular.md
+++ b/docs/src/atlas/models/IsingTriangular.md
@@ -40,4 +40,13 @@ All `(Quantity, BC)` hubs `src` claims for **`IsingTriangular`**.  Cells link to
 | [`CriticalTemperature`](../quantities/CriticalTemperature.md) | 🟢 [hub](../hubs/IsingTriangular_CriticalTemperature_Infinite.md) |
 | [`ResidualEntropy`](../quantities/ResidualEntropy.md) | 🟢 [hub](../hubs/IsingTriangular_ResidualEntropy_Infinite.md) |
 
+## Derivation notes
+
+Matched by filename substring (no annotation; substrate-derived):
+
+- [`ad-thermodynamics-from-z.md`](../../calc/ad-thermodynamics-from-z.md)
+- [`ising-cft-magnetic-perturbation.md`](../../calc/ising-cft-magnetic-perturbation.md)
+- [`ising-cft-primary-operators.md`](../../calc/ising-cft-primary-operators.md)
+- [`ising-scaling-relations.md`](../../calc/ising-scaling-relations.md)
+
 [← Atlas index](../index.md) · [Model list →](../ModelList.md)

--- a/docs/src/atlas/models/TFIM.md
+++ b/docs/src/atlas/models/TFIM.md
@@ -78,10 +78,20 @@ All `(Quantity, BC)` hubs `src` claims for **`TFIM`**.  Cells link to the per-hu
 
 Matched by filename substring (no annotation; substrate-derived):
 
+- [`ad-thermodynamics-from-z.md`](../../calc/ad-thermodynamics-from-z.md)
+- [`calabrese-cardy-obc-vs-pbc.md`](../../calc/calabrese-cardy-obc-vs-pbc.md)
+- [`e8-mass-spectrum-derivation.md`](../../calc/e8-mass-spectrum-derivation.md)
+- [`ising-cft-magnetic-perturbation.md`](../../calc/ising-cft-magnetic-perturbation.md)
+- [`ising-cft-primary-operators.md`](../../calc/ising-cft-primary-operators.md)
+- [`ising-scaling-relations.md`](../../calc/ising-scaling-relations.md)
 - [`jw-tfim-bdg.md`](../../calc/jw-tfim-bdg.md)
+- [`kramers-wannier-duality.md`](../../calc/kramers-wannier-duality.md)
 - [`tfim-entanglement-peschel.md`](../../calc/tfim-entanglement-peschel.md)
 - [`tfim-gge.md`](../../calc/tfim-gge.md)
 - [`tfim-loschmidt.md`](../../calc/tfim-loschmidt.md)
 - [`tfim-sigma-x-quench.md`](../../calc/tfim-sigma-x-quench.md)
+- [`transfer-matrix-symmetric-split.md`](../../calc/transfer-matrix-symmetric-split.md)
+- [`xx-quench.md`](../../calc/xx-quench.md)
+- [`yang-magnetization-toeplitz.md`](../../calc/yang-magnetization-toeplitz.md)
 
 [← Atlas index](../index.md) · [Model list →](../ModelList.md)

--- a/docs/src/atlas/models/XXZ1D.md
+++ b/docs/src/atlas/models/XXZ1D.md
@@ -65,6 +65,10 @@ All `(Quantity, BC)` hubs `src` claims for **`XXZ1D`**.  Cells link to the per-h
 
 Matched by filename substring (no annotation; substrate-derived):
 
+- [`ad-thermodynamics-from-z.md`](../../calc/ad-thermodynamics-from-z.md)
+- [`calabrese-cardy-obc-vs-pbc.md`](../../calc/calabrese-cardy-obc-vs-pbc.md)
+- [`xx-quench.md`](../../calc/xx-quench.md)
 - [`xxz-luttinger-parameters.md`](../../calc/xxz-luttinger-parameters.md)
+- [`yang-magnetization-toeplitz.md`](../../calc/yang-magnetization-toeplitz.md)
 
 [← Atlas index](../index.md) · [Model list →](../ModelList.md)


### PR DESCRIPTION
Adds _CALC_BIND_OVERRIDES Dict mapping 10 cross-cutting calc notes (general CFT, duality, transfer-matrix, scaling) to curated lists of relevant model names.\n\n_calc_files_for_model now consults the override after the substring match fails. Hub-level matching is unchanged. Audit section 3 orphan calc notes: 10 -> 0.\n\nNo version bump. Guards 2/2 + 189/189.