### PR TITLE
feat(HeisenbergXYZ): CorrelationLength@Infinite (PR_δ, stacked on PR_γ)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.6"
+version = "0.23.7"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/models/quantum/HeisenbergXYZ/HeisenbergXYZ.jl
+++ b/src/models/quantum/HeisenbergXYZ/HeisenbergXYZ.jl
@@ -277,8 +277,7 @@ function fetch(
     if Jx == Jy
         Jx > 0 || throw(
             DomainError(
-                Jx,
-                "HeisenbergXYZ MassGap axial branch requires Jx > 0; got Jx = $Jx.",
+                Jx, "HeisenbergXYZ MassGap axial branch requires Jx > 0; got Jx = $Jx."
             ),
         )
         if abs(Jz / Jx) <= 1
@@ -305,6 +304,77 @@ function fetch(
                 "HeisenbergXYZ MassGap: generic XYZ (Jx != Jy, Jz != 0) requires " *
                 "the Baxter (1972) / Johnson-Krinsky-McCoy (1973) elliptic mass " *
                 "spectrum, deferred to Phase 3. Got (Jx, Jy, Jz) = ($Jx, $Jy, $Jz).",
+            ),
+        )
+    end
+end
+
+# ==============================================================================
+# Correlation length (Phase 2: critical axial + XY line free-fermion)
+# ==============================================================================
+
+"""
+    fetch(m::HeisenbergXYZ, ::CorrelationLength, ::Infinite;
+          Jx=m.Jx, Jy=m.Jy, Jz=m.Jz) -> Float64
+
+Asymptotic correlation length of the spin-1/2 XYZ chain at the
+thermodynamic limit.
+
+| Regime                              | Method                                                              |
+|-------------------------------------|---------------------------------------------------------------------|
+| `Jx = Jy`, `abs(Jz/Jx) <= 1`        | gapless critical XXZ: returns `Inf`                                 |
+| `Jz = 0` (XY line, `Jx != Jy`)      | `xi = 1/asinh(abs(Jx-Jy) / (2*sqrt(Jx*Jy)))` (dispersion zero)      |
+| massive axial AFM (`Jz/Jx > 1`)     | `DomainError`                                                       |
+| generic XYZ                         | `DomainError` (Baxter elliptic Phase 3)                             |
+
+# References
+
+- E. Lieb, T. Schultz, D. Mattis, *Ann. Phys.* **16**, 407 (1961).
+- B. M. McCoy, T. T. Wu, *Phys. Rev.* **174**, 546 (1968).
+"""
+function fetch(
+    m::HeisenbergXYZ,
+    ::CorrelationLength,
+    ::Infinite;
+    Jx::Real=m.Jx,
+    Jy::Real=m.Jy,
+    Jz::Real=m.Jz,
+    kwargs...,
+)
+    if Jx == Jy
+        Jx > 0 || throw(
+            DomainError(
+                Jx,
+                "HeisenbergXYZ CorrelationLength axial branch requires Jx > 0; got Jx = $Jx.",
+            ),
+        )
+        if abs(Jz / Jx) <= 1
+            return Inf
+        else
+            throw(
+                DomainError(
+                    Jz / Jx,
+                    "HeisenbergXYZ CorrelationLength at Jx = Jy: massive AFM " *
+                    "Delta = Jz/Jx > 1 not yet implemented; got Delta = $(Jz/Jx).",
+                ),
+            )
+        end
+    elseif Jz == 0
+        prod = Jx * Jy
+        prod > 0 || throw(
+            DomainError(
+                (Jx, Jy),
+                "HeisenbergXYZ CorrelationLength on XY line requires Jx Jy > 0; " *
+                "got Jx*Jy = $prod.",
+            ),
+        )
+        return 1 / asinh(abs(Jx - Jy) / (2 * sqrt(prod)))
+    else
+        throw(
+            DomainError(
+                (Jx, Jy, Jz),
+                "HeisenbergXYZ CorrelationLength: generic XYZ requires Baxter " *
+                "(1972) elliptic correlation, deferred to Phase 3. Got (Jx, Jy, Jz) = ($Jx, $Jy, $Jz).",
             ),
         )
     end

--- a/src/models/quantum/HeisenbergXYZ/HeisenbergXYZ_registry.jl
+++ b/src/models/quantum/HeisenbergXYZ/HeisenbergXYZ_registry.jl
@@ -51,3 +51,16 @@
           "line (Jz=0): single-particle gap (1/4)|Jx-Jy| from LSM dispersion. " *
           "Massive AFM and generic XYZ deferred to Phase 3.",
 )
+
+@register(
+    HeisenbergXYZ,
+    CorrelationLength,
+    Infinite,
+    method=:closed_form,
+    reliability=:high,
+    tested_in="test/models/quantum/HeisenbergXYZ/test_heisenberg_xyz_gs.jl",
+    references=["LiebSchultzMattis1961", "McCoyWu1978"],
+    notes="Critical axial XXZ (Jx=Jy, |Jz/Jx|<=1): Inf (gapless). XY line (Jz=0): " *
+          "xi = 1/asinh(|Jx-Jy|/(2 sqrt(Jx Jy))) from dispersion zero on imaginary " *
+          "momentum axis. Massive AFM and generic XYZ deferred to Phase 3.",
+)

--- a/test/models/quantum/HeisenbergXYZ/test_heisenberg_xyz_gs.jl
+++ b/test/models/quantum/HeisenbergXYZ/test_heisenberg_xyz_gs.jl
@@ -85,4 +85,24 @@ using QAtlas: fetch, GroundStateEnergyDensity, Infinite, HeisenbergXYZ
         m_generic = HeisenbergXYZ(; Jx=2.0, Jy=1.0, Jz=0.5)
         @test_throws DomainError fetch(m_generic, QAtlas.MassGap(), Infinite())
     end
+
+    @testset "CorrelationLength@Infinite -- critical + XY line" begin
+        for (Jx, Jy, Jz) in ((1.0, 1.0, 1.0), (1.0, 1.0, 0.5), (1.0, 1.0, 0.0))
+            m = HeisenbergXYZ(; Jx=Jx, Jy=Jy, Jz=Jz)
+            @test fetch(m, QAtlas.CorrelationLength(), Infinite()) == Inf
+        end
+        for (Jx, Jy) in ((2.0, 1.0), (3.0, 0.5), (1.0, 2.0))
+            m = HeisenbergXYZ(; Jx=Jx, Jy=Jy, Jz=0.0)
+            xi_ref = 1 / asinh(abs(Jx - Jy) / (2 * sqrt(Jx * Jy)))
+            @test fetch(m, QAtlas.CorrelationLength(), Infinite()) ≈ xi_ref atol=1e-12
+        end
+        m_strong = HeisenbergXYZ(; Jx=10.0, Jy=1.0, Jz=0.0)
+        m_weak = HeisenbergXYZ(; Jx=2.0, Jy=1.0, Jz=0.0)
+        @test fetch(m_strong, QAtlas.CorrelationLength(), Infinite()) <
+            fetch(m_weak, QAtlas.CorrelationLength(), Infinite())
+        m_massive = HeisenbergXYZ(; Jx=1.0, Jy=1.0, Jz=1.5)
+        @test_throws DomainError fetch(m_massive, QAtlas.CorrelationLength(), Infinite())
+        m_generic = HeisenbergXYZ(; Jx=2.0, Jy=1.0, Jz=0.5)
+        @test_throws DomainError fetch(m_generic, QAtlas.CorrelationLength(), Infinite())
+    end
 end


### PR DESCRIPTION
## PR_δ — CorrelationLength

Stacked on PR_γ (MassGap). Adds correlation length via dispersion zero on imaginary momentum axis.

| Regime | Method |
|---|---|
| Jx = Jy, |Jz/Jx| ≤ 1 | Inf (gapless) |
| Jz = 0, Jx ≠ Jy | ξ = 1/asinh(|Jx-Jy|/(2√(Jx Jy))) |
| massive AFM, generic XYZ | DomainError (Phase 3) |

30/30 tests pass. Version 0.23.6 → 0.23.7.

Fold-back: → PR_γ branch → PR_α.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
