### PR TITLE
feat(XYh1D): PBC site-local observables MagnetizationZLocal, EnergyLocal (#292)

### DIFF
--- a/src/models/quantum/XYh1D/XYh1D.jl
+++ b/src/models/quantum/XYh1D/XYh1D.jl
@@ -704,3 +704,48 @@ for (QTy, qsym) in _XYH1D_PBC_THERMAL_METHODS
         end
     end
 end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Site-local observables at PBC (Phase 2, #292)
+# (Translational invariance → uniform vector = bulk per-site scalar)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    fetch(model::XYh1D, ::MagnetizationZLocal, bc::PBC; beta) -> Vector{Float64}
+
+Site-resolved ⟨σᶻ_i⟩ on the PBC chain. Translational invariance gives a
+uniform vector of length N filled with the bulk MagnetizationZ value.
+"""
+function fetch(model::XYh1D, ::MagnetizationZLocal, bc::PBC; beta::Real, kwargs...)
+    N = _bc_size(bc, kwargs)
+    return _xyh1d_pbc_local_mz(N, model.Jx, model.Jy, model.h, beta)
+end
+
+"""
+    fetch(model::XYh1D, ::MagnetizationXLocal{:equilibrium}, bc::PBC; beta) -> Vector{Float64}
+
+Vanishes by Z₂ symmetry σˣ → −σˣ; returns zeros of length N.
+"""
+function fetch(::XYh1D, ::MagnetizationXLocal{:equilibrium}, bc::PBC; beta::Real, kwargs...)
+    return zeros(Float64, _bc_size(bc, kwargs))
+end
+
+"""
+    fetch(model::XYh1D, ::MagnetizationYLocal, bc::PBC; beta) -> Vector{Float64}
+
+Vanishes by Z₂ symmetry σʸ → −σʸ; returns zeros of length N.
+"""
+function fetch(::XYh1D, ::MagnetizationYLocal, bc::PBC; beta::Real, kwargs...)
+    return zeros(Float64, _bc_size(bc, kwargs))
+end
+
+"""
+    fetch(model::XYh1D, ::EnergyLocal, bc::PBC; beta) -> Vector{Float64}
+
+Site-resolved energy density on the PBC chain. Translational invariance
+gives a uniform vector ε_i = E_total / N.
+"""
+function fetch(model::XYh1D, ::EnergyLocal, bc::PBC; beta::Real, kwargs...)
+    N = _bc_size(bc, kwargs)
+    return _xyh1d_pbc_local_energy(N, model.Jx, model.Jy, model.h, beta)
+end

--- a/src/models/quantum/XYh1D/XYh1D_registry.jl
+++ b/src/models/quantum/XYh1D/XYh1D_registry.jl
@@ -189,3 +189,45 @@ for QTy in (FreeEnergy, ThermalEntropy, SpecificHeat, MagnetizationZ, Susceptibi
         notes="Per-site PBC quantity via two-sector free-fermion partition (AP + P).",
     )
 end
+
+# ── Site-local observables at PBC (Phase 2, #292) ──────────────────────
+register!(
+    XYh1D,
+    MagnetizationZLocal,
+    PBC;
+    method=:translational_invariance,
+    reliability=:high,
+    tested_in="test/models/quantum/misc/test_xyh1d_pbc.jl",
+    references=["Lieb-Schultz-Mattis 1961"],
+    notes="Uniform site-resolved ⟨σᶻ_i⟩ from bulk MagnetizationZ.",
+)
+register!(
+    XYh1D,
+    MagnetizationXLocal{:equilibrium},
+    PBC;
+    method=:symmetry,
+    reliability=:high,
+    tested_in="test/models/quantum/misc/test_xyh1d_pbc.jl",
+    references=["Lieb-Schultz-Mattis 1961"],
+    notes="Vanishes by Z₂ symmetry; returns zeros.",
+)
+register!(
+    XYh1D,
+    MagnetizationYLocal,
+    PBC;
+    method=:symmetry,
+    reliability=:high,
+    tested_in="test/models/quantum/misc/test_xyh1d_pbc.jl",
+    references=["Lieb-Schultz-Mattis 1961"],
+    notes="Vanishes by Z₂ symmetry; returns zeros.",
+)
+register!(
+    XYh1D,
+    EnergyLocal,
+    PBC;
+    method=:translational_invariance,
+    reliability=:high,
+    tested_in="test/models/quantum/misc/test_xyh1d_pbc.jl",
+    references=["Lieb-Schultz-Mattis 1961"],
+    notes="Uniform site-resolved ε_i = E_total / N.",
+)

--- a/test/models/quantum/misc/test_xyh1d_pbc.jl
+++ b/test/models/quantum/misc/test_xyh1d_pbc.jl
@@ -110,3 +110,33 @@ end
         @test χ > -1e-6
     end
 end
+
+@testset "XYh1D PBC — Site-local observables uniformity" begin
+    let m = XYh1D(; Jx=1.0, Jy=0.5, h=0.6), β = 1.0, N = 100
+        mz_local = QAtlas.fetch(m, MagnetizationZLocal(), PBC(N=N); beta=β)
+        @test length(mz_local) == N
+        @test all(isfinite, mz_local)
+        # Translational invariance: all sites equal to first
+        @test all(isapprox.(mz_local, mz_local[1]; atol=1e-12))
+        # Matches bulk MagnetizationZ
+        mz_bulk = QAtlas.fetch(m, MagnetizationZ(), PBC(N=N); beta=β)
+        @test isapprox(mz_local[1], mz_bulk; atol=1e-12)
+    end
+
+    let m = XYh1D(; Jx=1.0, Jy=0.5, h=0.6), β = 1.0, N = 50
+        mx = QAtlas.fetch(m, MagnetizationXLocal{:equilibrium}(), PBC(N=N); beta=β)
+        my = QAtlas.fetch(m, MagnetizationYLocal(), PBC(N=N); beta=β)
+        @test length(mx) == N && all(iszero, mx)
+        @test length(my) == N && all(iszero, my)
+    end
+
+    let m = XYh1D(; Jx=1.0, Jy=0.5, h=0.6), β = 1.0, N = 100
+        ε = QAtlas.fetch(m, EnergyLocal(), PBC(N=N); beta=β)
+        @test length(ε) == N
+        @test all(isfinite, ε)
+        @test all(isapprox.(ε, ε[1]; atol=1e-12))
+        # Sum reproduces Energy{:total}
+        E_total = QAtlas.fetch(m, Energy{:total}(), PBC(N=N); beta=β)
+        @test isapprox(sum(ε), E_total; atol=1e-6)
+    end
+end


### PR DESCRIPTION
## Summary
Adds site-resolved local observables for PBC XYh1D:
`MagnetizationZLocal`, `MagnetizationXLocal`, `MagnetizationYLocal`, `EnergyLocal`.

### Implementation
By **translational invariance** of PBC, all sites are equivalent:
- `MagnetizationZLocal[i]` = bulk ⟨σᶻ⟩/site  (uniform vector)
- `EnergyLocal[i]`         = E_total / N       (uniform vector, sums to ⟨H⟩ exactly)
- `MagnetizationXLocal`, `MagnetizationYLocal` = 0 by Z₂ symmetry.

Closes part of #292.
