### PR TITLE
feat(HaldaneShastry): finite-T at Infinite via c=1 CFT (#524 stopgap)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.22.18"
+version = "0.22.19"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -250,6 +250,7 @@ include("models/quantum/Hubbard1D/Hubbard1D_registry.jl")  # populates REGISTRY 
 include("models/quantum/MajumdarGhosh/MajumdarGhosh.jl")
 include("models/quantum/MajumdarGhosh/MajumdarGhosh_registry.jl")
 include("models/quantum/HaldaneShastry/HaldaneShastry.jl")
+include("models/quantum/HaldaneShastry/HaldaneShastry_thermal_cft.jl")  # c=1 CFT low-T (#524 stopgap)
 include("models/quantum/HaldaneShastry/HaldaneShastry_registry.jl")  # populates REGISTRY for HaldaneShastry
 include("models/quantum/ShastrySutherland/ShastrySutherland.jl")
 include("models/quantum/ShastrySutherland/ShastrySutherland_registry.jl")  # populates REGISTRY for ShastrySutherland (#259)

--- a/src/models/quantum/HaldaneShastry/HaldaneShastry_registry.jl
+++ b/src/models/quantum/HaldaneShastry/HaldaneShastry_registry.jl
@@ -15,3 +15,41 @@
     references=["Haldane PRL 60, 635 (1988)", "Shastry PRL 60, 639 (1988)"],
     notes="E_0/N = -π² J / 24, finite-N exact (Gutzwiller-projected free-fermion eigenstate of the chord-distance Hamiltonian).",
 )
+
+# ── Finite-T at Infinite() via c=1 CFT low-T (#524 stopgap) ────────────
+# Mirrors the Heisenberg1D Path B (#521 / PR #526): same v_s = π J / 2,
+# different e_0. Valid β > 5/J. The full Haldane semion gas will replace
+# these once #524 is closed.
+
+@register(
+    HaldaneShastry,
+    FreeEnergy,
+    Infinite,
+    method=:cft_low_T,
+    reliability=:medium,
+    tested_in="test/models/quantum/HaldaneShastry/test_haldane_shastry_thermal_cft.jl",
+    references=["Haldane PRL 60, 635 (1988)", "Affleck PRL 56, 746 (1986)"],
+    notes="f = -π² J / 24 - π T² / (6 v_s), v_s = π J / 2. Valid β > 5/J.",
+)
+
+@register(
+    HaldaneShastry,
+    ThermalEntropy,
+    Infinite,
+    method=:cft_low_T,
+    reliability=:medium,
+    tested_in="test/models/quantum/HaldaneShastry/test_haldane_shastry_thermal_cft.jl",
+    references=["Haldane PRL 60, 635 (1988)", "Affleck PRL 56, 746 (1986)"],
+    notes="s = π T / (3 v_s) = 2T / (3J). Valid β > 5/J.",
+)
+
+@register(
+    HaldaneShastry,
+    SpecificHeat,
+    Infinite,
+    method=:cft_low_T,
+    reliability=:medium,
+    tested_in="test/models/quantum/HaldaneShastry/test_haldane_shastry_thermal_cft.jl",
+    references=["Haldane PRL 60, 635 (1988)", "Affleck PRL 56, 746 (1986)"],
+    notes="c_v = π T / (3 v_s) = 2T / (3J). Equals s at LO CFT. Valid β > 5/J.",
+)

--- a/src/models/quantum/HaldaneShastry/HaldaneShastry_thermal_cft.jl
+++ b/src/models/quantum/HaldaneShastry/HaldaneShastry_thermal_cft.jl
@@ -1,0 +1,146 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Haldane-Shastry — Infinite() finite-T observables via c = 1 CFT
+#
+# Stopgap path for issue #524 (semion gas finite-T). The Haldane-Shastry
+# chain flows to the same c = 1 SU(2)_1 WZW CFT as the SU(2)-symmetric
+# Heisenberg chain, with sound velocity v_s = π J / 2. The leading-order
+# CFT thermodynamics are therefore identical to the Heisenberg case
+# (issue #521 Path B, PR #526) modulo the ground-state energy density:
+#
+#     v_s = π J / 2
+#     f(T) = e_0 - π T² / (6 v_s) = -π² J / 24 - T² / (3 J)
+#     s(T) = π T / (3 v_s) = 2 T / (3 J)
+#     c(T) = π T / (3 v_s) = 2 T / (3 J)
+#
+# Validity window (matches PR #526)
+# =================================
+#
+# The Eggert-Affleck-Takahashi log corrections that apply to Heisenberg
+# do *not* apply identically to HS — HS has no marginally irrelevant
+# operator (it sits exactly on the SU(2)_1 fixed point), so the
+# leading-order CFT is accurate to higher T than for Heisenberg.
+# Nevertheless we keep the same conservative β > 5/J floor here
+# until the full semion gas (Haldane 1991, BHR 2008) replaces this
+# under #524, at which point the validity will be β > 0.
+#
+# References
+# ==========
+#
+#   - F. D. M. Haldane, Phys. Rev. Lett. 60, 635 (1988) — model + e_0
+#   - F. D. M. Haldane, Phys. Rev. Lett. 66, 1529 (1991) — Yangian,
+#     spinon dispersion confirming v_s = π J / 2
+#   - I. Affleck, Phys. Rev. Lett. 56, 746 (1986) — c=1 CFT form
+#   - B. A. Bernevig, F. D. M. Haldane, N. Regnault, J. Phys. A 41,
+#     304005 (2008) — semion gas thermodynamics (issue #524)
+# ─────────────────────────────────────────────────────────────────────────────
+
+const _HS_CFT_BETA_MIN = 5.0  # in units of 1/J; mirrors Heisenberg1D LO-CFT floor
+
+"""
+    _haldane_shastry_cft_freeenergy(J::Real, beta::Real) -> Float64
+
+Leading-order c = 1 CFT free-energy density for HS:
+`f = -π² J / 24 - T² / (3 J)`, with v_s = π J / 2.
+"""
+function _haldane_shastry_cft_freeenergy(J::Real, beta::Real)
+    e0 = -π^2 * J / 24
+    T = 1 / beta
+    v_s = π * J / 2
+    return e0 - π * T^2 / (6 * v_s)
+end
+
+"""
+    _haldane_shastry_cft_entropy(J::Real, beta::Real) -> Float64
+
+Leading-order c = 1 CFT entropy density: `s = 2 T / (3 J)`.
+"""
+function _haldane_shastry_cft_entropy(J::Real, beta::Real)
+    T = 1 / beta
+    v_s = π * J / 2
+    return π * T / (3 * v_s)
+end
+
+"""
+    _haldane_shastry_cft_specific_heat(J::Real, beta::Real) -> Float64
+
+Leading-order c = 1 CFT specific heat: `c_v = 2 T / (3 J)`. Coincides
+with the entropy at LO CFT.
+"""
+function _haldane_shastry_cft_specific_heat(J::Real, beta::Real)
+    T = 1 / beta
+    v_s = π * J / 2
+    return π * T / (3 * v_s)
+end
+
+"""
+    _haldane_shastry_cft_validity_warn(quantity::Symbol, J::Real, beta::Real)
+
+NaN-return + warning above the LO CFT validity floor.
+"""
+function _haldane_shastry_cft_validity_warn(quantity::Symbol, J::Real, beta::Real)
+    @warn (
+        "HaldaneShastry " *
+        String(quantity) *
+        " at Infinite() uses a c=1 " *
+        "CFT low-T expansion that is only validated for β > $(_HS_CFT_BETA_MIN)/J. " *
+        "At β = $(beta) (T = $(round(1/beta; digits=3))) the LO term may carry > 5% " *
+        "systematic error. The full Haldane semion gas (issue #524) will replace " *
+        "this stopgap with the full β > 0 result. Returning NaN."
+    )
+    return NaN
+end
+
+# ── Dispatches ──────────────────────────────────────────────────────────────
+
+"""
+    fetch(::HaldaneShastry, ::FreeEnergy, ::Infinite; beta, kwargs...)
+
+Per-site free energy of the infinite HS chain via leading-order c = 1
+CFT: `f = -π² J / 24 - T² / (3 J)`. Valid β > 5/J; NaN+warn outside.
+"""
+function fetch(m::HaldaneShastry, ::FreeEnergy, ::Infinite; beta::Real, kwargs...)
+    isempty(kwargs) || @warn(
+        "fetch(HaldaneShastry, FreeEnergy, Infinite) received unrecognized kwargs; they are ignored.",
+        kwargs=collect(keys(kwargs))
+    )
+    beta > 0 || throw(DomainError(beta, "beta must be > 0"))
+    if beta * m.J ≤ _HS_CFT_BETA_MIN
+        return _haldane_shastry_cft_validity_warn(:FreeEnergy, m.J, beta)
+    end
+    return _haldane_shastry_cft_freeenergy(m.J, beta)
+end
+
+"""
+    fetch(::HaldaneShastry, ::ThermalEntropy, ::Infinite; beta, kwargs...)
+
+Per-site entropy via leading-order c = 1 CFT: `s = 2 T / (3 J)`.
+"""
+function fetch(m::HaldaneShastry, ::ThermalEntropy, ::Infinite; beta::Real, kwargs...)
+    isempty(kwargs) || @warn(
+        "fetch(HaldaneShastry, ThermalEntropy, Infinite) received unrecognized kwargs; they are ignored.",
+        kwargs=collect(keys(kwargs))
+    )
+    beta > 0 || throw(DomainError(beta, "beta must be > 0"))
+    if beta * m.J ≤ _HS_CFT_BETA_MIN
+        return _haldane_shastry_cft_validity_warn(:ThermalEntropy, m.J, beta)
+    end
+    return _haldane_shastry_cft_entropy(m.J, beta)
+end
+
+"""
+    fetch(::HaldaneShastry, ::SpecificHeat, ::Infinite; beta, kwargs...)
+
+Per-site specific heat via leading-order c = 1 CFT: `c_v = 2 T / (3 J)`.
+Coincides with the entropy at LO.
+"""
+function fetch(m::HaldaneShastry, ::SpecificHeat, ::Infinite; beta::Real, kwargs...)
+    isempty(kwargs) || @warn(
+        "fetch(HaldaneShastry, SpecificHeat, Infinite) received unrecognized kwargs; they are ignored.",
+        kwargs=collect(keys(kwargs))
+    )
+    beta > 0 || throw(DomainError(beta, "beta must be > 0"))
+    if beta * m.J ≤ _HS_CFT_BETA_MIN
+        return _haldane_shastry_cft_validity_warn(:SpecificHeat, m.J, beta)
+    end
+    return _haldane_shastry_cft_specific_heat(m.J, beta)
+end

--- a/test/models/quantum/HaldaneShastry/test_haldane_shastry_thermal_cft.jl
+++ b/test/models/quantum/HaldaneShastry/test_haldane_shastry_thermal_cft.jl
@@ -1,0 +1,77 @@
+# test/models/quantum/HaldaneShastry/test_haldane_shastry_thermal_cft.jl
+#
+# c=1 CFT low-T stopgap for HaldaneShastry at Infinite() (#524).
+# Mirrors test_heisenberg1d_thermal_cft.jl (PR #526) — same v_s, same
+# validity gate, different e_0.
+
+using Test
+using QAtlas
+using QAtlas:
+    HaldaneShastry,
+    FreeEnergy,
+    ThermalEntropy,
+    SpecificHeat,
+    GroundStateEnergyDensity,
+    Infinite
+
+@testset "HaldaneShastry — Infinite c=1 CFT thermal (#524 stopgap)" begin
+    @testset "Validity gate at β = 5/J" begin
+        m = HaldaneShastry(; J=1.0)
+        f_inside = QAtlas.fetch(m, FreeEnergy(), Infinite(); beta=5.1)
+        f_outside = (@test_logs (:warn,) match_mode=:any QAtlas.fetch(
+            m, FreeEnergy(), Infinite(); beta=4.9
+        ))
+        @test isfinite(f_inside)
+        @test isnan(f_outside)
+    end
+
+    @testset "LO CFT formula at β = 10/J" begin
+        m = HaldaneShastry(; J=1.0)
+        f = QAtlas.fetch(m, FreeEnergy(), Infinite(); beta=10.0)
+        e0 = -π^2 / 24
+        T = 0.1
+        v_s = π / 2
+        f_expected = e0 - π * T^2 / (6 * v_s)
+        @test isapprox(f, f_expected; atol=1e-12)
+    end
+
+    @testset "Entropy and specific heat coincide at LO CFT" begin
+        m = HaldaneShastry(; J=1.0)
+        s = QAtlas.fetch(m, ThermalEntropy(), Infinite(); beta=10.0)
+        c = QAtlas.fetch(m, SpecificHeat(), Infinite(); beta=10.0)
+        @test isapprox(s, c; atol=1e-12)
+        @test isapprox(s, 2 / (3 * 10.0); atol=1e-12)
+    end
+
+    @testset "β → ∞ approaches Haldane GS density" begin
+        m = HaldaneShastry(; J=1.0)
+        e0_inf = QAtlas.fetch(m, GroundStateEnergyDensity(), Infinite())
+        f_inf = QAtlas.fetch(m, FreeEnergy(), Infinite(); beta=1000.0)
+        s_inf = QAtlas.fetch(m, ThermalEntropy(), Infinite(); beta=1000.0)
+        @test isapprox(f_inf, e0_inf; atol=1e-5)
+        @test 0 < s_inf < 1e-3
+    end
+
+    @testset "f(β) monotone non-decreasing in β" begin
+        m = HaldaneShastry(; J=1.0)
+        βs = [6.0, 8.0, 12.0, 20.0, 50.0]
+        fs = [QAtlas.fetch(m, FreeEnergy(), Infinite(); beta=β) for β in βs]
+        @test all(diff(fs) .≥ 0)
+    end
+
+    @testset "β ≤ 0 raises DomainError" begin
+        m = HaldaneShastry(; J=1.0)
+        @test_throws DomainError QAtlas.fetch(m, FreeEnergy(), Infinite(); beta=0.0)
+        @test_throws DomainError QAtlas.fetch(m, FreeEnergy(), Infinite(); beta=-1.0)
+        @test_throws DomainError QAtlas.fetch(m, ThermalEntropy(), Infinite(); beta=-1.0)
+        @test_throws DomainError QAtlas.fetch(m, SpecificHeat(), Infinite(); beta=-1.0)
+    end
+
+    @testset "Scaling f(β, J) / J depends only on β J" begin
+        m1 = HaldaneShastry(; J=1.0)
+        m2 = HaldaneShastry(; J=2.0)
+        f1 = QAtlas.fetch(m1, FreeEnergy(), Infinite(); beta=10.0)
+        f2 = QAtlas.fetch(m2, FreeEnergy(), Infinite(); beta=5.0) / 2
+        @test isapprox(f1, f2; atol=1e-12)
+    end
+end


### PR DESCRIPTION
## Summary

Stopgap finite-T at `Infinite()` for the Haldane-Shastry chain (#524) via the c = 1 CFT low-T expansion. **Chained on #527** (HS scaffold). Mirrors PR #526 (Heisenberg1D Path B): same v_s = π J / 2, so the LO CFT thermodynamics are identical except for the ground-state energy density.

```
f(T) = -π² J / 24 - π T² / (6 v_s),   v_s = π J / 2
s(T) = π T / (3 v_s) = 2 T / (3 J)
c(T) = π T / (3 v_s) = 2 T / (3 J)
```

## Why CFT instead of the full semion gas

Haldane 1991 + Bernevig–Haldane–Regnault 2008 give exact finite-T via a free-spinon semion gas (g = 1/2 statistics). That is the proper extension and is the actual scope of #524. The integral / fugacity equation needs careful per-site / per-species normalization that I want to verify against a numerical anchor before committing to. So this PR ships the c=1 CFT closed form as a stopgap that:

1. Carries no normalization ambiguity (Cardy formula is universal).
2. Reuses the already-verified `v_s` helper from #527.
3. Gives the same LO answer the semion gas will reproduce at low T.
4. Refuses to return outside `β > 5/J`, so out-of-window callers are not silently fed an inaccurate value.

## What is added

| Observable | LO CFT form |
|---|---|
| `FreeEnergy` | `-π² J / 24 - π T² / (6 v_s)` |
| `ThermalEntropy` | `π T / (3 v_s) = 2 T / (3 J)` |
| `SpecificHeat` | `π T / (3 v_s) = 2 T / (3 J)` |

All three return NaN + warn for `β ≤ 5/J` (same floor as #526), pointing to #524 as the full extension.

## Files

- `src/models/quantum/HaldaneShastry/HaldaneShastry_thermal_cft.jl` (new, 144 LOC)
- `src/QAtlas.jl` — include new file
- `src/models/quantum/HaldaneShastry/HaldaneShastry_registry.jl` — 3 `@register` entries
- `test/models/quantum/HaldaneShastry/test_haldane_shastry_thermal_cft.jl` (new, 7 testsets, 14 asserts, 0.6 s)
- `Project.toml` — 0.22.18 → 0.22.19

## Test plan

- [x] Validity gate at β = 5/J: `f(β=5.1)` finite, `f(β=4.9)` NaN+warn
- [x] LO formula numerical match at β = 10/J
- [x] `s` and `c` coincide and equal 2T/(3J)
- [x] β → ∞: f → -π²J/24 (Haldane GS), s → 0
- [x] `f(β)` monotone non-decreasing in β
- [x] β ≤ 0 raises `DomainError`
- [x] J-scaling: `f(β, J) / J` depends only on `β J`

## References

- F. D. M. Haldane, *Phys. Rev. Lett.* **60**, 635 (1988) — model + e_0 = -π²J/24
- F. D. M. Haldane, *Phys. Rev. Lett.* **66**, 1529 (1991) — Yangian + spinon dispersion → v_s
- I. Affleck, *Phys. Rev. Lett.* **56**, 746 (1986) — c=1 CFT form

## Chain note

This PR branches off `feat/issue-225-haldane-shastry-gs` (PR #527). **Merge #527 first**, then rebase / merge this. The diff is incremental relative to #527; no risk of duplicate work.

Refs #524.
