### PR TITLE
chore(version): roll back 0.23.8 -> 0.23.4 (single-bump policy, fix General #156970 skip)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.8"
+version = "0.23.4"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]


### PR DESCRIPTION
## What

Roll `Project.toml` version from `0.23.8` back to `0.23.4`. **No code change.**

## Why

PR #568 (HeisenbergXYZ Phase 2 consolidated) landed on `main` at `0.23.8` because the fold-back from PR_β/γ/δ/ε retained each sub-branch's Project.toml bump (`0.23.5/6/7/8`) in the final commit instead of collapsing to `0.23.4`. JuliaRegistries/General#156970 AutoMerge correctly rejected the registration with:

> Does not meet sequential version number guideline: version 0.23.8 skips over 0.23.4.

Per project policy **1 model = 1 PR = 1 patch bump**, the entire PR #568 batch is a single coherent feature release and should register as `0.23.3 -> 0.23.4`. `v0.23.8` was never registered (the General PR is still OPEN at time of this PR); this is **not** a downgrade of any registered version.

## After-merge plan

1. Close JuliaRegistries/General#156970 with explanatory comment.
2. Re-trigger `@JuliaRegistrator register` on the merge commit of this PR.
3. The next General PR will read `v0.23.4` from `Project.toml`, pass the sequential-version AutoMerge guideline (`0.23.3 -> 0.23.4`), and merge cleanly.

## Risk

None for already-merged code. Only the registration metadata changes.
