### PR TITLE
fix(TFIM): LiebRobinsonVelocity = 2 min(|J|, |h|) tight free-fermion bound (refs #579, #586)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.17"
+version = "0.23.18"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/docs/src/atlas/hubs/TFIM_LiebRobinsonVelocity_Infinite.md
+++ b/docs/src/atlas/hubs/TFIM_LiebRobinsonVelocity_Infinite.md
@@ -9,7 +9,7 @@
 ## `src` claim
 
 - method `closed_form`, reliability `high`, refs: LiebRobinson1972 | HastingsKoma2006
-- v_LR = 2|J|, free-fermion (Jordan-Wigner) saturated bound, h-independent.
+- v_LR = 2 min(|J|, |h|) tight free-fermion saturated bound (max group velocity over BdG dispersion). At criticality h=J, v_LR=2J. Vanishes at h=0 (classical Ising) or J=0 (decoupled spins). The h-independent 2|J| Hastings-Koma upper bound is loose; use this tight value for entanglement-growth slope (PR #588) and other dynamical formulas.
 
 ## Corroboration
 

--- a/src/models/quantum/TFIM/TFIM.jl
+++ b/src/models/quantum/TFIM/TFIM.jl
@@ -278,19 +278,38 @@ end
 # ─────────────────────────────────────────────────────────────────────────────
 
 """
-    fetch(model::TFIM, ::LiebRobinsonVelocity, ::Infinite; J=m.J) -> Float64
+    fetch(model::TFIM, ::LiebRobinsonVelocity, ::Infinite;
+          J=m.J, h=m.h) -> Float64
 
 Lieb-Robinson velocity of the transverse-field Ising chain. Via the
 Jordan-Wigner mapping the TFIM is a free Bogoliubov-fermion system
-with dispersion `Λ(k) = 2 sqrt(J^2 + h^2 - 2 J h cos k)`. The
-maximum group velocity over `k` saturates the Lieb-Robinson bound,
+with dispersion `Λ(k) = 2 sqrt(J^2 + h^2 - 2 J h cos k)`. The tight
+Lieb-Robinson velocity is the maximum single-particle group velocity
+saturating the bound: differentiating `Λ(k)` and locating the
+interior stationary point at `cos k = min(|J|, |h|) / max(|J|, |h|)`
+gives
 
-    v_LR = max_k |dΛ/dk| = 2 |J|.
+    v_LR = max_k |dΛ/dk| = 2 min(|J|, |h|).
 
-This is independent of the transverse field `h`: it is the bandwidth
-of the JJ exchange divided by the spin spacing. Reference:
-Lieb-Robinson 1972; Calabrese-Cardy 2006 (quench dynamics).
+At criticality `h = J` this is `2J = 2h` (Calabrese-Cardy 2006).
+The Hastings-Koma upper bound `2 max(|J|, |h|)` is loose; the value
+returned here is the *tight* free-fermion saturated velocity that
+governs e.g. the linear-growth slope of post-quench entanglement
+(see PR #588 EntanglementGrowthSlope).
+
+At `h = 0` (classical Ising) or `J = 0` (decoupled site spins) the
+chain has no quantum dynamics and `v_LR = 0`.
+
+Reference: Lieb-Robinson 1972; Hastings-Koma 2006 (general bound);
+Calabrese-Cardy 2006 (free-fermion saturation in quench dynamics).
 """
-function fetch(model::TFIM, ::LiebRobinsonVelocity, ::Infinite; J::Real=model.J, kwargs...)
-    return 2 * abs(J)
+function fetch(
+    model::TFIM,
+    ::LiebRobinsonVelocity,
+    ::Infinite;
+    J::Real=model.J,
+    h::Real=model.h,
+    kwargs...,
+)
+    return 2 * min(abs(J), abs(h))
 end

--- a/src/models/quantum/TFIM/TFIM_registry.jl
+++ b/src/models/quantum/TFIM/TFIM_registry.jl
@@ -657,5 +657,5 @@
     reliability=:high,
     tested_in="test/models/quantum/TFIM/test_TFIM_lieb_robinson.jl",
     references=["LiebRobinson1972", "HastingsKoma2006"],
-    notes="v_LR = 2|J|, free-fermion (Jordan-Wigner) saturated bound, h-independent.",
+    notes="v_LR = 2 min(|J|, |h|) tight free-fermion saturated bound (max group velocity over BdG dispersion). At criticality h=J, v_LR=2J. Vanishes at h=0 (classical Ising) or J=0 (decoupled spins). The h-independent 2|J| Hastings-Koma upper bound is loose; use this tight value for entanglement-growth slope (PR #588) and other dynamical formulas.",
 )

--- a/test/models/quantum/TFIM/test_TFIM_lieb_robinson.jl
+++ b/test/models/quantum/TFIM/test_TFIM_lieb_robinson.jl
@@ -3,23 +3,51 @@ using QAtlas
 using QAtlas: TFIM, LiebRobinsonVelocity, Infinite
 
 @testset "TFIM LiebRobinsonVelocity (#579 Phase 1)" begin
-    @testset "v_LR = 2|J| independent of h" begin
-        for J in (0.5, 1.0, 2.5, 10.0), h in (0.0, 0.5, 1.0, 2.0, 5.0)
+    @testset "v_LR = 2 min(|J|, |h|) (tight free-fermion bound)" begin
+        for J in (0.5, 1.0, 2.5, 10.0), h in (0.5, 1.0, 2.0, 5.0)
             m = TFIM(; J=J, h=h)
+            v = QAtlas.fetch(m, LiebRobinsonVelocity(), Infinite())
+            @test v ≈ 2 * min(abs(J), abs(h)) atol = 1e-14
+        end
+    end
+
+    @testset "v_LR = 2J at criticality h = J" begin
+        for J in (0.5, 1.0, 2.5, 10.0)
+            m = TFIM(; J=J, h=J)
             v = QAtlas.fetch(m, LiebRobinsonVelocity(), Infinite())
             @test v ≈ 2 * abs(J) atol = 1e-14
         end
     end
 
-    @testset "Negative J: |J| handled" begin
-        m = TFIM(; J=-1.5, h=0.3)
-        v = QAtlas.fetch(m, LiebRobinsonVelocity(), Infinite())
-        @test v ≈ 3.0 atol = 1e-14
+    @testset "Vanishing v_LR at h = 0 or J = 0 (no quantum dynamics)" begin
+        # h = 0: classical Ising, H = -J σz σz commutes with σz at each
+        # site, no propagation.
+        for J in (0.5, 1.0, 2.5)
+            m = TFIM(; J=J, h=0.0)
+            v = QAtlas.fetch(m, LiebRobinsonVelocity(), Infinite())
+            @test v ≈ 0.0 atol = 1e-14
+        end
+        # J = 0: decoupled site spins under transverse field, no
+        # interaction means no propagation.
+        for h in (0.5, 1.0, 2.5)
+            m = TFIM(; J=0.0, h=h)
+            v = QAtlas.fetch(m, LiebRobinsonVelocity(), Infinite())
+            @test v ≈ 0.0 atol = 1e-14
+        end
     end
 
-    @testset "J kwarg overrides model.J" begin
+    @testset "Negative J / h handled via abs" begin
+        m = TFIM(; J=-1.5, h=0.7)
+        v = QAtlas.fetch(m, LiebRobinsonVelocity(), Infinite())
+        @test v ≈ 2 * min(1.5, 0.7) atol = 1e-14  # = 1.4
+        m2 = TFIM(; J=2.0, h=-0.8)
+        v2 = QAtlas.fetch(m2, LiebRobinsonVelocity(), Infinite())
+        @test v2 ≈ 2 * min(2.0, 0.8) atol = 1e-14  # = 1.6
+    end
+
+    @testset "J / h kwargs override model values" begin
         m = TFIM(; J=1.0, h=0.5)
-        v = QAtlas.fetch(m, LiebRobinsonVelocity(), Infinite(); J=4.0)
-        @test v ≈ 8.0 atol = 1e-14
+        v = QAtlas.fetch(m, LiebRobinsonVelocity(), Infinite(); J=4.0, h=10.0)
+        @test v ≈ 2 * min(4.0, 10.0) atol = 1e-14  # = 8.0
     end
 end


### PR DESCRIPTION
## What

Correct the TFIM LiebRobinsonVelocity dispatch introduced in PR #586:

```
v_LR = 2 |J|             # old, Hastings-Koma loose upper bound
v_LR = 2 min(|J|, |h|)   # new, tight free-fermion saturated bound
```

## Why

PR #586 dispatched the Hastings-Koma loose upper bound (the largest local coupling). The tight free-fermion saturated Lieb-Robinson velocity, given by max_k |dLambda / dk| over the BdG dispersion Lambda(k) = 2 sqrt(J^2 + h^2 - 2 J h cos k), is

    v_LR = 2 min(|J|, |h|).

Derivation: setting d|dLambda/dk|^2 / dk = 0 gives interior stationary points at cos k* = min(|J|, |h|) / max(|J|, |h|), at which the group velocity attains its max value 2 min(|J|, |h|).

At criticality h = J the two values agree (both 2J), but off criticality the loose upper bound systematically overestimates by a factor max/min. The tight value is what governs dynamical quantities including the EntanglementGrowthSlope = pi c v / (3 beta_eff) formula introduced in PR #588 (slope is overestimated by a factor max(J,h)/min(J,h) when using the loose v).

Boundary cases:
- h = 0 (classical Ising): no quantum dynamics, v_LR = 0
- J = 0 (decoupled site spins): no interaction, v_LR = 0

Both correctly returned by the tight formula but not by the old loose 2|J|.

## Tests

Updated from 22 to 29 assertions:
- new tight closed form v_LR = 2 min(|J|, |h|)
- criticality h = J -> 2J
- vanishing v_LR at h = 0 or J = 0
- negative-coupling abs handling
- both J and h kwargs override model values

All pass at atol = 1e-14.

## Stacking

Base = PR #591. Full stack:

```
main <- #582 <- #583 <- #584 <- #585 <- #586 <- #587 <- #588 <- #589 <- #590 <- #591 <- this PR
```

Patch bump 0.23.17 to 0.23.18.

Refs #579, #586.
