### PR TITLE
feat(Universality): Affleck-Ludwig BoundaryEntropy for Ising Cardy states (refs #580)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.18"
+version = "0.23.19"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -108,7 +108,7 @@ export GroundStateDegeneracy, TopologicalEntanglementEntropy, AnyonStatistics  #
 export CasimirEnergyCorrection                                              # CFT 1/L correction (#150)
 export ConformalWeights, PrimaryFields
 export StringOrderParameter
-export FermiVelocity, LuttingerVelocity, SpinWaveVelocity, LiebRobinsonVelocity, MutualInformation, EntanglementGrowthSlope, CardyEntropy, ConformalCasimirEnergy, LogarithmicNegativity
+export FermiVelocity, LuttingerVelocity, SpinWaveVelocity, LiebRobinsonVelocity, MutualInformation, EntanglementGrowthSlope, CardyEntropy, ConformalCasimirEnergy, LogarithmicNegativity, BoundaryEntropy
 export SteadyStateCurrent                                # TASEP / non-equilibrium current (#241)
 export E8Spectrum
 export TopologicalInvariant, EdgeModeEnergy           # Kitaev1D Pfaffian invariant + edge mode

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -617,6 +617,22 @@ formula with the prefactor c/3 replaced by c/4. Tracking: #580.
 struct LogarithmicNegativity <: AbstractQuantity end
 
 """
+    BoundaryEntropy() <: AbstractQuantity
+
+Affleck-Ludwig universal (non-integer) boundary entropy `log g`
+of a conformal boundary state in a 1+1D rational CFT, given by
+
+    g_a = S_{0a} / sqrt(S_{00})
+
+for the Cardy boundary state |a⟩ corresponding to primary `a`, where
+`S_{ab}` is the modular S-matrix. The quantity `log g` is non-negative
+under unitary RG and decreases monotonically (g-theorem). The
+universal "ground-state degeneracy" interpretation goes back to
+Affleck-Ludwig 1991. Tracking: #580.
+"""
+struct BoundaryEntropy <: AbstractQuantity end
+
+"""
     E8Spectrum() <: AbstractQuantity
 
 Zamolodchikov E8 mass spectrum (8 stable particles).  Concrete

--- a/src/universalities/CardyEntanglement.jl
+++ b/src/universalities/CardyEntanglement.jl
@@ -682,3 +682,55 @@ function fetch(
     c = _cardy_central_charge(model; kwargs...)
     return (c / 4) * log(ℓ_A * ℓ_B / (ℓ_A + ℓ_B))
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Affleck-Ludwig boundary entropy log g (#580)
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    fetch(::Universality{:Ising}, ::BoundaryEntropy, ::Infinite;
+          boundary_state::Symbol, kwargs...) -> Float64
+
+Affleck-Ludwig universal boundary entropy `log g` for an Ising CFT
+(M(3,4), c = 1/2) Cardy boundary state. From the modular S-matrix of
+the Ising minimal model the universal `g_a = S_{0a} / sqrt(S_{00})`
+values are
+
+    g_1 (identity)  = 1/sqrt(2),   log g = -(1/2) log 2
+    g_σ (spin)      = 1,           log g = 0
+    g_ε (energy)    = 1/sqrt(2),   log g = -(1/2) log 2
+
+Physical interpretation: `|σ⟩` is the "free" (unconstrained) boundary
+and `|1⟩` and `|ε⟩` are the "fixed" boundaries (spin pinned up or
+down). The free boundary has higher `g`, so free flows to fixed under
+RG (g-theorem).
+
+`boundary_state` selects the Cardy state, one of:
+    `:identity` (≡ `:fixed_up`),
+    `:sigma`    (≡ `:free`),
+    `:epsilon`  (≡ `:fixed_down`).
+
+Reference: Affleck-Ludwig PRL **67**, 161 (1991);
+Cardy *Nucl. Phys. B* **324**, 581 (1989) for the Cardy state
+construction. Tracking: #580.
+"""
+function fetch(
+    ::Universality{:Ising}, ::BoundaryEntropy, ::Infinite; boundary_state::Symbol, kwargs...
+)
+    if boundary_state === :identity ||
+        boundary_state === :fixed_up ||
+        boundary_state === :epsilon ||
+        boundary_state === :fixed_down
+        return -log(2) / 2  # log(1/sqrt(2))
+    elseif boundary_state === :sigma || boundary_state === :free
+        return 0.0           # log(1)
+    else
+        throw(
+            ArgumentError(
+                "Universality(:Ising) BoundaryEntropy: boundary_state must be one " *
+                "of :identity / :fixed_up / :sigma / :free / :epsilon / :fixed_down; " *
+                "got \$(boundary_state).",
+            ),
+        )
+    end
+end

--- a/test/universalities/test_universality_boundary_entropy.jl
+++ b/test/universalities/test_universality_boundary_entropy.jl
@@ -1,0 +1,50 @@
+using Test
+using QAtlas
+using QAtlas: Universality, BoundaryEntropy, Infinite
+
+@testset "Universality(:Ising) BoundaryEntropy Affleck-Ludwig log g (#580)" begin
+    @testset "Fixed boundary (identity / epsilon Cardy states): log g = -(1/2) log 2" begin
+        for state in (:identity, :epsilon, :fixed_up, :fixed_down)
+            g_log = QAtlas.fetch(
+                Universality(:Ising), BoundaryEntropy(), Infinite(); boundary_state=state
+            )
+            @test g_log ≈ -log(2) / 2 atol = 1e-14
+            @test exp(g_log) ≈ 1 / sqrt(2) atol = 1e-14
+        end
+    end
+
+    @testset "Free boundary (sigma Cardy state): log g = 0" begin
+        for state in (:sigma, :free)
+            g_log = QAtlas.fetch(
+                Universality(:Ising), BoundaryEntropy(), Infinite(); boundary_state=state
+            )
+            @test g_log ≈ 0.0 atol = 1e-14
+            @test exp(g_log) ≈ 1.0 atol = 1e-14
+        end
+    end
+
+    @testset "g-theorem ordering: free > fixed (g decreases under RG)" begin
+        g_free = exp(
+            QAtlas.fetch(
+                Universality(:Ising), BoundaryEntropy(), Infinite(); boundary_state=:free
+            ),
+        )
+        g_fixed = exp(
+            QAtlas.fetch(
+                Universality(:Ising),
+                BoundaryEntropy(),
+                Infinite();
+                boundary_state=:fixed_up,
+            ),
+        )
+        @test g_free > g_fixed
+        # The g ratio g_free / g_fixed = sqrt(2) (universal).
+        @test g_free / g_fixed ≈ sqrt(2) atol = 1e-14
+    end
+
+    @testset "Argument validation" begin
+        @test_throws ArgumentError QAtlas.fetch(
+            Universality(:Ising), BoundaryEntropy(), Infinite(); boundary_state=:bogus
+        )
+    end
+end


### PR DESCRIPTION
## What

Introduce BoundaryEntropy as a new AbstractQuantity. Universality-layer dispatch for Universality(:Ising) returns the universal Affleck-Ludwig boundary entropy log g of an Ising CFT Cardy boundary state via the modular S-matrix identity g_a = S_{0a} / sqrt(S_{00}).

## Values for Ising minimal model M(3,4)

| Cardy state | g | log g |
|---|---|---|
| |1> (identity) | 1/sqrt(2) | -(1/2) log 2 |
| |sigma> (spin) | 1 | 0 |
| |epsilon> (energy) | 1/sqrt(2) | -(1/2) log 2 |

Physical interpretation: |sigma> is the free (unconstrained) boundary and |1>, |epsilon> are the fixed boundaries (spin pinned up / down). The free boundary has higher g, so free flows to fixed under RG (g-theorem).

## API

```julia
fetch(Universality(:Ising), BoundaryEntropy(), Infinite(); boundary_state)
```

boundary_state kwarg accepts:
- primary labels: :identity, :sigma, :epsilon
- physical aliases: :fixed_up, :free, :fixed_down

## References

- Affleck-Ludwig, *Phys. Rev. Lett.* **67**, 161 (1991), DOI 10.1103/PhysRevLett.67.161 (metadata fetched via doiget; PDF behind APS paywall)
- Cardy, *Nucl. Phys. B* **324**, 581 (1989) for the Cardy state construction

## Tests

15 assertions across fixed and free state values, exp(log g) g-values, g-theorem ordering g_free > g_fixed plus universal ratio sqrt(2), argument validation. All pass at atol = 1e-14.

## Stacking

Base = PR #592. Full stack:

```
main <- #582 <- ... <- #591 <- #592 <- this PR
```

Patch bump 0.23.18 to 0.23.19.

## Follow-up

- Universality(:Potts3) M(5,6): boundary entropies for the 6 Cardy states from S-matrix
- Universality(:Heisenberg) free-boson c=1 with Dirichlet / Neumann boundaries (g depends on compactification radius)
- Quantum impurity boundary RG flows (Kondo, two-channel, etc.)

Refs #580.
