### PR TITLE
feat(Universality): MutualInformation for adjacent intervals at Infinite (refs #580)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.12"
+version = "0.23.13"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -108,7 +108,7 @@ export GroundStateDegeneracy, TopologicalEntanglementEntropy, AnyonStatistics  #
 export CasimirEnergyCorrection                                              # CFT 1/L correction (#150)
 export ConformalWeights, PrimaryFields
 export StringOrderParameter
-export FermiVelocity, LuttingerVelocity, SpinWaveVelocity, LiebRobinsonVelocity
+export FermiVelocity, LuttingerVelocity, SpinWaveVelocity, LiebRobinsonVelocity, MutualInformation
 export SteadyStateCurrent                                # TASEP / non-equilibrium current (#241)
 export E8Spectrum
 export TopologicalInvariant, EdgeModeEnergy           # Kitaev1D Pfaffian invariant + edge mode

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -540,6 +540,18 @@ Math. Phys.* **28**, 251 (1972); Hastings-Koma, *Commun. Math. Phys.*
 struct LiebRobinsonVelocity <: AbstractQuantity end
 
 """
+    MutualInformation() <: AbstractQuantity
+
+Mutual information between two subsystems, `I(A:B) = S(A) + S(B) - S(A ∪ B)`.
+
+This struct is the type tag; concrete `fetch` dispatches live at the
+universality layer (see `src/universalities/CardyEntanglement.jl` for
+the Calabrese-Cardy closed forms) and on model files for non-universal
+cases. Tracking: #580 entanglement universality catalog.
+"""
+struct MutualInformation <: AbstractQuantity end
+
+"""
     E8Spectrum() <: AbstractQuantity
 
 Zamolodchikov E8 mass spectrum (8 stable particles).  Concrete

--- a/src/universalities/CardyEntanglement.jl
+++ b/src/universalities/CardyEntanglement.jl
@@ -485,3 +485,53 @@ end
 fetch(m::MeanField, q::CriticalExponents, ::Infinite; kwargs...) = fetch(m, q; kwargs...)
 fetch(m::Ising2D, q::CriticalExponents, ::Infinite; kwargs...) = fetch(m, q; kwargs...)
 fetch(m::KPZ1D, q::CriticalExponents, ::Infinite; kwargs...) = fetch(m, q; kwargs...)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Mutual information for two adjacent intervals at Infinite (#580 Phase 2+)
+#
+# For two adjacent intervals of lengths ℓ_A and ℓ_B on an infinite
+# 1+1D-CFT chain at T = 0, I(A:B) = S(A) + S(B) - S(A ∪ B) reduces to
+#
+#     I(A:B) = (c/3) log[ℓ_A · ℓ_B / (ℓ_A + ℓ_B)]   (T = 0)
+#
+# At β finite each entropy takes the CC sinh form.
+#
+# Reference: Calabrese-Cardy J. Stat. Mech. P06002 (2004); J. Phys. A 42,
+# 504005 (2009). Tracking: #580.
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    fetch(::Universality{C}, ::MutualInformation, ::Infinite;
+          ℓ_A::Real, ℓ_B::Real, beta::Real = Inf, kwargs...) -> Float64
+
+Mutual information of two adjacent intervals of lengths `ℓ_A` and
+`ℓ_B` on an infinite 1+1D-CFT chain.  Closed form follows from the
+single-interval Calabrese-Cardy result via
+`I = S(A) + S(B) − S(A∪B)`:
+
+    I(A:B) = (c/3) log[ℓ_A · ℓ_B / (ℓ_A + ℓ_B)]      (T = 0)
+
+At finite β each single-interval entropy takes the sinh form.
+
+Refs Calabrese-Cardy 2004 / 2009; issue #580.
+"""
+function fetch(
+    model::Universality{C},
+    ::MutualInformation,
+    ::Infinite;
+    ℓ_A::Real,
+    ℓ_B::Real,
+    beta::Real=Inf,
+    kwargs...,
+) where {C}
+    ℓ_A > 0 || throw(
+        ArgumentError("Cardy Infinite MutualInformation: ℓ_A must be > 0; got ℓ_A=$ℓ_A."),
+    )
+    ℓ_B > 0 || throw(
+        ArgumentError("Cardy Infinite MutualInformation: ℓ_B must be > 0; got ℓ_B=$ℓ_B."),
+    )
+    S_A = fetch(model, VonNeumannEntropy(), Infinite(); ℓ=ℓ_A, beta=beta, kwargs...)
+    S_B = fetch(model, VonNeumannEntropy(), Infinite(); ℓ=ℓ_B, beta=beta, kwargs...)
+    S_AB = fetch(model, VonNeumannEntropy(), Infinite(); ℓ=ℓ_A + ℓ_B, beta=beta, kwargs...)
+    return S_A + S_B - S_AB
+end

--- a/test/universalities/test_universality_mutual_information.jl
+++ b/test/universalities/test_universality_mutual_information.jl
@@ -1,0 +1,74 @@
+using Test
+using QAtlas
+using QAtlas: Universality, MutualInformation, VonNeumannEntropy, Infinite, CentralCharge
+
+@testset "Universality MutualInformation adjacent intervals (#580)" begin
+    @testset "T=0 closed form: I = (c/3) log[ℓ_A ℓ_B / (ℓ_A + ℓ_B)]" begin
+        d_for = Dict(:Ising=>2, :XY=>2, :Heisenberg=>1, :Potts3=>2, :Potts4=>2)
+        for class in (:Ising, :XY, :Heisenberg, :Potts3, :Potts4)
+            c = float(QAtlas.fetch(Universality(class), CentralCharge(); d=d_for[class]))
+            for (ℓ_A, ℓ_B) in ((5.0, 10.0), (1.0, 1.0), (50.0, 100.0))
+                I = QAtlas.fetch(
+                    Universality(class), MutualInformation(), Infinite(); ℓ_A=ℓ_A, ℓ_B=ℓ_B
+                )
+                expected = (c / 3) * log(ℓ_A * ℓ_B / (ℓ_A + ℓ_B))
+                @test I ≈ expected atol = 1e-12
+            end
+        end
+    end
+
+    @testset "I = S(A) + S(B) - S(A∪B) consistency at T = 0 + finite β" begin
+        for class in (:Ising, :Heisenberg)
+            for β in (Inf, 50.0, 5.0), (ℓ_A, ℓ_B) in ((3.0, 7.0), (10.0, 20.0))
+                I = QAtlas.fetch(
+                    Universality(class),
+                    MutualInformation(),
+                    Infinite();
+                    ℓ_A=ℓ_A,
+                    ℓ_B=ℓ_B,
+                    beta=β,
+                )
+                S_A = QAtlas.fetch(
+                    Universality(class), VonNeumannEntropy(), Infinite(); ℓ=ℓ_A, beta=β
+                )
+                S_B = QAtlas.fetch(
+                    Universality(class), VonNeumannEntropy(), Infinite(); ℓ=ℓ_B, beta=β
+                )
+                S_AB = QAtlas.fetch(
+                    Universality(class),
+                    VonNeumannEntropy(),
+                    Infinite();
+                    ℓ=ℓ_A + ℓ_B,
+                    beta=β,
+                )
+                @test I ≈ (S_A + S_B - S_AB) atol = 1e-12
+            end
+        end
+    end
+
+    @testset "I > 0 for ℓ_A · ℓ_B / (ℓ_A + ℓ_B) > 1 (positive universal log)" begin
+        # Only the universal log piece is returned; the non-universal
+        # S_0 offsets are dropped. So I_universal > 0 iff the argument
+        # of the log exceeds the UV cutoff (here a = 1). At very small
+        # ℓ (ℓ_A·ℓ_B / (ℓ_A+ℓ_B) < 1) the universal piece alone can be
+        # negative, with the physical I > 0 requiring the dropped
+        # constant.
+        for class in (:Ising, :Heisenberg),
+            (ℓ_A, ℓ_B) in ((5.0, 10.0), (20.0, 50.0), (100.0, 200.0))
+
+            I = QAtlas.fetch(
+                Universality(class), MutualInformation(), Infinite(); ℓ_A=ℓ_A, ℓ_B=ℓ_B
+            )
+            @test I > 0
+        end
+    end
+
+    @testset "Argument validation" begin
+        @test_throws ArgumentError QAtlas.fetch(
+            Universality(:Ising), MutualInformation(), Infinite(); ℓ_A=-1.0, ℓ_B=5.0
+        )
+        @test_throws ArgumentError QAtlas.fetch(
+            Universality(:Ising), MutualInformation(), Infinite(); ℓ_A=5.0, ℓ_B=0.0
+        )
+    end
+end


### PR DESCRIPTION
## What

Introduce MutualInformation as a new AbstractQuantity and add a universality-layer dispatch for two ADJACENT intervals on an infinite 1+1D-CFT chain.

The closed form follows from the Calabrese-Cardy single-interval result via I(A:B) = S(A) + S(B) - S(A union B):

```
T = 0:        I = (c/3) log[ell_A * ell_B / (ell_A + ell_B)]
beta < Inf:   each single-interval entropy uses the sinh form, three-term combination evaluated piecewise.
```

The implementation delegates to the existing Universality VonNeumannEntropy dispatches added in PR #582, so it automatically inherits the c-universal central charge per class and any lattice-spacing kwarg machinery (a) added in PR #585. Non-universal additive constants are dropped at each entropy and cancel structurally in the three-term combination (modulo a UV cutoff effect for very small intervals where the universal log can be negative).

## Tests

test_universality_mutual_information.jl: 35 assertions covering

- T=0 closed form across five 1+1D CFT classes (Ising, XY, Heisenberg, Potts3, Potts4) x three (ell_A, ell_B) cases
- I = S_A + S_B - S_AB consistency at beta in (Inf, 50, 5)
- Positivity for ell_A * ell_B / (ell_A + ell_B) > 1
- Argument validation

All pass at atol = 1e-12.

## Stacking

Base = PR #586. Full stack:

```
main <- #582 <- #583 <- #584 <- #585 <- #586 <- this PR
```

Patch bump 0.23.12 to 0.23.13.

## Follow-up

- Disjoint-interval mutual information (Calabrese-Cardy 2009) involves cross-ratio + operator content; closed forms exist for c=1/2 Ising (Casini-Huerta-Hung-Myers) and c=1 free boson; deferred.
- Renyi mutual information (alpha != 1) is a separate quantity.
- Logarithmic negativity is yet another quantity.

Refs #580.
