### PR TITLE
docs(TFIM): clarify CorrelationLength convention (Closes #448)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.4"
+version = "0.23.5"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.3"
+version = "0.23.4"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/models/quantum/TFIM/TFIM_registry.jl
+++ b/src/models/quantum/TFIM/TFIM_registry.jl
@@ -346,7 +346,7 @@
     method=:analytic,
     reliability=:high,
     tested_in="test/models/test_TFIM_zaxis.jl",
-    notes="ξ = 1/(2|h-J|) (gapped phase); Inf at criticality.",
+    notes="Relativistic inverse-mass-gap convention: ξ = 1/Δ = 1/(2|h-J|) (gapped); Inf at criticality. Pfeuty 1/log(max/min) lattice form (alt convention) not exposed — agrees to leading order near criticality. See docstring Convention table.",
 )
 @register(
     TFIM,

--- a/src/models/quantum/TFIM/TFIM_zaxis.jl
+++ b/src/models/quantum/TFIM/TFIM_zaxis.jl
@@ -97,14 +97,31 @@ end
 """
     fetch(model::TFIM, ::CorrelationLength, ::Infinite; kwargs...) -> Float64
 
-T = 0 longitudinal correlation length of the infinite TFIM,
+T = 0 correlation length of the infinite TFIM in the **relativistic
+continuum convention** (inverse mass gap),
 
     ξ = 1 / (2|h - J|)        (gapped phase)
     ξ = Inf                   (critical point h = J)
 
-This is set by the inverse mass gap `Δ = 2|h - J|` (see
-[`MassGap`](@ref) at `Infinite`); the asymptotic exponential decay
-of the connected longitudinal correlator is `e^{-r/ξ}`.
+set by the lattice mass gap `Δ = 2|h - J|` via the universal IR
+relation `ξ = 1/Δ` (with `v_F = 1` implicit; lattice units). Tracks
+[`MassGap`](@ref) at `Infinite`.
+
+# Convention note
+
+Three legitimate conventions exist for the TFIM correlation length on
+the lattice; QAtlas exposes the first by default for consistency with
+`MassGap`:
+
+| Convention                        | Formula                       | Origin                                 |
+|-----------------------------------|-------------------------------|----------------------------------------|
+| **Inverse mass gap** (this fetch) | `1 / (2|h - J|)`              | relativistic continuum / Sachdev IR    |
+| Pfeuty 1970 longitudinal          | `1 / log(max(J,h) / min(J,h))` | lattice JW-fermion <σᶻσᶻ> decay exact  |
+| Sachdev lattice relativistic      | `min(J,h) / |h - J|`           | E²(k) = Δ² + v²k² with v_F = 2·min     |
+
+The three agree to leading order near criticality (|h - J| << max). For
+exact lattice decay of the longitudinal correlator at any (J, h), use
+the Pfeuty form externally.
 
 In QAtlas convention ξ is dimensionless (in units of the lattice
 spacing).


### PR DESCRIPTION
## What

Clarify the **TFIM CorrelationLength@Infinite** convention in
docstring + registry note. **No behavior change** — the closed-form
value `xi = 1/(2|h - J|)` is unchanged.

## Why (Closes #448)

Issue #448 (filed during the model audit) flagged the convention
choice as undocumented and ambiguous between three lattice forms:

| Convention                | Formula                       | Origin                              |
|---------------------------|-------------------------------|-------------------------------------|
| **Inverse mass gap**      | `1 / (2|h - J|)`              | relativistic continuum / Sachdev IR |
| Pfeuty 1970 longitudinal  | `1 / log(max(J,h) / min(J,h))` | lattice JW-fermion exact            |
| Sachdev lattice relativ.  | `min(J,h) / |h - J|`           | E²(k) = Δ² + v²k² with v_F = 2·min  |

QAtlas picks the first for consistency with `MassGap` (the
identity `xi = 1/Delta` from `MassGap()`@Infinite). All three
agree to leading order near criticality.

## Changes

- `src/models/quantum/TFIM/TFIM_zaxis.jl`: docstring now explicitly
  states "relativistic continuum convention (inverse mass gap)"
  and includes a Convention table listing the alternatives.
- `src/models/quantum/TFIM/TFIM_registry.jl`: registry note mirrors
  the same statement and points to the docstring table.
- Patch bump `0.23.4 -> 0.23.5` (sequenced **after** the rollback
  PR #574; merge that one first).

## Tests

Existing TFIM CorrelationLength closed-form tests (61/61) still pass;
no test logic change required.

## Merge order

This PR is sequenced **after** PR #574 (which rolls main back
`0.23.8 -> 0.23.4` to recover from the General #156970 skip
incident). Merge order: **#574 first, then this PR**.

## Closes

Closes #448.
