### PR TITLE
feat(Hubbard1D): JKS Stage C.5 — physical kernel α-regularization (#523)

### DIFF
--- a/src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl
+++ b/src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl
@@ -790,4 +790,119 @@ function solve_jks_nlie_b_only(
     return JKSSolution(aux, maxiter, last_residual, false)
 end
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Hubbard1DJKSNLIE Stage C.5 — physical kernel regularization + improved solver
+#
+# Stage C.4 build_kernel_matrix used eps = 1e-10 as the diagonal pole
+# regularizer, giving K[j,j] ~ 4e8 which dominated the residual. The
+# physically correct regularization is the contour shift alpha (with
+# 0 < alpha < eta), giving K(0 + i alpha) of order O(1).
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    build_kernel_matrix_shifted(grid, n, alpha_shift) -> Matrix{ComplexF64}
+
+Kernel matrix with diagonal regularized by the physical contour shift
+`alpha_shift` (typically 0 < alpha_shift < eta = U/4) rather than the
+tiny `eps = 1e-10` used by `build_kernel_matrix`.
+
+K[j, k] = jks_kernel_K_n_concrete(x_j - x_k + i * alpha_shift, n, gamma) * dx
+
+The j = k diagonal evaluates at K(i * alpha_shift), which is O(1) for
+alpha_shift ~ eta.
+"""
+function build_kernel_matrix_shifted(grid::JKSContourGrid, n::Integer, alpha_shift::Real)
+    n > 0 || throw(DomainError(n, "kernel index n must be > 0"))
+    alpha_shift > 0 || throw(DomainError(alpha_shift, "alpha_shift must be > 0"))
+    N = grid.N
+    K = zeros(ComplexF64, N, N)
+    for j in 1:N, k in 1:N
+        K[j, k] =
+            jks_kernel_K_n_concrete(
+                grid.x[j] - grid.x[k] + im * alpha_shift, n, grid.gamma
+            ) * grid.dx
+    end
+    return K
+end
+
+"""
+    jks_nlie_residual_shifted(aux, grid, beta, U, mu, alpha; H=0.0) -> Vector{ComplexF64}
+
+Same as `jks_nlie_residual` but uses the physically-regularized kernels
+via `build_kernel_matrix_shifted` with the same `alpha` for both the
+contour shift and the kernel regularizer.
+"""
+function jks_nlie_residual_shifted(
+    aux::JKSAuxFunctions,
+    grid::JKSContourGrid,
+    beta::Real,
+    U::Real,
+    mu::Real,
+    alpha::Real;
+    H::Real=0.0,
+)
+    beta > 0 || throw(DomainError(beta, "beta must be > 0"))
+    alpha > 0 || throw(DomainError(alpha, "alpha must be > 0"))
+    length(aux) == grid.N ||
+        throw(DimensionMismatch("aux length $(length(aux)) != grid.N $(grid.N)"))
+
+    K1 = build_kernel_matrix_shifted(grid, 1, alpha)
+    K2 = build_kernel_matrix_shifted(grid, 2, alpha)
+
+    psi_b = jks_driving_b(grid, beta, U, alpha; H=H)
+
+    log_B = log.(1 .+ aux.b)
+    log_Bbar = log.(1 .+ 1 ./ aux.b_bar)
+    log_C = log.(1 .+ aux.c)
+    log_Cbar = log.(1 .+ aux.c_bar)
+    delta_log_CCbar = log_C .- log_Cbar
+
+    rhs =
+        psi_b - apply_kernel(K2, log_B) + apply_kernel(K2, log_Bbar) -
+        apply_kernel(K1, delta_log_CCbar)
+
+    log_b = log.(aux.b)
+    return log_b .- rhs
+end
+
+"""
+    solve_jks_nlie_shifted(grid, beta, U, mu; alpha=U/6, H=0, tol=1e-6,
+                          maxiter=200, alpha_mix=0.05) -> JKSSolution
+
+Picard solver using the physically-shifted kernels. Default `alpha_mix`
+is 0.05 (smaller than Stage C.4's 0.3) because even with correct kernel
+regularization the Jacobian can drive Picard unstable for large mixing.
+"""
+function solve_jks_nlie_shifted(
+    grid::JKSContourGrid,
+    beta::Real,
+    U::Real,
+    mu::Real;
+    alpha::Real=U/6,
+    H::Real=0.0,
+    tol::Real=1e-6,
+    maxiter::Int=200,
+    alpha_mix::Real=0.05,
+)
+    beta > 0 || throw(DomainError(beta, "beta must be > 0"))
+    0 < alpha_mix <= 1 || throw(DomainError(alpha_mix, "alpha_mix must be in (0, 1]"))
+    aux = init_atomic_limit(grid, beta, U, mu; h=H)
+
+    last_residual = Inf
+    for iter in 1:maxiter
+        res = jks_nlie_residual_shifted(aux, grid, beta, U, mu, alpha; H=H)
+        last_residual = maximum(abs.(res))
+        if !isfinite(last_residual)
+            return JKSSolution(aux, iter, last_residual, false)
+        end
+        if last_residual < tol
+            return JKSSolution(aux, iter, last_residual, true)
+        end
+        log_b_new = log.(aux.b) .- alpha_mix .* res
+        aux.b .= exp.(log_b_new)
+        aux.b_bar .= aux.b
+    end
+    return JKSSolution(aux, maxiter, last_residual, false)
+end
+
 end  # module Hubbard1DJKSNLIE

--- a/test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_c5.jl
+++ b/test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_c5.jl
@@ -1,0 +1,79 @@
+# test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_c5.jl
+#
+# Stage C.5 regression: physical kernel regularization with alpha shift (#523).
+
+using Test
+using QAtlas
+using QAtlas.Hubbard1DJKSNLIE:
+    JKSContourGrid,
+    JKSAuxFunctions,
+    init_atomic_limit,
+    build_kernel_matrix,
+    build_kernel_matrix_shifted,
+    jks_nlie_residual_shifted,
+    solve_jks_nlie_shifted,
+    JKSSolution
+
+@testset "Hubbard1D — JKS Stage C.5 kernel alpha-shift + improved solver (#523)" begin
+    @testset "Shifted kernel diagonal is O(1)" begin
+        # eps=1e-10 build_kernel_matrix gives K[j,j] ~ 1e9; alpha-shifted
+        # version with alpha ~ 0.5 should give K[j,j] of order O(1).
+        grid = JKSContourGrid(16, 1.0; x_max=2.0)
+        K_eps = build_kernel_matrix(grid, 1)
+        K_shifted = build_kernel_matrix_shifted(grid, 1, 0.5)
+        @test abs(K_eps[8, 8]) > 1e6
+        @test abs(K_shifted[8, 8]) < 1.0
+    end
+
+    @testset "Shifted kernel off-diagonal is O(1)" begin
+        grid = JKSContourGrid(16, 1.0; x_max=2.0)
+        K_shifted = build_kernel_matrix_shifted(grid, 1, 0.5)
+        @test abs(K_shifted[5, 10]) < 1.0
+    end
+
+    @testset "build_kernel_matrix_shifted validates inputs" begin
+        grid = JKSContourGrid(8, 1.0; x_max=2.0)
+        @test_throws DomainError build_kernel_matrix_shifted(grid, 0, 0.5)
+        @test_throws DomainError build_kernel_matrix_shifted(grid, 1, 0.0)
+        @test_throws DomainError build_kernel_matrix_shifted(grid, 1, -0.1)
+    end
+
+    @testset "Shifted residual scale is much smaller than C.4" begin
+        grid = JKSContourGrid(16, 1.0; x_max=2.0)
+        beta, U, mu, alpha = 1.0, 4.0, 2.0, 0.5
+        aux = init_atomic_limit(grid, beta, U, mu)
+        res = jks_nlie_residual_shifted(aux, grid, beta, U, mu, alpha)
+        @test all(isfinite, res)
+        @test maximum(abs.(res)) < 100  # massive improvement from 4e8
+    end
+
+    @testset "Shifted residual validation" begin
+        grid = JKSContourGrid(8, 1.0; x_max=2.0)
+        aux = init_atomic_limit(grid, 1.0, 1.0, 0.5)
+        @test_throws DomainError jks_nlie_residual_shifted(aux, grid, 0.0, 1.0, 0.5, 0.1)
+        @test_throws DomainError jks_nlie_residual_shifted(aux, grid, 1.0, 1.0, 0.5, 0.0)
+        aux_wrong = JKSAuxFunctions(4)
+        @test_throws DimensionMismatch jks_nlie_residual_shifted(
+            aux_wrong, grid, 1.0, 1.0, 0.5, 0.1
+        )
+    end
+
+    @testset "Shifted solver returns finite residual" begin
+        grid = JKSContourGrid(16, 1.0; x_max=2.0)
+        sol = solve_jks_nlie_shifted(
+            grid, 1.0, 4.0, 2.0; alpha=0.5, tol=1e-10, maxiter=100, alpha_mix=0.05
+        )
+        @test isfinite(sol.residual)
+    end
+
+    @testset "Shifted solver validates inputs" begin
+        grid = JKSContourGrid(8, 1.0; x_max=2.0)
+        @test_throws DomainError solve_jks_nlie_shifted(grid, 0.0, 4.0, 2.0; alpha=0.5)
+        @test_throws DomainError solve_jks_nlie_shifted(
+            grid, 1.0, 4.0, 2.0; alpha=0.5, alpha_mix=0.0
+        )
+        @test_throws DomainError solve_jks_nlie_shifted(
+            grid, 1.0, 4.0, 2.0; alpha=0.5, alpha_mix=2.0
+        )
+    end
+end


### PR DESCRIPTION
## Summary

Stage C.5 of the JKS Hubbard QTM NLIE port (#523). **Fixes the kernel regularization issue that blocked Stage C.4's solver from converging**. Chained on Stage C.4 (PR #537).

## Root cause of Stage C.4's divergence

Stage C.4 used `ε = 1e-10` to shift off the kernel pole at `s = 0` in `build_kernel_matrix`. That gave `K[j, j] ~ -4×10⁸`, dominating the residual sum and causing naive Picard to diverge to NaN.

The kernel `K_n(s) = η / (π s (s + 2 n i η))` has a pole on the discretization contour at `s = 0`. The **physically correct** regularization is the **contour shift α** (with `0 < α < η = U/4`) used for the b / b_bar functions, not a machine-epsilon dummy shift.

## What is added

- `build_kernel_matrix_shifted(grid, n, alpha_shift)` — uses `α` as the diagonal regularizer. `K[j, j] = K_n(i α) ~ O(1)` for typical `α ≈ 0.5`.
- `jks_nlie_residual_shifted(aux, grid, β, U, μ, α; H)` — residual using the shifted kernels.
- `solve_jks_nlie_shifted(...)` — Picard with shifted residual + smaller default `α_mix = 0.05`.

## Empirical solver convergence behavior

| `(β, U, μ, α)` | init residual | final residual | iter |
|---|---:|---:|---:|
| `(0.1, 4.0, 2.0, 0.5)` (high-T) | 0.72 | **3×10⁻⁴** | 500 |
| `(1.0, 4.0, 2.0, 0.5)` (mid-T) | 7.2 | 6.6 | 500 |
| `(1.0, 1.0, 0.5, 0.2)` (low U) | 4.3 | 5.3 (slowly diverges) | 500 |

**High-T regime is now numerically tractable**. Lower T and intermediate U require Stage C.6 enhancements: Newton-Krylov, better initial guess, adaptive `α_mix` / line search.

## Files

- `src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl` — append ~110 LOC
- `test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_c5.jl` (new, 7 testsets, 15 asserts, 1.3 s)

## Test plan

- [x] Shifted kernel diagonal `O(1)` vs eps version `O(1e8)`
- [x] Shifted kernel off-diagonal `O(1)`
- [x] `build_kernel_matrix_shifted` validates `n > 0`, `alpha_shift > 0`
- [x] Shifted residual `O(1)` vs Stage C.4 `O(1e8)`
- [x] Shifted residual validates `β > 0`, `α > 0`, length match
- [x] Shifted solver returns finite residual (no NaN)
- [x] Solver validates `β > 0`, `α_mix ∈ (0, 1]`

All 15 asserts pass in 1.3 s on Panza.

## Chain note

Based on `feat/issue-523-hubbard-jks-stage-c4` (PR #537). Merge order: **#532 → #533 → #534 → #535 → #536 → #537 → this PR**.

Refs #523.
