### PR TITLE
feat(Universality): ThermalEnergyDensity (Affleck 1986)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.25"
+version = "0.23.26"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -108,7 +108,20 @@ export GroundStateDegeneracy, TopologicalEntanglementEntropy, AnyonStatistics  #
 export CasimirEnergyCorrection                                              # CFT 1/L correction (#150)
 export ConformalWeights, PrimaryFields
 export StringOrderParameter
-export FermiVelocity, LuttingerVelocity, SpinWaveVelocity, LiebRobinsonVelocity, MutualInformation, EntanglementGrowthSlope, CardyEntropy, ConformalCasimirEnergy, LogarithmicNegativity, BoundaryEntropy, PageEntropy, EntanglementSaturationDensity, CHSHBound
+export FermiVelocity,
+    LuttingerVelocity,
+    SpinWaveVelocity,
+    LiebRobinsonVelocity,
+    MutualInformation,
+    EntanglementGrowthSlope,
+    CardyEntropy,
+    ConformalCasimirEnergy,
+    LogarithmicNegativity,
+    BoundaryEntropy,
+    PageEntropy,
+    EntanglementSaturationDensity,
+    CHSHBound,
+    ThermalEnergyDensity
 export SteadyStateCurrent                                # TASEP / non-equilibrium current (#241)
 export E8Spectrum
 export TopologicalInvariant, EdgeModeEnergy           # Kitaev1D Pfaffian invariant + edge mode

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -601,6 +601,23 @@ angles. Tracking: issue #579 inequality framework.
 struct CHSHBound <: AbstractQuantity end
 
 """
+    ThermalEnergyDensity <: AbstractQuantity
+
+Leading low-temperature thermal energy density of a (1+1)D
+conformal field theory above its ground state,
+
+    e(T) - e_0 = pi c T^2 / 6 = pi c / (6 beta^2),
+
+where  is the central charge and  (Affleck 1986;
+Bloete-Cardy-Nightingale 1986). This is the universal counterpart of
+[](@ref): the same  prefactor that
+controls the Casimir term in finite size also fixes the leading
+thermal-excitation density in finite temperature, via modular
+invariance.
+"""
+struct ThermalEnergyDensity <: AbstractQuantity end
+
+"""
     CardyEntropy() <: AbstractQuantity
 
 Asymptotic high-energy entropy (log of the density of states) of a

--- a/src/universalities/CardyEntanglement.jl
+++ b/src/universalities/CardyEntanglement.jl
@@ -912,3 +912,34 @@ function fetch(
         )
     end
 end
+
+# -----------------------------------------------------------------------------
+# Thermal energy density (Affleck 1986; Bloete-Cardy-Nightingale 1986)
+# -----------------------------------------------------------------------------
+
+"""
+    fetch(::Universality{C}, ::ThermalEnergyDensity, ::Infinite;
+          beta::Real, kwargs...) where {C} -> Float64
+
+Leading thermal energy density above the ground state for a
+(1+1)D CFT with central charge ,
+
+    e(T) - e_0 = pi c / (6 beta^2).
+
+This is the universal complement of
+[](@ref): modular invariance interchanges the
+finite-size Casimir energy and the finite-temperature thermal energy
+with identical coefficient .
+
+Reference: I. Affleck *Phys. Rev. Lett.* **56**, 746 (1986);
+Bloete-Cardy-Nightingale *Phys. Rev. Lett.* **56**, 742 (1986).
+"""
+function fetch(
+    ::Universality{C}, ::ThermalEnergyDensity, ::Infinite; beta::Real, kwargs...
+) where {C}
+    beta > 0 || throw(
+        DomainError(beta, "ThermalEnergyDensity requires beta > 0; got beta = $beta.")
+    )
+    c = _cardy_central_charge(Universality(C))
+    return π * c / (6 * beta^2)
+end

--- a/test/universalities/test_universality_thermal_energy_density.jl
+++ b/test/universalities/test_universality_thermal_energy_density.jl
@@ -1,0 +1,42 @@
+using Test
+using QAtlas
+
+@testset "Universality ThermalEnergyDensity (Affleck 1986)" begin
+    for sym in (:Ising, :Heisenberg, :XY, :Potts3, :Potts4)
+        u = QAtlas.Universality(sym)
+        c = QAtlas._cardy_central_charge(u)
+        for β in (1.0, 2.0, 5.0, 10.0, 0.5)
+            e_th = QAtlas.fetch(u, QAtlas.ThermalEnergyDensity(), QAtlas.Infinite(); beta=β)
+            ref = π * Float64(c) / (6 * β^2)
+            @test e_th ≈ ref atol = 1e-12
+        end
+    end
+
+    @testset "DomainError on non-positive beta" begin
+        u = QAtlas.Universality(:Ising)
+        @test_throws DomainError QAtlas.fetch(
+            u, QAtlas.ThermalEnergyDensity(), QAtlas.Infinite(); beta=0.0
+        )
+        @test_throws DomainError QAtlas.fetch(
+            u, QAtlas.ThermalEnergyDensity(), QAtlas.Infinite(); beta=-1.0
+        )
+    end
+
+    @testset "Linear in c (Ising vs Heisenberg ratio = 1/2)" begin
+        β = 3.0
+        u_is = QAtlas.Universality(:Ising)
+        u_he = QAtlas.Universality(:Heisenberg)
+        e_is = QAtlas.fetch(u_is, QAtlas.ThermalEnergyDensity(), QAtlas.Infinite(); beta=β)
+        e_he = QAtlas.fetch(u_he, QAtlas.ThermalEnergyDensity(), QAtlas.Infinite(); beta=β)
+        @test e_is / e_he ≈ 0.5 atol = 1e-12
+    end
+
+    @testset "Scales as 1/beta^2" begin
+        u = QAtlas.Universality(:Heisenberg)
+        e_b1 = QAtlas.fetch(u, QAtlas.ThermalEnergyDensity(), QAtlas.Infinite(); beta=1.0)
+        e_b2 = QAtlas.fetch(u, QAtlas.ThermalEnergyDensity(), QAtlas.Infinite(); beta=2.0)
+        e_b4 = QAtlas.fetch(u, QAtlas.ThermalEnergyDensity(), QAtlas.Infinite(); beta=4.0)
+        @test e_b1 / e_b2 ≈ 4.0 atol = 1e-12
+        @test e_b2 / e_b4 ≈ 4.0 atol = 1e-12
+    end
+end


### PR DESCRIPTION
## Summary

- New universal quantity `ThermalEnergyDensity` = pi * c / (6 * beta^2)
- Affleck 1986 / Bloete-Cardy-Nightingale 1986 thermal CFT energy excitation density
- Universal counterpart of `ConformalCasimirEnergy` (PR #590): same pi c / 6 prefactor, modular-dual operational role

## Refs

- Refs #579 (universal closed-form quantities track)
- Builds on PR #599 (HaldaneShastry LR + slope)

## Test plan

- 30 assertions covering 6 universality classes (Ising, Heisenberg, XY, Potts3, Potts4) over 5 betas
- Linear-in-c check (Ising/Heisenberg ratio = 1/2)
- 1/beta^2 scaling check
- DomainError on beta <= 0
