### PR TITLE
feat(HeisenbergXYZ): SpontaneousMagnetization@Infinite (PR_ε, stacked on PR_α)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.4"
+version = "0.23.8"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/models/quantum/HeisenbergXYZ/HeisenbergXYZ.jl
+++ b/src/models/quantum/HeisenbergXYZ/HeisenbergXYZ.jl
@@ -239,3 +239,77 @@ function fetch(
         )
     end
 end
+
+# ==============================================================================
+# Spontaneous magnetization (Phase 2: XY anisotropic line)
+# ==============================================================================
+
+"""
+    fetch(m::HeisenbergXYZ, ::SpontaneousMagnetization, ::Infinite;
+          Jx=m.Jx, Jy=m.Jy, Jz=m.Jz) -> Float64
+
+Spontaneous magnetization (sublattice order parameter) of the spin-1/2
+XYZ chain at the thermodynamic limit.
+
+| Regime                              | Method                                                            |
+|-------------------------------------|-------------------------------------------------------------------|
+| `Jx = Jy`, `abs(Jz/Jx) <= 1`        | gapless critical XXZ, no LRO in 1D: returns `0.0`                 |
+| `Jz = 0` (XY line, `Jx != Jy`)      | McCoy-Wu / Pfeuty 1/8: `M = (1 - (Jmin/Jmax)^2)^(1/8)`            |
+| massive axial AFM (`Jz/Jx > 1`)     | `DomainError` (Neel staggered M Baxter 1971 deferred)             |
+| generic XYZ                         | `DomainError` (Baxter 1973 PRL elliptic theta deferred)           |
+
+# References
+
+- B. M. McCoy, T. T. Wu, *Phys. Rev.* **174**, 546 (1968).
+- P. Pfeuty, *Ann. Phys.* **57**, 79 (1970).
+- R. J. Baxter, *Phys. Rev. Lett.* **31**, 1294 (1973) -- generic XYZ.
+"""
+function fetch(
+    m::HeisenbergXYZ,
+    ::SpontaneousMagnetization,
+    ::Infinite;
+    Jx::Real=m.Jx,
+    Jy::Real=m.Jy,
+    Jz::Real=m.Jz,
+    kwargs...,
+)
+    if Jx == Jy
+        Jx > 0 || throw(
+            DomainError(
+                Jx,
+                "HeisenbergXYZ SpontaneousMagnetization axial branch requires Jx > 0; got Jx = $Jx.",
+            ),
+        )
+        if abs(Jz / Jx) <= 1
+            return 0.0
+        else
+            throw(
+                DomainError(
+                    Jz / Jx,
+                    "HeisenbergXYZ SpontaneousMagnetization at Jx = Jy: massive AFM " *
+                    "(Neel staggered M) deferred to Phase 3; got Delta = $(Jz/Jx).",
+                ),
+            )
+        end
+    elseif Jz == 0
+        ax, ay = abs(Jx), abs(Jy)
+        (ax > 0 && ay > 0) || throw(
+            DomainError(
+                (Jx, Jy),
+                "HeisenbergXYZ SpontaneousMagnetization on XY line requires both " *
+                "|Jx| > 0 and |Jy| > 0; got (Jx, Jy) = ($Jx, $Jy).",
+            ),
+        )
+        jmin, jmax = minmax(ax, ay)
+        return (1 - (jmin / jmax)^2)^(1 / 8)
+    else
+        throw(
+            DomainError(
+                (Jx, Jy, Jz),
+                "HeisenbergXYZ SpontaneousMagnetization: generic XYZ requires Baxter " *
+                "(1973) elliptic theta-function staggered polarization, deferred " *
+                "to Phase 3. Got (Jx, Jy, Jz) = ($Jx, $Jy, $Jz).",
+            ),
+        )
+    end
+end

--- a/src/models/quantum/HeisenbergXYZ/HeisenbergXYZ_registry.jl
+++ b/src/models/quantum/HeisenbergXYZ/HeisenbergXYZ_registry.jl
@@ -38,3 +38,17 @@
           "closed form; axial XXZ case (Jx=Jy) delegated to XXZ1D Energy(:per_site). " *
           "Generic XYZ (Jx!=Jy, Jz!=0) deferred to Baxter elliptic Phase 3.",
 )
+
+@register(
+    HeisenbergXYZ,
+    SpontaneousMagnetization,
+    Infinite,
+    method=:closed_form,
+    reliability=:high,
+    tested_in="test/models/quantum/HeisenbergXYZ/test_heisenberg_xyz_gs.jl",
+    references=["McCoyWu1978"],
+    notes="Critical axial XXZ (Jx=Jy, |Jz/Jx|<=1): 0 (no LRO in 1D). XY anisotropic " *
+          "line (Jz=0, Jx != Jy): McCoy-Wu / Pfeuty Onsager 1/8 exponent " *
+          "M = (1-(Jmin/Jmax)^2)^(1/8) along dominant axis. Massive AFM Neel order " *
+          "and generic XYZ Baxter (1973) elliptic deferred to Phase 3.",
+)

--- a/test/models/quantum/HeisenbergXYZ/test_heisenberg_xyz_gs.jl
+++ b/test/models/quantum/HeisenbergXYZ/test_heisenberg_xyz_gs.jl
@@ -65,4 +65,28 @@ using QAtlas: fetch, GroundStateEnergyDensity, Infinite, HeisenbergXYZ
         m_fm = HeisenbergXYZ(; Jx=-1.0, Jy=-1.0, Jz=0.5)
         @test_throws DomainError fetch(m_fm, GroundStateEnergyDensity(), Infinite())
     end
+
+    @testset "SpontaneousMagnetization@Infinite -- McCoy-Wu XY line + critical" begin
+        for (Jx, Jy, Jz) in
+            ((1.0, 1.0, 1.0), (1.0, 1.0, 0.5), (1.0, 1.0, -0.5), (1.0, 1.0, 0.0))
+            m = HeisenbergXYZ(; Jx=Jx, Jy=Jy, Jz=Jz)
+            @test fetch(m, QAtlas.SpontaneousMagnetization(), Infinite()) == 0.0
+        end
+        for (Jx, Jy) in ((2.0, 1.0), (3.0, 0.5), (10.0, 1.0), (1.0, 2.0))
+            m = HeisenbergXYZ(; Jx=Jx, Jy=Jy, Jz=0.0)
+            jmin, jmax = minmax(abs(Jx), abs(Jy))
+            M_ref = (1 - (jmin / jmax)^2)^(1 / 8)
+            @test fetch(m, QAtlas.SpontaneousMagnetization(), Infinite()) ≈ M_ref atol=1e-12
+        end
+        m_strong = HeisenbergXYZ(; Jx=100.0, Jy=1.0, Jz=0.0)
+        @test fetch(m_strong, QAtlas.SpontaneousMagnetization(), Infinite()) > 0.999
+        m_massive = HeisenbergXYZ(; Jx=1.0, Jy=1.0, Jz=1.5)
+        @test_throws DomainError fetch(
+            m_massive, QAtlas.SpontaneousMagnetization(), Infinite()
+        )
+        m_generic = HeisenbergXYZ(; Jx=2.0, Jy=1.0, Jz=0.5)
+        @test_throws DomainError fetch(
+            m_generic, QAtlas.SpontaneousMagnetization(), Infinite()
+        )
+    end
 end


### PR DESCRIPTION
## PR_ε — McCoy-Wu Spontaneous Magnetization

Stacked on PR_α. Sublattice order parameter via Onsager 1/8 exponent.

| Regime | Method |
|---|---|
| Jx = Jy, |Jz/Jx| ≤ 1 | 0.0 (no LRO in 1D critical) |
| Jz = 0, Jx ≠ Jy | M = (1 - (Jmin/Jmax)²)^(1/8) (McCoy-Wu 1968 / Pfeuty 1970) |
| massive AFM, generic XYZ | DomainError (Phase 3) |

23/23 tests pass (12 PR_α + 11 SpontMag). Version 0.23.4 → 0.23.8.

Fold-back: → PR_α (#568).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
