### PR TITLE
feat(3 models): MutualInformation wrappers (CC 2009)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.34"
+version = "0.23.35"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/models/quantum/HaldaneShastry/HaldaneShastry_thermal_cft.jl
+++ b/src/models/quantum/HaldaneShastry/HaldaneShastry_thermal_cft.jl
@@ -281,3 +281,30 @@ function fetch(
         kwargs...,
     )
 end
+
+"""
+    fetch(::HaldaneShastry, ::MutualInformation, ::Infinite;
+          ℓ_A::Real, ℓ_B::Real, beta::Real=Inf, kwargs...) -> Float64
+
+Calabrese-Cardy mutual information of two adjacent intervals,
+delegated to `Universality(:Heisenberg)` (c = 1).
+"""
+function fetch(
+    ::HaldaneShastry,
+    ::MutualInformation,
+    ::Infinite;
+    ℓ_A::Real,
+    ℓ_B::Real,
+    beta::Real=Inf,
+    kwargs...,
+)
+    return fetch(
+        Universality(:Heisenberg),
+        MutualInformation(),
+        Infinite();
+        ℓ_A=ℓ_A,
+        ℓ_B=ℓ_B,
+        beta=beta,
+        kwargs...,
+    )
+end

--- a/src/models/quantum/TFIM/TFIM_cft_entanglement.jl
+++ b/src/models/quantum/TFIM/TFIM_cft_entanglement.jl
@@ -241,3 +241,45 @@ function fetch(
         kwargs...,
     )
 end
+
+# -----------------------------------------------------------------------------
+# Mutual information of two adjacent intervals at h = J (Calabrese-Cardy 2009)
+# -----------------------------------------------------------------------------
+
+"""
+    fetch(m::TFIM, ::MutualInformation, ::Infinite;
+          ℓ_A::Real, ℓ_B::Real, beta::Real=Inf, kwargs...) -> Float64
+
+Calabrese-Cardy mutual information `I(A:B)` of two adjacent intervals
+at the critical TFIM point `|h| = |J|`, with the same lattice
+spacing convention `a = 1/2` used by the VonNeumannEntropy /
+RenyiEntropy wrappers. The cutoff cancels in
+`S(A) + S(B) - S(A union B)`, so the result is independent of `a`.
+"""
+function fetch(
+    m::TFIM,
+    ::MutualInformation,
+    ::Infinite;
+    ℓ_A::Real,
+    ℓ_B::Real,
+    beta::Real=Inf,
+    kwargs...,
+)
+    isapprox(abs(m.h), abs(m.J); atol=1e-12) || throw(
+        DomainError(
+            (m.h, m.J),
+            "TFIM MutualInformation: closed-form CC applies only at the critical " *
+            "point |h| = |J|; got (h, J) = ($(m.h), $(m.J)).",
+        ),
+    )
+    return fetch(
+        Universality(:Ising),
+        MutualInformation(),
+        Infinite();
+        ℓ_A=ℓ_A,
+        ℓ_B=ℓ_B,
+        beta=beta,
+        a=1//2,
+        kwargs...,
+    )
+end

--- a/src/models/quantum/XXZ/XXZ_thermal.jl
+++ b/src/models/quantum/XXZ/XXZ_thermal.jl
@@ -660,3 +660,56 @@ function fetch(model::XXZ1D, q::RenyiEntropy, ::Infinite; ℓ::Int, beta::Real=I
         )
     end
 end
+
+"""
+    fetch(model::XXZ1D, ::MutualInformation, ::Infinite;
+          ℓ_A::Real, ℓ_B::Real, beta::Real=Inf, kwargs...) -> Float64
+
+Calabrese-Cardy mutual information of two adjacent intervals in the
+critical Luttinger-liquid regime `-1 < Δ <= 1` of the XXZ chain.
+Delegates to `Universality(:XY)` for `-1 < Δ < 1` and to
+`Universality(:Heisenberg)` at `Δ = 1`.
+
+Throws `DomainError` outside the critical regime.
+"""
+function fetch(
+    model::XXZ1D,
+    ::MutualInformation,
+    ::Infinite;
+    ℓ_A::Real,
+    ℓ_B::Real,
+    beta::Real=Inf,
+    kwargs...,
+)
+    Δ = model.Δ
+    if Δ == 1.0
+        return fetch(
+            Universality(:Heisenberg),
+            MutualInformation(),
+            Infinite();
+            ℓ_A=ℓ_A,
+            ℓ_B=ℓ_B,
+            beta=beta,
+            kwargs...,
+        )
+    elseif -1.0 < Δ < 1.0
+        return fetch(
+            Universality(:XY),
+            MutualInformation(),
+            Infinite();
+            ℓ_A=ℓ_A,
+            ℓ_B=ℓ_B,
+            beta=beta,
+            kwargs...,
+        )
+    else
+        throw(
+            DomainError(
+                Δ,
+                "XXZ1D MutualInformation at Infinite: only the critical " *
+                "Luttinger-liquid regime -1 < Δ <= 1 admits a c = 1 " *
+                "Calabrese-Cardy closed form. Got Δ = $Δ.",
+            ),
+        )
+    end
+end

--- a/test/cross_model/test_three_models_mutual_information.jl
+++ b/test/cross_model/test_three_models_mutual_information.jl
@@ -1,0 +1,99 @@
+using Test
+using QAtlas
+
+@testset "Three-model MutualInformation wrappers" begin
+    @testset "TFIM h = J critical: matches Universality(:Ising) with a = 1/2" begin
+        for J in (1.0, 2.0)
+            m = QAtlas.TFIM(; h=J, J=J)
+            for (ℓ_A, ℓ_B) in ((5.0, 10.0), (10.0, 20.0), (3.0, 30.0))
+                for β in (Inf, 5.0, 1.0)
+                    mi = QAtlas.fetch(
+                        m,
+                        QAtlas.MutualInformation(),
+                        QAtlas.Infinite();
+                        ℓ_A=ℓ_A,
+                        ℓ_B=ℓ_B,
+                        beta=β,
+                    )
+                    ref = QAtlas.fetch(
+                        QAtlas.Universality(:Ising),
+                        QAtlas.MutualInformation(),
+                        QAtlas.Infinite();
+                        ℓ_A=ℓ_A,
+                        ℓ_B=ℓ_B,
+                        beta=β,
+                        a=1//2,
+                    )
+                    @test mi ≈ ref atol = 1e-12
+                end
+            end
+        end
+        m_off = QAtlas.TFIM(; h=0.5, J=1.0)
+        @test_throws DomainError QAtlas.fetch(
+            m_off, QAtlas.MutualInformation(), QAtlas.Infinite(); ℓ_A=5.0, ℓ_B=5.0
+        )
+    end
+
+    @testset "HaldaneShastry: matches Universality(:Heisenberg)" begin
+        m = QAtlas.HaldaneShastry()
+        for (ℓ_A, ℓ_B) in ((5.0, 10.0), (10.0, 20.0))
+            for β in (Inf, 5.0)
+                mi = QAtlas.fetch(
+                    m,
+                    QAtlas.MutualInformation(),
+                    QAtlas.Infinite();
+                    ℓ_A=ℓ_A,
+                    ℓ_B=ℓ_B,
+                    beta=β,
+                )
+                ref = QAtlas.fetch(
+                    QAtlas.Universality(:Heisenberg),
+                    QAtlas.MutualInformation(),
+                    QAtlas.Infinite();
+                    ℓ_A=ℓ_A,
+                    ℓ_B=ℓ_B,
+                    beta=β,
+                )
+                @test mi ≈ ref atol = 1e-12
+            end
+        end
+    end
+
+    @testset "XXZ1D critical regime: matches Universality(:XY) or :Heisenberg" begin
+        for Δ in (0.0, 0.5, -0.5, 0.9)
+            m = QAtlas.XXZ1D(; J=1.0, Δ=Δ)
+            mi = QAtlas.fetch(
+                m, QAtlas.MutualInformation(), QAtlas.Infinite(); ℓ_A=8.0, ℓ_B=12.0
+            )
+            ref = QAtlas.fetch(
+                QAtlas.Universality(:XY),
+                QAtlas.MutualInformation(),
+                QAtlas.Infinite();
+                ℓ_A=8.0,
+                ℓ_B=12.0,
+            )
+            @test mi ≈ ref atol = 1e-12
+        end
+        m_isotropic = QAtlas.XXZ1D(; J=1.0, Δ=1.0)
+        mi_iso = QAtlas.fetch(
+            m_isotropic, QAtlas.MutualInformation(), QAtlas.Infinite(); ℓ_A=8.0, ℓ_B=12.0
+        )
+        ref_iso = QAtlas.fetch(
+            QAtlas.Universality(:Heisenberg),
+            QAtlas.MutualInformation(),
+            QAtlas.Infinite();
+            ℓ_A=8.0,
+            ℓ_B=12.0,
+        )
+        @test mi_iso ≈ ref_iso atol = 1e-12
+    end
+
+    @testset "XXZ1D off-critical (|Δ| > 1) throws DomainError" begin
+        for Δ in (1.5, -1.5, 2.0, -2.0)
+            m = QAtlas.XXZ1D(; J=1.0, Δ=Δ)
+            @test_throws DomainError QAtlas.fetch(
+                m, QAtlas.MutualInformation(), QAtlas.Infinite(); ℓ_A=8.0, ℓ_B=12.0
+            )
+        end
+    end
+end


### PR DESCRIPTION
## Summary

3 model wrappers for MutualInformation of two adjacent intervals (Calabrese-Cardy 2009, I = (c/3) log[ℓ_A ℓ_B / ((ℓ_A + ℓ_B) a)]):

- TFIM at |h| = |J| delegates to Universality(:Ising) with the existing a = 1/2 convention (matches VN/Renyi wrappers from PR #585)
- HaldaneShastry delegates to Universality(:Heisenberg) (always critical, c = 1)
- XXZ1D critical regime (-1 < Δ < 1 to :XY, Δ = 1 to :Heisenberg) — mirrors the existing Renyi dispatch logic

Note: although MI is often described as cutoff-independent, the leading-log Calabrese-Cardy form does retain a log(1/a) constant. Each wrapper inherits its model's natural cutoff convention.

## Refs

- Refs #580 (Calabrese-Cardy MI tracking)
- Builds on PR #608 (3-model EntanglementSaturationDensity)

## Test plan

- 32 assertions: TFIM matches Universality(:Ising) under a = 1/2 across multiple intervals/betas, HS and XXZ critical match their respective universality classes, DomainError off-critical
