### PR TITLE
feat(Universality): ScramblingTime (Sekino-Susskind 2008)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.28"
+version = "0.23.29"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -123,7 +123,8 @@ export FermiVelocity,
     CHSHBound,
     ThermalEnergyDensity,
     CFTThermalEntropyDensity,
-    ChaosBound
+    ChaosBound,
+    ScramblingTime
 export SteadyStateCurrent                                # TASEP / non-equilibrium current (#241)
 export E8Spectrum
 export TopologicalInvariant, EdgeModeEnergy           # Kitaev1D Pfaffian invariant + edge mode

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -649,6 +649,26 @@ charge, dimension, and microscopic detail.
 struct ChaosBound <: AbstractQuantity end
 
 """
+    ScramblingTime <: AbstractQuantity
+
+Sekino-Susskind / Maldacena-Shenker-Stanford fast-scrambling time
+scale of a quantum thermal system with  effective degrees of
+freedom,
+
+    t_star = (beta / (2 pi)) * log(N).
+
+Universal lower bound on the time required to spread localised
+information into the global state. Saturated by black holes (fastest
+possible scramblers); for local QM systems t_star is parametrically
+longer ().
+
+Reference: Y. Sekino, L. Susskind, *JHEP* **10**, 065 (2008),
+arXiv:0808.2096; J. Maldacena, S. H. Shenker, D. Stanford, *JHEP*
+**08**, 106 (2016).
+"""
+struct ScramblingTime <: AbstractQuantity end
+
+"""
     CardyEntropy() <: AbstractQuantity
 
 Asymptotic high-energy entropy (log of the density of states) of a

--- a/src/universalities/CardyEntanglement.jl
+++ b/src/universalities/CardyEntanglement.jl
@@ -997,3 +997,31 @@ function fetch(::Universality{C}, ::ChaosBound, ::Infinite; beta::Real, kwargs..
     beta > 0 || throw(DomainError(beta, "ChaosBound requires beta > 0; got beta = $beta."))
     return 2 * π / beta
 end
+
+# -----------------------------------------------------------------------------
+# Fast scrambling time (Sekino-Susskind 2008; MSS 2016)
+# -----------------------------------------------------------------------------
+
+"""
+    fetch(::Universality{C}, ::ScramblingTime, ::Infinite;
+          beta::Real, N::Real, kwargs...) where {C} -> Float64
+
+Saturating value of the Sekino-Susskind fast-scrambling time at
+inverse temperature  with  effective degrees of freedom,
+
+    t_star = (beta / (2 pi)) * log(N).
+
+This is the universal lower bound on the scrambling time; black
+holes saturate it.
+
+Reference: Sekino-Susskind *JHEP* **10**, 065 (2008); Maldacena-
+Shenker-Stanford *JHEP* **08**, 106 (2016).
+"""
+function fetch(
+    ::Universality{C}, ::ScramblingTime, ::Infinite; beta::Real, N::Real, kwargs...
+) where {C}
+    beta > 0 ||
+        throw(DomainError(beta, "ScramblingTime requires beta > 0; got beta = $beta."))
+    N > 1 || throw(DomainError(N, "ScramblingTime requires N > 1; got N = $N."))
+    return beta * log(N) / (2 * π)
+end

--- a/test/universalities/test_universality_scrambling_time.jl
+++ b/test/universalities/test_universality_scrambling_time.jl
@@ -1,0 +1,63 @@
+using Test
+using QAtlas
+
+@testset "Universality ScramblingTime (Sekino-Susskind 2008)" begin
+    @testset "Universal formula t = (β/2π) log N" begin
+        for sym in (:Ising, :Heisenberg, :XY, :Potts3, :Potts4)
+            u = QAtlas.Universality(sym)
+            for β in (0.5, 1.0, 5.0)
+                for N in (2.0, 10.0, 100.0, 1_000_000.0)
+                    t = QAtlas.fetch(
+                        u, QAtlas.ScramblingTime(), QAtlas.Infinite(); beta=β, N=N
+                    )
+                    @test t ≈ β * log(N) / (2π) atol = 1e-12
+                end
+            end
+        end
+    end
+
+    @testset "Class-independent at fixed (β, N)" begin
+        β, N = 3.0, 100.0
+        vals = [
+            QAtlas.fetch(
+                QAtlas.Universality(sym),
+                QAtlas.ScramblingTime(),
+                QAtlas.Infinite();
+                beta=β,
+                N=N,
+            ) for sym in (:Ising, :Heisenberg, :XY)
+        ]
+        @test all(isapprox(v, first(vals); atol=1e-12) for v in vals)
+    end
+
+    @testset "Scaling: doubling β doubles t; squaring N doubles t" begin
+        u = QAtlas.Universality(:Heisenberg)
+        t_b1_N10 = QAtlas.fetch(
+            u, QAtlas.ScramblingTime(), QAtlas.Infinite(); beta=1.0, N=10.0
+        )
+        t_b2_N10 = QAtlas.fetch(
+            u, QAtlas.ScramblingTime(), QAtlas.Infinite(); beta=2.0, N=10.0
+        )
+        t_b1_N100 = QAtlas.fetch(
+            u, QAtlas.ScramblingTime(), QAtlas.Infinite(); beta=1.0, N=100.0
+        )
+        @test t_b2_N10 ≈ 2 * t_b1_N10 atol = 1e-12
+        @test t_b1_N100 ≈ 2 * t_b1_N10 atol = 1e-12
+    end
+
+    @testset "DomainError on invalid args" begin
+        u = QAtlas.Universality(:Ising)
+        @test_throws DomainError QAtlas.fetch(
+            u, QAtlas.ScramblingTime(), QAtlas.Infinite(); beta=0.0, N=10.0
+        )
+        @test_throws DomainError QAtlas.fetch(
+            u, QAtlas.ScramblingTime(), QAtlas.Infinite(); beta=-1.0, N=10.0
+        )
+        @test_throws DomainError QAtlas.fetch(
+            u, QAtlas.ScramblingTime(), QAtlas.Infinite(); beta=1.0, N=1.0
+        )
+        @test_throws DomainError QAtlas.fetch(
+            u, QAtlas.ScramblingTime(), QAtlas.Infinite(); beta=1.0, N=0.5
+        )
+    end
+end


### PR DESCRIPTION
## Summary

- New universal quantity `ScramblingTime` = (beta / (2 pi)) * log(N)
- Sekino-Susskind 2008 (JHEP 10 065) fast-scrambling time scale; saturated by black holes
- Operational pair of PR #602 `ChaosBound`: same beta / 2 pi prefactor, complementary OTOC timescale

## Refs

- Refs #579 (universal closed-form quantities track)
- Builds on PR #602 (ChaosBound)

## Test plan

- 67 assertions: 5 universality classes x 3 betas x 4 N values
- Class independence at fixed (beta, N)
- Linear scaling in beta and in log(N)
- DomainError on beta <= 0 or N <= 1
