### PR TITLE
fix: correct version 0.22.30 -> 0.22.18 (General-registrable)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.22.30"
+version = "0.22.18"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]


### PR DESCRIPTION
#529 merged to `main` carrying `version = 0.22.30` — a stale over-bump inherited from the branch. That skips `0.22.18..0.22.29` and the **General registry rejected it**; no `v0.22.30` tag was ever created (tags stop at `v0.22.17`).

The correct next version after the released `v0.22.17` is **`0.22.18`**. This PR resets `main` to it so `v0.22.18` registers cleanly.

⚠️ **VersionCheck will be red**: it compares the PR version against the base (`main = 0.22.30`), so `0.22.18 < 0.22.30` reads as a downgrade. That is exactly the intent — **admin-merge / override** to undo the bad bump, then tag `v0.22.18`.

After merge: tag `v0.22.18` (re-trigger Registrator). The open feature PRs that pre-claimed numbers (#527=0.22.18, #530=0.22.20, #531=0.22.21, #532=0.22.22) will reconcile against the corrected `main` at their own merge time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)