### PR TITLE
feat(Hubbard1D): JKS Stage C.11 c/cbar residuals + 3N concatenation (#523)

### DIFF
--- a/src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl
+++ b/src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl
@@ -1340,4 +1340,110 @@ function hubbard1d_jks_free_energy(
     return free_energy_jks(sol.aux, grid, beta, U; mu=mu)
 end
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Hubbard1DJKSNLIE Stage C.11 — c, c_bar channel residuals + 3-equation system
+#
+# Stage C.4-C.10 only iterated the b channel; c and c_bar were held at
+# atomic-limit constants. That left a ~3 % offset in the high-T
+# hubbard1d_jks_free_energy vs atomic_free_energy comparison (#544).
+#
+# Adds residuals for the c and c_bar equations from JKS eq (53) and a
+# concatenation `jks_nlie_residual_full` that Stage C.12 will drive to
+# zero via a 3N x 3N Newton solver.
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    jks_nlie_residual_c(aux, grid, beta, U, mu, alpha; H=0.0) -> Vector{ComplexF64}
+
+c-channel NLIE residual `log c+ - RHS_c` per JKS eq (53).
+"""
+function jks_nlie_residual_c(
+    aux::JKSAuxFunctions,
+    grid::JKSContourGrid,
+    beta::Real,
+    U::Real,
+    mu::Real,
+    alpha::Real;
+    H::Real=0.0,
+)
+    beta > 0 || throw(DomainError(beta, "beta must be > 0"))
+    alpha > 0 || throw(DomainError(alpha, "alpha must be > 0"))
+    length(aux) == grid.N ||
+        throw(DimensionMismatch("aux length $(length(aux)) != grid.N $(grid.N)"))
+
+    K1 = build_kernel_matrix_shifted(grid, 1, alpha)
+    K2 = build_kernel_matrix_shifted(grid, 2, alpha)
+
+    psi_c = jks_driving_c(grid, beta, U, mu; H=H)
+
+    log_B = log.(1 .+ aux.b)
+    log_Bbar = log.(1 .+ 1 ./ aux.b_bar)
+    log_Cbar = log.(1 .+ aux.c_bar)
+
+    rhs =
+        psi_c + apply_kernel(K1, log_B) - apply_kernel(K1, log_Bbar) +
+        apply_kernel(K2, log_Cbar)
+
+    log_c = log.(aux.c)
+    return log_c .- rhs
+end
+
+"""
+    jks_nlie_residual_cbar(aux, grid, beta, U, mu, alpha; H=0.0) -> Vector{ComplexF64}
+
+c_bar-channel NLIE residual (particle-hole conjugate structure).
+"""
+function jks_nlie_residual_cbar(
+    aux::JKSAuxFunctions,
+    grid::JKSContourGrid,
+    beta::Real,
+    U::Real,
+    mu::Real,
+    alpha::Real;
+    H::Real=0.0,
+)
+    beta > 0 || throw(DomainError(beta, "beta must be > 0"))
+    alpha > 0 || throw(DomainError(alpha, "alpha must be > 0"))
+    length(aux) == grid.N ||
+        throw(DimensionMismatch("aux length $(length(aux)) != grid.N $(grid.N)"))
+
+    K1 = build_kernel_matrix_shifted(grid, 1, alpha)
+    K2 = build_kernel_matrix_shifted(grid, 2, alpha)
+
+    psi_cbar = jks_driving_cbar(grid, beta, U, mu; H=H)
+
+    log_B = log.(1 .+ aux.b)
+    log_Bbar = log.(1 .+ 1 ./ aux.b_bar)
+    log_C = log.(1 .+ aux.c)
+
+    rhs =
+        psi_cbar + apply_kernel(K1, log_B) - apply_kernel(K1, log_Bbar) +
+        apply_kernel(K2, log_C)
+
+    log_cbar = log.(aux.c_bar)
+    return log_cbar .- rhs
+end
+
+"""
+    jks_nlie_residual_full(aux, grid, beta, U, mu, alpha; H=0.0) -> Vector{ComplexF64}
+
+Concatenated NLIE residual covering all three channels (b, c, c_bar) as
+a single length-`3N` complex vector ordered `[res_b; res_c; res_cbar]`.
+Stage C.12's full-system Newton solver drives this to zero.
+"""
+function jks_nlie_residual_full(
+    aux::JKSAuxFunctions,
+    grid::JKSContourGrid,
+    beta::Real,
+    U::Real,
+    mu::Real,
+    alpha::Real;
+    H::Real=0.0,
+)
+    res_b = jks_nlie_residual_shifted(aux, grid, beta, U, mu, alpha; H=H)
+    res_c = jks_nlie_residual_c(aux, grid, beta, U, mu, alpha; H=H)
+    res_cbar = jks_nlie_residual_cbar(aux, grid, beta, U, mu, alpha; H=H)
+    return vcat(res_b, res_c, res_cbar)
+end
+
 end  # module Hubbard1DJKSNLIE

--- a/test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_c11.jl
+++ b/test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_c11.jl
@@ -1,0 +1,94 @@
+# test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_c11.jl
+#
+# Stage C.11 regression: c, c_bar channel residuals + full 3N residual (#523).
+
+using Test
+using QAtlas
+using QAtlas.Hubbard1DJKSNLIE:
+    JKSContourGrid,
+    JKSAuxFunctions,
+    init_atomic_limit,
+    jks_nlie_residual_shifted,
+    jks_nlie_residual_c,
+    jks_nlie_residual_cbar,
+    jks_nlie_residual_full
+
+@testset "Hubbard1D — JKS Stage C.11 c/c_bar residuals (#523)" begin
+    @testset "c residual has correct length + element type" begin
+        grid = JKSContourGrid(16, 1.0; x_max=2.0)
+        aux = init_atomic_limit(grid, 1.0, 4.0, 2.0)
+        res = jks_nlie_residual_c(aux, grid, 1.0, 4.0, 2.0, 0.5)
+        @test length(res) == 16
+        @test eltype(res) == ComplexF64
+        @test all(isfinite, res)
+    end
+
+    @testset "c_bar residual has correct length + element type" begin
+        grid = JKSContourGrid(16, 1.0; x_max=2.0)
+        aux = init_atomic_limit(grid, 1.0, 4.0, 2.0)
+        res = jks_nlie_residual_cbar(aux, grid, 1.0, 4.0, 2.0, 0.5)
+        @test length(res) == 16
+        @test eltype(res) == ComplexF64
+        @test all(isfinite, res)
+    end
+
+    @testset "PH-conjugate driving: res_c - res_cbar reflects psi_c - psi_cbar" begin
+        # At half filling h=0 the atomic-limit init has c_const == c_bar_const
+        # so log_c == log_cbar. The residual difference is then just the
+        # driving-term difference: res_c - res_cbar = psi_cbar - psi_c.
+        # We just verify the residuals are individually finite and bounded.
+        grid = JKSContourGrid(16, 1.0; x_max=2.0)
+        aux = init_atomic_limit(grid, 1.0, 4.0, 2.0)
+        res_c = jks_nlie_residual_c(aux, grid, 1.0, 4.0, 2.0, 0.5)
+        res_cbar = jks_nlie_residual_cbar(aux, grid, 1.0, 4.0, 2.0, 0.5)
+        @test all(isfinite, res_c)
+        @test all(isfinite, res_cbar)
+        @test maximum(abs.(res_c)) < 100
+        @test maximum(abs.(res_cbar)) < 100
+    end
+
+    @testset "Full residual is length 3N + concatenation order" begin
+        grid = JKSContourGrid(8, 1.0; x_max=2.0)
+        aux = init_atomic_limit(grid, 1.0, 4.0, 2.0)
+        res_full = jks_nlie_residual_full(aux, grid, 1.0, 4.0, 2.0, 0.5)
+        @test length(res_full) == 24  # 3 * 8
+
+        res_b = jks_nlie_residual_shifted(aux, grid, 1.0, 4.0, 2.0, 0.5)
+        res_c = jks_nlie_residual_c(aux, grid, 1.0, 4.0, 2.0, 0.5)
+        res_cbar = jks_nlie_residual_cbar(aux, grid, 1.0, 4.0, 2.0, 0.5)
+        @test res_full[1:8] == res_b
+        @test res_full[9:16] == res_c
+        @test res_full[17:24] == res_cbar
+    end
+
+    @testset "c residual: validates beta > 0, alpha > 0, length match" begin
+        grid = JKSContourGrid(8, 1.0; x_max=2.0)
+        aux = init_atomic_limit(grid, 1.0, 4.0, 2.0)
+        @test_throws DomainError jks_nlie_residual_c(aux, grid, 0.0, 4.0, 2.0, 0.5)
+        @test_throws DomainError jks_nlie_residual_c(aux, grid, 1.0, 4.0, 2.0, 0.0)
+        aux_wrong = JKSAuxFunctions(4)
+        @test_throws DimensionMismatch jks_nlie_residual_c(
+            aux_wrong, grid, 1.0, 4.0, 2.0, 0.5
+        )
+    end
+
+    @testset "c_bar residual: validates beta > 0, alpha > 0, length match" begin
+        grid = JKSContourGrid(8, 1.0; x_max=2.0)
+        aux = init_atomic_limit(grid, 1.0, 4.0, 2.0)
+        @test_throws DomainError jks_nlie_residual_cbar(aux, grid, 0.0, 4.0, 2.0, 0.5)
+        @test_throws DomainError jks_nlie_residual_cbar(aux, grid, 1.0, 4.0, 2.0, 0.0)
+        aux_wrong = JKSAuxFunctions(4)
+        @test_throws DimensionMismatch jks_nlie_residual_cbar(
+            aux_wrong, grid, 1.0, 4.0, 2.0, 0.5
+        )
+    end
+
+    @testset "Magnetic field h > 0 breaks res_c == res_cbar" begin
+        grid = JKSContourGrid(8, 1.0; x_max=2.0)
+        aux = init_atomic_limit(grid, 1.0, 4.0, 2.0; h=0.5)
+        res_c = jks_nlie_residual_c(aux, grid, 1.0, 4.0, 2.0, 0.5; H=0.5)
+        res_cbar = jks_nlie_residual_cbar(aux, grid, 1.0, 4.0, 2.0, 0.5; H=0.5)
+        # h > 0 makes c_const != c_bar_const, so the residuals must differ.
+        @test any(j -> !isapprox(res_c[j], res_cbar[j]; atol=1e-6), 1:8)
+    end
+end


### PR DESCRIPTION
## Summary

Stage C.11 of the JKS Hubbard QTM NLIE port (#523). **c, c̄ channel residuals + full 3N concatenated residual** that Stage C.12's full-system Newton will drive to zero. Chained on Stage C.10 (PR #544).

Stage C.4-C.10 only iterated the b channel; c and c̄ were held at atomic-limit constants, leaving a ~3% offset in the high-T agreement between `hubbard1d_jks_free_energy` and `atomic_free_energy` (PR #544).

## What is added

- `jks_nlie_residual_c(aux, grid, β, U, μ, α; H)` — c-channel `log c⁺ - RHS_c` per JKS eq (53)
- `jks_nlie_residual_cbar(aux, grid, β, U, μ, α; H)` — c̄-channel (PH conjugate)
- `jks_nlie_residual_full(aux, grid, β, U, μ, α; H)` — `[res_b; res_c; res_cbar]` concatenation, length 3N

## What is NOT yet shipped

- 3N × 3N Jacobian + full Newton solver → Stage C.12
- Wire `hubbard1d_jks_free_energy` to drive `res_full` to zero → Stage C.12

## Files

- `src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl` — append ~110 LOC
- `test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_c11.jl` (new, 7 testsets, 21 asserts, 1.6 s)

## Test plan

- [x] c residual has correct length + finite elements
- [x] c̄ residual has correct length + finite elements
- [x] PH-conjugate driving: residuals bounded + finite at symmetric init (NOT equal, since ψ_c ≠ ψ_c̄ even with c = c̄)
- [x] Full residual length 3N + concatenation order `[res_b; res_c; res_cbar]`
- [x] c / c̄ residuals validate `β > 0`, `α > 0`, length match
- [x] Magnetic field `h > 0` breaks `res_c == res_cbar`

All 21 asserts pass in 1.6 s on Panza.

## Chain note

Based on `feat/issue-523-hubbard-jks-stage-c10` (PR #544).

Refs #523.
