### PR TITLE
feat(HaldaneShastry): LiebRobinsonVelocity + EntanglementGrowthSlope wrappers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.24"
+version = "0.23.25"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/models/quantum/HaldaneShastry/HaldaneShastry_thermal_cft.jl
+++ b/src/models/quantum/HaldaneShastry/HaldaneShastry_thermal_cft.jl
@@ -202,3 +202,61 @@ function fetch(
 )
     return fetch(Universality(:Heisenberg), q, Infinite(); ℓ=ℓ, beta=beta, kwargs...)
 end
+
+# -----------------------------------------------------------------------------
+# Lieb-Robinson velocity + entanglement growth slope (#579, #580)
+# -----------------------------------------------------------------------------
+
+"""
+    fetch(m::HaldaneShastry, ::LiebRobinsonVelocity, ::Infinite;
+          J = m.J, kwargs...) -> Float64
+
+Spinon group velocity of the Haldane-Shastry chain. The free-spinon
+gas underlying the SU(2)_1 WZW description has linear low-energy
+dispersion with sound (spinon) velocity
+
+    v_s = pi J / 2.
+
+For the long-range 1/r^2 model the strict Lieb-Robinson bound is
+weaker (no exponential light cone), but the QUASIPARTICLE / spinon
+propagation velocity that governs entanglement spreading at low
+energies is v_s = pi J / 2.
+
+Reference: F. D. M. Haldane PRL 60, 635 (1988); B. S. Shastry PRL 60,
+639 (1988); Y. Kuramoto-N. Kato-A. Sutherland review on long-range
+integrable models.
+"""
+function fetch(
+    m::HaldaneShastry, ::LiebRobinsonVelocity, ::Infinite; J::Real=m.J, kwargs...
+)
+    return π * abs(J) / 2
+end
+
+"""
+    fetch(m::HaldaneShastry, ::EntanglementGrowthSlope, ::Infinite;
+          beta_eff::Real, kwargs...) -> Float64
+
+Linear-growth slope of post-quench half-system entanglement entropy
+of the Haldane-Shastry chain. The chain is gapless with c = 1, so the
+Calabrese-Cardy 2005 formula applies directly:
+
+    dS_A / dt = pi c v_s / (3 beta_eff) = pi^2 J / (6 beta_eff),
+
+with c = 1 from Universality(:Heisenberg) and v_s = pi J / 2 from the
+LiebRobinsonVelocity dispatch above.
+
+Reference: Calabrese-Cardy J. Stat. Mech. P04010 (2005); HS spinon
+velocity v_s = pi J / 2 as above.
+"""
+function fetch(
+    m::HaldaneShastry, ::EntanglementGrowthSlope, ::Infinite; beta_eff::Real, kwargs...
+)
+    return fetch(
+        Universality(:Heisenberg),
+        EntanglementGrowthSlope(),
+        Infinite();
+        v=fetch(m, LiebRobinsonVelocity(), Infinite()),
+        beta_eff=beta_eff,
+        kwargs...,
+    )
+end

--- a/test/models/quantum/HaldaneShastry/test_haldaneshastry_lr_slope.jl
+++ b/test/models/quantum/HaldaneShastry/test_haldaneshastry_lr_slope.jl
@@ -1,0 +1,28 @@
+using Test
+using QAtlas
+
+@testset "HaldaneShastry LR velocity + slope wrappers" begin
+    @testset "LiebRobinsonVelocity@Infinite" begin
+        m = HaldaneShastry()
+        v = QAtlas.fetch(m, QAtlas.LiebRobinsonVelocity(), QAtlas.Infinite())
+        @test v ≈ π / 2 atol = 1e-12
+        for J in (0.5, 1.0, 2.0, 3.7)
+            m2 = HaldaneShastry(; J=J)
+            v2 = QAtlas.fetch(m2, QAtlas.LiebRobinsonVelocity(), QAtlas.Infinite())
+            @test v2 ≈ π * J / 2 atol = 1e-12
+        end
+        # negative-J: HaldaneShastry constructor forbids J<=0, test via kwarg override
+        @test QAtlas.fetch(HaldaneShastry(), QAtlas.LiebRobinsonVelocity(), QAtlas.Infinite(); J=-2.0) ≈ π
+    end
+
+    @testset "EntanglementGrowthSlope@Infinite" begin
+        m = HaldaneShastry()
+        for β in (1.0, 2.0, 5.0, 10.0)
+            slope = QAtlas.fetch(m, QAtlas.EntanglementGrowthSlope(), QAtlas.Infinite(); beta_eff=β)
+            @test slope ≈ π^2 / (6 * β) atol = 1e-12
+        end
+        m2 = HaldaneShastry(; J=2.0)
+        slope2 = QAtlas.fetch(m2, QAtlas.EntanglementGrowthSlope(), QAtlas.Infinite(); beta_eff=4.0)
+        @test slope2 ≈ π * 1.0 * π / (3 * 4.0) atol = 1e-12
+    end
+end


### PR DESCRIPTION
## Summary

- fetch(HaldaneShastry, LiebRobinsonVelocity, Infinite) returns the spinon group velocity v_s = pi * J / 2
- fetch(HaldaneShastry, EntanglementGrowthSlope, Infinite; beta_eff) delegates to Universality(:Heisenberg) with v = v_s, giving dS/dt = pi^2 * J / (6 * beta_eff)
- Extends the TFIM h=J end-to-end LR-velocity + slope demonstration to a second model

## Refs

- Refs #579 (universal LiebRobinsonVelocity)
- Refs #580 (universal EntanglementGrowthSlope)
- Builds on PR #598 (CHSHBound)

## Test plan

- 11 assertions: spinon velocity pi/2, J-scaling, beta-scaling
- negative-J via kwarg override (HaldaneShastry constructor forbids J <= 0)
