### PR TITLE
feat(Hubbard1D): JKS Stage C.16 Option B — Delta dropped, -12 pp full Newton (#523)

### DIFF
--- a/src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl
+++ b/src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl
@@ -1378,11 +1378,13 @@ function jks_nlie_residual_c(
 
     log_B = log.(1 .+ aux.b)
     log_Bbar = log.(1 .+ 1 ./ aux.b_bar)
+    log_C = log.(1 .+ aux.c)
     log_Cbar = log.(1 .+ aux.c_bar)
 
+    # Stage C.16 Option B: add -(1/2) log C term (Delta dropped as typesetting).
     rhs =
         -psi_c + apply_kernel(K1, log_B) - apply_kernel(K1, log_Bbar) +
-        apply_kernel(K2, log_Cbar)
+        apply_kernel(K2, log_Cbar) - 0.5 .* log_C
 
     log_c = log.(aux.c)
     return log_c .- rhs
@@ -1415,10 +1417,12 @@ function jks_nlie_residual_cbar(
     log_B = log.(1 .+ aux.b)
     log_Bbar = log.(1 .+ 1 ./ aux.b_bar)
     log_C = log.(1 .+ aux.c)
+    log_Cbar = log.(1 .+ aux.c_bar)
 
+    # Stage C.16 Option B: add -(1/2) log Cbar term.
     rhs =
         -psi_cbar + apply_kernel(K1, log_B) - apply_kernel(K1, log_Bbar) +
-        apply_kernel(K2, log_C)
+        apply_kernel(K2, log_C) - 0.5 .* log_Cbar
 
     log_cbar = log.(aux.c_bar)
     return log_cbar .- rhs


### PR DESCRIPTION
## Summary

Option B of two parallel Stage C.14 follow-ups. Adds `-(1/2) log C` (and `-(1/2) log C̄`) — treating the paper's "Δlog" as a typesetting artifact (just plain `log`). Keeps C.13's `K_2 ⊛ log_Cbar` term.

**Result: moves the needle by 12-23 percentage points** in the right direction across all tested β.

## Empirical impact (8-point grid, α=0.5, U=4, μ=2)

| β | C.13 baseline full | **C.16 Opt B full** | Δ |
|---:|---:|---:|---|
| 0.01 | 1.525 | **1.404** | **-12 pp** ✓ |
| 0.1 | 1.432 | **1.316** | **-12 pp** ✓ |
| 1.0 | 1.127 | **0.895** | **-23 pp** ✓ |

## Interpretation

The companion PR (C.15 Option A) tried the Δ-as-cut-discontinuity reading (Δlog = 2i·Im log) — it vanished everywhere because the atomic-limit aux is real. Dropping the Δ entirely and treating it as plain `log` is the right move.

Full Newton now:
- **β=1.0 crosses below the atomic limit** (0.895), the qualitatively correct direction.
- High T still ~40 % off — one more kernel subscript or sign in the equations is still wrong. Stage C.17 will look at remaining `K_{1,*}` vs `K_{1,-}` distinction or the `K_{2,0} log Cbar` kernel choice.

## Files

- `src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl`: 2 block patches in `jks_nlie_residual_c` and `jks_nlie_residual_cbar`.

## Test plan

- [x] All Stage C.3-C.13 tests pass
- [x] Empirical 12+ pp improvement at all tested β

## Chain

Based on `feat/issue-523-hubbard-jks-stage-c13` (PR #547). Companion: Stage C.15 Option A.

Refs #523.
