### PR TITLE
feat(Universality): PageEntropy = Page 1993 random subsystem entropy (refs #580)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.19"
+version = "0.23.20"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -108,7 +108,7 @@ export GroundStateDegeneracy, TopologicalEntanglementEntropy, AnyonStatistics  #
 export CasimirEnergyCorrection                                              # CFT 1/L correction (#150)
 export ConformalWeights, PrimaryFields
 export StringOrderParameter
-export FermiVelocity, LuttingerVelocity, SpinWaveVelocity, LiebRobinsonVelocity, MutualInformation, EntanglementGrowthSlope, CardyEntropy, ConformalCasimirEnergy, LogarithmicNegativity, BoundaryEntropy
+export FermiVelocity, LuttingerVelocity, SpinWaveVelocity, LiebRobinsonVelocity, MutualInformation, EntanglementGrowthSlope, CardyEntropy, ConformalCasimirEnergy, LogarithmicNegativity, BoundaryEntropy, PageEntropy
 export SteadyStateCurrent                                # TASEP / non-equilibrium current (#241)
 export E8Spectrum
 export TopologicalInvariant, EdgeModeEnergy           # Kitaev1D Pfaffian invariant + edge mode

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -633,6 +633,25 @@ Affleck-Ludwig 1991. Tracking: #580.
 struct BoundaryEntropy <: AbstractQuantity end
 
 """
+    PageEntropy() <: AbstractQuantity
+
+Page average entropy of a subsystem for a Haar-random pure state in
+`H_A ⊗ H_B`. For `dim(H_A) = m`, `dim(H_B) = n` with `m ≤ n` (else
+swap by purity symmetry), Page 1993 found
+
+    <S_A> = sum_{k=n+1}^{m·n} 1/k - (m-1)/(2n).
+
+For `m = n` this gives `<S_A> ≈ log m - 1/2` (close to maximal but
+reduced by 1/2); for `m << n` it gives `<S_A> ≈ log m - m/(2n)`.
+This is the famous Page curve in dimension space underlying e.g. the
+information-paradox / Page-time analysis of evaporating black holes.
+
+Reference: D. N. Page, *Phys. Rev. Lett.* **71**, 1291 (1993),
+DOI 10.1103/PhysRevLett.71.1291. Tracking: #580.
+"""
+struct PageEntropy <: AbstractQuantity end
+
+"""
     E8Spectrum() <: AbstractQuantity
 
 Zamolodchikov E8 mass spectrum (8 stable particles).  Concrete

--- a/src/universalities/CardyEntanglement.jl
+++ b/src/universalities/CardyEntanglement.jl
@@ -734,3 +734,45 @@ function fetch(
         )
     end
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Page entropy for Haar-random pure states (#580)
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    fetch(::Universality{:HaarRandom}, ::PageEntropy, ::Infinite;
+          d_A::Integer, d_B::Integer, kwargs...) -> Float64
+
+Page 1993 average entropy of a subsystem `A` for a Haar-random pure
+state in `H_A ⊗ H_B` with `dim(H_A) = d_A`, `dim(H_B) = d_B`:
+
+    <S_A> = sum_{k=n+1}^{m·n} 1/k - (m-1)/(2n)
+
+where `m = min(d_A, d_B)` and `n = max(d_A, d_B)` (the formula is
+invariant under A ↔ B exchange by purity of the global state).
+
+Asymptotic limits:
+- `m == n`:   `<S_A> ≈ log m - 1/2`  (nearly maximal entropy)
+- `m << n`:   `<S_A> ≈ log m - m/(2n)`  (almost maximal volume law)
+- `m >> n`:   `<S_A> ≈ log n - n/(2m)`  (same by A ↔ B symmetry)
+
+Reference: D. N. Page, *Phys. Rev. Lett.* **71**, 1291 (1993),
+DOI 10.1103/PhysRevLett.71.1291.
+"""
+function fetch(
+    ::Universality{:HaarRandom},
+    ::PageEntropy,
+    ::Infinite;
+    d_A::Integer,
+    d_B::Integer,
+    kwargs...,
+)
+    d_A >= 1 || throw(ArgumentError("PageEntropy: d_A must be >= 1; got d_A=$d_A."))
+    d_B >= 1 || throw(ArgumentError("PageEntropy: d_B must be >= 1; got d_B=$d_B."))
+    m, n = minmax(d_A, d_B)
+    s = 0.0
+    for k in (n + 1):(m * n)
+        s += 1.0 / k
+    end
+    return s - (m - 1) / (2.0 * n)
+end

--- a/test/universalities/test_universality_page_entropy.jl
+++ b/test/universalities/test_universality_page_entropy.jl
@@ -1,0 +1,61 @@
+using Test
+using QAtlas
+using QAtlas: Universality, PageEntropy, Infinite
+
+@testset "Universality(:HaarRandom) PageEntropy Page 1993 (#580)" begin
+    @testset "m = 1: subsystem A is a single state -> S = 0" begin
+        for n in (1, 2, 4, 10, 100)
+            S = QAtlas.fetch(
+                Universality(:HaarRandom), PageEntropy(), Infinite(); d_A=1, d_B=n
+            )
+            @test S ≈ 0.0 atol = 1e-14
+        end
+    end
+
+    @testset "m = n = 2: <S_A> = sum_{k=3}^{4} 1/k - 1/4 = 7/12" begin
+        S = QAtlas.fetch(Universality(:HaarRandom), PageEntropy(), Infinite(); d_A=2, d_B=2)
+        # 1/3 + 1/4 - 1/4 = 1/3
+        @test S ≈ 1 / 3 atol = 1e-14
+    end
+
+    @testset "A ↔ B symmetry (purity of global state)" begin
+        for (dA, dB) in ((2, 4), (3, 8), (4, 16), (5, 7))
+            S1 = QAtlas.fetch(
+                Universality(:HaarRandom), PageEntropy(), Infinite(); d_A=dA, d_B=dB
+            )
+            S2 = QAtlas.fetch(
+                Universality(:HaarRandom), PageEntropy(), Infinite(); d_A=dB, d_B=dA
+            )
+            @test S1 ≈ S2 atol = 1e-14
+        end
+    end
+
+    @testset "m = n asymptotic: <S_A> → log m - 1/2 (large m)" begin
+        # Confirm convergence to Page asymptotic at successively larger m.
+        for m in (8, 16, 32, 64)
+            S = QAtlas.fetch(
+                Universality(:HaarRandom), PageEntropy(), Infinite(); d_A=m, d_B=m
+            )
+            @test abs(S - (log(m) - 0.5)) < 1.0 / m
+        end
+    end
+
+    @testset "Sub-maximal: 0 ≤ <S_A> ≤ log(min(d_A, d_B))" begin
+        for dA in (1, 2, 4, 8), dB in (1, 2, 4, 8, 16)
+            S = QAtlas.fetch(
+                Universality(:HaarRandom), PageEntropy(), Infinite(); d_A=dA, d_B=dB
+            )
+            @test S >= 0
+            @test S <= log(min(dA, dB)) + 1e-14
+        end
+    end
+
+    @testset "Argument validation" begin
+        @test_throws ArgumentError QAtlas.fetch(
+            Universality(:HaarRandom), PageEntropy(), Infinite(); d_A=0, d_B=4
+        )
+        @test_throws ArgumentError QAtlas.fetch(
+            Universality(:HaarRandom), PageEntropy(), Infinite(); d_A=4, d_B=-1
+        )
+    end
+end


### PR DESCRIPTION
## What

Introduce PageEntropy as a new AbstractQuantity. New universality class Universality(:HaarRandom) tags the Haar-random pure-state ensemble. Dispatch returns the Page 1993 average entropy of a subsystem:

```
<S_A> = sum_{k=n+1}^{m * n} 1/k - (m-1)/(2 n)
```

with m = min(d_A, d_B), n = max(d_A, d_B). Invariant under A <-> B by purity of the global state.

## Asymptotic limits

- m = n: <S_A> approaches log m - 1/2 (close to maximal but reduced)
- m << n: <S_A> approaches log m - m/(2 n) (near-maximal volume law)
- m >> n: same by A <-> B symmetry

## Reference

D. N. Page, *Phys. Rev. Lett.* **71**, 1291 (1993), DOI 10.1103/PhysRevLett.71.1291. PDF fetched via doiget (99 kB OA-accessible). The original PRL underlying the Page curve and information-paradox / Page-time analysis of evaporating black holes.

## Tests

56 assertions:
- m = 1 trivial: S = 0 across n
- m = n = 2 exact value 1/3
- A <-> B symmetry across 4 unequal pairs
- m = n asymptotic log m - 1/2 with error < 1/m
- 0 <= S <= log min bounds across 20 (d_A, d_B) combinations
- argument validation

All pass at atol = 1e-14.

## Stacking

Base = PR #593. Full stack:

```
main <- #582 <- ... <- #593 <- this PR
```

Patch bump 0.23.19 to 0.23.20.

## Follow-up

- Renyi-alpha generalisation (Bianchi-Hackl-Vidmar 2021)
- Microcanonical / Lubkin moment expansions
- Page time analysis for evaporating black holes interpretation
- Symmetry-resolved / charge-resolved variants

Refs #580.
