### PR TITLE
feat(3 models): LogarithmicNegativity wrappers (CC-Tonni 2012)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.35"
+version = "0.23.36"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/models/quantum/HaldaneShastry/HaldaneShastry_thermal_cft.jl
+++ b/src/models/quantum/HaldaneShastry/HaldaneShastry_thermal_cft.jl
@@ -308,3 +308,25 @@ function fetch(
         kwargs...,
     )
 end
+
+"""
+    fetch(::HaldaneShastry, ::LogarithmicNegativity, ::Infinite;
+          ℓ_A::Real, ℓ_B::Real, kwargs...) -> Float64
+
+CC-Tonni 2012 logarithmic negativity of two adjacent intervals,
+delegated to `Universality(:Heisenberg)` (c = 1):
+
+    E = (1/4) log[ℓ_A * ℓ_B / (ℓ_A + ℓ_B)].
+"""
+function fetch(
+    ::HaldaneShastry, ::LogarithmicNegativity, ::Infinite; ℓ_A::Real, ℓ_B::Real, kwargs...
+)
+    return fetch(
+        Universality(:Heisenberg),
+        LogarithmicNegativity(),
+        Infinite();
+        ℓ_A=ℓ_A,
+        ℓ_B=ℓ_B,
+        kwargs...,
+    )
+end

--- a/src/models/quantum/TFIM/TFIM_cft_entanglement.jl
+++ b/src/models/quantum/TFIM/TFIM_cft_entanglement.jl
@@ -283,3 +283,38 @@ function fetch(
         kwargs...,
     )
 end
+
+# -----------------------------------------------------------------------------
+# Logarithmic negativity of two adjacent intervals at h = J (CC-Tonni 2012)
+# -----------------------------------------------------------------------------
+
+"""
+    fetch(m::TFIM, ::LogarithmicNegativity, ::Infinite;
+          ℓ_A::Real, ℓ_B::Real, kwargs...) -> Float64
+
+Calabrese-Cardy-Tonni 2012 logarithmic negativity of two adjacent
+intervals at the critical TFIM point `|h| = |J|`:
+
+    E = (c/4) log[ℓ_A · ℓ_B / (ℓ_A + ℓ_B)],   c = 1/2.
+
+Delegates to `Universality(:Ising)`.
+"""
+function fetch(
+    m::TFIM, ::LogarithmicNegativity, ::Infinite; ℓ_A::Real, ℓ_B::Real, kwargs...
+)
+    isapprox(abs(m.h), abs(m.J); atol=1e-12) || throw(
+        DomainError(
+            (m.h, m.J),
+            "TFIM LogarithmicNegativity: closed-form CC-Tonni applies only at " *
+            "the critical point |h| = |J|; got (h, J) = ($(m.h), $(m.J)).",
+        ),
+    )
+    return fetch(
+        Universality(:Ising),
+        LogarithmicNegativity(),
+        Infinite();
+        ℓ_A=ℓ_A,
+        ℓ_B=ℓ_B,
+        kwargs...,
+    )
+end

--- a/src/models/quantum/XXZ/XXZ_thermal.jl
+++ b/src/models/quantum/XXZ/XXZ_thermal.jl
@@ -713,3 +713,46 @@ function fetch(
         )
     end
 end
+
+"""
+    fetch(model::XXZ1D, ::LogarithmicNegativity, ::Infinite;
+          ℓ_A::Real, ℓ_B::Real, kwargs...) -> Float64
+
+CC-Tonni 2012 logarithmic negativity of two adjacent intervals in the
+critical Luttinger-liquid regime `-1 < Δ <= 1`. Delegates to
+`Universality(:XY)` for `-1 < Δ < 1` and `Universality(:Heisenberg)`
+at `Δ = 1`.
+"""
+function fetch(
+    model::XXZ1D, ::LogarithmicNegativity, ::Infinite; ℓ_A::Real, ℓ_B::Real, kwargs...
+)
+    Δ = model.Δ
+    if Δ == 1.0
+        return fetch(
+            Universality(:Heisenberg),
+            LogarithmicNegativity(),
+            Infinite();
+            ℓ_A=ℓ_A,
+            ℓ_B=ℓ_B,
+            kwargs...,
+        )
+    elseif -1.0 < Δ < 1.0
+        return fetch(
+            Universality(:XY),
+            LogarithmicNegativity(),
+            Infinite();
+            ℓ_A=ℓ_A,
+            ℓ_B=ℓ_B,
+            kwargs...,
+        )
+    else
+        throw(
+            DomainError(
+                Δ,
+                "XXZ1D LogarithmicNegativity at Infinite: only the critical " *
+                "Luttinger-liquid regime -1 < Δ <= 1 admits a c = 1 " *
+                "CC-Tonni closed form. Got Δ = $Δ.",
+            ),
+        )
+    end
+end

--- a/test/cross_model/test_three_models_log_negativity.jl
+++ b/test/cross_model/test_three_models_log_negativity.jl
@@ -1,0 +1,67 @@
+using Test
+using QAtlas
+
+@testset "Three-model LogarithmicNegativity wrappers (CC-Tonni 2012)" begin
+    @testset "TFIM h = J: matches Universality(:Ising)" begin
+        for J in (1.0, 2.0)
+            m = QAtlas.TFIM(; h=J, J=J)
+            for (ℓ_A, ℓ_B) in ((5.0, 10.0), (10.0, 20.0), (3.0, 30.0))
+                e = QAtlas.fetch(
+                    m, QAtlas.LogarithmicNegativity(), QAtlas.Infinite(); ℓ_A=ℓ_A, ℓ_B=ℓ_B
+                )
+                ref = (0.5 / 4) * log(ℓ_A * ℓ_B / (ℓ_A + ℓ_B))
+                @test e ≈ ref atol = 1e-12
+            end
+        end
+        m_off = QAtlas.TFIM(; h=0.5, J=1.0)
+        @test_throws DomainError QAtlas.fetch(
+            m_off, QAtlas.LogarithmicNegativity(), QAtlas.Infinite(); ℓ_A=5.0, ℓ_B=5.0
+        )
+    end
+
+    @testset "HaldaneShastry: c = 1" begin
+        m = QAtlas.HaldaneShastry()
+        for (ℓ_A, ℓ_B) in ((5.0, 10.0), (10.0, 20.0))
+            e = QAtlas.fetch(
+                m, QAtlas.LogarithmicNegativity(), QAtlas.Infinite(); ℓ_A=ℓ_A, ℓ_B=ℓ_B
+            )
+            ref = (1.0 / 4) * log(ℓ_A * ℓ_B / (ℓ_A + ℓ_B))
+            @test e ≈ ref atol = 1e-12
+        end
+    end
+
+    @testset "XXZ1D critical regime: c = 1" begin
+        for Δ in (0.0, 0.5, -0.5, 0.9, 1.0)
+            m = QAtlas.XXZ1D(; J=1.0, Δ=Δ)
+            for (ℓ_A, ℓ_B) in ((8.0, 12.0), (15.0, 25.0))
+                e = QAtlas.fetch(
+                    m, QAtlas.LogarithmicNegativity(), QAtlas.Infinite(); ℓ_A=ℓ_A, ℓ_B=ℓ_B
+                )
+                ref = (1.0 / 4) * log(ℓ_A * ℓ_B / (ℓ_A + ℓ_B))
+                @test e ≈ ref atol = 1e-12
+            end
+        end
+    end
+
+    @testset "XXZ1D off-critical (|Δ| > 1) throws DomainError" begin
+        for Δ in (1.5, -1.5, 2.0)
+            m = QAtlas.XXZ1D(; J=1.0, Δ=Δ)
+            @test_throws DomainError QAtlas.fetch(
+                m, QAtlas.LogarithmicNegativity(), QAtlas.Infinite(); ℓ_A=8.0, ℓ_B=12.0
+            )
+        end
+    end
+
+    @testset "Central-charge ratio TFIM/HS = 1/2" begin
+        ℓ_A, ℓ_B = 10.0, 15.0
+        m_tfim = QAtlas.TFIM(; h=1.0, J=1.0)
+        m_hs = QAtlas.HaldaneShastry()
+        e_tfim = QAtlas.fetch(
+            m_tfim, QAtlas.LogarithmicNegativity(), QAtlas.Infinite(); ℓ_A=ℓ_A, ℓ_B=ℓ_B
+        )
+        e_hs = QAtlas.fetch(
+            m_hs, QAtlas.LogarithmicNegativity(), QAtlas.Infinite(); ℓ_A=ℓ_A, ℓ_B=ℓ_B
+        )
+        @test e_tfim / e_hs ≈ 0.5 atol = 1e-12
+    end
+end


### PR DESCRIPTION
## Summary

3 model wrappers for LogarithmicNegativity of two adjacent intervals (Calabrese-Cardy-Tonni 2012, E = (c/4) log[ℓ_A ℓ_B / (ℓ_A + ℓ_B)]):

- TFIM at |h| = |J| delegates to Universality(:Ising) (c = 1/2)
- HaldaneShastry delegates to Universality(:Heisenberg) (c = 1, always critical)
- XXZ1D critical regime (-1 < Δ < 1 to :XY, Δ = 1 to :Heisenberg)

Closer to the universal pure-log form than MutualInformation (PR #609): LN at Universality drops the non-universal constants entirely, so the c_Ising / c_Heisenberg = 1/2 ratio holds exactly across models. Pairs naturally with the MutualInformation wrappers.

## Refs

- Refs #580 (Calabrese-Cardy-Tonni LN tracking)
- Builds on PR #609 (3-model MutualInformation)

## Test plan

- 23 assertions: closed-form match across 3 models, c-ratio (TFIM Ising vs HS Heisenberg = 1/2), DomainError off-critical
