### PR TITLE
feat(Universality): CardyEntropy = 2 pi sqrt(c E / 6) Cardy 1986 (refs #580)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.14"
+version = "0.23.15"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -108,7 +108,7 @@ export GroundStateDegeneracy, TopologicalEntanglementEntropy, AnyonStatistics  #
 export CasimirEnergyCorrection                                              # CFT 1/L correction (#150)
 export ConformalWeights, PrimaryFields
 export StringOrderParameter
-export FermiVelocity, LuttingerVelocity, SpinWaveVelocity, LiebRobinsonVelocity, MutualInformation, EntanglementGrowthSlope
+export FermiVelocity, LuttingerVelocity, SpinWaveVelocity, LiebRobinsonVelocity, MutualInformation, EntanglementGrowthSlope, CardyEntropy
 export SteadyStateCurrent                                # TASEP / non-equilibrium current (#241)
 export E8Spectrum
 export TopologicalInvariant, EdgeModeEnergy           # Kitaev1D Pfaffian invariant + edge mode

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -571,6 +571,21 @@ P04010. Tracking: #580 quench-dynamics phase.
 struct EntanglementGrowthSlope <: AbstractQuantity end
 
 """
+    CardyEntropy() <: AbstractQuantity
+
+Asymptotic high-energy entropy (log of the density of states) of a
+1+1D CFT, given by the Cardy 1986 formula
+
+    S_Cardy(E) = 2 π sqrt(c E / 6),
+
+where `c` is the central charge of the CFT and `E` is the excitation
+energy (in units where the cylinder circumference is 1). This counts
+the number of CFT states at fixed energy `E` and underlies, e.g., the
+Cardy-Verlinde / black-hole-entropy correspondences. Tracking: #580.
+"""
+struct CardyEntropy <: AbstractQuantity end
+
+"""
     E8Spectrum() <: AbstractQuantity
 
 Zamolodchikov E8 mass spectrum (8 stable particles).  Concrete

--- a/src/universalities/CardyEntanglement.jl
+++ b/src/universalities/CardyEntanglement.jl
@@ -579,3 +579,30 @@ function fetch(
     c = _cardy_central_charge(model; kwargs...)
     return π * c * v / (3 * beta_eff)
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Cardy formula: asymptotic high-energy state-counting entropy (#580)
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    fetch(::Universality{C}, ::CardyEntropy, ::Infinite;
+          E::Real, kwargs...) -> Float64
+
+Asymptotic high-energy entropy of a 1+1D CFT (Cardy 1986):
+
+    S_Cardy(E) = 2 π sqrt(c E / 6),
+
+with `c` supplied by the universality class. This is the log of the
+microcanonical density of states at energy `E` on a cylinder of unit
+circumference. Valid asymptotically at large `E`; at low `E` the
+formula systematically underestimates the count.
+
+Reference: Cardy, *Nucl. Phys. B* **270**, 186 (1986).
+"""
+function fetch(
+    model::Universality{C}, ::CardyEntropy, ::Infinite; E::Real, kwargs...
+) where {C}
+    E >= 0 || throw(ArgumentError("CardyEntropy: E must be >= 0; got E=$E."))
+    c = _cardy_central_charge(model; kwargs...)
+    return 2 * π * sqrt(c * E / 6)
+end

--- a/test/universalities/test_universality_cardy_entropy.jl
+++ b/test/universalities/test_universality_cardy_entropy.jl
@@ -1,0 +1,49 @@
+using Test
+using QAtlas
+using QAtlas: Universality, CardyEntropy, Infinite, CentralCharge
+
+@testset "Universality CardyEntropy (Cardy 1986, #580)" begin
+    @testset "Formula 2 π sqrt(c E / 6) across 5 universality classes" begin
+        d_for = Dict(:Ising=>2, :XY=>2, :Heisenberg=>1, :Potts3=>2, :Potts4=>2)
+        for class in (:Ising, :XY, :Heisenberg, :Potts3, :Potts4)
+            c = float(QAtlas.fetch(Universality(class), CentralCharge(); d=d_for[class]))
+            for E in (0.1, 1.0, 10.0, 100.0, 1000.0)
+                S = QAtlas.fetch(Universality(class), CardyEntropy(), Infinite(); E=E)
+                expected = 2 * π * sqrt(c * E / 6)
+                @test S ≈ expected atol = 1e-14
+            end
+        end
+    end
+
+    @testset "E = 0 -> S = 0 (degenerate ground state)" begin
+        for class in (:Ising, :Heisenberg, :Potts3)
+            S = QAtlas.fetch(Universality(class), CardyEntropy(), Infinite(); E=0.0)
+            @test S ≈ 0.0 atol = 1e-14
+        end
+    end
+
+    @testset "S grows as sqrt(E) (asymptotic scaling)" begin
+        for class in (:Ising, :Heisenberg)
+            S1 = QAtlas.fetch(Universality(class), CardyEntropy(), Infinite(); E=1.0)
+            S100 = QAtlas.fetch(Universality(class), CardyEntropy(), Infinite(); E=100.0)
+            @test S100 ≈ 10 * S1 atol = 1e-12
+        end
+    end
+
+    @testset "S grows as sqrt(c) (universality scaling)" begin
+        E = 4.0
+        S_Ising = QAtlas.fetch(Universality(:Ising), CardyEntropy(), Infinite(); E=E)
+        S_Heisenberg = QAtlas.fetch(
+            Universality(:Heisenberg), CardyEntropy(), Infinite(); E=E
+        )
+        c_I = float(QAtlas.fetch(Universality(:Ising), CentralCharge(); d=2))
+        c_H = float(QAtlas.fetch(Universality(:Heisenberg), CentralCharge(); d=1))
+        @test S_Heisenberg / S_Ising ≈ sqrt(c_H / c_I) atol = 1e-12
+    end
+
+    @testset "Argument validation" begin
+        @test_throws ArgumentError QAtlas.fetch(
+            Universality(:Ising), CardyEntropy(), Infinite(); E=-1.0
+        )
+    end
+end


### PR DESCRIPTION
## What

Introduce CardyEntropy as a new AbstractQuantity. Universality-layer dispatch returns the Cardy 1986 asymptotic high-energy entropy of a 1+1D CFT:

```
S_Cardy(E) = 2 pi sqrt(c E / 6)
```

with c supplied by the universality class. This is the log of the microcanonical density of states at energy E on a cylinder of unit circumference; the classical Cardy formula underlying e.g. the Cardy-Verlinde / black-hole-entropy correspondences. Valid asymptotically at large E; at low E the formula systematically underestimates the count.

## Tests

32 assertions across 5 universality classes (Ising, XY, Heisenberg, Potts3, Potts4) x 5 energy values, E=0 limit, sqrt(E) scaling check, sqrt(c) scaling check across classes, argument validation. All pass at atol = 1e-14.

## Stacking

Base = PR #588. Full stack:

```
main <- #582 <- #583 <- #584 <- #585 <- #586 <- #587 <- #588 <- this PR
```

Patch bump 0.23.14 to 0.23.15.

## Related references

- Cardy, *Nucl. Phys. B* **270**, 186 (1986) — original formula
- Carlip, *Class. Quant. Grav.* **15**, 3609 (1998) — BTZ black hole entropy via Cardy
- Verlinde, hep-th/0008140 — Cardy-Verlinde holographic interpretation

Refs #580.
