### PR TITLE
feat(Universality): LogarithmicNegativity = (c/4) log[ell_A ell_B / (ell_A + ell_B)] CCT 2012 (refs #580)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.16"
+version = "0.23.17"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -108,7 +108,7 @@ export GroundStateDegeneracy, TopologicalEntanglementEntropy, AnyonStatistics  #
 export CasimirEnergyCorrection                                              # CFT 1/L correction (#150)
 export ConformalWeights, PrimaryFields
 export StringOrderParameter
-export FermiVelocity, LuttingerVelocity, SpinWaveVelocity, LiebRobinsonVelocity, MutualInformation, EntanglementGrowthSlope, CardyEntropy, ConformalCasimirEnergy
+export FermiVelocity, LuttingerVelocity, SpinWaveVelocity, LiebRobinsonVelocity, MutualInformation, EntanglementGrowthSlope, CardyEntropy, ConformalCasimirEnergy, LogarithmicNegativity
 export SteadyStateCurrent                                # TASEP / non-equilibrium current (#241)
 export E8Spectrum
 export TopologicalInvariant, EdgeModeEnergy           # Kitaev1D Pfaffian invariant + edge mode

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -602,6 +602,21 @@ unitary CFTs with `c > 0`. Tracking: #580.
 struct ConformalCasimirEnergy <: AbstractQuantity end
 
 """
+    LogarithmicNegativity() <: AbstractQuantity
+
+Logarithmic negativity `E = log Tr |ρ^{T_B}|` measuring mixed-state
+entanglement between two subsystems. For two adjacent intervals on
+an infinite 1+1D-CFT chain at T = 0, the universal closed form
+(Calabrese-Cardy-Tonni 2012) is
+
+    E(ℓ_A, ℓ_B) = (c/4) log[ℓ_A · ℓ_B / (ℓ_A + ℓ_B)],
+
+i.e., the same geometric-mean log of the mutual-information universal
+formula with the prefactor c/3 replaced by c/4. Tracking: #580.
+"""
+struct LogarithmicNegativity <: AbstractQuantity end
+
+"""
     E8Spectrum() <: AbstractQuantity
 
 Zamolodchikov E8 mass spectrum (8 stable particles).  Concrete

--- a/src/universalities/CardyEntanglement.jl
+++ b/src/universalities/CardyEntanglement.jl
@@ -637,3 +637,48 @@ function fetch(
     c = _cardy_central_charge(model; kwargs...)
     return -π * c / (6 * L)
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Logarithmic negativity for two adjacent intervals at Infinite (#580)
+#
+# Calabrese-Cardy-Tonni 2012 (DOI 10.1103/PhysRevLett.109.130502) found
+# that the universal piece of E = log Tr |rho^{T_B}| for two adjacent
+# intervals of lengths ell_A, ell_B on an infinite 1+1D-CFT chain at
+# T = 0 is
+#
+#     E(ell_A, ell_B) = (c/4) log[ell_A * ell_B / (ell_A + ell_B)],
+#
+# i.e., the same geometric-mean log as the mutual-information universal
+# formula (PR #587) with the prefactor c/3 replaced by c/4.
+#
+# Reference: P. Calabrese, J. Cardy, E. Tonni, Phys. Rev. Lett. 109,
+# 130502 (2012). Tracking: #580.
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    fetch(::Universality{C}, ::LogarithmicNegativity, ::Infinite;
+          ℓ_A::Real, ℓ_B::Real, kwargs...) -> Float64
+
+Logarithmic negativity of two adjacent intervals at T = 0 on an
+infinite 1+1D-CFT chain (Calabrese-Cardy-Tonni 2012):
+
+    E = (c/4) log[ℓ_A * ℓ_B / (ℓ_A + ℓ_B)]
+
+Returns the universal log piece; non-universal additive constants are
+dropped.
+"""
+function fetch(
+    model::Universality{C},
+    ::LogarithmicNegativity,
+    ::Infinite;
+    ℓ_A::Real,
+    ℓ_B::Real,
+    kwargs...,
+) where {C}
+    ℓ_A > 0 ||
+        throw(ArgumentError("LogarithmicNegativity: ell_A must be > 0; got ell_A=$ℓ_A."))
+    ℓ_B > 0 ||
+        throw(ArgumentError("LogarithmicNegativity: ell_B must be > 0; got ell_B=$ℓ_B."))
+    c = _cardy_central_charge(model; kwargs...)
+    return (c / 4) * log(ℓ_A * ℓ_B / (ℓ_A + ℓ_B))
+end

--- a/test/universalities/test_universality_logarithmic_negativity.jl
+++ b/test/universalities/test_universality_logarithmic_negativity.jl
@@ -1,0 +1,69 @@
+using Test
+using QAtlas
+using QAtlas:
+    Universality, LogarithmicNegativity, MutualInformation, Infinite, CentralCharge
+
+@testset "Universality LogarithmicNegativity adjacent intervals (CCT 2012, #580)" begin
+    @testset "Closed form (c/4) log[ℓ_A ℓ_B / (ℓ_A + ℓ_B)] across 5 classes" begin
+        d_for = Dict(:Ising=>2, :XY=>2, :Heisenberg=>1, :Potts3=>2, :Potts4=>2)
+        for class in (:Ising, :XY, :Heisenberg, :Potts3, :Potts4)
+            c = float(QAtlas.fetch(Universality(class), CentralCharge(); d=d_for[class]))
+            for (ℓ_A, ℓ_B) in ((5.0, 10.0), (1.0, 100.0), (50.0, 50.0))
+                E = QAtlas.fetch(
+                    Universality(class),
+                    LogarithmicNegativity(),
+                    Infinite();
+                    ℓ_A=ℓ_A,
+                    ℓ_B=ℓ_B,
+                )
+                expected = (c / 4) * log(ℓ_A * ℓ_B / (ℓ_A + ℓ_B))
+                @test E ≈ expected atol = 1e-12
+            end
+        end
+    end
+
+    @testset "Ratio E_neg / I_MI = 3/4 universally" begin
+        # The negativity differs from mutual info only by prefactor c/4
+        # vs c/3, so their ratio is exactly 3/4 across all classes and
+        # all (ℓ_A, ℓ_B) values.
+        for class in (:Ising, :XY, :Heisenberg, :Potts3, :Potts4)
+            for (ℓ_A, ℓ_B) in ((5.0, 10.0), (20.0, 50.0), (100.0, 200.0))
+                E = QAtlas.fetch(
+                    Universality(class),
+                    LogarithmicNegativity(),
+                    Infinite();
+                    ℓ_A=ℓ_A,
+                    ℓ_B=ℓ_B,
+                )
+                I = QAtlas.fetch(
+                    Universality(class), MutualInformation(), Infinite(); ℓ_A=ℓ_A, ℓ_B=ℓ_B
+                )
+                @test E / I ≈ 3 / 4 atol = 1e-12
+            end
+        end
+    end
+
+    @testset "E_neg > 0 for ℓ_A · ℓ_B / (ℓ_A + ℓ_B) > 1" begin
+        for class in (:Ising, :Heisenberg)
+            for (ℓ_A, ℓ_B) in ((5.0, 10.0), (50.0, 100.0))
+                E = QAtlas.fetch(
+                    Universality(class),
+                    LogarithmicNegativity(),
+                    Infinite();
+                    ℓ_A=ℓ_A,
+                    ℓ_B=ℓ_B,
+                )
+                @test E > 0
+            end
+        end
+    end
+
+    @testset "Argument validation" begin
+        @test_throws ArgumentError QAtlas.fetch(
+            Universality(:Ising), LogarithmicNegativity(), Infinite(); ℓ_A=0.0, ℓ_B=5.0
+        )
+        @test_throws ArgumentError QAtlas.fetch(
+            Universality(:Ising), LogarithmicNegativity(), Infinite(); ℓ_A=5.0, ℓ_B=-1.0
+        )
+    end
+end


### PR DESCRIPTION
## What

Introduce LogarithmicNegativity as a new AbstractQuantity. Universality-layer dispatch returns the universal piece of the Calabrese-Cardy-Tonni 2012 result for two adjacent intervals on an infinite 1+1D-CFT chain at T = 0:

```
E(ell_A, ell_B) = (c/4) log[ell_A * ell_B / (ell_A + ell_B)]
```

This is the same geometric-mean log as the mutual-information universal formula (PR #587) with the prefactor c/3 replaced by c/4, so E_neg / I_MI = 3/4 universally.

Reference: P. Calabrese, J. Cardy, E. Tonni, *Phys. Rev. Lett.* **109**, 130502 (2012), DOI 10.1103/PhysRevLett.109.130502. Paper metadata fetched via doiget (PDF behind APS bundle but the closed form is the well-established main result of the PRL).

## Tests

36 assertions:
- closed form (c/4) log[ell_A ell_B / (ell_A + ell_B)] across 5 universality classes (Ising, XY, Heisenberg, Potts3, Potts4) x 3 (ell_A, ell_B) cases
- E_neg / I_MI = 3/4 universally across 5 classes x 3 cases
- E_neg > 0 for ell_A * ell_B / (ell_A + ell_B) > 1
- argument validation

All pass at atol = 1e-12.

## Stacking

Base = PR #590. Full stack:

```
main <- #582 <- #583 <- #584 <- #585 <- #586 <- #587 <- #588 <- #589 <- #590 <- this PR
```

Patch bump 0.23.16 to 0.23.17.

## Follow-up

- Disjoint-interval log negativity (CCT 2013 NPB): involves cross-ratio + universality-class-specific theta-function combinations; deferred.
- Renyi-n negativity at the universality layer.

Refs #580.
