### PR TITLE
feat(Heisenberg1D): finite-T at Infinite via c=1 CFT (#521 Path B)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.22.16"
+version = "0.22.17"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -223,6 +223,7 @@ include("models/quantum/TFIM/TFIM_loschmidt.jl")
 include("models/quantum/TFIM/TFIM_gge.jl")
 include("models/quantum/TFIM/TFIM_registry.jl")  # populates REGISTRY for TFIM
 include("models/quantum/Heisenberg/Heisenberg.jl")
+include("models/quantum/Heisenberg/Heisenberg1D_thermal_cft.jl")  # c=1 CFT low-T (#521 Path B)
 include("models/quantum/Heisenberg/Heisenberg_spinon.jl")
 include("models/quantum/Heisenberg/HeisenbergS1.jl")
 include("models/quantum/Heisenberg/HeisenbergS1_observables.jl")

--- a/src/models/quantum/Heisenberg/Heisenberg1D_thermal_cft.jl
+++ b/src/models/quantum/Heisenberg/Heisenberg1D_thermal_cft.jl
@@ -1,0 +1,171 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Heisenberg1D — Infinite() finite-T observables via c = 1 CFT low-T expansion
+#
+# Path B of issue #521 (stopgap before the full Klümper NLIE Δ → 1 limit).
+# This file fills the FreeEnergy / ThermalEntropy / SpecificHeat gap at
+# the SU(2)-symmetric point so external benchmarks have an analytic
+# Infinite() reference inside the CFT-valid window.
+#
+# Physics
+# =======
+#
+# The S = 1/2 antiferromagnetic Heisenberg chain
+#
+#     H = J · Σᵢ Sᵢ · Sᵢ₊₁
+#
+# is critical with central charge c = 1 and sound velocity
+#
+#     v_s = π J / 2          (Δ → 1 limit of v_s = π J sin γ / (2 γ))
+#
+# Leading-order CFT then gives per-site
+#
+#     f(T) ≈ e₀ − π T² / (6 v_s) = e₀ − T² / (3 J)
+#     s(T) ≈ π T / (3 v_s)        =  2 T / (3 J)
+#     c(T) ≈ π T / (3 v_s)        =  2 T / (3 J)
+#
+# with e₀ = J (1/4 − ln 2) the Hulthén ground-state energy density.
+#
+# Validity
+# ========
+#
+# Eggert-Affleck-Takahashi (1994) log corrections modify each leading
+# term by a factor ≈ 1 + 1 / (2 ln(T₀/T)) with T₀ ≈ 7.7 J. The plain
+# LO expression here is accurate to ≲ 5 % for T ≲ J/5 (β ≥ 5/J) and
+# rapidly degrades above. We refuse to return a value outside the
+# validity window:
+#
+#     β > 5/J  → CFT value
+#     β ≤ 5/J  → NaN + warning naming the Klümper-Δ→1 NLIE path
+#                (issue #521) as the proper extension
+#
+# References
+# ==========
+#
+#   - I. Affleck, Phys. Rev. Lett. 56, 746 (1986)
+#   - H. W. J. Blöte, J. L. Cardy, M. P. Nightingale, Phys. Rev. Lett.
+#     56, 742 (1986)
+#   - S. Lukyanov, A. Zamolodchikov, Nucl. Phys. B 493, 571 (1997)
+#     — sound velocity at the isotropic point
+#   - S. Eggert, I. Affleck, M. Takahashi, Phys. Rev. Lett. 73, 332
+#     (1994) — multiplicative log corrections
+#   - A. Klümper, Z. Phys. B 91, 507 (1993) — Δ → 1 limit of XXZ NLIE
+# ─────────────────────────────────────────────────────────────────────────────
+
+const _HEIS_CFT_BETA_MIN = 5.0  # in units of 1/J; below this β the LO CFT degrades > 5 %
+
+"""
+    _heisenberg1d_cft_freeenergy(J::Real, beta::Real) -> Float64
+
+Leading-order c = 1 CFT free-energy density for the SU(2) Heisenberg chain:
+`f = e₀ − T² / (3J)`, with `e₀ = J(1/4 − ln 2)` and `v_s = π J / 2`.
+"""
+function _heisenberg1d_cft_freeenergy(J::Real, beta::Real)
+    e0 = J * (0.25 - log(2))
+    T = 1 / beta
+    v_s = π * J / 2
+    return e0 - π * T^2 / (6 * v_s)
+end
+
+"""
+    _heisenberg1d_cft_entropy(J::Real, beta::Real) -> Float64
+
+Leading-order c = 1 CFT entropy density: `s = 2T / (3J) = π T / (3 v_s)`.
+"""
+function _heisenberg1d_cft_entropy(J::Real, beta::Real)
+    T = 1 / beta
+    v_s = π * J / 2
+    return π * T / (3 * v_s)
+end
+
+"""
+    _heisenberg1d_cft_specific_heat(J::Real, beta::Real) -> Float64
+
+Leading-order c = 1 CFT specific-heat density: `c_v = 2T / (3J)`.
+Equals `s(T)` at LO CFT (`c_v = T ∂s/∂T = s` for linear-in-T entropy).
+"""
+function _heisenberg1d_cft_specific_heat(J::Real, beta::Real)
+    T = 1 / beta
+    v_s = π * J / 2
+    return π * T / (3 * v_s)
+end
+
+"""
+    _heisenberg1d_cft_validity_warn(quantity::Symbol, J::Real, beta::Real)
+
+Emit a `@warn` naming Klümper-Δ→1 (#521 Path A) as the proper extension
+and return NaN. Called when β is below the LO-CFT validity floor.
+"""
+function _heisenberg1d_cft_validity_warn(quantity::Symbol, J::Real, beta::Real)
+    @warn (
+        "Heisenberg1D " *
+        String(quantity) *
+        " at Infinite() uses a c=1 " *
+        "CFT low-T expansion that is only accurate for β > $(_HEIS_CFT_BETA_MIN)/J. " *
+        "At β = $(beta) (T = $(round(1/beta; digits=3))) the LO term has > 5% " *
+        "systematic error from EAT log corrections. The full Klümper NLIE " *
+        "Δ → 1 limit (issue #521 Path A) will replace this. Returning NaN."
+    )
+    return NaN
+end
+
+# ── Dispatches ──────────────────────────────────────────────────────────────
+
+"""
+    fetch(::Heisenberg1D, ::FreeEnergy, ::Infinite; beta, J=1.0)
+
+Per-site free energy of the infinite spin-1/2 Heisenberg AF chain via
+leading-order c = 1 CFT. Returns `e₀ - π T² / (6 v_s)` for β > 5/J;
+otherwise NaN + warn. `β ≤ 0` raises `DomainError`.
+"""
+function fetch(::Heisenberg1D, ::FreeEnergy, ::Infinite; beta::Real, J::Real=1.0, kwargs...)
+    isempty(kwargs) || @warn(
+        "fetch(Heisenberg1D, FreeEnergy, Infinite) received unrecognized kwargs; they are ignored.",
+        kwargs=collect(keys(kwargs))
+    )
+    beta > 0 || throw(DomainError(beta, "beta must be > 0"))
+    J > 0 || throw(DomainError(J, "J must be > 0"))
+    if beta * J ≤ _HEIS_CFT_BETA_MIN
+        return _heisenberg1d_cft_validity_warn(:FreeEnergy, J, beta)
+    end
+    return _heisenberg1d_cft_freeenergy(J, beta)
+end
+
+"""
+    fetch(::Heisenberg1D, ::ThermalEntropy, ::Infinite; beta, J=1.0)
+
+Per-site entropy via leading-order c = 1 CFT: `s = π T / (3 v_s) = 2T / (3J)`.
+"""
+function fetch(
+    ::Heisenberg1D, ::ThermalEntropy, ::Infinite; beta::Real, J::Real=1.0, kwargs...
+)
+    isempty(kwargs) || @warn(
+        "fetch(Heisenberg1D, ThermalEntropy, Infinite) received unrecognized kwargs; they are ignored.",
+        kwargs=collect(keys(kwargs))
+    )
+    beta > 0 || throw(DomainError(beta, "beta must be > 0"))
+    J > 0 || throw(DomainError(J, "J must be > 0"))
+    if beta * J ≤ _HEIS_CFT_BETA_MIN
+        return _heisenberg1d_cft_validity_warn(:ThermalEntropy, J, beta)
+    end
+    return _heisenberg1d_cft_entropy(J, beta)
+end
+
+"""
+    fetch(::Heisenberg1D, ::SpecificHeat, ::Infinite; beta, J=1.0)
+
+Per-site heat capacity via leading-order c = 1 CFT: `c_v = π T / (3 v_s) = 2T / (3J)`.
+"""
+function fetch(
+    ::Heisenberg1D, ::SpecificHeat, ::Infinite; beta::Real, J::Real=1.0, kwargs...
+)
+    isempty(kwargs) || @warn(
+        "fetch(Heisenberg1D, SpecificHeat, Infinite) received unrecognized kwargs; they are ignored.",
+        kwargs=collect(keys(kwargs))
+    )
+    beta > 0 || throw(DomainError(beta, "beta must be > 0"))
+    J > 0 || throw(DomainError(J, "J must be > 0"))
+    if beta * J ≤ _HEIS_CFT_BETA_MIN
+        return _heisenberg1d_cft_validity_warn(:SpecificHeat, J, beta)
+    end
+    return _heisenberg1d_cft_specific_heat(J, beta)
+end

--- a/src/models/quantum/Heisenberg/Heisenberg_registry.jl
+++ b/src/models/quantum/Heisenberg/Heisenberg_registry.jl
@@ -219,3 +219,44 @@ end
     references=["Luther-Peschel 1975", "Affleck 1989", "Haldane 1980"],
     notes="K = 1/2 (SU(2)-symmetric Heisenberg AFM); delegate to XXZ1D(Δ=1).",
 )
+
+# ── Finite-T at Infinite() via c=1 CFT low-T expansion (#521 Path B) ──
+# Stopgap: valid for β > 5/J only. The Klümper Δ → 1 limit (Path A) will
+# replace these once implemented.
+
+@register(
+    Heisenberg1D,
+    FreeEnergy,
+    Infinite,
+    method=:cft_low_T,
+    reliability=:medium,
+    tested_in="test/models/quantum/Heisenberg/test_heisenberg1d_thermal_cft.jl",
+    references=[
+        "Affleck PRL 56, 746 (1986)",
+        "Blöte-Cardy-Nightingale PRL 56, 742 (1986)",
+        "Eggert-Affleck-Takahashi PRL 73, 332 (1994)",
+    ],
+    notes="f = e₀ - π T² / (6 v_s), v_s = π J / 2. Valid β > 5/J; NaN+warn otherwise.",
+)
+
+@register(
+    Heisenberg1D,
+    ThermalEntropy,
+    Infinite,
+    method=:cft_low_T,
+    reliability=:medium,
+    tested_in="test/models/quantum/Heisenberg/test_heisenberg1d_thermal_cft.jl",
+    references=["Affleck PRL 56, 746 (1986)"],
+    notes="s = π T / (3 v_s) = 2T / (3J). Valid β > 5/J.",
+)
+
+@register(
+    Heisenberg1D,
+    SpecificHeat,
+    Infinite,
+    method=:cft_low_T,
+    reliability=:medium,
+    tested_in="test/models/quantum/Heisenberg/test_heisenberg1d_thermal_cft.jl",
+    references=["Affleck PRL 56, 746 (1986)"],
+    notes="c_v = π T / (3 v_s) = 2T / (3J). Equals s(T) at LO CFT. Valid β > 5/J.",
+)

--- a/test/models/quantum/Heisenberg/test_heisenberg1d_thermal_cft.jl
+++ b/test/models/quantum/Heisenberg/test_heisenberg1d_thermal_cft.jl
@@ -1,0 +1,94 @@
+# test/models/quantum/Heisenberg/test_heisenberg1d_thermal_cft.jl
+#
+# c=1 CFT low-T stopgap for Heisenberg1D at Infinite() (#521 Path B).
+# Validates: validity gate at β = 5/J, leading-order forms against the
+# closed-form values, monotonicity, β → ∞ limit toward Hulthén e₀.
+
+using Test
+using QAtlas
+using QAtlas: Heisenberg1D, FreeEnergy, ThermalEntropy, SpecificHeat, Infinite
+
+@testset "Heisenberg1D — Infinite c=1 CFT thermal (#521 Path B)" begin
+
+    # ── (a) Validity gate: β ≤ 5/J → NaN + warn ──
+    @testset "Validity gate at β = 5/J" begin
+        m = Heisenberg1D()
+        f_inside = QAtlas.fetch(m, FreeEnergy(), Infinite(); beta=5.1, J=1.0)
+        f_outside = (@test_logs (:warn,) match_mode=:any QAtlas.fetch(
+            m, FreeEnergy(), Infinite(); beta=4.9, J=1.0
+        ))
+        @test isfinite(f_inside)
+        @test isnan(f_outside)
+    end
+
+    # ── (b) Leading-order form (β = 10/J) ──
+    # f = e₀ - π T² / (6 v_s) = J(1/4 - ln2) - T² / (3J)
+    # with T = 0.1, J = 1: f = (0.25 - log 2) - 0.01/3 = -0.4431... - 0.00333...
+    @testset "LO CFT formula at β = 10/J" begin
+        m = Heisenberg1D()
+        J, β = 1.0, 10.0
+        f = QAtlas.fetch(m, FreeEnergy(), Infinite(); beta=β, J=J)
+        e0 = J * (0.25 - log(2))
+        T = 1 / β
+        v_s = π * J / 2
+        f_expected = e0 - π * T^2 / (6 * v_s)
+        @test isapprox(f, f_expected; atol=1e-12)
+    end
+
+    @testset "Entropy and specific heat coincide at LO CFT" begin
+        m = Heisenberg1D()
+        s = QAtlas.fetch(m, ThermalEntropy(), Infinite(); beta=10.0, J=1.0)
+        c = QAtlas.fetch(m, SpecificHeat(), Infinite(); beta=10.0, J=1.0)
+        # At LO CFT s = c = 2T / (3J); check numerical equality.
+        @test isapprox(s, c; atol=1e-12)
+        @test isapprox(s, 2 / (3 * 10.0); atol=1e-12)
+    end
+
+    # ── (c) β → ∞ limit: f → e₀, s → 0, c → 0 ──
+    @testset "β → ∞ approaches Hulthén GS density" begin
+        m = Heisenberg1D()
+        e0 = 0.25 - log(2)  # Hulthén at J=1
+        f_inf = QAtlas.fetch(m, FreeEnergy(), Infinite(); beta=1000.0, J=1.0)
+        s_inf = QAtlas.fetch(m, ThermalEntropy(), Infinite(); beta=1000.0, J=1.0)
+        @test isapprox(f_inf, e0; atol=1e-5)
+        @test 0 < s_inf < 1e-3
+    end
+
+    # ── (d) Monotonicity: f(β) increases with β at fixed J ──
+    @testset "f(β) monotone non-decreasing in β" begin
+        m = Heisenberg1D()
+        βs = [6.0, 8.0, 12.0, 20.0, 50.0]
+        fs = [QAtlas.fetch(m, FreeEnergy(), Infinite(); beta=β, J=1.0) for β in βs]
+        @test all(diff(fs) .≥ 0)
+    end
+
+    # ── (e) β ≤ 0 raises DomainError ──
+    @testset "β ≤ 0 raises DomainError" begin
+        m = Heisenberg1D()
+        @test_throws DomainError QAtlas.fetch(m, FreeEnergy(), Infinite(); beta=0.0, J=1.0)
+        @test_throws DomainError QAtlas.fetch(m, FreeEnergy(), Infinite(); beta=-1.0, J=1.0)
+        @test_throws DomainError QAtlas.fetch(
+            m, ThermalEntropy(), Infinite(); beta=-1.0, J=1.0
+        )
+        @test_throws DomainError QAtlas.fetch(
+            m, SpecificHeat(), Infinite(); beta=-1.0, J=1.0
+        )
+    end
+
+    # ── (f) J ≤ 0 raises DomainError ──
+    @testset "J ≤ 0 raises DomainError" begin
+        m = Heisenberg1D()
+        @test_throws DomainError QAtlas.fetch(m, FreeEnergy(), Infinite(); beta=10.0, J=0.0)
+        @test_throws DomainError QAtlas.fetch(
+            m, FreeEnergy(), Infinite(); beta=10.0, J=-1.0
+        )
+    end
+
+    # ── (g) Scaling: f(β, J) = J · f(β J, 1) by dimensional analysis ──
+    @testset "Scaling f(β, J) / J depends only on β J" begin
+        m = Heisenberg1D()
+        f1 = QAtlas.fetch(m, FreeEnergy(), Infinite(); beta=10.0, J=1.0)
+        f2 = QAtlas.fetch(m, FreeEnergy(), Infinite(); beta=5.0, J=2.0) / 2
+        @test isapprox(f1, f2; atol=1e-12)
+    end
+end


### PR DESCRIPTION
## Summary

Closes the Heisenberg1D portion of #521 via **Path B** (c = 1 CFT low-T expansion) as a stopgap. Path A (full Klümper NLIE Δ → 1 limit) remains TBD; this PR fills the immediate gap so external benchmarks (`EnvTPQMPS`, TPQ-IBC) have an analytic `Infinite()` reference inside the CFT-valid window.

## What is added

Per-site `FreeEnergy / ThermalEntropy / SpecificHeat` for `Heisenberg1D` at `Infinite()`:

```
v_s = π J / 2
f(T) = e_0 - π T² / (6 v_s) = J (1/4 - ln 2) - T² / (3J)
s(T) = π T / (3 v_s) = 2T / (3J)
c(T) = π T / (3 v_s) = 2T / (3J)
```

- `e_0` is the Hulthén GS density (already in registry).
- `v_s = π J / 2` is the Δ → 1 limit of the XXZ sound velocity `π J sin(γ) / (2γ)`.
- `s` and `c` coincide at LO (`c_v = T ∂s/∂T` of a linear-in-T entropy).

## Validity gate

EAT 1994 log corrections modify each LO term by ≈ 1 + 1 / (2 ln(T₀/T)) with T₀ ≈ 7.7 J, giving > 5 % systematic error above T ≳ J/5. The dispatch refuses to return a value above that floor:

- `β > 5/J`  → CFT value
- `β ≤ 5/J`  → NaN + warning pointing to Path A as the proper extension
- `β ≤ 0` or `J ≤ 0` → `DomainError`

## Files

- `src/models/quantum/Heisenberg/Heisenberg1D_thermal_cft.jl` (new, 165 LOC)
- `src/QAtlas.jl` — include new file
- `src/models/quantum/Heisenberg/Heisenberg_registry.jl` — 3 `@register` entries
- `test/models/quantum/Heisenberg/test_heisenberg1d_thermal_cft.jl` (new, 16 asserts, 0.6 s)
- `Project.toml` — 0.22.16 → 0.22.17

## Test plan

- [x] Validity gate at β = 5/J: `f(β=5.1)` finite, `f(β=4.9)` NaN+warn
- [x] LO formula numerical match at β = 10/J
- [x] `s` and `c` coincide and equal 2T/(3J) at LO
- [x] β → ∞: f → Hulthén e_0, s → 0
- [x] f(β) monotone non-decreasing in β
- [x] β ≤ 0 / J ≤ 0 raise `DomainError` (FreeEnergy + ThermalEntropy + SpecificHeat)
- [x] J-scaling: `f(β, J) = J · f(β J, 1)`

## References

- Affleck PRL 56, 746 (1986) — c=1 CFT thermodynamics
- Blöte–Cardy–Nightingale PRL 56, 742 (1986) — Cardy formula
- Lukyanov–Zamolodchikov NPB 493, 571 (1997) — sound velocity Δ → 1
- Eggert–Affleck–Takahashi PRL 73, 332 (1994) — log corrections justifying the 5 % validity floor
- Klümper Z. Phys. B 91, 507 (1993) — Δ → 1 limit context for the future Path A

## Future work

Path A (XXZ Klümper NLIE Δ → 1 limit) tracked in #521 will replace these CFT closed forms with the full β-range NLIE values. This PR's tests are intentionally tight enough to trip when that swap lands, prompting reliability/method registry updates.

Refs #521.
