### PR TITLE
fix(ci): publish release passes body via env: to escape backticks

### DIFF
--- a/.github/workflows/PublishRelease.yml
+++ b/.github/workflows/PublishRelease.yml
@@ -38,9 +38,15 @@ jobs:
       - name: Create or update release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pass body via env so bash never parses it. Inline
+          # ${{ steps.body.outputs.content }} would interpolate the body
+          # straight into the script source, where backticks inside the body
+          # (e.g. `Version bumped from \`0.22.19\` -> \`0.23.0\`` from
+          # release-drafter or AutoCompatBump output) trigger command
+          # substitution and exit 127.
+          BODY: ${{ steps.body.outputs.content }}
         run: |
           TAG="${{ github.ref_name }}"
-          BODY="${{ steps.body.outputs.content }}"
 
           if gh release view "$TAG" >/dev/null 2>&1; then
             gh release edit "$TAG" --title "$TAG" --notes "$BODY" --draft=false


### PR DESCRIPTION
## Problem

v0.23.0 release publish failed with exit 127:

```
/home/runner/work/_temp/...sh: line 16: 0.22.19: command not found
/home/runner/work/_temp/...sh: line 16: 0.23.0: command not found
Error: Process completed with exit code 127.
```

## Root cause

```yaml
run: |
  BODY="${{ steps.body.outputs.content }}"
```

GitHub Actions interpolates `${{ steps.body.outputs.content }}` **into
the bash script source itself**, before bash starts. release-drafter /
AutoCompatBump emit lines like

> Version bumped from `0.22.19` -> `0.23.0` by commit ...

So bash sees:

```bash
BODY="...Version bumped from \ -> \ by commit ..."
```

and the backticks open command substitution, trying to execute
`0.22.19` as a command.

## Fix

Pass the body through the `env:` block:

```yaml
env:
  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  BODY: ${{ steps.body.outputs.content }}
run: |
  TAG="${{ github.ref_name }}"
  ...
  gh release edit "$TAG" --title "$TAG" --notes "$BODY" --draft=false
```

Env vars are populated by Actions **before** bash starts, so bash
never re-parses the body string. `$BODY` reads back verbatim regardless
of any backticks, dollar signs, semicolons, etc. in it.

This is the ["intermediate environment variable"](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable)
pattern from GitHub's own Actions security guide for exactly this
class of bug.

## Verification

- [ ] Once merged, the next `v*` tag should publish without exit 127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)