### PR TITLE
feat(Universality): BekensteinBound (Bekenstein 1981)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.30"
+version = "0.23.31"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -126,7 +126,8 @@ export FermiVelocity,
     ChaosBound,
     ScramblingTime,
     MandelstamTammBound,
-    MargolusLevitinBound
+    MargolusLevitinBound,
+    BekensteinBound
 export SteadyStateCurrent                                # TASEP / non-equilibrium current (#241)
 export E8Spectrum
 export TopologicalInvariant, EdgeModeEnergy           # Kitaev1D Pfaffian invariant + edge mode

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -701,6 +701,20 @@ The tightest known QM speed limit is the maximum of
 struct MargolusLevitinBound <: AbstractQuantity end
 
 """
+    BekensteinBound <: AbstractQuantity
+
+Bekenstein 1981 universal upper bound on the von Neumann entropy of
+any physical system of linear size `R` and total energy `E`,
+
+    S <= 2 pi R E / (hbar c).
+
+Holographic in spirit and historically motivated by black-hole
+thermodynamics, but applies to any QFT in flat space. Saturated by
+black holes.
+"""
+struct BekensteinBound <: AbstractQuantity end
+
+"""
     CardyEntropy() <: AbstractQuantity
 
 Asymptotic high-energy entropy (log of the density of states) of a

--- a/src/universalities/CardyEntanglement.jl
+++ b/src/universalities/CardyEntanglement.jl
@@ -1072,3 +1072,26 @@ function fetch(
     )
     return pi / (2 * mean_E)
 end
+
+# -----------------------------------------------------------------------------
+# Bekenstein bound (Bekenstein 1981)
+# -----------------------------------------------------------------------------
+
+"""
+    fetch(::Universality{C}, ::BekensteinBound, ::Infinite;
+          R::Real, E::Real, kwargs...) where {C} -> Float64
+
+Universal Bekenstein upper bound on entropy of any system of linear
+size `R` and total energy `E`,
+
+    S_max = 2 pi R E       (hbar = c = 1).
+
+Reference: J. D. Bekenstein, *Phys. Rev. D* **23**, 287 (1981).
+"""
+function fetch(
+    ::Universality{C}, ::BekensteinBound, ::Infinite; R::Real, E::Real, kwargs...
+) where {C}
+    R > 0 || throw(DomainError(R, "BekensteinBound requires R > 0; got R = $R."))
+    E > 0 || throw(DomainError(E, "BekensteinBound requires E > 0; got E = $E."))
+    return 2 * pi * R * E
+end

--- a/test/universalities/test_universality_bekenstein.jl
+++ b/test/universalities/test_universality_bekenstein.jl
@@ -1,0 +1,59 @@
+using Test
+using QAtlas
+
+@testset "Universality BekensteinBound (Bekenstein 1981)" begin
+    @testset "S_max = 2π R E" begin
+        for sym in (:Ising, :Heisenberg, :XY, :Potts3, :Potts4)
+            u = QAtlas.Universality(sym)
+            for R in (0.1, 1.0, 10.0, 100.0)
+                for E in (0.5, 1.0, 5.0, 50.0)
+                    s = QAtlas.fetch(
+                        u, QAtlas.BekensteinBound(), QAtlas.Infinite(); R=R, E=E
+                    )
+                    @test s ≈ 2π * R * E atol = 1e-10
+                end
+            end
+        end
+    end
+
+    @testset "Class-independent at fixed (R, E)" begin
+        R, E = 3.0, 4.0
+        vals = [
+            QAtlas.fetch(
+                QAtlas.Universality(sym),
+                QAtlas.BekensteinBound(),
+                QAtlas.Infinite();
+                R=R,
+                E=E,
+            ) for sym in (:Ising, :Heisenberg, :XY)
+        ]
+        @test all(isapprox(v, first(vals); atol=1e-12) for v in vals)
+    end
+
+    @testset "Bilinear: doubling R doubles S; doubling E doubles S" begin
+        u = QAtlas.Universality(:Heisenberg)
+        s_base = QAtlas.fetch(u, QAtlas.BekensteinBound(), QAtlas.Infinite(); R=1.0, E=1.0)
+        s_2R = QAtlas.fetch(u, QAtlas.BekensteinBound(), QAtlas.Infinite(); R=2.0, E=1.0)
+        s_2E = QAtlas.fetch(u, QAtlas.BekensteinBound(), QAtlas.Infinite(); R=1.0, E=2.0)
+        s_4 = QAtlas.fetch(u, QAtlas.BekensteinBound(), QAtlas.Infinite(); R=2.0, E=2.0)
+        @test s_2R ≈ 2 * s_base atol = 1e-12
+        @test s_2E ≈ 2 * s_base atol = 1e-12
+        @test s_4 ≈ 4 * s_base atol = 1e-12
+    end
+
+    @testset "DomainError on non-positive R or E" begin
+        u = QAtlas.Universality(:Ising)
+        @test_throws DomainError QAtlas.fetch(
+            u, QAtlas.BekensteinBound(), QAtlas.Infinite(); R=0.0, E=1.0
+        )
+        @test_throws DomainError QAtlas.fetch(
+            u, QAtlas.BekensteinBound(), QAtlas.Infinite(); R=-1.0, E=1.0
+        )
+        @test_throws DomainError QAtlas.fetch(
+            u, QAtlas.BekensteinBound(), QAtlas.Infinite(); R=1.0, E=0.0
+        )
+        @test_throws DomainError QAtlas.fetch(
+            u, QAtlas.BekensteinBound(), QAtlas.Infinite(); R=1.0, E=-2.0
+        )
+    end
+end


### PR DESCRIPTION
## Summary

- New universal quantity `BekensteinBound` = 2 * pi * R * E
- Bekenstein 1981 (PRD 23 287) universal upper bound on the von Neumann entropy of any QFT state confined to a region of size R with total energy E
- Saturated by black holes; class-independent

## Refs

- Refs #579 (universal closed-form quantities track)
- Builds on PR #604 (quantum speed limits)

## Test plan

- 88 assertions: 5 classes x 4 radii x 4 energies + class independence + bilinear scaling + 4 DomainError checks
