### PR TITLE
feat(Hubbard1D): JKS Stage C.7 damped Newton (high-T converges in 2 iter) (#523)

### DIFF
--- a/src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl
+++ b/src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl
@@ -979,4 +979,122 @@ function solve_jks_nlie_adaptive(
     return JKSSolution(aux, maxiter, last_residual, false)
 end
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Hubbard1DJKSNLIE Stage C.7 — damped Newton solver
+#
+# Picard variants (Stage C.4, C.5, C.6) are first-order. Newton gives
+# quadratic convergence near the solution at the price of a Jacobian
+# solve per iteration. We use forward finite differences for the
+# Jacobian and damped line search to handle overshoot.
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    jks_jacobian_b_finite_diff(aux, grid, beta, U, mu, alpha; H=0.0, eps=1e-6)
+        -> Matrix{ComplexF64}
+
+Numerical Jacobian `J[i, k] = d residual_i / d log b_k` via forward
+finite difference at step `eps`. Requires `N + 1` residual evaluations
+on an `N`-point grid.
+"""
+function jks_jacobian_b_finite_diff(
+    aux::JKSAuxFunctions,
+    grid::JKSContourGrid,
+    beta::Real,
+    U::Real,
+    mu::Real,
+    alpha::Real;
+    H::Real=0.0,
+    eps::Real=1e-6,
+)
+    N = grid.N
+    res0 = jks_nlie_residual_shifted(aux, grid, beta, U, mu, alpha; H=H)
+    J = zeros(ComplexF64, N, N)
+    log_b0 = log.(aux.b)
+    for k in 1:N
+        aux_pert = copy(aux)
+        log_b_pert = copy(log_b0)
+        log_b_pert[k] += eps
+        aux_pert.b .= exp.(log_b_pert)
+        aux_pert.b_bar .= aux_pert.b
+        res_pert = jks_nlie_residual_shifted(aux_pert, grid, beta, U, mu, alpha; H=H)
+        J[:, k] = (res_pert .- res0) ./ eps
+    end
+    return J
+end
+
+"""
+    solve_jks_nlie_newton(grid, beta, U, mu; alpha=U/6, H=0, tol=1e-6,
+                          maxiter=50, jac_eps=1e-6,
+                          damps=(1.0, 0.5, 0.25, 0.1, 0.05, 0.01)) -> JKSSolution
+
+Damped Newton solver. At each iteration: compute residual r and Jacobian
+J, solve `J · δ = -r`, then try damping factors from largest to smallest
+and accept the first that decreases the residual.
+"""
+function solve_jks_nlie_newton(
+    grid::JKSContourGrid,
+    beta::Real,
+    U::Real,
+    mu::Real;
+    alpha::Real=U/6,
+    H::Real=0.0,
+    tol::Real=1e-6,
+    maxiter::Int=50,
+    jac_eps::Real=1e-6,
+    damps=(1.0, 0.5, 0.25, 0.1, 0.05, 0.01),
+)
+    beta > 0 || throw(DomainError(beta, "beta must be > 0"))
+    aux = init_atomic_limit(grid, beta, U, mu; h=H)
+    last_residual = Inf
+
+    for iter in 1:maxiter
+        res = jks_nlie_residual_shifted(aux, grid, beta, U, mu, alpha; H=H)
+        last_residual = maximum(abs.(res))
+
+        if !isfinite(last_residual)
+            return JKSSolution(aux, iter, last_residual, false)
+        end
+        if last_residual < tol
+            return JKSSolution(aux, iter, last_residual, true)
+        end
+
+        J = jks_jacobian_b_finite_diff(aux, grid, beta, U, mu, alpha; H=H, eps=jac_eps)
+
+        delta = try
+            J \ (-res)
+        catch
+            return JKSSolution(aux, iter, last_residual, false)
+        end
+
+        if !all(isfinite, delta)
+            return JKSSolution(aux, iter, last_residual, false)
+        end
+
+        log_b_old = log.(aux.b)
+        accepted = false
+        for damp in damps
+            log_b_new = log_b_old .+ damp .* delta
+            aux_try = copy(aux)
+            aux_try.b .= exp.(log_b_new)
+            aux_try.b_bar .= aux_try.b
+            res_try = try
+                jks_nlie_residual_shifted(aux_try, grid, beta, U, mu, alpha; H=H)
+            catch
+                continue
+            end
+            res_try_norm = maximum(abs.(res_try))
+            if isfinite(res_try_norm) && res_try_norm < last_residual
+                aux.b .= aux_try.b
+                aux.b_bar .= aux_try.b_bar
+                accepted = true
+                break
+            end
+        end
+        if !accepted
+            return JKSSolution(aux, iter, last_residual, false)
+        end
+    end
+    return JKSSolution(aux, maxiter, last_residual, false)
+end
+
 end  # module Hubbard1DJKSNLIE

--- a/test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_c7.jl
+++ b/test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_c7.jl
@@ -1,0 +1,51 @@
+# test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_c7.jl
+#
+# Stage C.7 regression: damped Newton solver (#523).
+
+using Test
+using QAtlas
+using QAtlas.Hubbard1DJKSNLIE:
+    JKSContourGrid,
+    JKSAuxFunctions,
+    init_atomic_limit,
+    jks_nlie_residual_shifted,
+    jks_jacobian_b_finite_diff,
+    solve_jks_nlie_newton,
+    JKSSolution
+
+@testset "Hubbard1D — JKS Stage C.7 Newton solver (#523)" begin
+    @testset "Jacobian has correct shape + finite entries" begin
+        grid = JKSContourGrid(8, 1.0; x_max=2.0)
+        aux = init_atomic_limit(grid, 1.0, 4.0, 2.0)
+        J = jks_jacobian_b_finite_diff(aux, grid, 1.0, 4.0, 2.0, 0.5)
+        @test size(J) == (8, 8)
+        @test all(isfinite, J)
+    end
+
+    @testset "Newton solver returns JKSSolution" begin
+        grid = JKSContourGrid(8, 1.0; x_max=2.0)
+        sol = solve_jks_nlie_newton(grid, 0.5, 4.0, 2.0; alpha=0.5, maxiter=10)
+        @test sol isa JKSSolution
+        @test isfinite(sol.residual)
+        @test sol.iterations >= 1
+    end
+
+    @testset "Newton solver validates inputs" begin
+        grid = JKSContourGrid(8, 1.0; x_max=2.0)
+        @test_throws DomainError solve_jks_nlie_newton(grid, 0.0, 4.0, 2.0; alpha=0.5)
+        @test_throws DomainError solve_jks_nlie_newton(grid, -1.0, 4.0, 2.0; alpha=0.5)
+    end
+
+    @testset "Newton: high-T regime converges quickly" begin
+        grid = JKSContourGrid(8, 1.0; x_max=2.0)
+        sol = solve_jks_nlie_newton(grid, 0.01, 4.0, 2.0; alpha=0.5, tol=1e-6, maxiter=30)
+        @test sol.residual < 1e-3
+    end
+
+    @testset "Newton at mid-T: residual stays bounded" begin
+        grid = JKSContourGrid(8, 1.0; x_max=2.0)
+        sol = solve_jks_nlie_newton(grid, 1.0, 4.0, 2.0; alpha=0.5, tol=1e-10, maxiter=30)
+        @test isfinite(sol.residual)
+        @test sol.residual < 100
+    end
+end


### PR DESCRIPTION
## Summary

Stage C.7 of the JKS Hubbard QTM NLIE port (#523). **Damped Newton solver** with finite-difference Jacobian. Chained on Stage C.6 (PR #539).

Picard variants (C.4 / C.5 / C.6) are linear convergence; Newton gives quadratic near the solution at the price of a Jacobian solve per iteration.

## Empirical convergence — Newton vs Picard

8-point grid, α=0.5, tol=1e-8, maxiter=30 (Newton) / 500 (Picard):

| `(β, U, μ)` | Picard adaptive | **Newton (damped)** |
|---|---:|---:|
| (0.01, 4, 2) — high T | 1e-4 in 500 iter | **0.0 in 2 iter** ✓ |
| (0.1, 4, 2) — high T | 3e-4 in 500 iter | **0.0 in 2 iter** ✓ |
| (1.0, 4, 2) — mid T | stalled @ 6.6 | **1.6 in 10 iter** |
| (1.0, 1, 0.5) — low U | slowly diverging | **1.6 in 8 iter** |

**High-T: quadratic convergence to machine precision in 2 iterations**. Mid-T / low-U: 4-5× improvement over adaptive Picard.

## Files

- `src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl` — append ~115 LOC
- `test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_c7.jl` (new, 5 testsets, 10 asserts, 2.7 s)

## Test plan

- [x] Jacobian shape `(N × N)` + finite entries
- [x] Newton returns `JKSSolution` with finite residual
- [x] Validates `β > 0`
- [x] High-T (β=0.01) converges to tol < 1e-3 within 30 iterations
- [x] Mid-T (β=1, U=4) residual stays bounded (< 100)

All 10 asserts pass in 2.7 s on Panza.

## Chain note

Based on `feat/issue-523-hubbard-jks-stage-c6` (PR #539). Merge order: **#532 → #533 → #534 → #535 → #536 → #537 → #538 → #539 → this PR**.

Refs #523.
