### PR TITLE
feat(3 models): EntanglementSaturationDensity wrappers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.33"
+version = "0.23.34"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/models/quantum/HaldaneShastry/HaldaneShastry_thermal_cft.jl
+++ b/src/models/quantum/HaldaneShastry/HaldaneShastry_thermal_cft.jl
@@ -260,3 +260,24 @@ function fetch(
         kwargs...,
     )
 end
+
+"""
+    fetch(::HaldaneShastry, ::EntanglementSaturationDensity, ::Infinite;
+          beta_eff::Real, kwargs...) -> Float64
+
+Long-time saturation `S_A(infty)/L = pi c / (6 beta_eff)` after a
+global quench. Haldane-Shastry is gapless with `c = 1`, so the
+formula gives `pi / (6 beta_eff)`. Delegates to
+`Universality(:Heisenberg)`.
+"""
+function fetch(
+    ::HaldaneShastry, ::EntanglementSaturationDensity, ::Infinite; beta_eff::Real, kwargs...
+)
+    return fetch(
+        Universality(:Heisenberg),
+        EntanglementSaturationDensity(),
+        Infinite();
+        beta_eff=beta_eff,
+        kwargs...,
+    )
+end

--- a/src/models/quantum/TFIM/TFIM_cft_entanglement.jl
+++ b/src/models/quantum/TFIM/TFIM_cft_entanglement.jl
@@ -203,3 +203,41 @@ function fetch(
         kwargs...,
     )
 end
+
+# -----------------------------------------------------------------------------
+# Post-quench entanglement saturation density at h = J (Calabrese-Cardy 2005)
+# -----------------------------------------------------------------------------
+
+"""
+    fetch(m::TFIM, ::EntanglementSaturationDensity, ::Infinite;
+          beta_eff::Real, h = m.h, J = m.J, kwargs...) -> Float64
+
+Long-time saturation `S_A(infty)/L = pi c / (6 beta_eff)` of the
+half-system entanglement entropy after a global quench at the
+critical TFIM point `|h| = |J|`. Delegates to `Universality(:Ising)`
+(c = 1/2).
+"""
+function fetch(
+    m::TFIM,
+    ::EntanglementSaturationDensity,
+    ::Infinite;
+    beta_eff::Real,
+    h::Real=m.h,
+    J::Real=m.J,
+    kwargs...,
+)
+    isapprox(abs(h), abs(J); atol=1e-12) || throw(
+        DomainError(
+            (h, J),
+            "TFIM EntanglementSaturationDensity: closed form applies only at the " *
+            "critical point |h| = |J|; got (h, J) = ($h, $J).",
+        ),
+    )
+    return fetch(
+        Universality(:Ising),
+        EntanglementSaturationDensity(),
+        Infinite();
+        beta_eff=beta_eff,
+        kwargs...,
+    )
+end

--- a/src/models/quantum/XXZ/XXZ_xx_quench.jl
+++ b/src/models/quantum/XXZ/XXZ_xx_quench.jl
@@ -310,3 +310,33 @@ function fetch(
         kwargs...,
     )
 end
+
+"""
+    fetch(model::XXZ1D, ::EntanglementSaturationDensity, ::Infinite;
+          beta_eff::Real, kwargs...) -> Float64
+
+Long-time saturation of post-quench half-system entanglement entropy
+at the XX point (`Delta = 0`). The XX chain is gapless with c = 1,
+so delegates to `Universality(:XY)` returning `pi / (6 beta_eff)`.
+
+Off-XX (`Delta != 0`) throws `DomainError` -- interacting regime
+deferred.
+"""
+function fetch(
+    model::XXZ1D, ::EntanglementSaturationDensity, ::Infinite; beta_eff::Real, kwargs...
+)
+    isapprox(model.Δ, 0.0; atol=1e-12) || throw(
+        DomainError(
+            model.Δ,
+            "XXZ1D EntanglementSaturationDensity: closed form only at the XX " *
+            "point (Delta = 0); got Delta = $(model.Δ).",
+        ),
+    )
+    return fetch(
+        Universality(:XY),
+        EntanglementSaturationDensity(),
+        Infinite();
+        beta_eff=beta_eff,
+        kwargs...,
+    )
+end

--- a/test/cross_model/test_three_models_saturation_density.jl
+++ b/test/cross_model/test_three_models_saturation_density.jl
@@ -1,0 +1,69 @@
+using Test
+using QAtlas
+
+@testset "Three-model EntanglementSaturationDensity wrappers" begin
+    @testset "TFIM h = J critical → Universality(:Ising) (c = 1/2)" begin
+        for J in (1.0, 2.0)
+            m = QAtlas.TFIM(; h=J, J=J)
+            for β in (1.0, 2.0, 5.0)
+                s = QAtlas.fetch(
+                    m, QAtlas.EntanglementSaturationDensity(), QAtlas.Infinite(); beta_eff=β
+                )
+                ref = π * 0.5 / (6 * β)
+                @test s ≈ ref atol = 1e-12
+            end
+        end
+        m_off = QAtlas.TFIM(; h=0.5, J=1.0)
+        @test_throws DomainError QAtlas.fetch(
+            m_off, QAtlas.EntanglementSaturationDensity(), QAtlas.Infinite(); beta_eff=1.0
+        )
+    end
+
+    @testset "HaldaneShastry → Universality(:Heisenberg) (c = 1)" begin
+        for J in (0.5, 1.0, 2.0)
+            m = QAtlas.HaldaneShastry(; J=J)
+            for β in (1.0, 2.0, 5.0)
+                s = QAtlas.fetch(
+                    m, QAtlas.EntanglementSaturationDensity(), QAtlas.Infinite(); beta_eff=β
+                )
+                ref = π / (6 * β)
+                @test s ≈ ref atol = 1e-12
+            end
+        end
+    end
+
+    @testset "XXZ1D at XX (Δ = 0) → Universality(:XY) (c = 1)" begin
+        for J in (0.5, 1.0, 2.0)
+            m = QAtlas.XXZ1D(; J=J, Δ=0.0)
+            for β in (1.0, 2.0, 5.0)
+                s = QAtlas.fetch(
+                    m, QAtlas.EntanglementSaturationDensity(), QAtlas.Infinite(); beta_eff=β
+                )
+                ref = π / (6 * β)
+                @test s ≈ ref atol = 1e-12
+            end
+        end
+        for Δ in (0.5, 1.0, -0.5)
+            m_off = QAtlas.XXZ1D(; J=1.0, Δ=Δ)
+            @test_throws DomainError QAtlas.fetch(
+                m_off,
+                QAtlas.EntanglementSaturationDensity(),
+                QAtlas.Infinite();
+                beta_eff=1.0,
+            )
+        end
+    end
+
+    @testset "Universality central-charge ratio reflected in 3 models" begin
+        β = 3.0
+        m_tfim = QAtlas.TFIM(; h=1.0, J=1.0)
+        m_hs = QAtlas.HaldaneShastry(; J=1.0)
+        s_tfim = QAtlas.fetch(
+            m_tfim, QAtlas.EntanglementSaturationDensity(), QAtlas.Infinite(); beta_eff=β
+        )
+        s_hs = QAtlas.fetch(
+            m_hs, QAtlas.EntanglementSaturationDensity(), QAtlas.Infinite(); beta_eff=β
+        )
+        @test s_tfim / s_hs ≈ 0.5 atol = 1e-12
+    end
+end


### PR DESCRIPTION
## Summary

3 model wrappers for EntanglementSaturationDensity (Calabrese-Cardy 2005, S_A(infty)/L = pi c / (6 beta_eff)):

- TFIM at |h| = |J| delegates to Universality(:Ising)  (c = 1/2)
- HaldaneShastry delegates to Universality(:Heisenberg) (c = 1, always critical)
- XXZ1D at XX point (Delta = 0) delegates to Universality(:XY) (c = 1)

Pairs with each model's existing EntanglementGrowthSlope wrapper (PR #595, #599, #606): the slope and saturation jointly determine the kinematic crossover time L / (2 v).

## Refs

- Refs #580 (universal saturation tracking)
- Builds on PR #607 (TFIM BoundaryEntropy)

## Test plan

- 29 assertions across 3 models x multiple J/beta + DomainError off-critical + Universality c-ratio check
