### PR TITLE
feat(Hubbard1D): JKS Stage C.12 3N Newton infrastructure — reveals residual equation issue (#523)

### DIFF
--- a/src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl
+++ b/src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl
@@ -1446,4 +1446,154 @@ function jks_nlie_residual_full(
     return vcat(res_b, res_c, res_cbar)
 end
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Hubbard1DJKSNLIE Stage C.12 — full 3N x 3N Newton solver
+#
+# Stage C.7 b-only Newton converged in 2 iter at high T but stalled at
+# mid-T because c, c_bar were held at atomic-limit constants. Stage C.11
+# added the c and c_bar residuals. This file assembles them into a
+# 3N x 3N Jacobian and damped Newton solver.
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    jks_jacobian_full_finite_diff(aux, grid, beta, U, mu, alpha; H=0.0, eps=1e-6)
+        -> Matrix{ComplexF64}
+
+Numerical Jacobian of the full 3N residual (`[res_b; res_c; res_cbar]`)
+with respect to `[log b; log c; log c_bar]`, via forward finite
+differences. Returns a `3N x 3N` complex matrix.
+"""
+function jks_jacobian_full_finite_diff(
+    aux::JKSAuxFunctions,
+    grid::JKSContourGrid,
+    beta::Real,
+    U::Real,
+    mu::Real,
+    alpha::Real;
+    H::Real=0.0,
+    eps::Real=1e-6,
+)
+    N = grid.N
+    M = 3 * N
+    res0 = jks_nlie_residual_full(aux, grid, beta, U, mu, alpha; H=H)
+    J = zeros(ComplexF64, M, M)
+
+    log_b0 = log.(aux.b)
+    for k in 1:N
+        aux_pert = copy(aux)
+        log_pert = copy(log_b0)
+        log_pert[k] += eps
+        aux_pert.b .= exp.(log_pert)
+        aux_pert.b_bar .= aux_pert.b
+        res_pert = jks_nlie_residual_full(aux_pert, grid, beta, U, mu, alpha; H=H)
+        J[:, k] = (res_pert .- res0) ./ eps
+    end
+
+    log_c0 = log.(aux.c)
+    for k in 1:N
+        aux_pert = copy(aux)
+        log_pert = copy(log_c0)
+        log_pert[k] += eps
+        aux_pert.c .= exp.(log_pert)
+        res_pert = jks_nlie_residual_full(aux_pert, grid, beta, U, mu, alpha; H=H)
+        J[:, N + k] = (res_pert .- res0) ./ eps
+    end
+
+    log_cbar0 = log.(aux.c_bar)
+    for k in 1:N
+        aux_pert = copy(aux)
+        log_pert = copy(log_cbar0)
+        log_pert[k] += eps
+        aux_pert.c_bar .= exp.(log_pert)
+        res_pert = jks_nlie_residual_full(aux_pert, grid, beta, U, mu, alpha; H=H)
+        J[:, 2 * N + k] = (res_pert .- res0) ./ eps
+    end
+
+    return J
+end
+
+"""
+    solve_jks_nlie_full_newton(grid, beta, U, mu; alpha=U/6, H=0, tol=1e-6,
+                                maxiter=50, jac_eps=1e-6,
+                                damps=(1.0, 0.5, 0.25, 0.1, 0.05, 0.01))
+        -> JKSSolution
+
+Damped 3N x 3N Newton solver on the full (b, c, c_bar) residual system.
+"""
+function solve_jks_nlie_full_newton(
+    grid::JKSContourGrid,
+    beta::Real,
+    U::Real,
+    mu::Real;
+    alpha::Real=U/6,
+    H::Real=0.0,
+    tol::Real=1e-6,
+    maxiter::Int=50,
+    jac_eps::Real=1e-6,
+    damps=(1.0, 0.5, 0.25, 0.1, 0.05, 0.01),
+)
+    beta > 0 || throw(DomainError(beta, "beta must be > 0"))
+    aux = init_atomic_limit(grid, beta, U, mu; h=H)
+    N = grid.N
+    last_residual = Inf
+
+    for iter in 1:maxiter
+        res = jks_nlie_residual_full(aux, grid, beta, U, mu, alpha; H=H)
+        last_residual = maximum(abs.(res))
+
+        if !isfinite(last_residual)
+            return JKSSolution(aux, iter, last_residual, false)
+        end
+        if last_residual < tol
+            return JKSSolution(aux, iter, last_residual, true)
+        end
+
+        J = jks_jacobian_full_finite_diff(aux, grid, beta, U, mu, alpha; H=H, eps=jac_eps)
+
+        delta = try
+            J \ (-res)
+        catch
+            return JKSSolution(aux, iter, last_residual, false)
+        end
+        if !all(isfinite, delta)
+            return JKSSolution(aux, iter, last_residual, false)
+        end
+
+        delta_b = delta[1:N]
+        delta_c = delta[(N + 1):(2 * N)]
+        delta_cbar = delta[(2 * N + 1):(3 * N)]
+
+        log_b_old = log.(aux.b)
+        log_c_old = log.(aux.c)
+        log_cbar_old = log.(aux.c_bar)
+
+        accepted = false
+        for damp in damps
+            aux_try = copy(aux)
+            aux_try.b .= exp.(log_b_old .+ damp .* delta_b)
+            aux_try.b_bar .= aux_try.b
+            aux_try.c .= exp.(log_c_old .+ damp .* delta_c)
+            aux_try.c_bar .= exp.(log_cbar_old .+ damp .* delta_cbar)
+            res_try = try
+                jks_nlie_residual_full(aux_try, grid, beta, U, mu, alpha; H=H)
+            catch
+                continue
+            end
+            res_try_norm = maximum(abs.(res_try))
+            if isfinite(res_try_norm) && res_try_norm < last_residual
+                aux.b .= aux_try.b
+                aux.b_bar .= aux_try.b_bar
+                aux.c .= aux_try.c
+                aux.c_bar .= aux_try.c_bar
+                accepted = true
+                break
+            end
+        end
+        if !accepted
+            return JKSSolution(aux, iter, last_residual, false)
+        end
+    end
+    return JKSSolution(aux, maxiter, last_residual, false)
+end
+
 end  # module Hubbard1DJKSNLIE

--- a/test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_c12.jl
+++ b/test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_c12.jl
@@ -1,0 +1,55 @@
+# test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_c12.jl
+#
+# Stage C.12 regression: 3N x 3N full Newton solver (#523).
+
+using Test
+using QAtlas
+using QAtlas.Hubbard1DJKSNLIE:
+    JKSContourGrid,
+    JKSAuxFunctions,
+    init_atomic_limit,
+    jks_nlie_residual_full,
+    jks_jacobian_full_finite_diff,
+    solve_jks_nlie_full_newton,
+    JKSSolution
+
+@testset "Hubbard1D — JKS Stage C.12 full 3N Newton (#523)" begin
+    @testset "Full Jacobian has shape 3N x 3N + finite entries" begin
+        grid = JKSContourGrid(8, 1.0; x_max=2.0)
+        aux = init_atomic_limit(grid, 1.0, 4.0, 2.0)
+        J = jks_jacobian_full_finite_diff(aux, grid, 1.0, 4.0, 2.0, 0.5)
+        @test size(J) == (24, 24)  # 3 * 8
+        @test all(isfinite, J)
+    end
+
+    @testset "Full Newton returns JKSSolution" begin
+        grid = JKSContourGrid(8, 1.0; x_max=2.0)
+        sol = solve_jks_nlie_full_newton(grid, 0.1, 4.0, 2.0; alpha=0.5, maxiter=10)
+        @test sol isa JKSSolution
+        @test isfinite(sol.residual)
+        @test sol.iterations >= 1
+    end
+
+    @testset "Full Newton solver validates inputs" begin
+        grid = JKSContourGrid(8, 1.0; x_max=2.0)
+        @test_throws DomainError solve_jks_nlie_full_newton(grid, 0.0, 4.0, 2.0; alpha=0.5)
+        @test_throws DomainError solve_jks_nlie_full_newton(grid, -1.0, 4.0, 2.0; alpha=0.5)
+    end
+
+    @testset "High-T: full Newton converges to tol" begin
+        grid = JKSContourGrid(8, 1.0; x_max=2.0)
+        sol = solve_jks_nlie_full_newton(
+            grid, 0.01, 4.0, 2.0; alpha=0.5, tol=1e-6, maxiter=20
+        )
+        @test sol.residual < 1e-3
+    end
+
+    @testset "Mid-T: residual stays bounded" begin
+        grid = JKSContourGrid(8, 1.0; x_max=2.0)
+        sol = solve_jks_nlie_full_newton(
+            grid, 1.0, 4.0, 2.0; alpha=0.5, tol=1e-10, maxiter=20
+        )
+        @test isfinite(sol.residual)
+        @test sol.residual < 100
+    end
+end


### PR DESCRIPTION
## Summary

Stage C.12 of the JKS Hubbard QTM NLIE port (#523). **3N × 3N Jacobian + full Newton solver infrastructure** on the (b, c, c̄) system. Chained on Stage C.11 (PR #545).

## Empirical convergence vs b-only Newton (8-point grid, α=0.5, U=4, μ=2)

| β | b-only res | **full res** | f_full | f_atom | f_full / f_atom |
|---:|---:|---:|---:|---:|---:|
| 0.01 | 6.4×10⁻¹² | **1.2×10⁻¹¹** | -213.1 | -139.6 | 1.526 |
| 0.1 | 1.7×10⁻¹⁰ | **1.5×10⁻¹⁰** | -21.4 | -14.9 | 1.438 |
| 1.0 | 1.6 | **5.0** | -3.50 | -2.82 | 1.240 |

## Observations + honest interpretation

- **3N Newton converges to machine precision at high T** — the Jacobian + damped line search infrastructure works correctly.
- But the converged free-energy value is now **40-50% off the atomic limit** (vs 3% off when only b was iterated). Driving c, c̄ to fixed-point of MY schematic residual gives a different answer than the JKS NLIE solution.

Stage C.4-C.12 residual equations are a **schematic reading** of JKS eq (53). At high T the b-only path happened to give approximately right answers because the b channel + atomic-limit c, c̄ approximately satisfy the FE evaluator. Now that all three channels are iterated, the discrepancy with the true JKS NLIE becomes visible.

**Stage C.13** will compare the b/c/c̄ residual signs and kernel subscripts (K_{1,-}, K̄_{1,*}, K_{2,0}) against the JKS paper page 15 image character-by-character and fix the equations so full Newton at high T reproduces `atomic_free_energy` to < 1%.

This PR ships the **infrastructure**. The residual **equations** will be refined in C.13.

## What is added

- `jks_jacobian_full_finite_diff(aux, grid, β, U, μ, α; H, eps)` — forward FD Jacobian, (3N+1) residual evals.
- `solve_jks_nlie_full_newton(grid, β, U, μ; alpha, H, tol, maxiter, jac_eps, damps)` — damped Newton on the full system.

## Files

- `src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl` — append ~150 LOC
- `test/models/quantum/Hubbard1D/test_hubbard1d_jks_stage_c12.jl` (new, 5 testsets, 10 asserts, 3.2 s)

## Test plan

- [x] Full Jacobian shape `(3N × 3N)` + finite entries
- [x] Full Newton returns `JKSSolution` with finite residual
- [x] Validates `β > 0`
- [x] High-T (β=0.01) converges to tol < 1e-3
- [x] Mid-T (β=1) residual stays bounded

All 10 asserts pass in 3.2 s on Panza.

## Chain note

Based on `feat/issue-523-hubbard-jks-stage-c11` (PR #545).

Refs #523.
