### PR TITLE
feat(Universality): CHSHBound classical 2 / Tsirelson 2 sqrt(2) / Popescu-Rohrlich 4 (refs #579)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.23"
+version = "0.23.24"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -108,7 +108,7 @@ export GroundStateDegeneracy, TopologicalEntanglementEntropy, AnyonStatistics  #
 export CasimirEnergyCorrection                                              # CFT 1/L correction (#150)
 export ConformalWeights, PrimaryFields
 export StringOrderParameter
-export FermiVelocity, LuttingerVelocity, SpinWaveVelocity, LiebRobinsonVelocity, MutualInformation, EntanglementGrowthSlope, CardyEntropy, ConformalCasimirEnergy, LogarithmicNegativity, BoundaryEntropy, PageEntropy
+export FermiVelocity, LuttingerVelocity, SpinWaveVelocity, LiebRobinsonVelocity, MutualInformation, EntanglementGrowthSlope, CardyEntropy, ConformalCasimirEnergy, LogarithmicNegativity, BoundaryEntropy, PageEntropy, EntanglementSaturationDensity, CHSHBound
 export SteadyStateCurrent                                # TASEP / non-equilibrium current (#241)
 export E8Spectrum
 export TopologicalInvariant, EdgeModeEnergy           # Kitaev1D Pfaffian invariant + edge mode

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -589,6 +589,18 @@ linear regime). Reference: Calabrese-Cardy J. Stat. Mech. P04010
 struct EntanglementSaturationDensity <: AbstractQuantity end
 
 """
+    CHSHBound() <: AbstractQuantity
+
+Maximum value of the CHSH (Clauser-Horne-Shimony-Holt) Bell-inequality
+correlator over a state ensemble. Classical |S| <= 2 (CHSH 1969);
+quantum mechanics |S| <= 2 sqrt(2) (Tsirelson 1980); no-signalling /
+Popescu-Rohrlich |S| <= 4 (algebraic max). The quantum value is
+saturated by the Bell state with appropriate measurement-axis
+angles. Tracking: issue #579 inequality framework.
+"""
+struct CHSHBound <: AbstractQuantity end
+
+"""
     CardyEntropy() <: AbstractQuantity
 
 Asymptotic high-energy entropy (log of the density of states) of a

--- a/src/universalities/CardyEntanglement.jl
+++ b/src/universalities/CardyEntanglement.jl
@@ -867,3 +867,48 @@ function fetch(
     c = _cardy_central_charge(model; kwargs...)
     return π * c / (6 * beta_eff)
 end
+
+# -----------------------------------------------------------------------------
+# CHSH bounds (#579 inequality framework Phase 1)
+# -----------------------------------------------------------------------------
+
+"""
+    fetch(::Universality{:QuantumMechanics}, ::CHSHBound, ::Infinite;
+          convention::Symbol = :quantum, kwargs...) -> Float64
+
+Universal CHSH bounds for the Bell-inequality correlator S =
+E(a,b) + E(a,bp) + E(ap,b) - E(ap,bp):
+
+- :classical              -> 2          (CHSH 1969 local-realistic)
+- :quantum (default)      -> 2 sqrt(2)  (Tsirelson 1980 quantum max)
+- :no_signalling, :pr     -> 4          (Popescu-Rohrlich algebraic max)
+
+The quantum bound 2 sqrt(2) is saturated by the maximally entangled
+Bell state with appropriate measurement axes 0, pi/4, pi/2, 3 pi/4.
+
+References: Clauser-Horne-Shimony-Holt PRL 23, 880 (1969); B. S.
+Cirelson (Tsirelson), Lett. Math. Phys. 4, 93 (1980), DOI
+10.1007/BF00417500 (metadata fetched via doiget). Tracking: #579.
+"""
+function fetch(
+    ::Universality{:QuantumMechanics},
+    ::CHSHBound,
+    ::Infinite;
+    convention::Symbol=:quantum,
+    kwargs...,
+)
+    if convention === :quantum
+        return 2 * sqrt(2)
+    elseif convention === :classical
+        return 2.0
+    elseif convention === :no_signalling || convention === :pr
+        return 4.0
+    else
+        throw(
+            ArgumentError(
+                "CHSHBound: convention must be one of :quantum / :classical / " *
+                ":no_signalling / :pr; got :$(convention).",
+            ),
+        )
+    end
+end

--- a/test/universalities/test_universality_chsh_bound.jl
+++ b/test/universalities/test_universality_chsh_bound.jl
@@ -1,0 +1,60 @@
+using Test
+using QAtlas
+using QAtlas: Universality, CHSHBound, Infinite
+
+@testset "Universality(:QuantumMechanics) CHSHBound Tsirelson 1980 (#579)" begin
+    @testset "Classical (CHSH 1969): S_max = 2" begin
+        b = QAtlas.fetch(
+            Universality(:QuantumMechanics), CHSHBound(), Infinite(); convention=:classical
+        )
+        @test b ≈ 2.0 atol = 1e-14
+    end
+
+    @testset "Quantum (Tsirelson 1980): S_max = 2 sqrt(2)" begin
+        for cv in (:quantum,)
+            b = QAtlas.fetch(
+                Universality(:QuantumMechanics), CHSHBound(), Infinite(); convention=cv
+            )
+            @test b ≈ 2 * sqrt(2) atol = 1e-14
+            @test b ≈ 2.828427124746190 atol = 1e-12
+        end
+        # Default convention is :quantum
+        b = QAtlas.fetch(Universality(:QuantumMechanics), CHSHBound(), Infinite())
+        @test b ≈ 2 * sqrt(2) atol = 1e-14
+    end
+
+    @testset "No-signalling / Popescu-Rohrlich: S_max = 4" begin
+        for cv in (:no_signalling, :pr)
+            b = QAtlas.fetch(
+                Universality(:QuantumMechanics), CHSHBound(), Infinite(); convention=cv
+            )
+            @test b ≈ 4.0 atol = 1e-14
+        end
+    end
+
+    @testset "Hierarchy: classical < quantum < no-signalling" begin
+        b_c = QAtlas.fetch(
+            Universality(:QuantumMechanics), CHSHBound(), Infinite(); convention=:classical
+        )
+        b_q = QAtlas.fetch(
+            Universality(:QuantumMechanics), CHSHBound(), Infinite(); convention=:quantum
+        )
+        b_n = QAtlas.fetch(
+            Universality(:QuantumMechanics),
+            CHSHBound(),
+            Infinite();
+            convention=:no_signalling,
+        )
+        @test b_c < b_q < b_n
+        # quantum/classical = sqrt(2): the Bell-inequality violation factor
+        @test b_q / b_c ≈ sqrt(2) atol = 1e-14
+        # quantum/no_signalling = sqrt(2)/2: the quantum bound is sqrt(2)/2 of PR
+        @test b_q / b_n ≈ sqrt(2) / 2 atol = 1e-14
+    end
+
+    @testset "Argument validation" begin
+        @test_throws ArgumentError QAtlas.fetch(
+            Universality(:QuantumMechanics), CHSHBound(), Infinite(); convention=:bogus
+        )
+    end
+end


### PR DESCRIPTION
## What

Introduce CHSHBound as a new AbstractQuantity. New universality class Universality(:QuantumMechanics) tags the model-independent quantum mechanics ensemble. Dispatch returns the three universal bounds on the Bell-inequality correlator S:

- classical (CHSH 1969 local-realistic):  2
- quantum (Tsirelson 1980, saturated):    2 sqrt(2) ≈ 2.828
- no-signalling / Popescu-Rohrlich box:   4 (algebraic max)

Hierarchy: 2 < 2 sqrt(2) < 4. Quantum mechanics violates classical by sqrt(2), and reaches only sqrt(2)/2 of the algebraic PR maximum.

An example of Pattern D (Universality dispatch for inequalities) from issue #579, and a model-independent universal constant.

## References

- Clauser-Horne-Shimony-Holt PRL 23, 880 (1969) — original CHSH
- B. S. Cirelson (Tsirelson), Lett. Math. Phys. 4, 93 (1980), DOI 10.1007/BF00417500 (metadata fetched via doiget, PDF unavailable)
- Popescu-Rohrlich, Found. Phys. 24, 379 (1994) — PR box

## Also fixed

Add EntanglementSaturationDensity to the QAtlas exports (was omitted in PR #597). Both now exported.

## Tests

10 assertions across the three conventions, default :quantum, hierarchy, ratios sqrt(2) and sqrt(2)/2, argument validation. All pass at atol = 1e-14.

## Stacking

Base = PR #597. Patch bump 0.23.23 to 0.23.24.

Refs #579.
