### PR TITLE
feat(XYh1D): site-local observables (Phase 2, #292)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.22.14"
+version = "0.22.15"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/models/quantum/XYh1D/XYh1D.jl
+++ b/src/models/quantum/XYh1D/XYh1D.jl
@@ -412,3 +412,51 @@ function fetch(m::XYh1D, ::MagnetizationZLocal, bc::OBC; beta::Real, kwargs...)
     Σ = _xyh1d_majorana_thermal_covariance(hmat, beta)
     return Float64[Σ[2i - 1, 2i] for i in 1:N]
 end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Site-local observables (Phase 2, #292)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    fetch(model::XYh1D, ::MagnetizationXLocal{:equilibrium}, bc::OBC; beta) -> Vector{Float64}
+
+Site-resolved ⟨σˣ_i⟩ at equilibrium. By the residual Z₂ symmetry σˣ → −σˣ of
+the XYh1D Hamiltonian at zero longitudinal field, the equilibrium expectation
+vanishes identically: returns the zero vector of length N.
+"""
+function fetch(::XYh1D, ::MagnetizationXLocal{:equilibrium}, bc::OBC; beta::Real, kwargs...)
+    N = _bc_size(bc, kwargs)
+    return zeros(Float64, N)
+end
+
+"""
+    fetch(model::XYh1D, ::MagnetizationYLocal, bc::OBC; beta) -> Vector{Float64}
+
+Site-resolved ⟨σʸ_i⟩. Vanishes by Z₂ symmetry σʸ → −σʸ; returns zeros.
+"""
+function fetch(::XYh1D, ::MagnetizationYLocal, bc::OBC; beta::Real, kwargs...)
+    N = _bc_size(bc, kwargs)
+    return zeros(Float64, N)
+end
+
+"""
+    fetch(model::XYh1D, ::EnergyLocal, bc::OBC; beta) -> Vector{Float64}
+
+Site-resolved energy density ε_i = ⟨H_i⟩ on the OBC chain, where H_i is the
+symmetric bond split. Computed from the Majorana thermal covariance.
+"""
+function fetch(model::XYh1D, ::EnergyLocal, bc::OBC; beta::Real, kwargs...)
+    N = _bc_size(bc, kwargs)
+    hmat = _xyh1d_majorana_ham(N, model.Jx, model.Jy, model.h)
+    Σ = _xyh1d_majorana_thermal_covariance(hmat, beta)
+    bonds = Float64[
+        -model.Jx * Σ[2i, 2i + 1] + model.Jy * Σ[2i - 1, 2i + 2] for i in 1:(N - 1)
+    ]
+    ε = Vector{Float64}(undef, N)
+    @inbounds for i in 1:N
+        left = i > 1 ? bonds[i - 1] : 0.0
+        right = i < N ? bonds[i] : 0.0
+        ε[i] = 0.5 * (left + right) - model.h * Σ[2i - 1, 2i]
+    end
+    return ε
+end

--- a/src/models/quantum/XYh1D/XYh1D_registry.jl
+++ b/src/models/quantum/XYh1D/XYh1D_registry.jl
@@ -105,3 +105,35 @@ register!(
     references=["Lieb-Schultz-Mattis 1961", "Pfeuty 1970"],
     notes="Site-resolved ⟨σᶻ_i⟩ from Majorana thermal covariance on OBC chain.",
 )
+
+# ── Site-local observables (Phase 2, #292) ─────────────────────────────
+register!(
+    XYh1D,
+    MagnetizationXLocal{:equilibrium},
+    OBC;
+    method=:symmetry,
+    reliability=:high,
+    tested_in="test/models/quantum/misc/test_xyh1d.jl",
+    references=["Lieb-Schultz-Mattis 1961"],
+    notes="Vanishes by Z₂ symmetry at zero longitudinal field; returns zeros.",
+)
+register!(
+    XYh1D,
+    MagnetizationYLocal,
+    OBC;
+    method=:symmetry,
+    reliability=:high,
+    tested_in="test/models/quantum/misc/test_xyh1d.jl",
+    references=["Lieb-Schultz-Mattis 1961"],
+    notes="Vanishes by Z₂ symmetry; returns zeros.",
+)
+register!(
+    XYh1D,
+    EnergyLocal,
+    OBC;
+    method=:bdg,
+    reliability=:high,
+    tested_in="test/models/quantum/misc/test_xyh1d.jl",
+    references=["Lieb-Schultz-Mattis 1961"],
+    notes="Site-resolved bond-symmetric energy density from Majorana covariance.",
+)

--- a/test/models/quantum/misc/test_xyh1d.jl
+++ b/test/models/quantum/misc/test_xyh1d.jl
@@ -91,3 +91,19 @@ end
         @test all(isfinite, mz)
     end
 end
+
+@testset "XYh1D — site-local observables (X, Y, EnergyLocal)" begin
+    let m = XYh1D(; Jx=1.0, Jy=0.5, h=0.6), β = 1.0, N = 12
+        mx = QAtlas.fetch(m, MagnetizationXLocal{:equilibrium}(), OBC(N); beta=β)
+        my = QAtlas.fetch(m, MagnetizationYLocal(), OBC(N); beta=β)
+        @test length(mx) == N && all(iszero, mx)
+        @test length(my) == N && all(iszero, my)
+
+        e = QAtlas.fetch(m, EnergyLocal(), OBC(N); beta=β)
+        @test length(e) == N
+        @test all(isfinite, e)
+        # Sum of local energies should equal total Energy{:total}
+        E_total = QAtlas.fetch(m, Energy{:total}(), OBC(N); beta=β)
+        @test isapprox(sum(e), E_total; atol=1e-6)
+    end
+end


### PR DESCRIPTION
## Summary
Adds site-resolved local observables for OBC chains:
`MagnetizationZLocal`, `MagnetizationXLocal`, `MagnetizationYLocal`, `EnergyLocal`.

### Implementation
All derived from Majorana thermal covariance Σ(β).
`EnergyLocal` uses symmetric bond-splitting so `sum(ε)==⟨H⟩` exactly.

Depends on Magnetization PR. Closes part of #292.
