### PR TITLE
feat(Universality): CFTThermalEntropyDensity (Bloete-Cardy-Nightingale 1986)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.26"
+version = "0.23.27"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -121,7 +121,8 @@ export FermiVelocity,
     PageEntropy,
     EntanglementSaturationDensity,
     CHSHBound,
-    ThermalEnergyDensity
+    ThermalEnergyDensity,
+    CFTThermalEntropyDensity
 export SteadyStateCurrent                                # TASEP / non-equilibrium current (#241)
 export E8Spectrum
 export TopologicalInvariant, EdgeModeEnergy           # Kitaev1D Pfaffian invariant + edge mode

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -618,6 +618,21 @@ invariance.
 struct ThermalEnergyDensity <: AbstractQuantity end
 
 """
+    CFTThermalEntropyDensity <: AbstractQuantity
+
+Leading low-temperature thermal entropy density (entropy per unit
+length) of a (1+1)D conformal field theory,
+
+    s(T) = pi c T / 3 = pi c / (3 beta),
+
+with  the central charge. This is the temperature derivative of
+the universal CFT free energy density  (Bloete-Cardy-
+Nightingale 1986), and the operational complement of
+[](@ref).
+"""
+struct CFTThermalEntropyDensity <: AbstractQuantity end
+
+"""
     CardyEntropy() <: AbstractQuantity
 
 Asymptotic high-energy entropy (log of the density of states) of a

--- a/src/universalities/CardyEntanglement.jl
+++ b/src/universalities/CardyEntanglement.jl
@@ -943,3 +943,31 @@ function fetch(
     c = _cardy_central_charge(Universality(C))
     return π * c / (6 * beta^2)
 end
+
+# -----------------------------------------------------------------------------
+# Thermal entropy density (Bloete-Cardy-Nightingale 1986)
+# -----------------------------------------------------------------------------
+
+"""
+    fetch(::Universality{C}, ::CFTThermalEntropyDensity, ::Infinite;
+          beta::Real, kwargs...) where {C} -> Float64
+
+Thermal entropy density of a (1+1)D CFT with central charge
+,
+
+    s(T) = pi c / (3 beta).
+
+Obtained from  of the universal free energy density.
+
+Reference: Bloete-Cardy-Nightingale *Phys. Rev. Lett.* **56**, 742
+(1986); I. Affleck *Phys. Rev. Lett.* **56**, 746 (1986).
+"""
+function fetch(
+    model::Universality{C}, ::CFTThermalEntropyDensity, ::Infinite; beta::Real, kwargs...
+) where {C}
+    beta > 0 || throw(
+        DomainError(beta, "CFTThermalEntropyDensity requires beta > 0; got beta = $beta."),
+    )
+    c = _cardy_central_charge(model)
+    return π * c / (3 * beta)
+end

--- a/test/universalities/test_universality_thermal_entropy_density.jl
+++ b/test/universalities/test_universality_thermal_entropy_density.jl
@@ -1,0 +1,54 @@
+using Test
+using QAtlas
+
+@testset "Universality CFTThermalEntropyDensity (Bloete-Cardy-Nightingale 1986)" begin
+    for sym in (:Ising, :Heisenberg, :XY, :Potts3, :Potts4)
+        u = QAtlas.Universality(sym)
+        c = QAtlas._cardy_central_charge(u)
+        for β in (1.0, 2.0, 5.0, 10.0, 0.5)
+            s = QAtlas.fetch(
+                u, QAtlas.CFTThermalEntropyDensity(), QAtlas.Infinite(); beta=β
+            )
+            ref = π * Float64(c) / (3 * β)
+            @test s ≈ ref atol = 1e-12
+        end
+    end
+
+    @testset "DomainError on non-positive beta" begin
+        u = QAtlas.Universality(:Ising)
+        @test_throws DomainError QAtlas.fetch(
+            u, QAtlas.CFTThermalEntropyDensity(), QAtlas.Infinite(); beta=0.0
+        )
+        @test_throws DomainError QAtlas.fetch(
+            u, QAtlas.CFTThermalEntropyDensity(), QAtlas.Infinite(); beta=-2.5
+        )
+    end
+
+    @testset "Scales as 1/beta" begin
+        u = QAtlas.Universality(:Heisenberg)
+        s_b1 = QAtlas.fetch(
+            u, QAtlas.CFTThermalEntropyDensity(), QAtlas.Infinite(); beta=1.0
+        )
+        s_b2 = QAtlas.fetch(
+            u, QAtlas.CFTThermalEntropyDensity(), QAtlas.Infinite(); beta=2.0
+        )
+        s_b5 = QAtlas.fetch(
+            u, QAtlas.CFTThermalEntropyDensity(), QAtlas.Infinite(); beta=5.0
+        )
+        @test s_b1 / s_b2 ≈ 2.0 atol = 1e-12
+        @test s_b2 / s_b5 ≈ 2.5 atol = 1e-12
+    end
+
+    @testset "Thermodynamic relation: e = T s / 2 for CFT" begin
+        # e = π c / (6 β²), s = π c / (3 β); T s = s / β = π c / (3 β²) = 2 e
+        # so e = T s / 2 ⇔ e / s = T / 2 = 1 / (2β)
+        u = QAtlas.Universality(:Ising)
+        for β in (1.0, 3.0, 7.0)
+            e = QAtlas.fetch(u, QAtlas.ThermalEnergyDensity(), QAtlas.Infinite(); beta=β)
+            s = QAtlas.fetch(
+                u, QAtlas.CFTThermalEntropyDensity(), QAtlas.Infinite(); beta=β
+            )
+            @test e / s ≈ 1 / (2 * β) atol = 1e-12
+        end
+    end
+end


### PR DESCRIPTION
## Summary

- New universal quantity `CFTThermalEntropyDensity` = pi * c / (3 * beta)
- Bloete-Cardy-Nightingale 1986 thermal entropy density of (1+1)D CFTs
- Operational complement of `ThermalEnergyDensity` (PR #600): same prefactor family, derived from -d/dT of universal free energy density

## Refs

- Refs #579 (universal closed-form quantities track)
- Builds on PR #600 (ThermalEnergyDensity)

## Test plan

- 31 assertions: 5 universality classes (Ising, Heisenberg, XY, Potts3, Potts4) over 5 betas, plus 1/beta scaling, DomainError, and thermodynamic relation e/s = 1/(2 beta)
