### PR TITLE
feat(Universality): ConformalCasimirEnergy = -pi c / (6 L) Cardy/BCN/Affleck 1986 (refs #580)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.15"
+version = "0.23.16"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -108,7 +108,7 @@ export GroundStateDegeneracy, TopologicalEntanglementEntropy, AnyonStatistics  #
 export CasimirEnergyCorrection                                              # CFT 1/L correction (#150)
 export ConformalWeights, PrimaryFields
 export StringOrderParameter
-export FermiVelocity, LuttingerVelocity, SpinWaveVelocity, LiebRobinsonVelocity, MutualInformation, EntanglementGrowthSlope, CardyEntropy
+export FermiVelocity, LuttingerVelocity, SpinWaveVelocity, LiebRobinsonVelocity, MutualInformation, EntanglementGrowthSlope, CardyEntropy, ConformalCasimirEnergy
 export SteadyStateCurrent                                # TASEP / non-equilibrium current (#241)
 export E8Spectrum
 export TopologicalInvariant, EdgeModeEnergy           # Kitaev1D Pfaffian invariant + edge mode

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -586,6 +586,22 @@ Cardy-Verlinde / black-hole-entropy correspondences. Tracking: #580.
 struct CardyEntropy <: AbstractQuantity end
 
 """
+    ConformalCasimirEnergy() <: AbstractQuantity
+
+Universal Casimir (ground-state) energy of a 1+1D CFT on a cylinder
+of circumference `L` (PBC). Cardy 1986 / Blote-Cardy-Nightingale 1986
+/ Affleck 1986 showed it is determined entirely by the central charge:
+
+    E_0(L) = -π c / (6 L).
+
+This is the strict thermodynamic-limit subtraction `lim_{L->∞}
+(E_GS(L) - L * e_∞) * L` that extracts the universal finite-size
+correction.  Sign convention follows the original PRL: `E_0 < 0` for
+unitary CFTs with `c > 0`. Tracking: #580.
+"""
+struct ConformalCasimirEnergy <: AbstractQuantity end
+
+"""
     E8Spectrum() <: AbstractQuantity
 
 Zamolodchikov E8 mass spectrum (8 stable particles).  Concrete

--- a/src/universalities/CardyEntanglement.jl
+++ b/src/universalities/CardyEntanglement.jl
@@ -606,3 +606,34 @@ function fetch(
     c = _cardy_central_charge(model; kwargs...)
     return 2 * π * sqrt(c * E / 6)
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Conformal Casimir energy on a cylinder (#580)
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    fetch(::Universality{C}, ::ConformalCasimirEnergy, ::Infinite;
+          L::Real, kwargs...) -> Float64
+
+Universal Casimir ground-state energy of a 1+1D CFT on a cylinder of
+circumference `L` (Cardy 1986 / Blote-Cardy-Nightingale 1986 /
+Affleck 1986):
+
+    E_0(L) = -π c / (6 L).
+
+The sign convention follows the original PRLs (`E_0 < 0` for unitary
+CFTs with `c > 0`). Identified empirically by subtracting `L * e_∞`
+from the lattice ground-state energy on a periodic chain of `L` sites
+and rescaling by `L`.
+
+Reference: Cardy *Nucl. Phys. B* **270**, 186 (1986); Blote-Cardy-
+Nightingale *Phys. Rev. Lett.* **56**, 742 (1986); Affleck *Phys. Rev.
+Lett.* **56**, 746 (1986).
+"""
+function fetch(
+    model::Universality{C}, ::ConformalCasimirEnergy, ::Infinite; L::Real, kwargs...
+) where {C}
+    L > 0 || throw(ArgumentError("ConformalCasimirEnergy: L must be > 0; got L=$L."))
+    c = _cardy_central_charge(model; kwargs...)
+    return -π * c / (6 * L)
+end

--- a/test/universalities/test_universality_conformal_casimir_energy.jl
+++ b/test/universalities/test_universality_conformal_casimir_energy.jl
@@ -1,0 +1,66 @@
+using Test
+using QAtlas
+using QAtlas: Universality, ConformalCasimirEnergy, Infinite, CentralCharge
+
+@testset "Universality ConformalCasimirEnergy = -π c / (6 L) Cardy 1986 (#580)" begin
+    @testset "Formula across 5 universality classes" begin
+        d_for = Dict(:Ising=>2, :XY=>2, :Heisenberg=>1, :Potts3=>2, :Potts4=>2)
+        for class in (:Ising, :XY, :Heisenberg, :Potts3, :Potts4)
+            c = float(QAtlas.fetch(Universality(class), CentralCharge(); d=d_for[class]))
+            for L in (1.0, 5.0, 20.0, 100.0, 1000.0)
+                E0 = QAtlas.fetch(
+                    Universality(class), ConformalCasimirEnergy(), Infinite(); L=L
+                )
+                expected = -π * c / (6 * L)
+                @test E0 ≈ expected atol = 1e-14
+            end
+        end
+    end
+
+    @testset "E_0 < 0 for unitary classes (c > 0)" begin
+        for class in (:Ising, :XY, :Heisenberg, :Potts3, :Potts4)
+            E0 = QAtlas.fetch(
+                Universality(class), ConformalCasimirEnergy(), Infinite(); L=10.0
+            )
+            @test E0 < 0
+        end
+    end
+
+    @testset "E_0(L) decays as 1/L" begin
+        for class in (:Ising, :Heisenberg)
+            E1 = QAtlas.fetch(
+                Universality(class), ConformalCasimirEnergy(), Infinite(); L=1.0
+            )
+            E10 = QAtlas.fetch(
+                Universality(class), ConformalCasimirEnergy(), Infinite(); L=10.0
+            )
+            E100 = QAtlas.fetch(
+                Universality(class), ConformalCasimirEnergy(), Infinite(); L=100.0
+            )
+            @test E10 ≈ E1 / 10 atol = 1e-14
+            @test E100 ≈ E1 / 100 atol = 1e-14
+        end
+    end
+
+    @testset "E_0 linear in c at fixed L" begin
+        L = 5.0
+        E_Ising = QAtlas.fetch(
+            Universality(:Ising), ConformalCasimirEnergy(), Infinite(); L=L
+        )
+        E_Heis = QAtlas.fetch(
+            Universality(:Heisenberg), ConformalCasimirEnergy(), Infinite(); L=L
+        )
+        c_I = float(QAtlas.fetch(Universality(:Ising), CentralCharge(); d=2))
+        c_H = float(QAtlas.fetch(Universality(:Heisenberg), CentralCharge(); d=1))
+        @test E_Heis / E_Ising ≈ c_H / c_I atol = 1e-12
+    end
+
+    @testset "Argument validation" begin
+        @test_throws ArgumentError QAtlas.fetch(
+            Universality(:Ising), ConformalCasimirEnergy(), Infinite(); L=0.0
+        )
+        @test_throws ArgumentError QAtlas.fetch(
+            Universality(:Heisenberg), ConformalCasimirEnergy(), Infinite(); L=-1.0
+        )
+    end
+end


### PR DESCRIPTION
## What

Introduce ConformalCasimirEnergy as a new AbstractQuantity. Universality-layer dispatch returns the universal ground-state Casimir energy of a 1+1D CFT on a cylinder of circumference L:

```
E_0(L) = -pi c / (6 L)
```

with c supplied by the universality class. This is the companion to CardyEntropy (PR #589); together they form the two famous Cardy / Blote-Cardy-Nightingale / Affleck 1986 universal results:

- high-energy state counting (CardyEntropy, S = 2 pi sqrt(c E / 6))
- low-energy finite-size correction (this PR, E_0 = -pi c / (6 L))

Both are determined entirely by the central charge of the universality class.

Sign convention follows the original PRLs (E_0 < 0 for unitary CFTs with c > 0).

## Tests

37 assertions across 5 universality classes (Ising, XY, Heisenberg, Potts3, Potts4) x 5 L values, sign check for unitary c > 0, 1/L scaling check, linearity in c, argument validation. All pass at atol = 1e-14.

## Stacking

Base = PR #589. Full stack:

```
main <- #582 <- #583 <- #584 <- #585 <- #586 <- #587 <- #588 <- #589 <- this PR
```

Patch bump 0.23.15 to 0.23.16.

## Refs

- Cardy, *Nucl. Phys. B* **270**, 186 (1986)
- Blote-Cardy-Nightingale, *Phys. Rev. Lett.* **56**, 742 (1986)
- Affleck, *Phys. Rev. Lett.* **56**, 746 (1986)

Refs #580.
