### PR TITLE
feat(Universality): Mandelstam-Tamm + Margolus-Levitin quantum speed limits

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.29"
+version = "0.23.30"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -124,7 +124,9 @@ export FermiVelocity,
     ThermalEnergyDensity,
     CFTThermalEntropyDensity,
     ChaosBound,
-    ScramblingTime
+    ScramblingTime,
+    MandelstamTammBound,
+    MargolusLevitinBound
 export SteadyStateCurrent                                # TASEP / non-equilibrium current (#241)
 export E8Spectrum
 export TopologicalInvariant, EdgeModeEnergy           # Kitaev1D Pfaffian invariant + edge mode

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -669,6 +669,38 @@ arXiv:0808.2096; J. Maldacena, S. H. Shenker, D. Stanford, *JHEP*
 struct ScramblingTime <: AbstractQuantity end
 
 """
+    MandelstamTammBound <: AbstractQuantity
+
+Mandelstam-Tamm universal quantum speed limit: the minimum time
+required for a quantum state to evolve into a state orthogonal to
+itself,
+
+    t_QSL = pi hbar / (2 Delta E),
+
+where Delta E is the energy uncertainty (root variance of the
+Hamiltonian in the initial state). Universal across quantum
+mechanics; one of the canonical time-energy uncertainty bounds.
+
+Complemented by [`MargolusLevitinBound`](@ref), which uses the mean
+energy above the ground state in place of Delta E.
+"""
+struct MandelstamTammBound <: AbstractQuantity end
+
+"""
+    MargolusLevitinBound <: AbstractQuantity
+
+Margolus-Levitin universal quantum speed limit: the minimum time
+required for a quantum state to evolve into an orthogonal one,
+expressed in terms of the mean energy above the ground state,
+
+    t_ML = pi hbar / (2 (E - E_0)).
+
+The tightest known QM speed limit is the maximum of
+[`MandelstamTammBound`](@ref) and `MargolusLevitinBound`.
+"""
+struct MargolusLevitinBound <: AbstractQuantity end
+
+"""
     CardyEntropy() <: AbstractQuantity
 
 Asymptotic high-energy entropy (log of the density of states) of a

--- a/src/universalities/CardyEntanglement.jl
+++ b/src/universalities/CardyEntanglement.jl
@@ -1025,3 +1025,50 @@ function fetch(
     N > 1 || throw(DomainError(N, "ScramblingTime requires N > 1; got N = $N."))
     return beta * log(N) / (2 * π)
 end
+
+# -----------------------------------------------------------------------------
+# Quantum speed limits: Mandelstam-Tamm 1945; Margolus-Levitin 1998
+# -----------------------------------------------------------------------------
+
+"""
+    fetch(::Universality{C}, ::MandelstamTammBound, ::Infinite;
+          delta_E::Real, kwargs...) where {C} -> Float64
+
+Mandelstam-Tamm minimal orthogonalization time
+
+    t_QSL = pi / (2 Delta E)        (hbar = 1).
+
+Reference: L. Mandelstam, I. Tamm, *J. Phys. (USSR)* **9**, 249 (1945);
+see also Anandan-Aharonov *Phys. Rev. Lett.* **65**, 1697 (1990).
+"""
+function fetch(
+    ::Universality{C}, ::MandelstamTammBound, ::Infinite; delta_E::Real, kwargs...
+) where {C}
+    delta_E > 0 || throw(
+        DomainError(
+            delta_E, "MandelstamTammBound requires delta_E > 0; got delta_E = $delta_E."
+        ),
+    )
+    return pi / (2 * delta_E)
+end
+
+"""
+    fetch(::Universality{C}, ::MargolusLevitinBound, ::Infinite;
+          mean_E::Real, kwargs...) where {C} -> Float64
+
+Margolus-Levitin minimal orthogonalization time
+
+    t_ML = pi / (2 (E - E_0))         (hbar = 1).
+
+Reference: N. Margolus, L. B. Levitin, *Physica D* **120**, 188 (1998).
+"""
+function fetch(
+    ::Universality{C}, ::MargolusLevitinBound, ::Infinite; mean_E::Real, kwargs...
+) where {C}
+    mean_E > 0 || throw(
+        DomainError(
+            mean_E, "MargolusLevitinBound requires mean_E > 0; got mean_E = $mean_E."
+        ),
+    )
+    return pi / (2 * mean_E)
+end

--- a/test/universalities/test_universality_speed_limits.jl
+++ b/test/universalities/test_universality_speed_limits.jl
@@ -1,0 +1,73 @@
+using Test
+using QAtlas
+
+@testset "Universality QuantumSpeedLimits (Mandelstam-Tamm + Margolus-Levitin)" begin
+    @testset "MandelstamTammBound = π / (2 ΔE)" begin
+        for sym in (:Ising, :Heisenberg, :XY, :Potts3, :Potts4)
+            u = QAtlas.Universality(sym)
+            for ΔE in (0.5, 1.0, 2.5, 10.0, 100.0)
+                t = QAtlas.fetch(
+                    u, QAtlas.MandelstamTammBound(), QAtlas.Infinite(); delta_E=ΔE
+                )
+                @test t ≈ π / (2 * ΔE) atol = 1e-12
+            end
+        end
+    end
+
+    @testset "MargolusLevitinBound = π / (2 E)" begin
+        for sym in (:Ising, :Heisenberg, :XY, :Potts3, :Potts4)
+            u = QAtlas.Universality(sym)
+            for E in (0.5, 1.0, 2.5, 10.0, 100.0)
+                t = QAtlas.fetch(
+                    u, QAtlas.MargolusLevitinBound(), QAtlas.Infinite(); mean_E=E
+                )
+                @test t ≈ π / (2 * E) atol = 1e-12
+            end
+        end
+    end
+
+    @testset "MT = ML when ΔE = E - E_0 (coincidence point)" begin
+        u = QAtlas.Universality(:Heisenberg)
+        for x in (0.7, 1.3, 5.0)
+            t_MT = QAtlas.fetch(
+                u, QAtlas.MandelstamTammBound(), QAtlas.Infinite(); delta_E=x
+            )
+            t_ML = QAtlas.fetch(
+                u, QAtlas.MargolusLevitinBound(), QAtlas.Infinite(); mean_E=x
+            )
+            @test t_MT ≈ t_ML atol = 1e-12
+        end
+    end
+
+    @testset "Class independence" begin
+        ΔE = 3.0
+        E = 2.0
+        for sym in (:Ising, :Heisenberg, :XY)
+            u = QAtlas.Universality(sym)
+            t_MT = QAtlas.fetch(
+                u, QAtlas.MandelstamTammBound(), QAtlas.Infinite(); delta_E=ΔE
+            )
+            t_ML = QAtlas.fetch(
+                u, QAtlas.MargolusLevitinBound(), QAtlas.Infinite(); mean_E=E
+            )
+            @test t_MT ≈ π / 6 atol = 1e-12
+            @test t_ML ≈ π / 4 atol = 1e-12
+        end
+    end
+
+    @testset "DomainError on non-positive energy" begin
+        u = QAtlas.Universality(:Ising)
+        @test_throws DomainError QAtlas.fetch(
+            u, QAtlas.MandelstamTammBound(), QAtlas.Infinite(); delta_E=0.0
+        )
+        @test_throws DomainError QAtlas.fetch(
+            u, QAtlas.MandelstamTammBound(), QAtlas.Infinite(); delta_E=-1.0
+        )
+        @test_throws DomainError QAtlas.fetch(
+            u, QAtlas.MargolusLevitinBound(), QAtlas.Infinite(); mean_E=0.0
+        )
+        @test_throws DomainError QAtlas.fetch(
+            u, QAtlas.MargolusLevitinBound(), QAtlas.Infinite(); mean_E=-2.0
+        )
+    end
+end


### PR DESCRIPTION
## Summary

- New universal quantities MandelstamTammBound = pi / (2 * Delta E) and MargolusLevitinBound = pi / (2 * mean_E)
- Mandelstam-Tamm 1945 + Margolus-Levitin 1998 quantum speed limits: minimum orthogonalization time of any QM state
- Universal across QM (independent of Hamiltonian, dimension, central charge)
- Operational triple with ChaosBound (PR #602) and ScramblingTime (PR #603): time-scale bounds family

## Refs

- Refs #579 (universal closed-form quantities track)
- Builds on PR #603 (ScramblingTime)

## Test plan

- 63 assertions: 5 universality classes x 5 energies for each bound
- MT = ML coincidence at Delta E = mean_E
- Class independence
- DomainError on non-positive energies
