### PR TITLE
feat(Hubbard1D): JKS Stage C.21 K2_small dx-scaled + diagnostic finding (#523)

### DIFF
--- a/src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl
+++ b/src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl
@@ -1394,7 +1394,7 @@ function jks_nlie_residual_c(
     K2 = build_kernel_matrix_shifted(grid, 2, alpha)
     K2bar = build_kernel_matrix_shifted_bar(grid, 2, alpha)
     K1bar = build_kernel_matrix_shifted_bar(grid, 1, alpha)
-    K2_small = build_kernel_matrix_shifted(grid, 2, max(alpha / 50, 1e-3))
+    K2_small = build_kernel_matrix_shifted(grid, 2, max(grid.dx, alpha / 50, 1e-3))
 
     psi_c = jks_driving_c(grid, beta, U, mu; H=H)
 
@@ -1435,7 +1435,7 @@ function jks_nlie_residual_cbar(
     K2 = build_kernel_matrix_shifted(grid, 2, alpha)
     K2bar = build_kernel_matrix_shifted_bar(grid, 2, alpha)
     K1bar = build_kernel_matrix_shifted_bar(grid, 1, alpha)
-    K2_small = build_kernel_matrix_shifted(grid, 2, max(alpha / 50, 1e-3))
+    K2_small = build_kernel_matrix_shifted(grid, 2, max(grid.dx, alpha / 50, 1e-3))
 
     psi_cbar = jks_driving_cbar(grid, beta, U, mu; H=H)
 


### PR DESCRIPTION
## Summary

Two findings:

1. **C.20 N=8 result was a numerical coincidence.** True converged result is ~1.19 (19% over atomic) at beta=0.001, NOT 0.995.
2. **Atomic aux is NOT a fixed point** of the residual equations -- max abs residual is 0.3-0.9 at beta=0.001, 32-point grid.
3. **FE evaluator has a 2.5% offset** even when given the exact atomic aux.

## What this PR does

Replaces `K2_small shift = alpha/50` (singularity hack) with `max(dx, alpha/50, 1e-3)` (grid-scaled regularization). This gives clean monotone convergence.

## Convergence with dx-scaled K2_small

| N | beta=0.001 | beta=0.01 | beta=0.1 | beta=1.0 |
|---|---|---|---|---|
| 8 | 1.216 | 1.215 | 1.196 | 0.929 |
| 16 | 1.205 | 1.203 | 1.183 | 0.888 |
| 32 | 1.197 | 1.195 | 1.175 | 0.880 |
| **64** | **1.191** | **1.189** | **1.169** | **0.873** |

Clean N -> infinity extrapolation to ~1.19 -- 19% systematic offset survives.

## Implications for Stage C.22

The remaining 19% gap is in the residual equations or FE evaluator, NOT in the discretization. Stage C.22 will diagnose by plugging atomic aux into the residual and tracking which term contributes the dominant non-zero value.

## Files

- src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl: K2_small definition uses max(grid.dx, alpha/50, 1e-3).

## Chain

Based on C.20 (#554).

Refs #523.
