### PR TITLE
feat(Hubbard1D): JKS NLIE Stage A scaffold + atomic limit (#523)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.22.16"
+version = "0.22.22"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -245,6 +245,7 @@ include("models/quantum/XXZ/XXZ_klumper_nlie.jl")  # Klümper QTM NLIE for criti
 include("models/quantum/XXZ/XXZ_registry.jl")  # populates REGISTRY for XXZ1D
 include("models/quantum/Heisenberg/Heisenberg_registry.jl")  # populates REGISTRY for Heisenberg1D
 include("models/quantum/Hubbard1D/Hubbard1D.jl")
+include("models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl")  # JKS NLIE Stage A scaffold (#523)
 include("models/quantum/Hubbard1D/Hubbard1D_registry.jl")  # populates REGISTRY for Hubbard1D
 include("models/quantum/MajumdarGhosh/MajumdarGhosh.jl")
 include("models/quantum/MajumdarGhosh/MajumdarGhosh_registry.jl")  # populates REGISTRY for MajumdarGhosh

--- a/src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl
+++ b/src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl
@@ -1,0 +1,168 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Hubbard1DJKSNLIE — Juttner-Klumper-Suzuki QTM NLIE module (#523)
+#
+# Phase-2B foundation for the full thermodynamics of the 1D Hubbard model
+# at arbitrary (T, U, mu, h). Stage A (this file) ships:
+#
+#   (i)  the atomic-limit closed-form free energy (t = 0), exact for any
+#        (T, U, mu, h)
+#   (ii) a typed Grid skeleton (`JKSGrid`) that Stage B will fill with
+#        full NLIE contour + auxiliary-function storage
+#   (iii) stub signatures for the kernels and driving functions Stage B
+#        will implement
+#
+# No NLIE solver is wired up in Stage A. Production fetch dispatches for
+# `Hubbard1D` still go through the regime-based stopgap in
+# `Hubbard1D_thermal_stopgap.jl` (PR #530). Stage B will route them
+# through the full Picard NLIE solver and remove the NaN intermediate
+# regime.
+#
+# Math reference: G. Juttner, A. Klumper, J. Suzuki, "The Hubbard chain
+# at finite temperatures: ab initio calculations of Tomonaga-Luttinger
+# liquid properties", Nucl. Phys. B 522, 471 (1998), arXiv:cond-mat/
+# 9711310. Numbering below cites that paper's equations.
+# ─────────────────────────────────────────────────────────────────────────────
+
+module Hubbard1DJKSNLIE
+
+export atomic_free_energy, atomic_free_energy_half_filling
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Atomic limit (t = 0) — closed form
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# At t = 0 the Hubbard sites decouple. The grand-canonical per-site
+# partition function for U, mu, H (H = magnetic field) is
+#
+#     Z_site = sum over {empty, up, down, doubly} of e^{-beta(E - mu N - h M)}
+#            = 1 + e^{beta(mu + h/2)} + e^{beta(mu - h/2)} + e^{beta(2 mu - U)}
+#
+# yielding f_atomic = -T ln Z_site. At H = 0 this collapses to
+#
+#     Z_site = 1 + 2 e^{beta mu} + e^{beta(2 mu - U)}
+#
+# which drives the JKS high-T asymptotic analysis (Sec 7.3). Limits:
+#
+#   - T -> infinity, any (U, mu, h):  f -> -T ln 4   (all 4 states equally weighted)
+#   - T -> 0,        mu = U/2:        f -> -U/2 - T ln 2 (singly-occupied doublet
+#                                                       residual spin entropy)
+
+"""
+    atomic_free_energy(beta, U, mu; h=0.0) -> Float64
+
+Atomic-limit (t = 0) Helmholtz free-energy density of the Hubbard model
+in the grand canonical ensemble. Returns
+
+    f = -T ln[1 + e^{beta(mu + h/2)} + e^{beta(mu - h/2)} + e^{beta(2 mu - U)}].
+
+Exact for any (T, U, mu, h) at t = 0 and reproduces JKS Sec 7.3 high-T
+limit when used as the leading-order term in beta * t.
+
+Throws `DomainError` for `beta <= 0`.
+"""
+function atomic_free_energy(beta::Real, U::Real, mu::Real; h::Real=0.0)
+    beta > 0 || throw(DomainError(beta, "beta must be > 0"))
+    Z = 1 + exp(beta * (mu + h/2)) + exp(beta * (mu - h/2)) + exp(beta * (2 * mu - U))
+    return -log(Z) / beta
+end
+
+"""
+    atomic_free_energy_half_filling(beta, U) -> Float64
+
+Specialization of `atomic_free_energy` at half filling (`mu = U/2`,
+`h = 0`):
+
+    f = -T ln[2(1 + e^{beta U / 2})] = -T ln 2 - T ln(1 + e^{beta U / 2}).
+
+Reduces to `-T ln 4` at `U = 0` and `-U/2 - T ln 2` at low T (singly-
+occupied doublet residual entropy).
+"""
+function atomic_free_energy_half_filling(beta::Real, U::Real)
+    return atomic_free_energy(beta, U, U/2)
+end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Stage-B placeholders — NLIE grid + kernels + driving functions
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# The structs and signatures below establish the API that Stage B's
+# full Picard solver will fill. They error in Stage A to make accidental
+# calls during this phase loud rather than silent.
+
+"""
+    JKSGrid(N, gamma)
+
+NLIE discretization grid for the JKS QTM NLIE (Stage B). At full
+implementation will hold the contour points, kernel cache, and
+auxiliary-function arrays for `b, b_bar, c, c_bar`. Stage A reserves
+the type for forward compatibility only.
+
+# Fields
+
+- `N::Int` — number of contour points (default 128 in Stage B)
+- `gamma::Float64` — contour-shift parameter `gamma in (0, pi)` (eq 51,
+  default `2*pi/3`)
+"""
+struct JKSGrid
+    N::Int
+    gamma::Float64
+    function JKSGrid(N::Int, gamma::Real)
+        N > 0 || throw(DomainError(N, "N must be > 0"))
+        0 < gamma < pi || throw(DomainError(gamma, "gamma must be in (0, pi)"))
+        return new(N, Float64(gamma))
+    end
+end
+
+"""
+    jks_kernel_K_n(s, n, gamma) -> ComplexF64
+
+JKS kernel `K_n(s) = gamma / (pi * s * (s + 2 n i gamma))` from eq (38),
+used in the NLIE convolutions of Sec 5. Stage A: not yet implemented;
+calling it raises `ErrorException` so accidental Stage-A use is loud.
+
+Stage B will provide the full evaluator and a cached Toeplitz/full
+convolution operator.
+"""
+function jks_kernel_K_n(s::Number, n::Integer, gamma::Real)
+    error("Hubbard1DJKSNLIE.jks_kernel_K_n is not yet implemented (Stage B / #523).")
+end
+
+"""
+    jks_driving_b(x; h=0.0) -> Float64
+
+JKS spin-channel driving term `d_b(x) = -h` from eq (54). Constant in
+`x` because the field couples uniformly to the magnetization.
+
+This one is fully implemented (it is trivial); the corresponding c /
+c_bar driving terms still need the Trotter-limit function
+`log lambda_0(x)` that Stage B will derive from Sec 4.
+"""
+jks_driving_b(x::Real; h::Real=0.0) = -float(h)
+
+"""
+    jks_driving_c(x; U, mu, h=0.0) -> Float64
+
+JKS charge-channel driving term `d_c(x) = -U/2 + (mu + h/2) + log lambda_0(x)`
+from eq (54). Stage A returns the constant part only; the Trotter-limit
+`log lambda_0(x)` term is deferred to Stage B. Calling Stage A is loud:
+we error so a Stage-A caller does not silently get a wrong value.
+"""
+function jks_driving_c(x::Real; U::Real, mu::Real, h::Real=0.0)
+    error(
+        "Hubbard1DJKSNLIE.jks_driving_c needs Trotter-limit log lambda_0; deferred to Stage B (#523).",
+    )
+end
+
+"""
+    jks_driving_cbar(x; U, mu, h=0.0) -> Float64
+
+Conjugate of `jks_driving_c`: `d_c_bar(x) = -U/2 - (mu + h/2) - log lambda_0(x)`
+from eq (55). Stage A error; full implementation in Stage B.
+"""
+function jks_driving_cbar(x::Real; U::Real, mu::Real, h::Real=0.0)
+    error(
+        "Hubbard1DJKSNLIE.jks_driving_cbar needs Trotter-limit log lambda_0; deferred to Stage B (#523).",
+    )
+end
+
+end  # module Hubbard1DJKSNLIE

--- a/test/ci/universe.jl
+++ b/test/ci/universe.jl
@@ -15,6 +15,7 @@ const ALL_DIRS = [
     "models/quantum/TFIM/",
     "models/quantum/XXZ/",
     "models/quantum/Heisenberg/",
+    "models/quantum/Hubbard1D/",
     "models/quantum/KitaevHoneycomb/",
     "models/quantum/misc/",
     "models/quantum/tightbinding/",

--- a/test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_a.jl
+++ b/test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_a.jl
@@ -1,0 +1,105 @@
+# test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_a.jl
+#
+# Stage A regression for the Juttner-Klumper-Suzuki NLIE module skeleton
+# (#523). Tests:
+#   - atomic_free_energy reproduces -T ln 4 at U = 0 (high-T baseline)
+#   - half-filling specialization matches the general form at mu = U/2
+#   - low-T limit at half filling: f -> -U/2 - T ln 2
+#   - Stage-B stubs error loudly when called
+#   - JKSGrid validates its inputs
+
+using Test
+using QAtlas
+using QAtlas.Hubbard1DJKSNLIE:
+    atomic_free_energy,
+    atomic_free_energy_half_filling,
+    JKSGrid,
+    jks_kernel_K_n,
+    jks_driving_b,
+    jks_driving_c,
+    jks_driving_cbar
+
+@testset "Hubbard1D — JKS Stage A skeleton (#523)" begin
+    @testset "Atomic limit at U = 0 reproduces -T ln 4" begin
+        for beta in (0.01, 0.1, 1.0, 10.0)
+            f = atomic_free_energy(beta, 0.0, 0.0)
+            @test isapprox(f, -log(4) / beta; atol=1e-12)
+        end
+    end
+
+    @testset "Half-filling specialization matches general form at mu = U/2" begin
+        for U in (0.0, 1.0, 4.0, 10.0), beta in (0.1, 1.0, 5.0)
+            f_general = atomic_free_energy(beta, U, U/2)
+            f_half = atomic_free_energy_half_filling(beta, U)
+            @test isapprox(f_general, f_half; atol=1e-12)
+        end
+    end
+
+    @testset "Half-filling closed form: f = -T ln[2(1 + e^{beta U / 2})]" begin
+        for U in (1.0, 4.0, 10.0), beta in (0.1, 1.0, 5.0)
+            f = atomic_free_energy_half_filling(beta, U)
+            expected = -log(2 * (1 + exp(beta * U / 2))) / beta
+            @test isapprox(f, expected; atol=1e-12)
+        end
+    end
+
+    @testset "Low-T atomic-limit half-filling: f -> -U/2 - T ln 2" begin
+        # At large beta the singly-occupied doublet (energy -U/2) dominates with
+        # 2-fold spin degeneracy: f = -U/2 - T ln 2 + O(e^{-beta U / 2}).
+        U = 4.0
+        beta = 20.0
+        f = atomic_free_energy_half_filling(beta, U)
+        f_expected = -U/2 - log(2) / beta
+        # Corrections are O(e^{-beta U / 2}) = O(e^{-40}) at this regime,
+        # vastly below 1e-10 absolute.
+        @test isapprox(f, f_expected; atol=1e-10)
+    end
+
+    @testset "High-T limit f -> -T ln 4 at any U" begin
+        # As beta -> 0 the four states are equally weighted, so f -> -T ln 4
+        # regardless of U. Use beta * U = 0.01 (small enough that the
+        # difference between exp(beta * U / 2) and 1 is O(beta U)).
+        for U in (1.0, 4.0, 10.0)
+            beta = 1e-6 / max(U, 1e-9)
+            f = atomic_free_energy(beta, U, U/2)
+            @test isapprox(f, -log(4) / beta; rtol=1e-3)
+        end
+    end
+
+    @testset "Magnetic field decreases the free energy" begin
+        # At fixed mu, an h > 0 favours the up-spin state, lowering f.
+        for h in (0.1, 0.5)
+            f_zero = atomic_free_energy(1.0, 4.0, 2.0; h=0.0)
+            f_h = atomic_free_energy(1.0, 4.0, 2.0; h=h)
+            @test f_h < f_zero
+        end
+    end
+
+    @testset "beta <= 0 raises DomainError" begin
+        @test_throws DomainError atomic_free_energy(0.0, 1.0, 0.5)
+        @test_throws DomainError atomic_free_energy(-1.0, 1.0, 0.5)
+        @test_throws DomainError atomic_free_energy_half_filling(0.0, 1.0)
+    end
+
+    @testset "Stage-B stubs error loudly" begin
+        @test_throws ErrorException jks_kernel_K_n(0.5 + 0.1im, 1, 2*pi/3)
+        @test_throws ErrorException jks_driving_c(0.0; U=1.0, mu=0.5)
+        @test_throws ErrorException jks_driving_cbar(0.0; U=1.0, mu=0.5)
+    end
+
+    @testset "jks_driving_b returns the constant -h" begin
+        @test jks_driving_b(0.0) == 0.0
+        @test jks_driving_b(0.0; h=0.5) == -0.5
+        @test jks_driving_b(123.0; h=1.0) == -1.0
+    end
+
+    @testset "JKSGrid validates inputs" begin
+        g = JKSGrid(128, 2*pi/3)
+        @test g.N == 128
+        @test isapprox(g.gamma, 2*pi/3)
+        @test_throws DomainError JKSGrid(0, 2*pi/3)
+        @test_throws DomainError JKSGrid(128, 0.0)
+        @test_throws DomainError JKSGrid(128, pi)
+        @test_throws DomainError JKSGrid(128, -1.0)
+    end
+end


### PR DESCRIPTION
## Summary

Stage A of the full Jüttner-Klümper-Suzuki (JKS) Hubbard QTM NLIE port (#523). This PR ships:

- `Hubbard1DJKSNLIE` submodule scaffold
- **Atomic-limit (t = 0) free energy in closed form** — exact for any (T, U, μ, h)
- Typed `JKSGrid` struct + kernel / driving-term signatures as docking points for Stage B
- Tests against analytic limits

**No production fetch dispatch changes**. The regime-based stopgap from PR #530 still routes `(FreeEnergy / ThermalEntropy / SpecificHeat) at Infinite()` until Stage B plugs in the full Picard solver.

## What is added

| Symbol | Form | Status |
|---|---|---|
| `atomic_free_energy(β, U, μ; h)` | `-T ln[1 + e^{β(μ+h/2)} + e^{β(μ-h/2)} + e^{β(2μ-U)}]` | ✓ implemented |
| `atomic_free_energy_half_filling(β, U)` | `-T ln[2(1 + e^{βU/2})]` | ✓ specialization |
| `JKSGrid(N, γ)` | typed scaffold | ✓ struct + validation |
| `jks_driving_b(x; h)` | `-h` (eq 54, trivial) | ✓ implemented |
| `jks_kernel_K_n(s, n, γ)` | `γ / (π s (s + 2niγ))` | 🚧 Stage B (errors loudly) |
| `jks_driving_c / cbar(x; U, μ, h)` | requires Trotter `log λ₀(x)` | 🚧 Stage B (errors loudly) |

## Why this scope

The atomic limit `f = -T ln Z_site` is the **exact** t = 0 closed form for the grand-canonical Hubbard model. It is the cleanest "high-T baseline" for the JKS analysis (Sec 7.3) and reduces to known limits:

- **T → ∞**: `f → -T ln 4` (4 states equally weighted) — matches #530 regime (B)
- **T → 0, μ = U/2**: `f → -U/2 - T ln 2` (singly-occupied doublet residual spin entropy) — consistent with Hubbard Mott physics

Stage B will use the atomic limit as the **initial condition** for the Picard NLIE iteration (auxiliary functions tend to the atomic-limit constants at high T per JKS Sec 7.3), so shipping it now both lays groundwork and gives an immediate useful utility.

The non-trivial stubs (`jks_kernel_K_n`, `jks_driving_c`, `jks_driving_cbar`) error rather than return wrong values — Stage-A callers will hit a loud `ErrorException` rather than silently get NaN.

## Files

- `src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl` (new, 155 LOC)
- `src/QAtlas.jl` — include new file
- `test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_a.jl` (new, 10 testsets, 46 asserts, 0.1 s)
- `test/ci/universe.jl` — register `models/quantum/Hubbard1D/` in `ALL_DIRS`
- `Project.toml` — 0.22.16 → 0.22.22

## Test plan

- [x] U = 0 → `-T ln 4` exactly (4 β values)
- [x] Half-filling specialization matches general form at μ = U/2 (9 combos)
- [x] Closed form `f = -T ln[2(1+e^{βU/2})]` matches construction (9 combos)
- [x] Low-T limit at half filling: `f → -U/2 - T ln 2` (abs tol 1e-10)
- [x] High-T limit: `f → -T ln 4` at any U (rtol 1e-3)
- [x] Magnetic field h > 0 lowers f
- [x] β ≤ 0 raises `DomainError`
- [x] Stage-B stubs error loudly when called
- [x] `JKSGrid` validates N > 0 and γ ∈ (0, π)

All 46 asserts pass in 0.1 s on Panza.

## References

- G. Jüttner, A. Klümper, J. Suzuki, *Nucl. Phys. B* **522**, 471 (1998), arXiv:cond-mat/9711310 — Stage A targets Sec 7.3 (atomic limit); Stage B targets Sec 5 (full NLIE)

## Stage B preview

Stage B will:

1. Implement the Trotter-limit `log λ₀(x)` to give `jks_driving_c / cbar` real values.
2. Implement the 4 complex-valued auxiliary-function arrays + kernel convolutions.
3. Implement the Picard iteration solver `solve_jks_nlie`.
4. Switch the Hubbard1D `(FreeEnergy / ThermalEntropy / SpecificHeat) at Infinite()` dispatch to use the JKS NLIE in the intermediate regime, removing the `NaN+warn` paths from #530.

Estimated Stage B scope: ~500 LOC + paper Fig 5-10 numerical agreement tests.

Refs #523.
