### PR TITLE
ci(docs): add workflow_dispatch + pages rebuild trigger

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -7,10 +7,12 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 permissions:
   contents: write
   statuses: write
   pull-requests: write
+  pages: write
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -27,6 +29,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: julia --project=docs/ docs/make.jl
+      - name: Trigger GitHub Pages rebuild
+        if: success()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl -s -X POST \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/pages/builds
       - name: Find existing preview comment
         if: github.event_name == 'pull_request'
         id: find-comment


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger so the Documentation workflow can be manually triggered
- Adds `pages: write` permission
- Adds a step to call `POST /pages/builds` after each Documenter deploy to ensure GitHub Pages picks up preview deployments

## Why

GitHub Pages legacy mode only auto-deploys when main-branch CI pushes to gh-pages. PR-branch CI previews get pushed to gh-pages correctly but GitHub Pages doesn't serve them because no deployment is triggered. This workflow change fixes that by explicitly requesting a Pages rebuild after each deploy.

## Immediate use

After merging, run the Documentation workflow manually (`workflow_dispatch`) from GitHub Actions UI to force a Pages rebuild that will make PR#501 preview accessible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)