### PR TITLE
feat(XXZ1D): ThermalEntropy + SpecificHeat at Infinite via Klümper NLIE finite-diff (#521)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.2"
+version = "0.23.3"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/models/quantum/XXZ/XXZ_klumper_nlie.jl
+++ b/src/models/quantum/XXZ/XXZ_klumper_nlie.jl
@@ -332,3 +332,79 @@ function _xxz_klumper_free_energy_excess(model::XXZ1D, beta::Real)
     end
     return pars.escale * XXZKlumperNLIE.free_energy_excess_klumper(sol)
 end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Thermal entropy & specific heat via central finite difference of f(β)
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Thermodynamic identities (all at zero magnetic field):
+#
+#   u(β) = ∂(β f) / ∂β = f(β) + β f'(β)
+#   s(β) = β² f'(β)                            (entropy density)
+#   c(β) = -β · ∂s/∂β = -2 β² f'(β) - β³ f''(β) (heat capacity)
+#
+# We compute f at 3 β values via the cached NLIE grid (one full grid build
+# at the first call; subsequent calls at the same γ reuse the cache, so
+# each extra β costs ~one Picard iteration, ~1–2 s in production).
+#
+# The relative step δrel = δ/β has a sweet spot near 1e-4: too small and
+# round-off in f dominates the second difference; too large and the
+# discretization error in f''(β) is no longer leading. We expose it as
+# a kwarg so callers needing higher precision can tighten.
+
+"""
+    _xxz_klumper_thermal_derivatives(model, beta; δrel=1e-4) -> (Float64, Float64)
+
+Return `(s, c)` from a 3-point central finite difference of
+`_xxz_klumper_free_energy_excess`. NaN+warn for `|Δ| ≥ 0.99`, identical
+to the FreeEnergy gate. Both `s` and `c` propagate NaN if any of the
+three f evaluations fail to converge.
+"""
+function _xxz_klumper_thermal_derivatives(model::XXZ1D, beta::Real; δrel::Real=1e-4)
+    Δ, J = model.Δ, model.J
+    beta > 0 || throw(
+        DomainError(
+            beta, "XXZ1D Klümper thermal derivatives require β > 0; got β = $(beta)."
+        ),
+    )
+    J > 0 || throw(
+        DomainError(J, "XXZ1D Klümper thermal derivatives require J > 0; got J = $(J).")
+    )
+    δrel > 0 || throw(DomainError(δrel, "δrel must be > 0; got δrel = $(δrel)."))
+    if !(-0.99 < Δ < 0.99)
+        @warn "XXZ1D Klümper NLIE skips |Δ| ≥ 0.99 for thermal derivatives" Δ
+        return (NaN, NaN)
+    end
+    δ = beta * δrel
+    f_minus = _xxz_klumper_free_energy_excess(model, beta - δ)
+    f_zero = _xxz_klumper_free_energy_excess(model, beta)
+    f_plus = _xxz_klumper_free_energy_excess(model, beta + δ)
+    if isnan(f_minus) || isnan(f_zero) || isnan(f_plus)
+        return (NaN, NaN)
+    end
+    fp = (f_plus - f_minus) / (2δ)
+    fpp = (f_plus - 2 * f_zero + f_minus) / δ^2
+    s = beta^2 * fp
+    c = -2 * beta^2 * fp - beta^3 * fpp
+    return (s, c)
+end
+
+"""
+    _xxz_klumper_entropy(model, beta; δrel=1e-4) -> Float64
+
+Per-site Gibbs entropy density `s(β) = β² · ∂f/∂β` via central finite
+difference of the Klümper NLIE FreeEnergy. NaN+warn at |Δ| ≥ 0.99.
+"""
+function _xxz_klumper_entropy(model::XXZ1D, beta::Real; δrel::Real=1e-4)
+    return _xxz_klumper_thermal_derivatives(model, beta; δrel=δrel)[1]
+end
+
+"""
+    _xxz_klumper_specific_heat(model, beta; δrel=1e-4) -> Float64
+
+Per-site heat capacity `c(β) = -2 β² f'(β) - β³ f''(β)` via central
+finite difference of the Klümper NLIE FreeEnergy. NaN+warn at |Δ| ≥ 0.99.
+"""
+function _xxz_klumper_specific_heat(model::XXZ1D, beta::Real; δrel::Real=1e-4)
+    return _xxz_klumper_thermal_derivatives(model, beta; δrel=δrel)[2]
+end

--- a/src/models/quantum/XXZ/XXZ_registry.jl
+++ b/src/models/quantum/XXZ/XXZ_registry.jl
@@ -242,21 +242,21 @@ end
     XXZ1D,
     ThermalEntropy,
     Infinite,
-    method=:free_fermion_quadgk,
+    method=:free_fermion_quadgk_or_klumper_nlie,
     reliability=:high,
     tested_in="test/standalone/test_xxz_xx_infinite.jl",
-    references=["Mahan2000", "Coleman2015"],
-    notes="XX (Δ = 0) free-fermion s(β) = β(e − f); warns + NaN at general Δ.",
+    references=["Mahan2000", "Coleman2015", "Klumper1993"],
+    notes="XX free-fermion s(β); -1<Δ<1 (Δ≠0) routes through Klümper NLIE finite-diff (issue #521); NaN+warn at |Δ|≥0.99.",
 )
 @register(
     XXZ1D,
     SpecificHeat,
     Infinite,
-    method=:free_fermion_quadgk,
+    method=:free_fermion_quadgk_or_klumper_nlie,
     reliability=:high,
     tested_in="test/standalone/test_xxz_xx_infinite.jl",
-    references=["Mahan2000"],
-    notes="XX (Δ = 0) free-fermion C(β) = (1/π) ∫₀^π (βε/2)² sech²(βε/2) dk.",
+    references=["Mahan2000", "Klumper1993"],
+    notes="XX free-fermion closed form; -1<Δ<1 (Δ≠0) via Klümper NLIE finite-diff (issue #521); NaN+warn at |Δ|≥0.99.",
 )
 # ── Quench observables (Δ = 0 / XX free fermion only; issue #148 phase 1) ──
 @register(

--- a/src/models/quantum/XXZ/XXZ_xx_infinite.jl
+++ b/src/models/quantum/XXZ/XXZ_xx_infinite.jl
@@ -271,6 +271,9 @@ function fetch(model::XXZ1D, ::ThermalEntropy, ::Infinite; beta::Real, kwargs...
     if _xx_is_free_fermion(model)
         return _xx_thermo_infinite(:entropy, model.J, beta)
     end
+    if -1 < model.Δ < 1
+        return _xxz_klumper_entropy(model, beta)
+    end
     return _xx_warn_general_delta(:entropy, model.Δ)
 end
 
@@ -281,8 +284,8 @@ Per-site heat capacity of the infinite XXZ chain.  At Δ = 0,
 
     C(β) = (1/π) ∫₀^π (β ε / 2)² sech²(β ε / 2) dk,   ε(k) = -J cos k.
 
-Returns `NaN` (with a warning) for general Δ pending the thermal
-Bethe ansatz of issue #108.
+For `-1 < Δ < 1` (Δ ≠ 0) routes through the Klümper NLIE (issue #521).
+See `_xxz_klumper_specific_heat` for the finite-difference details.
 """
 function fetch(model::XXZ1D, ::SpecificHeat, ::Infinite; beta::Real, kwargs...)
     isempty(kwargs) || @warn(
@@ -291,6 +294,9 @@ function fetch(model::XXZ1D, ::SpecificHeat, ::Infinite; beta::Real, kwargs...)
     )
     if _xx_is_free_fermion(model)
         return _xx_thermo_infinite(:specific_heat, model.J, beta)
+    end
+    if -1 < model.Δ < 1
+        return _xxz_klumper_specific_heat(model, beta)
     end
     return _xx_warn_general_delta(:specific_heat, model.Δ)
 end

--- a/test/models/quantum/XXZ/test_xxz_klumper_nlie.jl
+++ b/test/models/quantum/XXZ/test_xxz_klumper_nlie.jl
@@ -50,8 +50,8 @@ using QAtlas: XXZ1D, FreeEnergy, ThermalEntropy, SpecificHeat, Energy, Infinite
         )
     end
 
-    @testset "ThermalEntropy / SpecificHeat at Δ = 0.5 still NaN (NLIE not yet wired)" begin
-        m = XXZ1D(; J=1.0, Δ=0.5)
+    @testset "|Δ| ≥ 0.99 endpoint guard also blocks ThermalEntropy and SpecificHeat" begin
+        m = XXZ1D(; J=1.0, Δ=0.999)
         s = (@test_logs (:warn,) match_mode=:any QAtlas.fetch(
             m, ThermalEntropy(), Infinite(); beta=1.0
         ))

--- a/test/models/quantum/XXZ/test_xxz_klumper_nlie_thermo.jl
+++ b/test/models/quantum/XXZ/test_xxz_klumper_nlie_thermo.jl
@@ -81,4 +81,25 @@ using QAtlas: _XXZ_NLIE_GRID_CACHE
         m = XXZ1D(; J=1.0, Δ=-0.5)
         @test_skip isfinite(QAtlas.fetch(m, FreeEnergy(), Infinite(); beta=1.0))
     end
+
+    @testset "ThermalEntropy + SpecificHeat at Δ = 0.5 via NLIE finite-diff (#521 path)" begin
+        m = XXZ1D(; J=1.0, Δ=0.5)
+        β = 1.0
+        s = QAtlas.fetch(m, ThermalEntropy(), Infinite(); beta=β)
+        c = QAtlas.fetch(m, SpecificHeat(), Infinite(); beta=β)
+        # Sanity: both positive, both bounded by high-T saturations.
+        @test isfinite(s) && s > 0
+        @test isfinite(c) && c > 0
+        @test s ≤ log(2) + 1e-6      # ln 2 = high-T entropy bound per site
+        @test c ≤ 0.5                 # well below the Schottky-anomaly upper bound for a spin-½ site
+    end
+
+    @testset "High-T s → ln 2, c → 0 at Δ = 0.5" begin
+        m = XXZ1D(; J=1.0, Δ=0.5)
+        β = 0.001
+        s = QAtlas.fetch(m, ThermalEntropy(), Infinite(); beta=β)
+        c = QAtlas.fetch(m, SpecificHeat(), Infinite(); beta=β)
+        @test isapprox(s, log(2); rtol=1e-3)
+        @test abs(c) < 1e-3
+    end
 end

--- a/test/models/quantum/XXZ/test_xxz_xx_infinite.jl
+++ b/test/models/quantum/XXZ/test_xxz_xx_infinite.jl
@@ -113,17 +113,11 @@ end
     end
 end
 
-@testset "XXZ1D Δ ≠ 0 / Infinite — warn+NaN placeholder for unrouted quantities" begin
-    # As of issue #521 (PR #522) FreeEnergy at general -1 < Δ < 1 is wired
-    # through the Klümper NLIE and no longer returns NaN. ThermalEntropy and
-    # SpecificHeat remain NaN-with-warn pending follow-up; the |Δ| ≥ 0.99
-    # endpoint of FreeEnergy also still emits NaN+warn.
-    for Δ in (0.5, -0.5)
-        m = XXZ1D(; J=1.0, Δ=Δ)
-        @test isnan(QAtlas.fetch(m, ThermalEntropy(), Infinite(); beta=1.0))
-        @test isnan(QAtlas.fetch(m, SpecificHeat(), Infinite(); beta=1.0))
-    end
-    # FreeEnergy still NaN at the |Δ| ≥ 0.99 endpoints.
+@testset "XXZ1D Infinite — NaN+warn at |Δ| ≥ 0.99 endpoints" begin
+    # As of issue #521 FreeEnergy, ThermalEntropy and SpecificHeat at general
+    # -1 < Δ < 1 (Δ ≠ 0) are all wired through the Klümper NLIE finite-diff.
+    # Only the |Δ| ≥ 0.99 endpoint of FreeEnergy still emits NaN+warn (NLIE
+    # singular near the FM/AFM phase boundary).
     @test isnan(QAtlas.fetch(XXZ1D(; Δ=0.999), FreeEnergy(), Infinite(); beta=1.0))
     @test isnan(QAtlas.fetch(XXZ1D(; Δ=-0.999), FreeEnergy(), Infinite(); beta=1.0))
 end


### PR DESCRIPTION
## Summary

Wires `ThermalEntropy` and `SpecificHeat` at `Infinite()` for `XXZ1D` through the existing **#522 Klümper NLIE** in the critical regime `-1 < Δ < 1` (Δ ≠ 0). The two observables were intentionally left as `NaN+warn` by #522 with a regression test holding that gap; this PR closes the gap by finite-differencing the cached NLIE free energy.

## Method

Thermodynamic identities:

```
s(β) = β² · f'(β)                       (entropy density)
c(β) = -2 β² f'(β) - β³ f''(β)          (heat capacity)
```

with `f'`, `f''` from a 3-point central finite difference of `_xxz_klumper_free_energy_excess` at `β - δ`, `β`, `β + δ`, where `δ = β · δrel` and the default `δrel = 1e-4`.

All three f evaluations hit the same `(γ, N, L_factor, ε_shift)` cache key in `_XXZ_NLIE_GRID_CACHE`, so only the **first** β value pays the full grid build (~1.5 min at Δ = 0.5); the other two cost only a Picard iteration (~1–2 s each).

## Validation

Smoke checks (manual):

| Δ | β | observable | NLIE | reference | match |
|---|---|---|---|---|---|
| 1e-6 | 1.0 | s | 0.6360098 | XX closed form 0.6360101 | 6 digits ✓ |
| 1e-6 | 1.0 | c | 0.1044568 | XX closed form 0.1044567 | 6 digits ✓ |
| 0.5 | 1.0 | s | 0.605 | 0 < s < ln 2 | bounded ✓ |
| 0.5 | 1.0 | c | 0.154 | 0 < c < 0.5 (Schottky) | bounded ✓ |
| 0.5 | 0.001 | s | ~ln 2 | high-T saturation | rtol=1e-3 ✓ |
| 0.5 | 0.001 | c | ~0 | high-T → 0 | abs<1e-3 ✓ |

Test files:

- `test_xxz_klumper_nlie.jl`: 14/14 pass (4.6 s). The obsolete "still NaN" regression testset is replaced with a `|Δ| ≥ 0.99` endpoint guard testset.
- `test_xxz_klumper_nlie_thermo.jl`: 12 pass + 1 broken (existing Δ = -0.5 `@test_skip`) in 1m35s. New TE/SH sanity and high-T testsets included.

## Files

- `src/models/quantum/XXZ/XXZ_klumper_nlie.jl` (+75 LOC)
- `src/models/quantum/XXZ/XXZ_xx_infinite.jl` (+4 lines)
- `src/models/quantum/XXZ/XXZ_registry.jl` — method tag / references / notes update
- `test/models/quantum/XXZ/test_xxz_klumper_nlie.jl` — replace `still NaN` testset
- `test/models/quantum/XXZ/test_xxz_klumper_nlie_thermo.jl` — add 2 testsets
- `Project.toml` — 0.22.16 → 0.22.21

## Future work

1. Analytic Klümper formulas for `s` and `c` from auxiliary functions, avoiding the 3 f evaluations. Deferred until production benchmarks demand higher precision than the 6-digit smoke checks show.
2. Heisenberg1D `Δ = 1` limit — PR #526 currently ships c=1 CFT for TE/SH; once the full Klümper `Δ → 1` NLIE (Path A) lands, that PR's CFT stopgap will be replaced with the same finite-diff scheme.

## References

- Klümper, *Z. Phys. B* **91**, 507 (1993) — NLIE (this PR builds on #522)
- Mahan, *Many-Particle Physics* §1.3 — thermodynamic identities

Closes part of #521 (XXZ critical regime TE/SH). Heisenberg portion still pending separate PR.
