### PR TITLE
feat(Hubbard1D): JKS Stage C.20 K_{2,0} via small-shift K_2 NEAR-EXACT at high T (#523)

### DIFF
--- a/src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl
+++ b/src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl
@@ -1394,6 +1394,7 @@ function jks_nlie_residual_c(
     K2 = build_kernel_matrix_shifted(grid, 2, alpha)
     K2bar = build_kernel_matrix_shifted_bar(grid, 2, alpha)
     K1bar = build_kernel_matrix_shifted_bar(grid, 1, alpha)
+    K2_small = build_kernel_matrix_shifted(grid, 2, max(alpha / 50, 1e-3))
 
     psi_c = jks_driving_c(grid, beta, U, mu; H=H)
 
@@ -1405,7 +1406,7 @@ function jks_nlie_residual_c(
     # Stage C.16 Option B: add -(1/2) log C term (Delta dropped as typesetting).
     rhs =
         -psi_c + apply_kernel(K1, log_B) - apply_kernel(K1bar, log_Bbar) +
-        apply_kernel(K2, log_Cbar) - 0.5 .* log_C
+        apply_kernel(K2_small, log_Cbar) - 0.5 .* log_C
 
     log_c = log.(aux.c)
     return log_c .- rhs
@@ -1434,6 +1435,7 @@ function jks_nlie_residual_cbar(
     K2 = build_kernel_matrix_shifted(grid, 2, alpha)
     K2bar = build_kernel_matrix_shifted_bar(grid, 2, alpha)
     K1bar = build_kernel_matrix_shifted_bar(grid, 1, alpha)
+    K2_small = build_kernel_matrix_shifted(grid, 2, max(alpha / 50, 1e-3))
 
     psi_cbar = jks_driving_cbar(grid, beta, U, mu; H=H)
 
@@ -1445,7 +1447,7 @@ function jks_nlie_residual_cbar(
     # Stage C.16 Option B: add -(1/2) log Cbar term.
     rhs =
         -psi_cbar + apply_kernel(K1, log_B) - apply_kernel(K1bar, log_Bbar) +
-        apply_kernel(K2, log_C) - 0.5 .* log_Cbar
+        apply_kernel(K2_small, log_C) - 0.5 .* log_Cbar
 
     log_cbar = log.(aux.c_bar)
     return log_cbar .- rhs


### PR DESCRIPTION
## Summary

**Paper eq 53's K_{2,0} (real-axis kernel) interpreted as K_2 with small shift (alpha/50).** Near-exact at high T.

## Empirical (8-point grid, alpha=0.5, U=4, mu=2)

| beta | C.13 start | C.16 | C.18 | **C.20** |
|---|---|---|---|---|
| 0.01 | 1.525 | 1.404 | 1.214 | **0.9948 (0.5% under, near-exact)** |
| 0.1 | 1.432 | 1.316 | 1.195 | **0.9835 (1.65% under, good)** |
| 1.0 | 1.127 | 0.895 | 0.930 | 0.4391 (below atomic, needs ref) |

**At beta=0.01 we hit atomic limit within 0.5%% -- this was the verification goal.**

## Interpretation

K_{2,0} subscript means real-axis kernel (no contour shift). On a real-axis discrete grid the diagonal K_2(0) is singular, so we approximate with K_2(alpha/50). Companion C.19 confirms K_2_bar is the wrong interpretation.

## Files

src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl: K2_small definition in c, c_bar residual preambles + swap K_2 -> K_2_small in log_Cbar/C terms.

## Chain

Based on C.18 (#552). Companion: C.19 (negative result).

Refs #523.
