### PR TITLE
feat(HeisenbergXYZ): extend Energy{:per_site}@Infinite to XY line (PR_β, stacked on PR_α)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.4"
+version = "0.23.5"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/models/quantum/HeisenbergXYZ/HeisenbergXYZ.jl
+++ b/src/models/quantum/HeisenbergXYZ/HeisenbergXYZ.jl
@@ -106,24 +106,31 @@ function fetch(
     Jz::Real=m.Jz,
     kwargs...,
 )
-    Jx == Jy || throw(
-        DomainError(
-            (Jx, Jy),
-            "HeisenbergXYZ Energy(:per_site) currently supports only the axis-aligned reduction Jx = Jy (delegated to XXZ1D); general XYZ via Baxter elliptic Bethe ansatz is tracked as Phase 2.  Got (Jx, Jy) = ($Jx, $Jy).",
-        ),
-    )
-    # Restrict to Jx > 0 so that Delta = Jz/Jx has unambiguous sign and the
-    # delegation lands in the XXZ1D-tested domain.  Jx < 0 (FM exchange) would
-    # flip Delta's sign into XXZ1D regions whose Yang-Yang analytic
-    # continuation is not exercised by the current XXZ1D test suite.
-    Jx > 0 || throw(
-        DomainError(
-            Jx,
-            "HeisenbergXYZ Energy(:per_site): Jx > 0 required (Jx == 0 is Ising-like; Jx < 0 is the FM-exchange XXZ regime whose XXZ1D delegation is not yet tested).  Got Jx = $Jx.",
-        ),
-    )
-    Δ = Jz / Jx
-    return QAtlas.fetch(QAtlas.XXZ1D(; J=Jx, Δ=Δ), Energy{:per_site}(), Infinite())
+    if Jx == Jy
+        Jx > 0 || throw(
+            DomainError(
+                Jx,
+                "HeisenbergXYZ Energy(:per_site): Jx > 0 required in the axial Jx = Jy " *
+                "branch (Jx == 0 is Ising-like; Jx < 0 is the FM-exchange XXZ regime " *
+                "whose XXZ1D delegation is not yet tested). Got Jx = $Jx.",
+            ),
+        )
+        Δ = Jz / Jx
+        return QAtlas.fetch(QAtlas.XXZ1D(; J=Jx, Δ=Δ), Energy{:per_site}(), Infinite())
+    elseif Jz == 0
+        # XY anisotropic line (Jx != Jy, Jz = 0). Lieb-Schultz-Mattis closed form.
+        return _heisenberg_xyz_gs_energy_xy_line(Jx, Jy)
+    else
+        throw(
+            DomainError(
+                (Jx, Jy, Jz),
+                "HeisenbergXYZ Energy(:per_site): generic XYZ (Jx != Jy, Jz != 0) " *
+                "requires the Baxter (1972) elliptic Bethe-ansatz machinery, deferred " *
+                "to Phase 3. Supported now: Jx = Jy (XXZ delegation) and Jz = 0 (XY line). " *
+                "Got (Jx, Jy, Jz) = ($Jx, $Jy, $Jz).",
+            ),
+        )
+    end
 end
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/src/models/quantum/HeisenbergXYZ/HeisenbergXYZ_registry.jl
+++ b/src/models/quantum/HeisenbergXYZ/HeisenbergXYZ_registry.jl
@@ -11,8 +11,8 @@
     method=:xxz_delegation,
     reliability=:high,
     tested_in="test/standalone/test_heisenberg_xyz.jl",
-    references=["YangYang1966", "Baxter1972"],
-    notes="Delegates to XXZ1D(J=Jx, Δ=Jz/Jx) when Jx=Jy; general (Jx≠Jy) raises DomainError (Baxter elliptic deferred to Phase 2).",
+    references=["YangYang1966", "LiebSchultzMattis1961", "Baxter1972"],
+    notes="Delegates to XXZ1D(J=Jx, Δ=Jz/Jx) when Jx=Jy; XY anisotropic line (Jz=0) via Lieb-Schultz-Mattis 1961 closed form; generic XYZ (Jx≠Jy, Jz≠0) deferred to Baxter elliptic Phase 3.",
 )
 
 @register(

--- a/test/models/quantum/HeisenbergXYZ/test_heisenberg_xyz_gs.jl
+++ b/test/models/quantum/HeisenbergXYZ/test_heisenberg_xyz_gs.jl
@@ -65,4 +65,19 @@ using QAtlas: fetch, GroundStateEnergyDensity, Infinite, HeisenbergXYZ
         m_fm = HeisenbergXYZ(; Jx=-1.0, Jy=-1.0, Jz=0.5)
         @test_throws DomainError fetch(m_fm, GroundStateEnergyDensity(), Infinite())
     end
+
+    @testset "Energy{:per_site} matches GroundStateEnergyDensity across regimes" begin
+        using QAtlas: Energy
+        for m in (
+            HeisenbergXYZ(; Jx=1.0, Jy=1.0, Jz=1.0),  # Heisenberg
+            HeisenbergXYZ(; Jx=1.0, Jy=1.0, Jz=0.5),  # XXZ
+            HeisenbergXYZ(; Jx=1.0, Jy=1.0, Jz=0.0),  # XX
+            HeisenbergXYZ(; Jx=2.0, Jy=1.0, Jz=0.0),  # anisotropic XY
+            HeisenbergXYZ(; Jx=3.0, Jy=0.5, Jz=0.0),  # extreme anisotropic XY
+        )
+            f_gsed = fetch(m, GroundStateEnergyDensity(), Infinite())
+            f_ener = fetch(m, Energy{:per_site}(), Infinite())
+            @test f_gsed == f_ener
+        end
+    end
 end


### PR DESCRIPTION
## Summary

**PR_β of the HeisenbergXYZ Baxter Phase 2 stack** — branched off PR_α (#568). Mirrors PR_α's three-regime dispatch on the existing `Energy{:per_site}` dispatch, which previously hard-threw for any `Jx ≠ Jy`.

Same physics as PR_α, different quantity name:

| Regime | Method |
|---|---|
| `Jx = Jy` | XXZ1D delegation |
| `Jz = 0` | LSM 1961 closed form (`_heisenberg_xyz_gs_energy_xy_line`) |
| generic XYZ | `DomainError` (Phase 3 deferred) |

## Test plan

- [x] **17/17 pass** (12 inherited from PR_α + 5 cross-quantity consistency: `Energy{:per_site}` ≡ `GroundStateEnergyDensity` numerically across all supported regimes)
- [x] JuliaFormatter clean
- [x] Aqua undocumented_names pass

## Fold-back target

→ `feat/heisenberg-xyz-baxter-gs` (PR_α). On user review/merge of PR_α, this branch is squash-folded into it.

## Version bump

`0.23.4 → 0.23.5` (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)