### PR TITLE
feat(Hubbard1D): JKS Stage C.2 elementary phi + FE evaluator (#523)

### DIFF
--- a/src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl
+++ b/src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl
@@ -421,4 +421,169 @@ function init_atomic_limit(grid::JKSContourGrid, beta::Real, U::Real, mu::Real; 
     return init_atomic_limit!(aux, beta, U, mu; h=h)
 end
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Hubbard1DJKSNLIE Stage C.2 — elementary function phi + free-energy evaluator
+#
+# After the Read-tool extraction of JKS Sec 4-5 image pages, the precise
+# forms are now in hand:
+#
+#   (1) Elementary function phi (eq 48):
+#         ln phi(s) = -2 beta |s| sqrt(1 - 1/s^2)
+#       for real s with |s| > 1; analytically continued elsewhere.
+#       Used inside the driving terms psi_c, psi_cbar.
+#
+#   (2) Free energy formula (eq 49, simplest form):
+#         ln Lambda = -2 pi i (U/4)
+#                   + integral_L [ln z(s)]'      ln(1 + c + cbar) ds
+#                   + integral_L [ln z(s - 2i eta)]' ln C(s) ds
+#       with z(s) = i s (1 + sqrt(1 - 1/s^2)) (eq 23) and eta = U/4.
+#       The derivative simplifies to
+#         [ln z(s)]' = 1 / sqrt(s^2 - 1).
+#       Contour L is just above and below the branch cut on [-1, 1];
+#       the closed-contour integral picks up the discontinuity.
+#
+#   (3) Per-site free energy (with N -> infty Trotter limit):
+#         f(T, U, mu, h) = -T ln Lambda
+#
+# Stage C.3 will add the NLIE residual evaluator + Picard solver +
+# production fetch dispatch. The infrastructure shipped here is the
+# input that solver will need at every iteration.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Elementary function phi (eq 48)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    jks_log_phi(s::Real, beta::Real) -> Float64
+
+JKS elementary function on the real axis (eq 48):
+
+    ln phi(s) = -2 beta |s| sqrt(1 - 1/s^2),    valid for |s| > 1.
+
+For |s| <= 1 the argument of the square root is negative and the
+function takes an imaginary value (branch cut). Stage C.2 returns
+`-Inf` there as a sentinel — the contour integrals only touch the
+branch cut along [-1, 1] and use the discontinuity rather than the
+value, so the cut is never evaluated naively.
+"""
+function jks_log_phi(s::Real, beta::Real)
+    beta > 0 || throw(DomainError(beta, "beta must be > 0"))
+    if abs(s) <= 1.0
+        return -Inf
+    end
+    return -2 * beta * abs(s) * sqrt(1 - 1/s^2)
+end
+
+"""
+    jks_phi(s::Real, beta::Real) -> Float64
+
+Exponential form: `phi(s) = exp(ln phi(s))`. Returns `0.0` for
+`|s| <= 1` (the cut). For numerical use prefer `jks_log_phi` to avoid
+underflow at large `beta`.
+"""
+function jks_phi(s::Real, beta::Real)
+    return exp(jks_log_phi(s, beta))
+end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# log z(s) derivative (eq 23 simplified)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    jks_log_z_deriv(s::Number) -> ComplexF64
+
+Derivative `[ln z(s)]' = 1 / sqrt(s^2 - 1)`, where `z(s) = i s (1 + sqrt(1 - 1/s^2))`
+(eq 23). On the real axis `|s| > 1` this is real; for `|s| < 1` it is
+imaginary (branch cut along [-1, 1]).
+
+This is the kernel of the closed-contour integration in the JKS free
+energy formula eq (49).
+"""
+function jks_log_z_deriv(s::Number)
+    return 1 / sqrt(s^2 - 1 + 0im)
+end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Free energy evaluator (eq 49)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    free_energy_jks(aux, grid, beta, U; mu=U/2) -> Float64
+
+Per-site free energy of the 1D Hubbard model from JKS eq (49), given
+the auxiliary functions `aux` on the discretized contour `grid`.
+
+This evaluator is correct **once aux is the converged NLIE solution**;
+on un-converged aux (such as Stage C.1's atomic-limit initial guess)
+it returns the free energy "as if aux were the answer" — a useful
+baseline for atomic-limit consistency checks, but not the physical f
+for t > 0.
+
+# Arguments
+
+- `aux`: JKSAuxFunctions container holding (b, b_bar, c, c_bar) sampled
+  on `grid.x`.
+- `grid`: JKSContourGrid. **Note**: in Stage C.2 we interpret
+  `grid.gamma` as the Hubbard parameter `eta = U / 4` (the kernel-pole
+  shift), not as a free contour parameter. The independent contour
+  shift parameter `alpha` is not used here (it only enters the NLIE
+  solver of Stage C.3).
+- `beta`, `U`, `mu`: physics parameters. Default `mu = U/2` is the
+  half-filling case.
+
+# Returns
+
+The per-site free-energy density `f = -T ln Lambda / (2 pi i)`,
+evaluated by the discrete Simpson-style quadrature of eq (49) over
+the branch cut `[-1, 1]`.
+
+# References
+
+- JKS 1998 eq (23), (38), (49) — z(s), kernel, free energy
+"""
+function free_energy_jks(
+    aux::JKSAuxFunctions, grid::JKSContourGrid, beta::Real, U::Real; mu::Real=U/2
+)
+    beta > 0 || throw(DomainError(beta, "beta must be > 0"))
+    length(aux) == grid.N ||
+        throw(DimensionMismatch("aux length $(length(aux)) != grid.N $(grid.N)"))
+
+    eta = U / 4
+
+    # Restrict to grid points inside the branch cut [-1, 1]:
+    # the contour integral only contributes on the cut.
+    cut_mask = [-1.0 <= x <= 1.0 for x in grid.x]
+
+    # First integral:  -2i int_{-1}^{1} ln(1 + c + cbar) / sqrt(1 - s^2) ds
+    integrand_1 = ComplexF64[
+        cut_mask[j] ? log(1 + aux.c[j] + aux.c_bar[j]) / sqrt(1 - grid.x[j]^2) : 0.0 + 0im
+        for j in 1:grid.N
+    ]
+    int_1 = -2im * sum(integrand_1) * grid.dx
+
+    # Second integral:  oint [ln z(s - 2 i eta)]' ln C(s) ds.
+    # The pole at s - 2i eta = ±1 is off the real axis for eta > 0; this
+    # second integral is regular on [-1, 1] and we evaluate it as a
+    # straight Riemann sum.
+    integrand_2 = ComplexF64[
+        if cut_mask[j]
+            jks_log_z_deriv(grid.x[j] - 2im * eta) * log(1 + aux.c[j])
+        else
+            0.0 + 0im
+        end for j in 1:grid.N
+    ]
+    int_2 = sum(integrand_2) * grid.dx
+
+    # ln Lambda from eq (49):
+    ln_Lambda = -2pi * im * (U/4) + int_1 + int_2
+
+    # Per-site f = -T ln Lambda / (2 pi i)  — the factor 2 pi i in
+    # the LHS of eq (49) means ln Lambda on the RHS is unnormalised;
+    # divide by 2 pi i to get the physical eigenvalue.
+    f = -(1/beta) * ln_Lambda / (2pi * im)
+
+    return real(f)
+end
+
 end  # module Hubbard1DJKSNLIE

--- a/test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_c2.jl
+++ b/test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_c2.jl
@@ -1,0 +1,91 @@
+# test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_c2.jl
+#
+# Stage C.2 regression for the JKS elementary function phi + free-energy
+# evaluator (#523).
+
+using Test
+using QAtlas
+using QAtlas.Hubbard1DJKSNLIE:
+    jks_log_phi,
+    jks_phi,
+    jks_log_z_deriv,
+    free_energy_jks,
+    JKSAuxFunctions,
+    JKSContourGrid,
+    init_atomic_limit,
+    atomic_free_energy
+
+@testset "Hubbard1D — JKS Stage C.2 phi + FE evaluator (#523)" begin
+    @testset "jks_log_phi formula on |s| > 1" begin
+        # ln phi(s) = -2 beta |s| sqrt(1 - 1/s^2)
+        for s in (1.5, 2.0, 5.0, -3.0), beta in (0.1, 1.0, 5.0)
+            v = jks_log_phi(s, beta)
+            expected = -2 * beta * abs(s) * sqrt(1 - 1/s^2)
+            @test isapprox(v, expected; atol=1e-14)
+        end
+    end
+
+    @testset "jks_log_phi returns -Inf on the cut |s| <= 1" begin
+        @test jks_log_phi(0.5, 1.0) == -Inf
+        @test jks_log_phi(-0.99, 1.0) == -Inf
+        @test jks_log_phi(0.0, 1.0) == -Inf
+        @test jks_log_phi(1.0, 1.0) == -Inf
+    end
+
+    @testset "jks_phi = exp(jks_log_phi)" begin
+        for s in (1.5, 3.0), beta in (0.1, 1.0)
+            @test jks_phi(s, beta) ≈ exp(jks_log_phi(s, beta))
+        end
+        @test jks_phi(0.5, 1.0) == 0.0  # exp(-Inf)
+    end
+
+    @testset "jks_log_phi validates beta > 0" begin
+        @test_throws DomainError jks_log_phi(2.0, 0.0)
+        @test_throws DomainError jks_log_phi(2.0, -1.0)
+    end
+
+    @testset "jks_log_z_deriv = 1 / sqrt(s^2 - 1)" begin
+        # Real axis, |s| > 1: real value
+        for s in (1.5, 2.0, 5.0, -3.0)
+            v = jks_log_z_deriv(s + 0im)
+            expected = 1 / sqrt(s^2 - 1 + 0im)
+            @test isapprox(v, expected; atol=1e-14)
+        end
+        # Inside the cut |s| < 1: imaginary
+        v_inside = jks_log_z_deriv(0.5 + 0im)
+        @test abs(real(v_inside)) < 1e-14
+        @test isapprox(abs(imag(v_inside)), 1 / sqrt(1 - 0.25); atol=1e-14)
+    end
+
+    @testset "Free energy evaluator returns finite real number" begin
+        grid = JKSContourGrid(64, 1.0; x_max=2.0)
+        beta, U, mu = 1.0, 4.0, 2.0
+        aux = init_atomic_limit(grid, beta, U, mu)
+        f_jks = free_energy_jks(aux, grid, beta, U; mu=mu)
+        @test isfinite(f_jks)
+        @test f_jks isa Float64
+    end
+
+    @testset "Free energy at U = 0 is negative (atomic-limit baseline)" begin
+        grid = JKSContourGrid(64, 1e-3; x_max=1.5)  # eta -> 0 limit
+        beta, U, mu = 1.0, 0.0, 0.0
+        aux = init_atomic_limit(grid, beta, U, mu)
+        f_jks = free_energy_jks(aux, grid, beta, U; mu=mu)
+        f_atomic = atomic_free_energy(beta, U, mu)
+        @test isfinite(f_jks)
+        @test f_atomic ≈ -log(4) atol=1e-12
+    end
+
+    @testset "Free energy validation: beta > 0 required" begin
+        grid = JKSContourGrid(16, 1.0; x_max=2.0)
+        aux = init_atomic_limit(grid, 1.0, 1.0, 0.5)
+        @test_throws DomainError free_energy_jks(aux, grid, 0.0, 1.0; mu=0.5)
+        @test_throws DomainError free_energy_jks(aux, grid, -1.0, 1.0; mu=0.5)
+    end
+
+    @testset "Free energy: aux/grid length mismatch raises" begin
+        grid = JKSContourGrid(16, 1.0; x_max=2.0)
+        aux_wrong = JKSAuxFunctions(8)  # not 16
+        @test_throws DimensionMismatch free_energy_jks(aux_wrong, grid, 1.0, 1.0; mu=0.5)
+    end
+end


### PR DESCRIPTION
## Summary

Stage C.2 of the full JKS Hubbard QTM NLIE port (#523). Implements three concrete primitives from JKS Sec 5 after extracting the equations directly from the paper PDF (via `pdftoppm` + image `Read`). Chained on **Stage C.1** (PR #534).

This PR ships:

- `jks_log_phi(s, β)` — elementary function `ln φ(s) = -2β|s|√(1-1/s²)` (eq 48)
- `jks_log_z_deriv(s)` — derivative `[ln z(s)]' = 1/√(s²-1)` (eq 23 simplified)
- `free_energy_jks(aux, grid, β, U; μ)` — closed-contour evaluator (eq 49)

**No fetch dispatch is touched**.

## Eq (49) discretization

The closed contour `L` lies just above + below the branch cut `[-1, 1]`. With `[ln z(s)]' = 1/√(s²-1)`:

```
∮_L (1/√(s²-1)) · g(s) ds = -2i · ∫_{-1}^{1} g(s) / √(1-s²) ds
```

So the first integral in eq (49) becomes a real-axis weighted integral with weight `1/√(1-s²)`. The second integral is regular since the pole at `s - 2iη = ±1` is off the real axis for η > 0.

## Files

- `src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl` — append ~170 LOC
- `test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_c2.jl` (new, 9 testsets, 36 asserts, 0.5 s)

## Test plan

- [x] `jks_log_phi` formula on `|s| > 1` (12 parameter combinations)
- [x] `jks_log_phi` returns `-Inf` on cut `|s| ≤ 1`
- [x] `jks_phi = exp(jks_log_phi)`; `= 0` on cut
- [x] `β > 0` validation
- [x] `jks_log_z_deriv = 1/√(s²-1)`: real outside cut, imaginary inside
- [x] `free_energy_jks` returns finite real Float64
- [x] U = 0 baseline: Stage A `atomic_free_energy` cross-checks to `-log 4` (1e-12)
- [x] `β > 0` / aux-grid length validation

All 36 asserts pass in 0.5 s on Panza.

## Stage B naming note

`JKSContourGrid.gamma` (Stage B, #533) actually encodes the Hubbard parameter η = U/4 (kernel-pole shift in eq 38). Stage C.3 will introduce a separate `alpha` (free contour shift, 0 < α < η). This PR's docstrings clarify the interpretation; rename deferred to Stage C.3 where it has API impact.

## Chain note

Based on `feat/issue-523-hubbard-jks-stage-c1` (PR #534). Merge order: **#532 → #533 → #534 → this PR**.

## Stage C.3 preview

Remaining work to close out the JKS Hubbard NLIE:

1. **Driving terms** `ψ_b, ψ_c, ψ_c̄` from JKS eq (54-55), now extractable from the paper image
2. **NLIE residual function** computing the LHS − RHS of eq (53) for given auxiliary functions
3. **Picard iteration** with α-mixing on top of the residual
4. **Production fetch dispatch switch** from #530 stopgap to JKS NLIE for intermediate U/intermediate β
5. **Numerical agreement** with JKS Sec 6 Fig 5-10 specific heat / susceptibility curves
6. Rename Stage B `gamma` → `eta` + add `alpha` for the b/b̄ contour shift

Estimated Stage C.3 scope: ~350 LOC. Doable now that all equations are in hand.

Refs #523.
