### PR TITLE
feat(TFIM): EntanglementGrowthSlope wrapper at h=J critical wires c + v_LR (refs #580, #579)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.20"
+version = "0.23.21"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/models/quantum/TFIM/TFIM.jl
+++ b/src/models/quantum/TFIM/TFIM.jl
@@ -313,3 +313,50 @@ function fetch(
 )
     return 2 * min(abs(J), abs(h))
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# EntanglementGrowthSlope wrapper at h = J critical (#580 / #579 cross)
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    fetch(model::TFIM, ::EntanglementGrowthSlope, ::Infinite;
+          beta_eff::Real, kwargs...) -> Float64
+
+Linear-growth slope of post-quench half-system entanglement entropy
+for the TFIM at the Ising critical point `h = J`. Wires together two
+universality-layer pieces
+
+    c = 1/2          (Universality(:Ising) CentralCharge)
+    v_LR = 2 |J|     (TFIM LiebRobinsonVelocity at h = J critical)
+
+into the Calabrese-Cardy 2005 result
+
+    dS_A/dt = π c v_LR / (3 beta_eff) = π J / (3 beta_eff).
+
+For non-critical TFIM (`h ≠ J`, gapped) the CC linear-growth picture
+does not apply and `DomainError` is thrown.
+
+Reference: Calabrese-Cardy *J. Stat. Mech.* P04010 (2005);
+combines universality-layer dispatches from PR #588 and the TFIM
+LiebRobinsonVelocity from PR #586 / fix #592.
+"""
+function fetch(
+    model::TFIM, ::EntanglementGrowthSlope, ::Infinite; beta_eff::Real, kwargs...
+)
+    isapprox(model.h, model.J; atol=1e-10) || throw(
+        DomainError(
+            (model.J, model.h),
+            "TFIM EntanglementGrowthSlope at Infinite is defined only at the Ising " *
+            "critical point h = J (gapless c = 1/2 CFT); off-critical TFIM is gapped " *
+            "and CC linear-growth does not apply. Got (J, h) = (\$(model.J), \$(model.h)).",
+        ),
+    )
+    return fetch(
+        Universality(:Ising),
+        EntanglementGrowthSlope(),
+        Infinite();
+        v=fetch(model, LiebRobinsonVelocity(), Infinite()),
+        beta_eff=beta_eff,
+        kwargs...,
+    )
+end

--- a/test/models/quantum/TFIM/test_TFIM_entanglement_growth_slope.jl
+++ b/test/models/quantum/TFIM/test_TFIM_entanglement_growth_slope.jl
@@ -1,0 +1,43 @@
+using Test
+using QAtlas
+using QAtlas: TFIM, EntanglementGrowthSlope, Infinite, Universality, LiebRobinsonVelocity
+
+@testset "TFIM EntanglementGrowthSlope wrapper at h=J critical (#580 + #579 cross)" begin
+    @testset "Slope = π J / (3 β_eff) at h = J critical" begin
+        for J in (0.5, 1.0, 2.0, 5.0), β in (1.0, 5.0, 20.0)
+            m = TFIM(; J=J, h=J)
+            slope = QAtlas.fetch(m, EntanglementGrowthSlope(), Infinite(); beta_eff=β)
+            expected = π * J / (3 * β)
+            @test slope ≈ expected atol = 1e-14
+        end
+    end
+
+    @testset "End-to-end chain: c(Ising) · v(TFIM) / (3 β_eff)" begin
+        m = TFIM(; J=1.5, h=1.5)
+        β = 4.0
+        slope_model = QAtlas.fetch(m, EntanglementGrowthSlope(), Infinite(); beta_eff=β)
+        c = float(QAtlas.fetch(Universality(:Ising), QAtlas.CentralCharge(); d=2))
+        v = QAtlas.fetch(m, LiebRobinsonVelocity(), Infinite())
+        slope_chain = π * c * v / (3 * β)
+        @test slope_model ≈ slope_chain atol = 1e-14
+        # Verify the values: c = 1/2, v = 2J = 3.0, expected = π·0.5·3 / 12 = π/8
+        @test slope_chain ≈ π / 8 atol = 1e-14
+    end
+
+    @testset "Off-critical h ≠ J: DomainError" begin
+        for (J, h) in ((1.0, 0.5), (1.0, 2.0), (1.0, 1.5))
+            m = TFIM(; J=J, h=h)
+            @test_throws DomainError QAtlas.fetch(
+                m, EntanglementGrowthSlope(), Infinite(); beta_eff=5.0
+            )
+        end
+    end
+
+    @testset "Critical detection tolerance" begin
+        # Within 1e-10 of criticality should still delegate (not throw).
+        m = TFIM(; J=1.0, h=1.0 + 1e-12)
+        slope = QAtlas.fetch(m, EntanglementGrowthSlope(), Infinite(); beta_eff=1.0)
+        @test isfinite(slope)
+        @test slope > 0
+    end
+end


### PR DESCRIPTION
## What

End-to-end demonstration of the Phase 2 universality stack: TFIM at h = J critical exposes EntanglementGrowthSlope by wiring together

```
c = 1/2          (from Universality(:Ising) CentralCharge)
v_LR = 2 |J|     (from TFIM LiebRobinsonVelocity, after fix #592)
```

into the Calabrese-Cardy 2005 quench-dynamics result

```
dS_A / dt = pi c v_LR / (3 beta_eff) = pi J / (3 beta_eff)
```

Off-critical (h != J, gapped phase): DomainError because CC linear growth does not apply outside the universality class.

## Why

Demonstrates the value of the universality-layer abstractions added in PR #582-#592:

- universality provides c
- model provides v
- universal quench formula (PR #588) combines them
- model-side wrapper composes the chain into a single user-facing call

Adding another model to the chain (XYh1D, XXZ free-fermion XX point, etc.) only requires a v dispatch — c and the universal formula are already there.

## Tests

19 assertions:
- closed form pi J / (3 beta_eff) at multiple (J, beta) pairs
- end-to-end manual chain verification c * v / (3 beta_eff)
- DomainError at off-critical h != J
- critical detection tolerance for |h - J| at machine precision

All pass at atol = 1e-14.

## Stacking

Base = PR #594. Full stack:

```
main <- #582 <- ... <- #594 <- this PR
```

Patch bump 0.23.20 to 0.23.21.

## Follow-up

- XYh1D Jx = Jy h = 0 (XX critical) -> Universality(:XY) chain analog
- XXZ1D Delta in (-1, 1] -> Universality(:XY) or Universality(:Heisenberg) chain analog
- HaldaneShastry -> Universality(:Heisenberg) chain analog (free-spinon velocity from earlier sound-velocity dispatch)

Refs #580, #579.
