### PR TITLE
feat(Universality): ChaosBound (Maldacena-Shenker-Stanford 2016)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.27"
+version = "0.23.28"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -122,7 +122,8 @@ export FermiVelocity,
     EntanglementSaturationDensity,
     CHSHBound,
     ThermalEnergyDensity,
-    CFTThermalEntropyDensity
+    CFTThermalEntropyDensity,
+    ChaosBound
 export SteadyStateCurrent                                # TASEP / non-equilibrium current (#241)
 export E8Spectrum
 export TopologicalInvariant, EdgeModeEnergy           # Kitaev1D Pfaffian invariant + edge mode

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -633,6 +633,22 @@ Nightingale 1986), and the operational complement of
 struct CFTThermalEntropyDensity <: AbstractQuantity end
 
 """
+    ChaosBound <: AbstractQuantity
+
+Maldacena-Shenker-Stanford 2016 universal Lyapunov bound for the
+out-of-time-ordered correlator (OTOC) growth rate of any quantum
+thermal many-body system,
+
+    lambda_L <= 2 pi / beta = 2 pi T.
+
+Equivalent to the universal scrambling rate cap. Saturated by
+Sachdev-Ye-Kitaev / Einstein-gravity black holes; conjectured to
+characterise maximally chaotic systems. Independent of central
+charge, dimension, and microscopic detail.
+"""
+struct ChaosBound <: AbstractQuantity end
+
+"""
     CardyEntropy() <: AbstractQuantity
 
 Asymptotic high-energy entropy (log of the density of states) of a

--- a/src/universalities/CardyEntanglement.jl
+++ b/src/universalities/CardyEntanglement.jl
@@ -971,3 +971,29 @@ function fetch(
     c = _cardy_central_charge(model)
     return π * c / (3 * beta)
 end
+
+# -----------------------------------------------------------------------------
+# MSS chaos bound (Maldacena-Shenker-Stanford 2016)
+# -----------------------------------------------------------------------------
+
+"""
+    fetch(::Universality{C}, ::ChaosBound, ::Infinite;
+          beta::Real, kwargs...) where {C} -> Float64
+
+MSS universal upper bound on the Lyapunov exponent of the OTOC at
+inverse temperature ,
+
+    lambda_L^max = 2 pi / beta = 2 pi T.
+
+Universality-class independent: any thermal quantum system that
+admits a microscopic description and a hermitian Hamiltonian
+satisfies this bound (the dispatch is provided on 
+only for API uniformity).
+
+Reference: J. Maldacena, S. H. Shenker, D. Stanford, *J. High Energy
+Phys.* **08**, 106 (2016), arXiv:1503.01409.
+"""
+function fetch(::Universality{C}, ::ChaosBound, ::Infinite; beta::Real, kwargs...) where {C}
+    beta > 0 || throw(DomainError(beta, "ChaosBound requires beta > 0; got beta = $beta."))
+    return 2 * π / beta
+end

--- a/test/universalities/test_universality_chaos_bound.jl
+++ b/test/universalities/test_universality_chaos_bound.jl
@@ -1,0 +1,42 @@
+using Test
+using QAtlas
+
+@testset "Universality ChaosBound (Maldacena-Shenker-Stanford 2016)" begin
+    @testset "Bound value 2 pi / beta" begin
+        for sym in (:Ising, :Heisenberg, :XY, :Potts3, :Potts4)
+            u = QAtlas.Universality(sym)
+            for β in (0.5, 1.0, 2.0, 5.0, 10.0)
+                λ = QAtlas.fetch(u, QAtlas.ChaosBound(), QAtlas.Infinite(); beta=β)
+                @test λ ≈ 2π / β atol = 1e-12
+            end
+        end
+    end
+
+    @testset "Universality-independent (same value across classes at fixed β)" begin
+        β = 3.0
+        vals = [
+            QAtlas.fetch(
+                QAtlas.Universality(sym), QAtlas.ChaosBound(), QAtlas.Infinite(); beta=β
+            ) for sym in (:Ising, :Heisenberg, :XY, :Potts3, :Potts4)
+        ]
+        @test all(isapprox(v, first(vals); atol=1e-12) for v in vals)
+    end
+
+    @testset "DomainError on non-positive beta" begin
+        u = QAtlas.Universality(:Ising)
+        @test_throws DomainError QAtlas.fetch(
+            u, QAtlas.ChaosBound(), QAtlas.Infinite(); beta=0.0
+        )
+        @test_throws DomainError QAtlas.fetch(
+            u, QAtlas.ChaosBound(), QAtlas.Infinite(); beta=-1.0
+        )
+    end
+
+    @testset "High-T limit blows up, low-T limit vanishes" begin
+        u = QAtlas.Universality(:Heisenberg)
+        λ_hot = QAtlas.fetch(u, QAtlas.ChaosBound(), QAtlas.Infinite(); beta=0.01)
+        λ_cold = QAtlas.fetch(u, QAtlas.ChaosBound(), QAtlas.Infinite(); beta=100.0)
+        @test λ_hot > 100
+        @test λ_cold < 0.1
+    end
+end


### PR DESCRIPTION
## Summary

- New universal quantity `ChaosBound` = 2 * pi / beta
- Maldacena-Shenker-Stanford 2016 (PRL 115 191601) bound on the OTOC Lyapunov exponent: any thermal QM system satisfies lambda_L <= 2 pi T
- Independent of central charge / dimension / microscopic detail; saturated by SYK / Einstein-gravity black holes

## Refs

- Refs #579 (universal closed-form quantities track)
- Builds on PR #601 (CFTThermalEntropyDensity)

## Test plan

- 30 assertions: 5 universality classes (Ising, Heisenberg, XY, Potts3, Potts4) over 5 betas
- Universality-class independence at fixed beta
- DomainError on beta <= 0
- High-T blow-up / low-T vanishing limits
