### PR TITLE
feat(Hubbard1D): JKS Stage C.23 FE eval /c fix, -24 pp at high T (#523)

### DIFF
--- a/src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl
+++ b/src/models/quantum/Hubbard1D/Hubbard1D_jks_nlie.jl
@@ -559,8 +559,11 @@ function free_energy_jks(
 
     # First integral:  -2i int_{-1}^{1} ln(1 + c + cbar) / sqrt(1 - s^2) ds
     integrand_1 = ComplexF64[
-        cut_mask[j] ? log(1 + aux.c[j] + aux.c_bar[j]) / sqrt(1 - grid.x[j]^2) : 0.0 + 0im
-        for j in 1:grid.N
+        if cut_mask[j]
+            log((1 + aux.c[j] + aux.c_bar[j]) / aux.c[j]) / sqrt(1 - grid.x[j]^2)
+        else
+            0.0 + 0im
+        end for j in 1:grid.N
     ]
     int_1 = -2im * sum(integrand_1) * grid.dx
 


### PR DESCRIPTION
## Summary

Paper eq (49) third form has integrand `ln((1+c+cbar)/c)` — the `/c` factor was missing from my Stage C.2 implementation.

## Empirical (32-pt, alpha=0.5, x_max=4)

| beta | C.22c full | **C.23 full** |
|---|---|---|
| 0.001 | 1.569 | **1.327 (-24 pp)** |
| 0.01 | 1.553 | **1.311** |
| 0.1 | 1.458 | **1.169** |
| 1.0 | 0.516 | 0.463 |

## Remaining

FE evaluator at atomic aux still gives ratio 1.467 — the kernel prefactor on the cut integral needs to match paper eq 57 `K(x) = -1/(2π√(1-x²))` (mine has `-2i/sqrt(1-x²)`). Stage C.24.

## Chain

Based on C.22c (#556). Next: C.24 prefactor fix.

Refs #523.
