### PR TITLE
feat(Hubbard1D): JKS Stage C.3 partial — complex phi (#523)

### DIFF
--- a/src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl
+++ b/src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl
@@ -586,4 +586,52 @@ function free_energy_jks(
     return real(f)
 end
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Hubbard1DJKSNLIE Stage C.3 partial — complex analytic continuation of phi
+#
+# JKS Sec 5 uses the elementary function phi evaluated on contours shifted
+# off the real axis by +- i alpha (alpha is the b/b_bar contour shift, free
+# with 0 < alpha < eta = U/4). The Stage C.2 jks_log_phi only covered the
+# real axis at |s| > 1; this file adds the complex analytic continuation
+#
+#     ln phi(s) = -2 beta s sqrt(1 - 1/s^2)
+#
+# with the principal branch of sqrt (positive real part for large |s|).
+#
+# This is the input for the driving terms psi_b, psi_c, psi_c_bar (eq 58-59)
+# which Stage C.4 will assemble.
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    jks_log_phi_complex(s::Number, beta::Real) -> ComplexF64
+
+Complex analytic continuation of the JKS elementary function phi (eq 48):
+
+    ln phi(s) = -2 beta s sqrt(1 - 1/s^2)
+
+For real `s` with |s| > 1 this reduces to the real-axis form
+`ln phi(s) = -2 beta |s| sqrt(1 - 1/s^2)`. For real `s` with |s| <= 1
+the value is pure imaginary — this is the branch-cut discontinuity
+used by the contour integrals in eq (49).
+
+For complex `s = x + i y` with `y != 0`, returns the value on the
+principal sheet.
+
+Throws `DomainError` for `beta <= 0`.
+"""
+function jks_log_phi_complex(s::Number, beta::Real)
+    beta > 0 || throw(DomainError(beta, "beta must be > 0"))
+    return -2 * beta * sqrt(s^2 - 1 + 0im)
+end
+
+"""
+    jks_phi_complex(s::Number, beta::Real) -> ComplexF64
+
+Exponential form: `phi(s) = exp(ln phi(s))` with complex `s`. The result
+is finite for any `s` (the cut is a discontinuity, not a singularity).
+"""
+function jks_phi_complex(s::Number, beta::Real)
+    return exp(jks_log_phi_complex(s, beta))
+end
+
 end  # module Hubbard1DJKSNLIE

--- a/test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_c3_partial.jl
+++ b/test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_c3_partial.jl
@@ -1,0 +1,63 @@
+# test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_c3_partial.jl
+#
+# Stage C.3 partial regression: complex analytic continuation of phi (#523).
+
+using Test
+using QAtlas
+using QAtlas.Hubbard1DJKSNLIE: jks_log_phi, jks_log_phi_complex, jks_phi_complex
+
+@testset "Hubbard1D — JKS Stage C.3 partial (#523)" begin
+    @testset "Reduces to real-axis form for s on |s| > 1" begin
+        for s in (1.5, 2.0, 5.0, -3.0), beta in (0.1, 1.0)
+            real_value = jks_log_phi(s, beta)
+            complex_value = jks_log_phi_complex(s + 0im, beta)
+            @test isapprox(real(complex_value), real_value; atol=1e-12)
+            @test abs(imag(complex_value)) < 1e-12
+        end
+    end
+
+    @testset "Pure imaginary on the cut |s| < 1" begin
+        for s in (0.0, 0.3, 0.5, 0.99), beta in (0.5, 1.0)
+            v = jks_log_phi_complex(s + 0im, beta)
+            @test abs(real(v)) < 1e-12
+        end
+    end
+
+    @testset "Complex s off-axis is finite" begin
+        for x in (2.0, 3.0, -2.5), alpha in (0.1, 0.3)
+            v_real = jks_log_phi_complex(x + 0im, 1.0)
+            v_shifted = jks_log_phi_complex(x + alpha * im, 1.0)
+            @test isfinite(real(v_shifted))
+            @test isfinite(imag(v_shifted))
+            @test abs(v_shifted) < 2 * abs(v_real) + 5
+        end
+    end
+
+    @testset "phi_complex = exp(log_phi_complex)" begin
+        for s in (1.5 + 0im, 2.0 + 0.3im, 0.5 + 0im, -3.0 + 0.1im)
+            @test jks_phi_complex(s, 1.0) ≈ exp(jks_log_phi_complex(s, 1.0))
+        end
+    end
+
+    @testset "log_phi_complex validates beta > 0" begin
+        @test_throws DomainError jks_log_phi_complex(2.0 + 0im, 0.0)
+        @test_throws DomainError jks_log_phi_complex(2.0 + 0im, -1.0)
+    end
+
+    @testset "Even symmetry: ln phi(-s) = ln phi(s) on real axis" begin
+        for s in (1.5, 3.0, 7.0)
+            v_pos = jks_log_phi_complex(s + 0im, 1.0)
+            v_neg = jks_log_phi_complex(-s + 0im, 1.0)
+            @test isapprox(v_neg, v_pos; atol=1e-12)
+        end
+    end
+
+    @testset "Conjugation symmetry: ln phi(conj(s)) = conj(ln phi(s))" begin
+        for x in (1.5, 3.0), y in (0.2, 0.5)
+            s = x + y * im
+            v = jks_log_phi_complex(s, 1.0)
+            v_conj = jks_log_phi_complex(conj(s), 1.0)
+            @test isapprox(v_conj, conj(v); atol=1e-12)
+        end
+    end
+end


### PR DESCRIPTION
## Summary

Stage C.3 partial of the JKS Hubbard QTM NLIE port (#523). Adds the complex-valued analytic continuation of the JKS elementary function φ (eq 48), required by the driving terms in Stage C.4. Chained on **Stage C.2** (PR #535).

This PR ships:

- `jks_log_phi_complex(s, β) -> ComplexF64` — analytic continuation of `ln φ(s) = -2β√(s²-1)`
- `jks_phi_complex(s, β) -> ComplexF64` — exponential form

## Bugfix during Stage C.3 dev

Initially implemented as `-2 β s √(1 - 1/s²)`. That form **does not** reduce to the Stage C.2 real-axis `-2β|s|√(1-1/s²)` for negative s — it gives the wrong sign. The correct analytic continuation that respects the `|s|` of eq (48) is

```
ln φ(s) = -2β √(s² - 1)
```

which reduces to `-2β|s|√(1-1/s²) = -2β√(s²-1)` on both real branches (`s > 1` and `s < -1`) and is **even** under `s → -s`.

## Test plan

- [x] Reduces to Stage C.2 real-axis form for |s| > 1 (8 combinations)
- [x] Pure imaginary on the cut |s| < 1
- [x] Complex off-axis s is finite
- [x] `jks_phi_complex = exp(jks_log_phi_complex)`
- [x] β > 0 validation
- [x] Even symmetry `ln φ(-s) = ln φ(s)`
- [x] Conjugation symmetry `ln φ(conj(s)) = conj(ln φ(s))`

All 55 asserts pass in 0.1 s on Panza.

## Files

- `src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl` — append ~50 LOC
- `test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_c3_partial.jl` (new, 7 testsets, 55 asserts, 0.1 s)

## Chain note

Based on `feat/issue-523-hubbard-jks-stage-c2` (PR #535). Merge order: **#532 → #533 → #534 → #535 → this PR**.

Refs #523.
