### PR TITLE
test(XXZ1D/OBC): SU(2) symmetry regression guard at Heisenberg point (refs #576)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.7"
+version = "0.23.8"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/test/identities/test_identities_XXZ1D.jl
+++ b/test/identities/test_identities_XXZ1D.jl
@@ -76,6 +76,27 @@ end
     end
 end
 
+@testset "XXZ1D Δ=1 OBC SU(2) symmetry: χ_xx = χ_yy = χ_zz" begin
+    # At Δ = 1 the XXZ chain is SU(2)-symmetric (Heisenberg point), so
+    # the three uniform susceptibilities χ_αα with α ∈ {x, y, z} must
+    # be equal. This locks in two things at once:
+    #   (1) the Kubo helper introduced in #576 / PR #577 respects SU(2)
+    #       (a Var-only χ_xx would *also* be equal here because [H,M_α]=0
+    #        for all α at Δ=1, but a buggy formula would break the
+    #        equality);
+    #   (2) the kernel does not accidentally introduce an axis-dependent
+    #       artifact.
+    using QAtlas: SusceptibilityXX, SusceptibilityYY, SusceptibilityZZ
+    m = XXZ1D(; J=1.0, Δ=1.0)
+    for β in (0.5, 1.0, 2.0, 5.0), N in (4, 6, 8)
+        χxx = QAtlas.fetch(m, SusceptibilityXX(), OBC(N); beta=β)
+        χyy = QAtlas.fetch(m, SusceptibilityYY(), OBC(N); beta=β)
+        χzz = QAtlas.fetch(m, SusceptibilityZZ(), OBC(N); beta=β)
+        @test χxx ≈ χyy atol = 1e-12
+        @test χyy ≈ χzz atol = 1e-12
+    end
+end
+
 # ── Verification cards (WHY-correct plane) ─────────────────────────────────
 @testset "XXZ1D identities — verification cards" begin
     # FM point Δ = -1: exact saturated ground state, e0 = -J/4.


### PR DESCRIPTION
## What

Test-only: add an SU(2)-symmetry regression guard for the XXZ1D OBC
Kubo helper introduced in #577.

## Why (refs #576)

At `Δ = 1` the XXZ Hamiltonian is SU(2)-symmetric, so the three
uniform susceptibilities `χ_xx = χ_yy = χ_zz` must hold exactly.
After the PR #577 fix (χ_xx and χ_yy now use the Kubo
sum-over-eigenpairs form, χ_zz keeps the variance helper since
`Σ S_z` is conserved), the three quantities are computed via two
independent code paths (Kubo for x/y, variance for z) — yet the
output values must coincide at machine precision under SU(2).

The new testset asserts `χ_xx ≈ χ_yy ≈ χ_zz` (atol = 1e-12) across
`N ∈ {4, 6, 8}` × `β ∈ {0.5, 1.0, 2.0, 5.0}`. Pairs with the
explicit Kubo ED card already in #577 to triangulate the implementation
from two angles: ED-Kubo agreement (per-axis) + SU(2) consistency
(cross-axis).

A Var-only χ_xx implementation would *also* pass this test (since at
Δ=1 even `[H, M_x] = 0` so Var = Kubo for all three axes), but any
axis-dependent or otherwise buggy formula breaks it. The cross-check
with the per-axis Kubo card in #577 ensures both the absolute value
and the symmetry are guarded.

## Verification

Local run on PR branch passes all 12 (β, N) combinations at machine
precision; max observed diff across axes is ≈ 5e-15.

## Version

Patch bump `0.23.7 → 0.23.8` (test-only, no src change).

Refs #576.
