### PR TITLE
feat(Universality): EntanglementSaturationDensity = pi c / (6 beta_eff) CC 2005 (refs #580)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.22"
+version = "0.23.23"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -571,6 +571,24 @@ P04010. Tracking: #580 quench-dynamics phase.
 struct EntanglementGrowthSlope <: AbstractQuantity end
 
 """
+    EntanglementSaturationDensity() <: AbstractQuantity
+
+Per-unit-length saturation value of post-quench entanglement entropy
+in the Calabrese-Cardy 2005 picture: in the long-time regime
+`t > L / (2 v)`, the half-system entropy saturates at
+
+    S_A(infty) / L = π c / (6 beta_eff),
+
+where `c` is the central charge of the post-quench critical
+Hamiltonian and `beta_eff` is the effective inverse temperature of the
+generalised-Gibbs steady state. Universal in (c, beta_eff). Partner to
+[`EntanglementGrowthSlope`](@ref) (which gives the dS/dt of the
+linear regime). Reference: Calabrese-Cardy J. Stat. Mech. P04010
+(2005). Tracking: #580.
+"""
+struct EntanglementSaturationDensity <: AbstractQuantity end
+
+"""
     CardyEntropy() <: AbstractQuantity
 
 Asymptotic high-energy entropy (log of the density of states) of a

--- a/src/universalities/CardyEntanglement.jl
+++ b/src/universalities/CardyEntanglement.jl
@@ -831,3 +831,39 @@ function fetch(
     D_sq = sum(d -> d^2, quantum_dimensions)
     return 0.5 * log(D_sq)
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Per-length saturation of post-quench entanglement (#580)
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    fetch(::Universality{C}, ::EntanglementSaturationDensity, ::Infinite;
+          beta_eff::Real, kwargs...) -> Float64
+
+Long-time saturation of post-quench entanglement entropy per unit
+length (Calabrese-Cardy 2005):
+
+    S_A(infty) / L = pi c / (6 beta_eff),
+
+with `c` provided by the universality class. Partner to
+EntanglementGrowthSlope (PR #588): the linear-regime extrapolation
+slope * (L / (2 v)) equals this saturation value, expressing the
+crossover at the boundary of the light cone.
+
+Reference: Calabrese-Cardy J. Stat. Mech. P04010 (2005). Tracking #580.
+"""
+function fetch(
+    model::Universality{C},
+    ::EntanglementSaturationDensity,
+    ::Infinite;
+    beta_eff::Real,
+    kwargs...,
+) where {C}
+    beta_eff > 0 || throw(
+        ArgumentError(
+            "EntanglementSaturationDensity: beta_eff must be > 0; got beta_eff=$beta_eff.",
+        ),
+    )
+    c = _cardy_central_charge(model; kwargs...)
+    return π * c / (6 * beta_eff)
+end

--- a/test/universalities/test_universality_entanglement_saturation_density.jl
+++ b/test/universalities/test_universality_entanglement_saturation_density.jl
@@ -1,0 +1,96 @@
+using Test
+using QAtlas
+using QAtlas:
+    Universality,
+    EntanglementSaturationDensity,
+    EntanglementGrowthSlope,
+    Infinite,
+    CentralCharge
+
+@testset "Universality EntanglementSaturationDensity = π c / (6 β_eff) CC 2005 (#580)" begin
+    @testset "Closed form across 5 universality classes" begin
+        d_for = Dict(:Ising=>2, :XY=>2, :Heisenberg=>1, :Potts3=>2, :Potts4=>2)
+        for class in (:Ising, :XY, :Heisenberg, :Potts3, :Potts4)
+            c = float(QAtlas.fetch(Universality(class), CentralCharge(); d=d_for[class]))
+            for β in (0.5, 1.0, 5.0, 20.0, 100.0)
+                s = QAtlas.fetch(
+                    Universality(class),
+                    EntanglementSaturationDensity(),
+                    Infinite();
+                    beta_eff=β,
+                )
+                expected = π * c / (6 * β)
+                @test s ≈ expected atol = 1e-14
+            end
+        end
+    end
+
+    @testset "Crossover relation: s_sat * (2 v) = slope * 1 (per universality + β_eff)" begin
+        # CC linear-regime extrapolation matches saturation at t = L / (2 v):
+        # slope * (L / (2 v)) = saturation * L  =>  s_sat / slope = 1 / (2 v)
+        for class in (:Ising, :Heisenberg)
+            for v in (1.0, 2.0, 5.0), β in (1.0, 10.0)
+                s_sat = QAtlas.fetch(
+                    Universality(class),
+                    EntanglementSaturationDensity(),
+                    Infinite();
+                    beta_eff=β,
+                )
+                slope = QAtlas.fetch(
+                    Universality(class),
+                    EntanglementGrowthSlope(),
+                    Infinite();
+                    v=v,
+                    beta_eff=β,
+                )
+                @test s_sat / slope ≈ 1 / (2 * v) atol = 1e-14
+            end
+        end
+    end
+
+    @testset "Inverse linearity in β_eff at fixed c" begin
+        for class in (:Ising, :Heisenberg)
+            s1 = QAtlas.fetch(
+                Universality(class),
+                EntanglementSaturationDensity(),
+                Infinite();
+                beta_eff=1.0,
+            )
+            s10 = QAtlas.fetch(
+                Universality(class),
+                EntanglementSaturationDensity(),
+                Infinite();
+                beta_eff=10.0,
+            )
+            @test s10 ≈ s1 / 10 atol = 1e-14
+        end
+    end
+
+    @testset "Linearity in c at fixed β_eff" begin
+        β = 4.0
+        s_Ising = QAtlas.fetch(
+            Universality(:Ising), EntanglementSaturationDensity(), Infinite(); beta_eff=β
+        )
+        s_Heis = QAtlas.fetch(
+            Universality(:Heisenberg),
+            EntanglementSaturationDensity(),
+            Infinite();
+            beta_eff=β,
+        )
+        c_I = float(QAtlas.fetch(Universality(:Ising), CentralCharge(); d=2))
+        c_H = float(QAtlas.fetch(Universality(:Heisenberg), CentralCharge(); d=1))
+        @test s_Heis / s_Ising ≈ c_H / c_I atol = 1e-12
+    end
+
+    @testset "Argument validation" begin
+        @test_throws ArgumentError QAtlas.fetch(
+            Universality(:Ising), EntanglementSaturationDensity(), Infinite(); beta_eff=-1.0
+        )
+        @test_throws ArgumentError QAtlas.fetch(
+            Universality(:Heisenberg),
+            EntanglementSaturationDensity(),
+            Infinite();
+            beta_eff=0.0,
+        )
+    end
+end


### PR DESCRIPTION
## What

Introduce EntanglementSaturationDensity as a new AbstractQuantity. Universality-layer dispatch returns the per-unit-length saturation value of post-quench half-system entanglement entropy in the Calabrese-Cardy 2005 picture:

```
S_A(infty) / L = pi c / (6 beta_eff)
```

Partner to EntanglementGrowthSlope (PR #588). At the crossover time t = L/(2v) the linear-regime extrapolation slope * L/(2v) equals the saturation density times L, expressing continuity at the boundary of the light cone:

```
s_sat / slope = 1 / (2 v)
```

## Tests

42 assertions covering closed form across 5 universality classes x 5 beta_eff values, crossover relation, inverse linearity in beta_eff, linearity in c, argument validation. All pass at atol = 1e-14.

## Reference

P. Calabrese, J. Cardy, *J. Stat. Mech.* P04010 (2005). Same paper as growth slope (PR #588); the saturation is the second half of the CC linear-then-saturate picture.

## Stacking

Base = PR #596. Patch bump 0.23.22 to 0.23.23.

Refs #580.
