### PR TITLE
feat(HeisenbergXYZ): MassGap@Infinite (PR_γ, stacked on PR_α)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.4"
+version = "0.23.6"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/models/quantum/HeisenbergXYZ/HeisenbergXYZ.jl
+++ b/src/models/quantum/HeisenbergXYZ/HeisenbergXYZ.jl
@@ -277,8 +277,7 @@ function fetch(
     if Jx == Jy
         Jx > 0 || throw(
             DomainError(
-                Jx,
-                "HeisenbergXYZ MassGap axial branch requires Jx > 0; got Jx = $Jx.",
+                Jx, "HeisenbergXYZ MassGap axial branch requires Jx > 0; got Jx = $Jx."
             ),
         )
         if abs(Jz / Jx) <= 1

--- a/src/models/quantum/HeisenbergXYZ/HeisenbergXYZ.jl
+++ b/src/models/quantum/HeisenbergXYZ/HeisenbergXYZ.jl
@@ -239,3 +239,73 @@ function fetch(
         )
     end
 end
+
+# ==============================================================================
+# Mass gap (Phase 2: critical axial + XY line free-fermion)
+# ==============================================================================
+
+"""
+    fetch(m::HeisenbergXYZ, ::MassGap, ::Infinite;
+          Jx=m.Jx, Jy=m.Jy, Jz=m.Jz) -> Float64
+
+Single-particle mass gap (smallest excitation energy above the ground
+state) of the spin-1/2 XYZ chain at the thermodynamic limit.
+
+| Regime                              | Method                                         |
+|-------------------------------------|------------------------------------------------|
+| `Jx = Jy`, `abs(Jz/Jx) <= 1`        | gapless critical XXZ: returns `0.0`            |
+| `Jz = 0` (XY line, `Jx != Jy`)      | LSM dispersion minimum: `(1/4)*abs(Jx - Jy)`   |
+| massive axial AFM (`Jz/Jx > 1`)     | `DomainError` (Yang-Yang gap deferred)         |
+| generic XYZ (`Jx != Jy`, `Jz != 0`) | `DomainError` (Baxter elliptic Phase 3)        |
+
+# References
+
+- E. Lieb, T. Schultz, D. Mattis, *Ann. Phys.* **16**, 407 (1961).
+- C. N. Yang, C. P. Yang, *Phys. Rev.* **150**, 327 (1966).
+- A. Luther, I. Peschel, *Phys. Rev. B* **12**, 3908 (1975).
+- R. J. Baxter, *Ann. Phys.* **70**, 193 (1972).
+"""
+function fetch(
+    m::HeisenbergXYZ,
+    ::MassGap,
+    ::Infinite;
+    Jx::Real=m.Jx,
+    Jy::Real=m.Jy,
+    Jz::Real=m.Jz,
+    kwargs...,
+)
+    if Jx == Jy
+        Jx > 0 || throw(
+            DomainError(
+                Jx,
+                "HeisenbergXYZ MassGap axial branch requires Jx > 0; got Jx = $Jx.",
+            ),
+        )
+        if abs(Jz / Jx) <= 1
+            return 0.0  # critical XXZ -1 <= Delta <= 1: gapless spinon spectrum
+        else
+            throw(
+                DomainError(
+                    Jz / Jx,
+                    "HeisenbergXYZ MassGap at Jx = Jy: massive AFM regime " *
+                    "Delta = Jz/Jx > 1 not yet implemented (Yang-Yang gap " *
+                    "formula deferred); got Delta = $(Jz/Jx).",
+                ),
+            )
+        end
+    elseif Jz == 0
+        # XY anisotropic line: single-fermion gap min_k epsilon(k) with
+        #   epsilon(k) = (1/4) * sqrt((Jx+Jy)^2 cos^2(k) + (Jx-Jy)^2 sin^2(k))
+        # Minimum at k = +- pi/2 gives (1/4)*|Jx - Jy|.
+        return abs(Jx - Jy) / 4
+    else
+        throw(
+            DomainError(
+                (Jx, Jy, Jz),
+                "HeisenbergXYZ MassGap: generic XYZ (Jx != Jy, Jz != 0) requires " *
+                "the Baxter (1972) / Johnson-Krinsky-McCoy (1973) elliptic mass " *
+                "spectrum, deferred to Phase 3. Got (Jx, Jy, Jz) = ($Jx, $Jy, $Jz).",
+            ),
+        )
+    end
+end

--- a/src/models/quantum/HeisenbergXYZ/HeisenbergXYZ_registry.jl
+++ b/src/models/quantum/HeisenbergXYZ/HeisenbergXYZ_registry.jl
@@ -38,3 +38,16 @@
           "closed form; axial XXZ case (Jx=Jy) delegated to XXZ1D Energy(:per_site). " *
           "Generic XYZ (Jx!=Jy, Jz!=0) deferred to Baxter elliptic Phase 3.",
 )
+
+@register(
+    HeisenbergXYZ,
+    MassGap,
+    Infinite,
+    method=:closed_form,
+    reliability=:high,
+    tested_in="test/models/quantum/HeisenbergXYZ/test_heisenberg_xyz_gs.jl",
+    references=["LiebSchultzMattis1961", "YangYang1966", "Baxter1972"],
+    notes="Critical axial XXZ (Jx=Jy, |Jz/Jx|<=1): gapless (0.0). XY anisotropic " *
+          "line (Jz=0): single-particle gap (1/4)|Jx-Jy| from LSM dispersion. " *
+          "Massive AFM and generic XYZ deferred to Phase 3.",
+)

--- a/test/models/quantum/HeisenbergXYZ/test_heisenberg_xyz_gs.jl
+++ b/test/models/quantum/HeisenbergXYZ/test_heisenberg_xyz_gs.jl
@@ -65,4 +65,24 @@ using QAtlas: fetch, GroundStateEnergyDensity, Infinite, HeisenbergXYZ
         m_fm = HeisenbergXYZ(; Jx=-1.0, Jy=-1.0, Jz=0.5)
         @test_throws DomainError fetch(m_fm, GroundStateEnergyDensity(), Infinite())
     end
+
+    @testset "MassGap@Infinite -- critical axial + XY line" begin
+        # Heisenberg, XXZ critical, XX point: all gapless
+        for (Jx, Jy, Jz) in
+            ((1.0, 1.0, 1.0), (1.0, 1.0, 0.5), (1.0, 1.0, -0.5), (1.0, 1.0, 0.0))
+            m = HeisenbergXYZ(; Jx=Jx, Jy=Jy, Jz=Jz)
+            @test fetch(m, QAtlas.MassGap(), Infinite()) == 0.0
+        end
+        # XY anisotropic line: gap = (1/4) |Jx - Jy|
+        for (Jx, Jy) in ((2.0, 1.0), (3.0, 0.5), (1.0, 2.0))
+            m = HeisenbergXYZ(; Jx=Jx, Jy=Jy, Jz=0.0)
+            @test fetch(m, QAtlas.MassGap(), Infinite()) ≈ abs(Jx - Jy) / 4 atol=1e-12
+        end
+        # Massive AFM (Jz/Jx > 1): not yet implemented, DomainError
+        m_massive = HeisenbergXYZ(; Jx=1.0, Jy=1.0, Jz=1.5)
+        @test_throws DomainError fetch(m_massive, QAtlas.MassGap(), Infinite())
+        # Generic XYZ: DomainError
+        m_generic = HeisenbergXYZ(; Jx=2.0, Jy=1.0, Jz=0.5)
+        @test_throws DomainError fetch(m_generic, QAtlas.MassGap(), Infinite())
+    end
 end


### PR DESCRIPTION
## PR_γ of HeisenbergXYZ Baxter Phase 2 stack

Branched off PR_α (#568). Adds single-particle mass-gap dispatch.

| Regime | Method |
|---|---|
| Jx = Jy, |Jz/Jx| ≤ 1 | gapless (returns 0.0) |
| Jz = 0, Jx ≠ Jy | (1/4)|Jx - Jy| from LSM dispersion min at k = ±π/2 |
| massive AFM Jz/Jx > 1 | DomainError (Yang-Yang deferred) |
| generic XYZ | DomainError (Baxter elliptic Phase 3) |

## Test plan
- [x] 21/21 pass (12 from PR_α + 9 new MassGap)
- [x] format + Aqua clean

## Fold-back target
→ feat/heisenberg-xyz-baxter-gs (PR_α).

## Version
0.23.4 → 0.23.6 (patch, jumping 0.23.5 reserved for PR_β).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
