### PR TITLE
feat(Hubbard1D): JKS Stage C.1 aux container + atomic init (#523)

### DIFF
--- a/src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl
+++ b/src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl
@@ -282,4 +282,143 @@ function apply_kernel(K::AbstractMatrix, f::AbstractVector)
     return K * f
 end
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Hubbard1DJKSNLIE Stage C.1 — auxiliary-function container
+#
+# Holds the 4 complex-valued auxiliary functions (b, b_bar, c, c_bar) of
+# JKS eq (27) on the discretised contour. Provides safe initialisation
+# from the atomic-limit fugacities (Stage A) — a reasonable Picard
+# starting point for any (beta, U, mu, h), but NOT claimed to be an
+# NLIE solution outside the atomic limit.
+#
+# Stage C.2 will add the NLIE residual evaluator (forward operator),
+# the Trotter-limit driving function `log lambda_0(x)`, and the Picard
+# iteration solver. Stage C.3 will wire the production fetch dispatch.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Auxiliary-function container
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    JKSAuxFunctions(N)
+
+Container for the four JKS auxiliary functions evaluated on an N-point
+discretised contour:
+
+- `b::Vector{ComplexF64}`     — b(x_j + i gamma)     (eq 27, 51)
+- `b_bar::Vector{ComplexF64}` — bar b(x_j - i gamma)
+- `c::Vector{ComplexF64}`     — c(x_j + i 0+)
+- `c_bar::Vector{ComplexF64}` — bar c(x_j - i 0+)
+
+Each vector has length `N`. The constructor `JKSAuxFunctions(N)` returns
+zero-initialised arrays — see `init_atomic_limit!` for a physically
+meaningful starting point.
+"""
+struct JKSAuxFunctions
+    b::Vector{ComplexF64}
+    b_bar::Vector{ComplexF64}
+    c::Vector{ComplexF64}
+    c_bar::Vector{ComplexF64}
+    function JKSAuxFunctions(N::Int)
+        N > 0 || throw(DomainError(N, "N must be > 0"))
+        return new(
+            zeros(ComplexF64, N),
+            zeros(ComplexF64, N),
+            zeros(ComplexF64, N),
+            zeros(ComplexF64, N),
+        )
+    end
+end
+
+"""
+    Base.length(aux::JKSAuxFunctions) -> Int
+
+Number of contour points (equal across all four arrays).
+"""
+Base.length(aux::JKSAuxFunctions) = length(aux.b)
+
+"""
+    Base.copy(aux::JKSAuxFunctions) -> JKSAuxFunctions
+
+Deep-copy of all four auxiliary-function arrays. Used by the Stage C.2
+Picard iteration to keep prior-iterate values for mixing.
+"""
+function Base.copy(aux::JKSAuxFunctions)
+    new_aux = JKSAuxFunctions(length(aux))
+    copyto!(new_aux.b, aux.b)
+    copyto!(new_aux.b_bar, aux.b_bar)
+    copyto!(new_aux.c, aux.c)
+    copyto!(new_aux.c_bar, aux.c_bar)
+    return new_aux
+end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Atomic-limit initialization
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# At t = 0 the Hubbard sites decouple. The four Boltzmann weights
+#
+#   z_empty  = 1
+#   z_up     = exp(beta * (mu + h/2))
+#   z_down   = exp(beta * (mu - h/2))
+#   z_double = exp(beta * (2 mu - U))
+#
+# give a per-site partition function Z_site. In this limit the auxiliary
+# functions become x-independent constants determined by the JKS Sec 7.3
+# high-T analysis. Without the full eq (138) at hand, we use the spin-
+# channel and charge-channel ratios as physically motivated initial
+# guesses:
+#
+#   b_const    = (z_up + z_down) / (z_empty + z_double)
+#   c_const    = z_up / Z_site
+#   cbar_const = z_down / Z_site
+#
+# These are NOT claimed to be exact NLIE solutions for t > 0; they are
+# the starting point Stage C.2's Picard iteration relaxes to the true
+# fixed-point auxiliary functions.
+
+"""
+    init_atomic_limit!(aux, beta, U, mu; h=0.0) -> JKSAuxFunctions
+
+Fill `aux` with x-independent constants derived from the atomic-limit
+Boltzmann weights at the requested `(beta, U, mu, h)`. Returns `aux`
+for chaining.
+
+Used as the Picard iteration starting point in Stage C.2. The constants
+are physically motivated but NOT verified against JKS eq (138); Stage
+C.2 may revise them once the paper's high-T analysis is fully ported.
+"""
+function init_atomic_limit!(
+    aux::JKSAuxFunctions, beta::Real, U::Real, mu::Real; h::Real=0.0
+)
+    beta > 0 || throw(DomainError(beta, "beta must be > 0"))
+    z_empty = 1.0
+    z_up = exp(beta * (mu + h/2))
+    z_down = exp(beta * (mu - h/2))
+    z_double = exp(beta * (2 * mu - U))
+    Z_site = z_empty + z_up + z_down + z_double
+
+    b_const = ComplexF64((z_up + z_down) / (z_empty + z_double))
+    c_const = ComplexF64(z_up / Z_site)
+    cbar_const = ComplexF64(z_down / Z_site)
+
+    fill!(aux.b, b_const)
+    fill!(aux.b_bar, b_const)
+    fill!(aux.c, c_const)
+    fill!(aux.c_bar, cbar_const)
+    return aux
+end
+
+"""
+    init_atomic_limit(grid, beta, U, mu; h=0.0) -> JKSAuxFunctions
+
+Convenience: allocate a fresh `JKSAuxFunctions(grid.N)` and initialise
+it via `init_atomic_limit!`.
+"""
+function init_atomic_limit(grid::JKSContourGrid, beta::Real, U::Real, mu::Real; h::Real=0.0)
+    aux = JKSAuxFunctions(grid.N)
+    return init_atomic_limit!(aux, beta, U, mu; h=h)
+end
+
 end  # module Hubbard1DJKSNLIE

--- a/test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_c1.jl
+++ b/test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_c1.jl
@@ -1,0 +1,96 @@
+# test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_c1.jl
+#
+# Stage C.1 regression for the JKS auxiliary-function container (#523).
+
+using Test
+using QAtlas
+using QAtlas.Hubbard1DJKSNLIE:
+    JKSAuxFunctions,
+    JKSContourGrid,
+    init_atomic_limit!,
+    init_atomic_limit,
+    atomic_free_energy
+
+@testset "Hubbard1D — JKS Stage C.1 aux container (#523)" begin
+    @testset "Construction + zero init" begin
+        aux = JKSAuxFunctions(64)
+        @test length(aux) == 64
+        @test length(aux.b) == 64
+        @test length(aux.b_bar) == 64
+        @test length(aux.c) == 64
+        @test length(aux.c_bar) == 64
+        @test all(iszero, aux.b)
+        @test all(iszero, aux.c_bar)
+    end
+
+    @testset "Construction validates N > 0" begin
+        @test_throws DomainError JKSAuxFunctions(0)
+        @test_throws DomainError JKSAuxFunctions(-1)
+    end
+
+    @testset "copy is deep" begin
+        aux = JKSAuxFunctions(8)
+        aux.b[1] = 1.0 + 0im
+        aux.c_bar[5] = 2.0 - 3im
+        aux2 = copy(aux)
+        @test aux2.b[1] == aux.b[1]
+        @test aux2.c_bar[5] == aux.c_bar[5]
+        # Mutating the copy must not affect the original.
+        aux2.b[1] = 99.0 + 0im
+        @test aux.b[1] == 1.0 + 0im
+        @test aux2.b[1] == 99.0 + 0im
+    end
+
+    @testset "init_atomic_limit! fills all four arrays with constants" begin
+        aux = JKSAuxFunctions(16)
+        init_atomic_limit!(aux, 1.0, 4.0, 2.0)  # half-filling beta=1, U=4
+        # Each array should be constant across x.
+        for arr in (aux.b, aux.b_bar, aux.c, aux.c_bar)
+            @test all(isapprox(v, arr[1]; atol=1e-14) for v in arr)
+        end
+        # At h = 0, c_const and c_bar_const coincide (z_up == z_down).
+        @test isapprox(aux.c[1], aux.c_bar[1]; atol=1e-14)
+        # b and b_bar are equal at h = 0 (initial-guess symmetry).
+        @test isapprox(aux.b[1], aux.b_bar[1]; atol=1e-14)
+    end
+
+    @testset "init_atomic_limit (grid wrapper) returns fresh aux" begin
+        g = JKSContourGrid(32, 2pi/3)
+        aux = init_atomic_limit(g, 1.0, 4.0, 2.0)
+        @test length(aux) == g.N
+        @test all(isapprox(v, aux.b[1]; atol=1e-14) for v in aux.b)
+    end
+
+    @testset "init_atomic_limit! validates beta > 0" begin
+        aux = JKSAuxFunctions(8)
+        @test_throws DomainError init_atomic_limit!(aux, 0.0, 4.0, 2.0)
+        @test_throws DomainError init_atomic_limit!(aux, -1.0, 4.0, 2.0)
+    end
+
+    @testset "init values reduce to atomic free energy via Boltzmann weights" begin
+        # Cross-check: the Boltzmann weights used in init_atomic_limit! reproduce
+        # Z_site = 1 + 2 exp(beta mu) + exp(beta(2 mu - U)) and hence
+        # f_atomic. This guards against silent mis-typed weights.
+        beta, U, mu = 1.0, 4.0, 2.0
+        aux = init_atomic_limit(JKSContourGrid(4, 2pi/3), beta, U, mu)
+        # Reverse-engineer Z_site from c_const = z_up / Z_site.
+        z_up = exp(beta * mu)
+        z_down = z_up
+        z_empty = 1.0
+        z_double = exp(beta * (2 * mu - U))
+        Z_site = z_empty + z_up + z_down + z_double
+        @test isapprox(real(aux.c[1]), z_up / Z_site; atol=1e-12)
+        @test isapprox(real(aux.b[1]), (z_up + z_down) / (z_empty + z_double); atol=1e-12)
+        # And the (independent) atomic_free_energy from Stage A.
+        f_atomic = atomic_free_energy(beta, U, mu)
+        f_check = -log(Z_site) / beta
+        @test isapprox(f_atomic, f_check; atol=1e-12)
+    end
+
+    @testset "Magnetic field breaks c / c_bar symmetry" begin
+        aux = JKSAuxFunctions(4)
+        init_atomic_limit!(aux, 1.0, 4.0, 2.0; h=0.5)
+        # h > 0 favours up-spin so c (up) > c_bar (down).
+        @test real(aux.c[1]) > real(aux.c_bar[1])
+    end
+end


### PR DESCRIPTION
## Summary

Stage C.1 of the full JKS Hubbard QTM NLIE port (#523). Adds the in-memory storage for the four auxiliary functions and a physically motivated atomic-limit initializer. Chained on **Stage B** (PR #533).

This PR ships:

- `JKSAuxFunctions(N)` struct holding 4 `ComplexF64` vectors for `b, b̄, c, c̄`
- `length` / `copy` methods
- `init_atomic_limit!(aux, β, U, μ; h)` filling with x-independent constants from the 4 atomic-limit Boltzmann weights
- `init_atomic_limit(grid, β, U, μ; h)` convenience wrapper

**No fetch dispatch is touched**.

## Auxiliary-function constants (initial guess)

From the atomic-limit per-site partition function `Z_site = z_empty + z_↑ + z_↓ + z_↑↓`:

```
b_const = (z_↑ + z_↓) / (z_empty + z_↑↓)
c_const = z_↑ / Z_site
c̄_const = z_↓ / Z_site
```

These are **physically motivated starting points** for Stage C.2's Picard iteration, *not* claimed to be the exact NLIE solutions for `t > 0`.

## Files

- `src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl` — append ~140 LOC
- `test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_c1.jl` (new, 7 testsets, 27 asserts, 0.5 s)

## Test plan

- [x] Construction + zero init
- [x] N > 0 validation
- [x] `copy` is deep
- [x] `init_atomic_limit!` fills all four arrays with constants
- [x] `init_atomic_limit` (grid wrapper) returns fresh aux
- [x] `β > 0` validation
- [x] Init values reduce to atomic `Z_site` via Boltzmann weights, cross-checked against Stage A `atomic_free_energy`
- [x] Magnetic field `h > 0` breaks `c / c̄` symmetry

All 27 asserts pass in 0.5 s on Panza.

## Chain note

Based on `feat/issue-523-hubbard-jks-stage-b` (PR #533). Merge order: **#532 → #533 → this PR**.

## Honest scoping (Stage C.2 / C.3 require dedicated paper session)

Stage C.2 (Trotter-limit `log λ₀(x)` driving + NLIE residual function) and Stage C.3 (Picard solver + free-energy evaluator + dispatch switch) require sustained paper reading of JKS Sec 4–5. The OCR-extracted text of arXiv:cond-mat/9711310 I have on Panza is fragmented enough that the precise driving formula `log λ₀(x)` and the closed-contour free-energy eq (49) need a cleaner reference (Essler-Frahm-Göhmann-Klümper-Korepin textbook Ch 6 would be ideal). Tracked under #523 for a dedicated future session.

The container shipped in this PR is the right shape for any reasonable Stage C.2 architecture — it just stores 4 arrays — so no risk of needing to reshape later.

Refs #523.
