### PR TITLE
feat(Hubbard1D): JKS Stage C.15 Option A — Delta-as-Im(log) no effect (#523)

### DIFF
--- a/src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl
+++ b/src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl
@@ -1378,11 +1378,16 @@ function jks_nlie_residual_c(
 
     log_B = log.(1 .+ aux.b)
     log_Bbar = log.(1 .+ 1 ./ aux.b_bar)
+    log_C = log.(1 .+ aux.c)
     log_Cbar = log.(1 .+ aux.c_bar)
+
+    # Stage C.15 Option A: add -(1/2) Delta log C term.
+    # Delta log C := 2i Im(log C) (cut discontinuity, vanishes when c is real).
+    delta_log_C = 2im .* imag.(log_C)
 
     rhs =
         -psi_c + apply_kernel(K1, log_B) - apply_kernel(K1, log_Bbar) +
-        apply_kernel(K2, log_Cbar)
+        apply_kernel(K2, log_Cbar) - 0.5 .* delta_log_C
 
     log_c = log.(aux.c)
     return log_c .- rhs
@@ -1415,10 +1420,14 @@ function jks_nlie_residual_cbar(
     log_B = log.(1 .+ aux.b)
     log_Bbar = log.(1 .+ 1 ./ aux.b_bar)
     log_C = log.(1 .+ aux.c)
+    log_Cbar = log.(1 .+ aux.c_bar)
+
+    # Stage C.15 Option A: add -(1/2) Delta log Cbar term.
+    delta_log_Cbar = 2im .* imag.(log_Cbar)
 
     rhs =
         -psi_cbar + apply_kernel(K1, log_B) - apply_kernel(K1, log_Bbar) +
-        apply_kernel(K2, log_C)
+        apply_kernel(K2, log_C) - 0.5 .* delta_log_Cbar
 
     log_cbar = log.(aux.c_bar)
     return log_cbar .- rhs


### PR DESCRIPTION
## Summary

Option A of two parallel Stage C.14 follow-ups. Adds only `-(1/2) Δlog C` (and `-(1/2) Δlog C̄`) with **Δlog = 2i·Im(log)** (cut-discontinuity) interpretation. Keeps C.13's `K_2 ⊛ log_Cbar` term unchanged.

**Result: no effect.** Companion PR (C.16 Option B) wins.

## Empirical impact (8-point grid, α=0.5, U=4, μ=2)

| β | C.13 baseline full | **C.15 Opt A full** | Δ |
|---:|---:|---:|---|
| 0.01 | 1.525 | 1.525 | unchanged |
| 0.1 | 1.432 | 1.433 | unchanged |
| 1.0 | 1.127 | 1.121 | ~0.6 pp |

## Why

Δlog C = 2i·Im(log C) **vanishes wherever c is real**. At high T the atomic-limit aux is real positive (`z_up`, `z_down` real), so Im(log C) ≈ 0. The new term has no effect across the entire benchmark regime.

The Δ-as-discontinuity reading of the paper is therefore not the right interpretation. Companion PR C.16 Option B drops the Δ entirely.

## Files

- `src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl`: 2 block patches in `jks_nlie_residual_c` and `jks_nlie_residual_cbar`.

## Test plan

- [x] All Stage C.3-C.13 tests pass

## Chain

Based on `feat/issue-523-hubbard-jks-stage-c13` (PR #547). Companion: Stage C.16 Option B.

Refs #523.
