### PR TITLE
feat(TFIM): BoundaryEntropy at h = J (Affleck-Ludwig)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.32"
+version = "0.23.33"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/models/quantum/TFIM/TFIM_cft_entanglement.jl
+++ b/src/models/quantum/TFIM/TFIM_cft_entanglement.jl
@@ -160,3 +160,46 @@ function fetch(model::TFIM, q::RenyiEntropy, ::Infinite; ℓ::Int, beta::Real=In
     end
     return _tfim_cc_entanglement(model.J, model.h, ℓ, beta; α=q.α)
 end
+
+# -----------------------------------------------------------------------------
+# Affleck-Ludwig boundary entropy at criticality (h = J)
+# -----------------------------------------------------------------------------
+
+"""
+    fetch(m::TFIM, ::BoundaryEntropy, ::Infinite;
+          h = m.h, J = m.J, boundary_state::Symbol, kwargs...) -> Float64
+
+Affleck-Ludwig boundary entropy `log g` of the critical TFIM at the
+quantum critical point `h = J`. Delegates to `Universality(:Ising)`
+with the same `boundary_state`, which is dimensionless (independent
+of the sound velocity).
+
+Off-critical (`h != J`) is gapped and Affleck-Ludwig does not apply —
+this dispatch throws `DomainError`.
+
+Reference: Affleck-Ludwig *Phys. Rev. Lett.* **67**, 161 (1991).
+"""
+function fetch(
+    m::TFIM,
+    ::BoundaryEntropy,
+    ::Infinite;
+    h::Real=m.h,
+    J::Real=m.J,
+    boundary_state::Symbol,
+    kwargs...,
+)
+    isapprox(abs(h), abs(J); atol=1e-12) || throw(
+        DomainError(
+            (h, J),
+            "TFIM BoundaryEntropy: closed-form Affleck-Ludwig applies only at " *
+            "the critical point |h| = |J|; got (h, J) = ($h, $J).",
+        ),
+    )
+    return fetch(
+        Universality(:Ising),
+        BoundaryEntropy(),
+        Infinite();
+        boundary_state=boundary_state,
+        kwargs...,
+    )
+end

--- a/test/models/quantum/TFIM/test_tfim_boundary_entropy.jl
+++ b/test/models/quantum/TFIM/test_tfim_boundary_entropy.jl
@@ -1,0 +1,65 @@
+using Test
+using QAtlas
+
+@testset "TFIM BoundaryEntropy at criticality (h = J)" begin
+    @testset "Critical point: matches Universality(:Ising)" begin
+        for J in (0.5, 1.0, 2.0)
+            m = QAtlas.TFIM(; h=J, J=J)
+            for bs in (:identity, :fixed_up, :fixed_down, :epsilon, :sigma, :free)
+                g_model = QAtlas.fetch(
+                    m, QAtlas.BoundaryEntropy(), QAtlas.Infinite(); boundary_state=bs
+                )
+                g_univ = QAtlas.fetch(
+                    QAtlas.Universality(:Ising),
+                    QAtlas.BoundaryEntropy(),
+                    QAtlas.Infinite();
+                    boundary_state=bs,
+                )
+                @test g_model ≈ g_univ atol = 1e-12
+            end
+        end
+    end
+
+    @testset "Specific values at h = J = 1" begin
+        m = QAtlas.TFIM(; h=1.0, J=1.0)
+        @test QAtlas.fetch(
+            m, QAtlas.BoundaryEntropy(), QAtlas.Infinite(); boundary_state=:identity
+        ) ≈ -log(2) / 2 atol = 1e-12
+        @test QAtlas.fetch(
+            m, QAtlas.BoundaryEntropy(), QAtlas.Infinite(); boundary_state=:epsilon
+        ) ≈ -log(2) / 2 atol = 1e-12
+        @test QAtlas.fetch(
+            m, QAtlas.BoundaryEntropy(), QAtlas.Infinite(); boundary_state=:sigma
+        ) ≈ 0.0 atol = 1e-12
+        @test QAtlas.fetch(
+            m, QAtlas.BoundaryEntropy(), QAtlas.Infinite(); boundary_state=:free
+        ) ≈ 0.0 atol = 1e-12
+    end
+
+    @testset "Critical at |h| = |J| (negative J or h)" begin
+        m1 = QAtlas.TFIM(; h=2.0, J=-2.0)
+        @test QAtlas.fetch(
+            m1, QAtlas.BoundaryEntropy(), QAtlas.Infinite(); boundary_state=:sigma
+        ) ≈ 0.0 atol = 1e-12
+        m2 = QAtlas.TFIM(; h=-3.5, J=3.5)
+        @test QAtlas.fetch(
+            m2, QAtlas.BoundaryEntropy(), QAtlas.Infinite(); boundary_state=:identity
+        ) ≈ -log(2) / 2 atol = 1e-12
+    end
+
+    @testset "DomainError off-critical (|h| != |J|)" begin
+        for (h, J) in ((0.5, 1.0), (2.0, 1.0), (0.0, 1.0), (1.0, 0.5))
+            m = QAtlas.TFIM(; h=h, J=J)
+            @test_throws DomainError QAtlas.fetch(
+                m, QAtlas.BoundaryEntropy(), QAtlas.Infinite(); boundary_state=:identity
+            )
+        end
+    end
+
+    @testset "Bad boundary_state propagates from Universality" begin
+        m = QAtlas.TFIM(; h=1.0, J=1.0)
+        @test_throws ArgumentError QAtlas.fetch(
+            m, QAtlas.BoundaryEntropy(), QAtlas.Infinite(); boundary_state=:nonsense
+        )
+    end
+end


### PR DESCRIPTION
## Summary

- fetch(TFIM, BoundaryEntropy, Infinite; boundary_state) at the critical point |h| = |J| delegates to Universality(:Ising)
- Affleck-Ludwig dimensionless log g (independent of sound velocity), so no convention conversion needed
- Continues the model-wrapper carve started by TFIM h=J VN/Renyi (PR #585), LR/slope (PR #595)

## Refs

- Refs #580 (Affleck-Ludwig universal tracking)
- Builds on PR #606 (XXZ XX wrappers)

## Test plan

- 29 assertions: critical-point match against Universality(:Ising), exact values at h = J = 1, critical at negative h/J, DomainError off-critical, ArgumentError propagation for bad boundary_state
