### PR TITLE
feat(Hubbard1D): JKS Stage C.13 psi sign fix per paper eq 53 (#523)

### DIFF
--- a/src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl
+++ b/src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl
@@ -726,7 +726,7 @@ function jks_nlie_residual(
     delta_log_CCbar = log_C .- log_Cbar
 
     rhs =
-        psi_b - apply_kernel(K2, log_B) + apply_kernel(K2, log_Bbar) -
+        -psi_b - apply_kernel(K2, log_B) + apply_kernel(K2, log_Bbar) -
         apply_kernel(K1, delta_log_CCbar)
 
     log_b = log.(aux.b)
@@ -858,7 +858,7 @@ function jks_nlie_residual_shifted(
     delta_log_CCbar = log_C .- log_Cbar
 
     rhs =
-        psi_b - apply_kernel(K2, log_B) + apply_kernel(K2, log_Bbar) -
+        -psi_b - apply_kernel(K2, log_B) + apply_kernel(K2, log_Bbar) -
         apply_kernel(K1, delta_log_CCbar)
 
     log_b = log.(aux.b)
@@ -1381,7 +1381,7 @@ function jks_nlie_residual_c(
     log_Cbar = log.(1 .+ aux.c_bar)
 
     rhs =
-        psi_c + apply_kernel(K1, log_B) - apply_kernel(K1, log_Bbar) +
+        -psi_c + apply_kernel(K1, log_B) - apply_kernel(K1, log_Bbar) +
         apply_kernel(K2, log_Cbar)
 
     log_c = log.(aux.c)
@@ -1417,7 +1417,7 @@ function jks_nlie_residual_cbar(
     log_C = log.(1 .+ aux.c)
 
     rhs =
-        psi_cbar + apply_kernel(K1, log_B) - apply_kernel(K1, log_Bbar) +
+        -psi_cbar + apply_kernel(K1, log_B) - apply_kernel(K1, log_Bbar) +
         apply_kernel(K2, log_C)
 
     log_cbar = log.(aux.c_bar)


### PR DESCRIPTION
## Summary

Stage C.13 of the JKS Hubbard QTM NLIE port (#523). **ψ sign fix per paper eq 53** — flips the leading sign on `psi_b`, `psi_c`, `psi_c_bar` in all 4 residual sites. Chained on Stage C.12 (PR #546).

## Paper vs Stage C.4-C.12 schematic

JKS paper eq (53):
```
log b⁺ = -ψ_b - K_{2,-} log B⁺ + K̄_{2,+} log B̄⁻ - K_{1,*} Δlog(C/C̄)
log c⁺ = -ψ_c - K_{1,-} log B⁺ + K̄_{1,*} log B̄⁻ + K_{2,0} Δlog C̄ - (1/2)Δlog C
log c̄⁺ = -ψ_c̄ - K_{1,*} log B⁺ + K̄_{1,-} log B̄⁻ + K_{2,0} Δlog C - (1/2)Δlog C̄
```

Stage C.4-C.12 wrote `+ψ` everywhere. This PR flips it in all 4 sites.

## Empirical impact (8-point grid, α=0.5, U=4, μ=2)

| β | b-only `f / f_atom` | full Newton `f / f_atom` |
|---:|---:|---:|
| **Before fix** (C.10/C.12) | | |
| 0.01 | 1.026 (3% over) | 1.526 |
| 0.1 | 1.026 | 1.438 |
| 1.0 | (stalled) | 1.240 |
| **After fix** (C.13) | | |
| 0.01 | 1.034 | 1.525 |
| 0.1 | **0.990** ← improved | 1.432 |
| 1.0 | 0.598 | 1.127 |

**Mid-T b-only improved** (1.026 → 0.99 at β=0.1). Full Newton still ~50% off — remaining work in Stage C.14:
- `K_{2,0}` vs `K_{1,0}` subscripts
- `(1/2) Δ log C` term currently dropped in c residual
- `K_{1,*}` vs `K_{1,-}` subscript differences

## Files

- `src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl` — 4 sed sign flips:
  - line 729: `rhs = psi_b - ...` → `rhs = -psi_b - ...` (b shifted residual)
  - line 861: same (b naive residual)
  - line 1384: `rhs = psi_c + ...` → `rhs = -psi_c + ...`
  - line 1420: `rhs = psi_cbar + ...` → `rhs = -psi_cbar + ...`

## Test plan

- [x] All Stage C.3-C.12 tests (210+ asserts) pass after sign flip
- [x] Empirical b-only at β=0.1 improved 1.026 → 0.99 documented

## Chain note

Based on `feat/issue-523-hubbard-jks-stage-c12` (PR #546).

Refs #523.
