### PR TITLE
feat(Hubbard1D): finite-T at Infinite via regime delegation (#523 stopgap)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.22.16"
+version = "0.22.20"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -245,7 +245,8 @@ include("models/quantum/XXZ/XXZ_klumper_nlie.jl")  # Klümper QTM NLIE for criti
 include("models/quantum/XXZ/XXZ_registry.jl")  # populates REGISTRY for XXZ1D
 include("models/quantum/Heisenberg/Heisenberg_registry.jl")  # populates REGISTRY for Heisenberg1D
 include("models/quantum/Hubbard1D/Hubbard1D.jl")
-include("models/quantum/Hubbard1D/Hubbard1D_registry.jl")  # populates REGISTRY for Hubbard1D
+include("models/quantum/Hubbard1D/Hubbard1D_registry.jl")
+include("models/quantum/Hubbard1D/Hubbard1D_thermal_stopgap.jl")  # finite-T Phase-2A delegation (#523 stopgap)
 include("models/quantum/MajumdarGhosh/MajumdarGhosh.jl")
 include("models/quantum/MajumdarGhosh/MajumdarGhosh_registry.jl")  # populates REGISTRY for MajumdarGhosh
 include("models/quantum/ShastrySutherland/ShastrySutherland.jl")

--- a/src/models/quantum/Hubbard1D/Hubbard1D_registry.jl
+++ b/src/models/quantum/Hubbard1D/Hubbard1D_registry.jl
@@ -48,3 +48,45 @@
     references=["Lieb-Wu PRL 20, 1445 (1968)", "Voit Rep. Prog. Phys. 58, 977 (1995)"],
     notes="K=1 at U=0 free-fermion limit; finite-U Lieb-Wu Bethe ansatz K_ρ, K_σ deferred Phase 2.",
 )
+
+# ── Finite-T at Infinite() — Phase-2A stopgap (#523) ────────────────────
+# Regime-based delegation: U=0 -> tight-binding, very-high-T -> -T ln 4,
+# strong-coupling+low-T -> Lieb-Wu + Heisenberg c=1 CFT, else NaN+warn.
+# Full JKS QTM NLIE (4 coupled NLIEs) is deferred to a separate large PR.
+
+@register(
+    Hubbard1D,
+    FreeEnergy,
+    Infinite,
+    method=:regime_delegation,
+    reliability=:medium,
+    tested_in="test/models/quantum/Hubbard1D/test_hubbard1d_thermal_stopgap.jl",
+    references=[
+        "Lieb-Wu PRL 20, 1445 (1968)",
+        "Anderson PR 115, 2 (1959)",
+        "Jüttner-Klümper-Suzuki NPB 522, 471 (1998)",
+    ],
+    notes="Half-filling stopgap. (A) U=0 exact: 2 x TightBinding1D. (B) very-high-T (β·max(t,U)≤0.05): -T ln 4. (C) strong+low-T (U/t≥10, βJ_eff≥5): Lieb-Wu e_0 - T²/(3 J_eff). (D) NaN+warn otherwise.",
+)
+
+@register(
+    Hubbard1D,
+    ThermalEntropy,
+    Infinite,
+    method=:regime_delegation,
+    reliability=:medium,
+    tested_in="test/models/quantum/Hubbard1D/test_hubbard1d_thermal_stopgap.jl",
+    references=["Lieb-Wu PRL 20, 1445 (1968)", "Anderson PR 115, 2 (1959)"],
+    notes="Half-filling stopgap. (A) U=0: 2 x TightBinding1D. (B) high-T: ln 4. (C) strong+low-T: 2T/(3 J_eff). (D) NaN+warn.",
+)
+
+@register(
+    Hubbard1D,
+    SpecificHeat,
+    Infinite,
+    method=:regime_delegation,
+    reliability=:medium,
+    tested_in="test/models/quantum/Hubbard1D/test_hubbard1d_thermal_stopgap.jl",
+    references=["Lieb-Wu PRL 20, 1445 (1968)", "Anderson PR 115, 2 (1959)"],
+    notes="Half-filling stopgap. (A) U=0: 2 x TightBinding1D. (B) high-T: 0 at LO. (C) strong+low-T: 2T/(3 J_eff). (D) NaN+warn.",
+)

--- a/src/models/quantum/Hubbard1D/Hubbard1D_thermal_stopgap.jl
+++ b/src/models/quantum/Hubbard1D/Hubbard1D_thermal_stopgap.jl
@@ -1,0 +1,208 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Hubbard1D — Infinite() finite-T observables via regime-based delegation
+#
+# Phase-2A stopgap for issue #523 (Juttner-Klumper-Suzuki QTM NLIE).
+# The full 4-NLIE QTM solver is large enough to warrant its own PR;
+# this file gives Hubbard1D some Infinite() finite-T coverage right now
+# by delegating to known limits and refusing intermediate regimes with
+# NaN-and-warn.
+#
+# Regimes covered (half filling mu = U/2 only)
+# ============================================
+#
+# (A)  U = 0 exact: free spinless fermion * 2 species
+#        f_Hubbard(beta, t, 0) = 2 * f_TightBinding1D(beta, t, mu = 0)
+#
+# (B)  Very high T (beta * max(t, U) <= 0.05): atomic limit dominates,
+#      every site has 4 equally weighted states
+#        f -> -T ln 4 + O(beta * max(t, U))
+#
+# (C)  Strong coupling + low T (U/t >= 10 AND beta * J_eff >= 5,
+#      J_eff = 4 t^2 / U): Anderson superexchange + Heisenberg c=1 CFT
+#        f = e_0_LiebWu(t, U) - T^2 / (3 J_eff)
+#      The Lieb-Wu integral gives the exact GS density (incl. higher
+#      order in t/U); the CFT excess uses v_s = pi J_eff / 2.
+#
+# (D)  Otherwise: NaN + warn, pointing to #523 for the full QTM NLIE.
+#
+# References
+# ==========
+#
+#   - E. H. Lieb, F. Y. Wu, Phys. Rev. Lett. 20, 1445 (1968) — GS BAE
+#   - P. W. Anderson, Phys. Rev. 115, 2 (1959) — strong-coupling
+#     superexchange J_eff = 4 t^2 / U
+#   - G. Juttner, A. Klumper, J. Suzuki, Nucl. Phys. B 522, 471 (1998)
+#     [arXiv:cond-mat/9711310] — full QTM NLIE; the U -> infinity
+#     analytic limit (Sec. 7.1) confirms the Heisenberg AFM mapping
+# ─────────────────────────────────────────────────────────────────────────────
+
+const _HUBBARD_HIGH_T_CUTOFF = 0.05   # beta * max(t, U) below this -> high-T limit
+const _HUBBARD_STRONG_U_RATIO = 10.0  # U/t above this -> strong-coupling regime
+const _HUBBARD_CFT_BETA_MIN = 5.0     # beta * J_eff above this -> CFT regime
+
+"""
+    _hubbard1d_assert_half_filling(m::Hubbard1D)
+
+Half-filling guard for Phase-2A stopgap (mu = U/2 within 1e-12). Off
+half-filling raises `DomainError`. Doped finite-T is deferred to a
+later phase together with the JKS NLIE.
+"""
+function _hubbard1d_assert_half_filling(m::Hubbard1D)
+    if !isapprox(m.μ, m.U / 2; atol=1e-12)
+        throw(
+            DomainError(
+                m.μ,
+                "Hubbard1D finite-T (Phase-2A) is half-filling only; need μ = U/2 (= $(m.U/2)).",
+            ),
+        )
+    end
+    return nothing
+end
+
+"""
+    _hubbard1d_thermal_regime(m::Hubbard1D, beta::Real) -> Symbol
+
+Classify (m, β) into :u_zero, :high_T, :strong_low_T, or :intermediate
+for delegation by the FreeEnergy/Entropy/SpecificHeat dispatches.
+"""
+function _hubbard1d_thermal_regime(m::Hubbard1D, beta::Real)
+    if iszero(m.U)
+        return :u_zero
+    end
+    if beta * max(m.t, m.U) ≤ _HUBBARD_HIGH_T_CUTOFF
+        return :high_T
+    end
+    J_eff = 4 * m.t^2 / m.U
+    if m.U / m.t ≥ _HUBBARD_STRONG_U_RATIO && beta * J_eff ≥ _HUBBARD_CFT_BETA_MIN
+        return :strong_low_T
+    end
+    return :intermediate
+end
+
+"""
+    _hubbard1d_intermediate_warn(quantity::Symbol, m::Hubbard1D, beta::Real)
+
+NaN-return + warn for the intermediate regime (no delegate). Names #523
+as the proper extension.
+"""
+function _hubbard1d_intermediate_warn(quantity::Symbol, m::Hubbard1D, beta::Real)
+    J_eff_str = m.U > 0 ? "J_eff = $(round(4 * m.t^2 / m.U; digits=3))" : ""
+    @warn (
+        "Hubbard1D " *
+        String(quantity) *
+        " at Infinite(): (U/t = $(m.U/m.t), " *
+        "β · t = $(beta * m.t)) lies in the intermediate regime that requires " *
+        "the full Juttner-Klumper-Suzuki QTM NLIE (issue #523). Phase-2A stopgap " *
+        "covers U = 0 exactly, very-high T (β · max(t,U) ≤ 0.05), and strong-" *
+        "coupling low T (U/t ≥ 10 with β · J_eff ≥ 5" *
+        (isempty(J_eff_str) ? "" : ", " * J_eff_str) *
+        "). Returning NaN."
+    )
+    return NaN
+end
+
+# ── FreeEnergy ──────────────────────────────────────────────────────────────
+
+"""
+    fetch(m::Hubbard1D, ::FreeEnergy, ::Infinite; beta, kwargs...)
+
+Per-site Helmholtz free energy of the half-filled infinite Hubbard1D
+chain. Phase-2A stopgap: dispatches to (A) free-fermion × 2 at U = 0,
+(B) -T ln 4 at very high T, (C) Lieb-Wu + Heisenberg CFT at strong
+coupling + low T, (D) NaN + warn otherwise.
+"""
+function fetch(m::Hubbard1D, ::FreeEnergy, ::Infinite; beta::Real, kwargs...)
+    isempty(kwargs) || @warn(
+        "fetch(Hubbard1D, FreeEnergy, Infinite) received unrecognized kwargs; they are ignored.",
+        kwargs=collect(keys(kwargs))
+    )
+    beta > 0 || throw(DomainError(beta, "beta must be > 0"))
+    m.t > 0 || throw(DomainError(m.t, "t must be > 0"))
+    m.U ≥ 0 || throw(DomainError(m.U, "U must be ≥ 0"))
+    _hubbard1d_assert_half_filling(m)
+
+    regime = _hubbard1d_thermal_regime(m, beta)
+    if regime === :u_zero
+        tb = TightBinding1D(; t=m.t, μ=0.0)
+        return 2 * QAtlas.fetch(tb, FreeEnergy(), Infinite(); beta=beta)
+    elseif regime === :high_T
+        return -log(4) / beta
+    elseif regime === :strong_low_T
+        e0 = QAtlas.fetch(m, GroundStateEnergyDensity(), Infinite())
+        J_eff = 4 * m.t^2 / m.U
+        T = 1 / beta
+        return e0 - T^2 / (3 * J_eff)
+    else
+        return _hubbard1d_intermediate_warn(:FreeEnergy, m, beta)
+    end
+end
+
+# ── ThermalEntropy ──────────────────────────────────────────────────────────
+
+"""
+    fetch(m::Hubbard1D, ::ThermalEntropy, ::Infinite; beta, kwargs...)
+
+Per-site Gibbs entropy density. Same regime classification as
+FreeEnergy: 2 × free-fermion at U = 0, ln 4 at very high T, 2T/(3 J_eff)
+at strong coupling + low T, NaN + warn otherwise.
+"""
+function fetch(m::Hubbard1D, ::ThermalEntropy, ::Infinite; beta::Real, kwargs...)
+    isempty(kwargs) || @warn(
+        "fetch(Hubbard1D, ThermalEntropy, Infinite) received unrecognized kwargs; they are ignored.",
+        kwargs=collect(keys(kwargs))
+    )
+    beta > 0 || throw(DomainError(beta, "beta must be > 0"))
+    m.t > 0 || throw(DomainError(m.t, "t must be > 0"))
+    m.U ≥ 0 || throw(DomainError(m.U, "U must be ≥ 0"))
+    _hubbard1d_assert_half_filling(m)
+
+    regime = _hubbard1d_thermal_regime(m, beta)
+    if regime === :u_zero
+        tb = TightBinding1D(; t=m.t, μ=0.0)
+        return 2 * QAtlas.fetch(tb, ThermalEntropy(), Infinite(); beta=beta)
+    elseif regime === :high_T
+        return log(4)
+    elseif regime === :strong_low_T
+        J_eff = 4 * m.t^2 / m.U
+        T = 1 / beta
+        return 2 * T / (3 * J_eff)
+    else
+        return _hubbard1d_intermediate_warn(:ThermalEntropy, m, beta)
+    end
+end
+
+# ── SpecificHeat ────────────────────────────────────────────────────────────
+
+"""
+    fetch(m::Hubbard1D, ::SpecificHeat, ::Infinite; beta, kwargs...)
+
+Per-site heat capacity density. 2 × free-fermion at U = 0; vanishes at
+leading order in the very-high-T regime; 2T/(3 J_eff) at strong coupling
++ low T; NaN + warn otherwise.
+"""
+function fetch(m::Hubbard1D, ::SpecificHeat, ::Infinite; beta::Real, kwargs...)
+    isempty(kwargs) || @warn(
+        "fetch(Hubbard1D, SpecificHeat, Infinite) received unrecognized kwargs; they are ignored.",
+        kwargs=collect(keys(kwargs))
+    )
+    beta > 0 || throw(DomainError(beta, "beta must be > 0"))
+    m.t > 0 || throw(DomainError(m.t, "t must be > 0"))
+    m.U ≥ 0 || throw(DomainError(m.U, "U must be ≥ 0"))
+    _hubbard1d_assert_half_filling(m)
+
+    regime = _hubbard1d_thermal_regime(m, beta)
+    if regime === :u_zero
+        tb = TightBinding1D(; t=m.t, μ=0.0)
+        return 2 * QAtlas.fetch(tb, SpecificHeat(), Infinite(); beta=beta)
+    elseif regime === :high_T
+        # Leading order: c_v -> 0 (entropy already saturated at ln 4).
+        # Sub-leading O((β t)²) plus O((β U)²) corrections are not captured.
+        return 0.0
+    elseif regime === :strong_low_T
+        J_eff = 4 * m.t^2 / m.U
+        T = 1 / beta
+        return 2 * T / (3 * J_eff)
+    else
+        return _hubbard1d_intermediate_warn(:SpecificHeat, m, beta)
+    end
+end

--- a/test/ci/universe.jl
+++ b/test/ci/universe.jl
@@ -15,6 +15,7 @@ const ALL_DIRS = [
     "models/quantum/TFIM/",
     "models/quantum/XXZ/",
     "models/quantum/Heisenberg/",
+    "models/quantum/Hubbard1D/",
     "models/quantum/KitaevHoneycomb/",
     "models/quantum/misc/",
     "models/quantum/tightbinding/",

--- a/test/models/quantum/Hubbard1D/test_hubbard1d_thermal_stopgap.jl
+++ b/test/models/quantum/Hubbard1D/test_hubbard1d_thermal_stopgap.jl
@@ -1,0 +1,103 @@
+# test/models/quantum/Hubbard1D/test_hubbard1d_thermal_stopgap.jl
+#
+# Phase-2A regime-based delegation tests (#523 stopgap).
+# Covers the 4 regimes:
+#   (a) U = 0 exact -> 2 x TightBinding1D
+#   (b) very-high T (β·max(t,U) <= 0.05) -> -T ln 4
+#   (c) strong-coupling + low T (U/t>=10, β·J_eff>=5) -> Lieb-Wu e_0 + Heisenberg CFT excess
+#   (d) intermediate -> NaN + warn
+# Plus validation: half-filling guard, beta/t/U DomainError.
+
+using Test
+using QAtlas
+using QAtlas:
+    Hubbard1D,
+    TightBinding1D,
+    FreeEnergy,
+    ThermalEntropy,
+    SpecificHeat,
+    GroundStateEnergyDensity,
+    Infinite
+
+@testset "Hubbard1D — finite-T Phase-2A stopgap (#523)" begin
+    @testset "(A) U = 0 delegates to 2 x TightBinding1D" begin
+        m = Hubbard1D(1.0, 0.0, 0.0)  # t=1, U=0, μ=U/2=0
+        tb = TightBinding1D(; t=1.0, μ=0.0)
+        β = 1.0
+        f_h = QAtlas.fetch(m, FreeEnergy(), Infinite(); beta=β)
+        f_tb = QAtlas.fetch(tb, FreeEnergy(), Infinite(); beta=β)
+        @test isapprox(f_h, 2 * f_tb; atol=1e-10)
+
+        s_h = QAtlas.fetch(m, ThermalEntropy(), Infinite(); beta=β)
+        s_tb = QAtlas.fetch(tb, ThermalEntropy(), Infinite(); beta=β)
+        @test isapprox(s_h, 2 * s_tb; atol=1e-10)
+    end
+
+    @testset "(B) very-high-T: -T ln 4 / ln 4 / 0" begin
+        m = Hubbard1D(1.0, 4.0, 2.0)  # half-filling
+        β = 0.01  # β·max(t,U) = 0.04 < 0.05
+        f = QAtlas.fetch(m, FreeEnergy(), Infinite(); beta=β)
+        @test isapprox(f, -log(4) / β; atol=1e-10)
+        @test isapprox(
+            QAtlas.fetch(m, ThermalEntropy(), Infinite(); beta=β), log(4); atol=1e-10
+        )
+        @test isapprox(QAtlas.fetch(m, SpecificHeat(), Infinite(); beta=β), 0.0; atol=1e-10)
+    end
+
+    @testset "(C) strong-coupling + low-T: e_0 - T^2/(3 J_eff)" begin
+        t, U = 1.0, 20.0  # U/t = 20 >= 10
+        m = Hubbard1D(t, U, U/2)
+        J_eff = 4 * t^2 / U  # = 0.2
+        β = 50.0  # β·J_eff = 10 >= 5
+        f = QAtlas.fetch(m, FreeEnergy(), Infinite(); beta=β)
+        e0 = QAtlas.fetch(m, GroundStateEnergyDensity(), Infinite())
+        T = 1/β
+        @test isapprox(f, e0 - T^2 / (3 * J_eff); atol=1e-12)
+
+        # Entropy & specific heat in this regime
+        s = QAtlas.fetch(m, ThermalEntropy(), Infinite(); beta=β)
+        c = QAtlas.fetch(m, SpecificHeat(), Infinite(); beta=β)
+        @test isapprox(s, 2 * T / (3 * J_eff); atol=1e-12)
+        @test isapprox(c, 2 * T / (3 * J_eff); atol=1e-12)
+    end
+
+    @testset "(D) intermediate regime: NaN + warn" begin
+        m = Hubbard1D(1.0, 4.0, 2.0)  # U/t = 4 < 10
+        β = 1.0  # β·max(t,U) = 4 >> 0.05
+        f = (@test_logs (:warn,) match_mode=:any QAtlas.fetch(
+            m, FreeEnergy(), Infinite(); beta=β
+        ))
+        @test isnan(f)
+
+        s = (@test_logs (:warn,) match_mode=:any QAtlas.fetch(
+            m, ThermalEntropy(), Infinite(); beta=β
+        ))
+        c = (@test_logs (:warn,) match_mode=:any QAtlas.fetch(
+            m, SpecificHeat(), Infinite(); beta=β
+        ))
+        @test isnan(s)
+        @test isnan(c)
+    end
+
+    @testset "Off half-filling raises DomainError" begin
+        m = Hubbard1D(1.0, 4.0, 1.0)  # μ = 1, but U/2 = 2 -> off half-filling
+        @test_throws DomainError QAtlas.fetch(m, FreeEnergy(), Infinite(); beta=1.0)
+        @test_throws DomainError QAtlas.fetch(m, ThermalEntropy(), Infinite(); beta=1.0)
+        @test_throws DomainError QAtlas.fetch(m, SpecificHeat(), Infinite(); beta=1.0)
+    end
+
+    @testset "β <= 0 raises DomainError" begin
+        m = Hubbard1D(1.0, 4.0, 2.0)
+        @test_throws DomainError QAtlas.fetch(m, FreeEnergy(), Infinite(); beta=0.0)
+        @test_throws DomainError QAtlas.fetch(m, FreeEnergy(), Infinite(); beta=-1.0)
+    end
+
+    @testset "C regime f(β) monotone non-decreasing in β" begin
+        t, U = 1.0, 20.0
+        m = Hubbard1D(t, U, U/2)
+        # β·J_eff: 50->10, 100->20, both >= 5
+        β_ok = [50.0, 100.0]
+        fs = [QAtlas.fetch(m, FreeEnergy(), Infinite(); beta=β) for β in β_ok]
+        @test all(diff(fs) .≥ 0)
+    end
+end


### PR DESCRIPTION
## Summary

Phase-2A stopgap for issue #523 (Hubbard1D finite-T at `Infinite()` via the Jüttner-Klümper-Suzuki QTM NLIE). The full 4-NLIE QTM solver is large enough to warrant its own PR; this PR ships regime-based delegation that covers the analytically tractable corners and refuses the intermediate-U / intermediate-β regime with `NaN` + warn.

## What is added (half-filling only)

| Regime | Trigger | FreeEnergy | ThermalEntropy | SpecificHeat |
|---|---|---|---|---|
| **(A) U = 0 exact** | `U == 0` | `2 × TightBinding1D(t, μ=0)` | same | same |
| **(B) very-high T** | `β · max(t, U) ≤ 0.05` | `-T ln 4` | `ln 4` | `0` (LO) |
| **(C) strong + low T** | `U/t ≥ 10` ∧ `β · J_eff ≥ 5` | `e_0_LiebWu(t,U) - T² / (3 J_eff)` | `2 T / (3 J_eff)` | `2 T / (3 J_eff)` |
| **(D) otherwise** | else | `NaN + warn` | same | same |

with `J_eff = 4 t² / U` (Anderson 1959 superexchange).

The strong-coupling delegate uses the **exact** Lieb-Wu integral for `e_0` (not the leading `J_eff (1/4 - ln 2)` approximation), so it is correct to all orders in `t/U` at zero T, with only the c=1 CFT thermal excess approximated.

## Why this stopgap

- `EnvTPQMPS` benchmark targets typically test U/t ∈ {0, 4, 8} with β ∈ [1, 10]. Regime (A) covers U=0 exactly. Regime (C) covers U/t ≥ 10 at low T. The intermediate U/t ∈ {4, 8} is exactly where the full JKS NLIE is needed — and where this PR returns `NaN+warn`. So callers know exactly what is and is not covered.
- The JKS 1998 paper (arXiv:cond-mat/9711310, 30 pages, 4 coupled NLIEs for `b, b̄, c, c̄`) is documented as the proper extension in the warn message. A separate PR will port that solver.

## Files

- `src/models/quantum/Hubbard1D/Hubbard1D_thermal_stopgap.jl` (new, 203 LOC)
- `src/QAtlas.jl` — include new file
- `src/models/quantum/Hubbard1D/Hubbard1D_registry.jl` — 3 `@register` entries
- `test/models/quantum/Hubbard1D/test_hubbard1d_thermal_stopgap.jl` (new, 7 testsets, 20 asserts, 2.2 s)
- `Project.toml` — 0.22.16 → 0.22.20

## Test plan

- [x] (A) `Hubbard1D(t=1, U=0, μ=0)` matches `2 × TightBinding1D(t=1, μ=0)` for FE and entropy at β=1
- [x] (B) `β=0.01, U=4, t=1` returns `-T ln 4`, `ln 4`, `0`
- [x] (C) `β=50, U=20, t=1` (β·J_eff=10, U/t=20) returns `e_0 - T²/(3 J_eff)`; entropy and SpHeat = `2T/(3 J_eff)`
- [x] (D) `β=1, U=4, t=1` (U/t=4 intermediate) returns `NaN+warn`
- [x] Off half-filling (`μ ≠ U/2`) raises `DomainError` (all 3 observables)
- [x] β ≤ 0 raises `DomainError`
- [x] (C) regime f(β) monotone non-decreasing

## References

- E. H. Lieb, F. Y. Wu, *Phys. Rev. Lett.* **20**, 1445 (1968)
- P. W. Anderson, *Phys. Rev.* **115**, 2 (1959)
- G. Jüttner, A. Klümper, J. Suzuki, *Nucl. Phys. B* **522**, 471 (1998), arXiv:cond-mat/9711310
- F. H. L. Essler, H. Frahm, F. Göhmann, A. Klümper, V. E. Korepin, *The One-Dimensional Hubbard Model* (Cambridge 2005), ch. 6

## Future work

Full JKS QTM NLIE (4 auxiliary functions on deformed contours) tracked under #523. The intermediate regime (D) is the part it will fill.

Refs #523.
