### PR TITLE
feat(Universality): MerminGHZBound (Mermin 1990)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.38"
+version = "0.23.39"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -127,7 +127,8 @@ export FermiVelocity,
     ScramblingTime,
     MandelstamTammBound,
     MargolusLevitinBound,
-    BekensteinBound
+    BekensteinBound,
+    MerminGHZBound
 export SteadyStateCurrent                                # TASEP / non-equilibrium current (#241)
 export E8Spectrum
 export TopologicalInvariant, EdgeModeEnergy           # Kitaev1D Pfaffian invariant + edge mode

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -715,6 +715,30 @@ black holes.
 struct BekensteinBound <: AbstractQuantity end
 
 """
+    MerminGHZBound <: AbstractQuantity
+
+Mermin 1990 3-party generalisation of the CHSH inequality. For the
+3-qubit Mermin operator
+
+    M_3 = X_1 Y_2 Y_3 + Y_1 X_2 Y_3 + Y_1 Y_2 X_3 - X_1 X_2 X_3,
+
+the universal bounds are:
+
+| Theory                              | Bound on |<M_3>| |
+|-------------------------------------|------------------|
+| Local realism / classical           | 2                |
+| Quantum mechanics (Tsirelson-like)  | 4                |
+| Non-signalling (Popescu-Rohrlich)   | 4                |
+
+The quantum bound 4 is saturated by the GHZ state |000> + |111> with
+appropriate Pauli settings; coincides with the no-signalling bound, so
+QM saturates the latter here (unlike CHSH where 2 sqrt(2) < 4).
+
+Use `theory` kwarg (`:classical`, `:quantum`, `:no_signalling`).
+"""
+struct MerminGHZBound <: AbstractQuantity end
+
+"""
     CardyEntropy() <: AbstractQuantity
 
 Asymptotic high-energy entropy (log of the density of states) of a

--- a/src/universalities/CardyEntanglement.jl
+++ b/src/universalities/CardyEntanglement.jl
@@ -1095,3 +1095,36 @@ function fetch(
     E > 0 || throw(DomainError(E, "BekensteinBound requires E > 0; got E = $E."))
     return 2 * pi * R * E
 end
+
+# -----------------------------------------------------------------------------
+# Mermin 3-party inequality bound (Mermin 1990 PRL)
+# -----------------------------------------------------------------------------
+
+"""
+    fetch(::Universality{C}, ::MerminGHZBound, ::Infinite;
+          theory::Symbol, kwargs...) where {C} -> Float64
+
+Maximum value of `|<M_3>|` for the Mermin 3-party operator under the
+selected `theory`:
+
+- `:classical`     -> 2          (local hidden-variable bound)
+- `:quantum`       -> 4          (saturated by GHZ state |000> + |111>)
+- `:no_signalling` -> 4          (same as QM, QM saturates here)
+
+Reference: N. D. Mermin, *Phys. Rev. Lett.* **65**, 1838 (1990).
+"""
+function fetch(
+    ::Universality{C}, ::MerminGHZBound, ::Infinite; theory::Symbol, kwargs...
+) where {C}
+    if theory === :classical
+        return 2.0
+    elseif theory === :quantum || theory === :no_signalling
+        return 4.0
+    else
+        throw(
+            ArgumentError(
+                "MerminGHZBound: theory must be one of :classical, :quantum, :no_signalling; got $theory.",
+            ),
+        )
+    end
+end

--- a/test/universalities/test_universality_mermin_ghz.jl
+++ b/test/universalities/test_universality_mermin_ghz.jl
@@ -1,0 +1,67 @@
+using Test
+using QAtlas
+
+@testset "Universality MerminGHZBound (Mermin 1990)" begin
+    @testset "Classical bound = 2" begin
+        for sym in (:Ising, :Heisenberg, :XY, :Potts3, :Potts4)
+            u = QAtlas.Universality(sym)
+            @test QAtlas.fetch(
+                u, QAtlas.MerminGHZBound(), QAtlas.Infinite(); theory=:classical
+            ) == 2.0
+        end
+    end
+
+    @testset "Quantum bound = 4 (GHZ saturates)" begin
+        for sym in (:Ising, :Heisenberg, :XY)
+            u = QAtlas.Universality(sym)
+            @test QAtlas.fetch(
+                u, QAtlas.MerminGHZBound(), QAtlas.Infinite(); theory=:quantum
+            ) == 4.0
+        end
+    end
+
+    @testset "No-signalling bound = 4 (QM saturates)" begin
+        u = QAtlas.Universality(:Ising)
+        @test QAtlas.fetch(
+            u, QAtlas.MerminGHZBound(), QAtlas.Infinite(); theory=:no_signalling
+        ) == 4.0
+    end
+
+    @testset "QM bound = no-signalling bound (unlike CHSH)" begin
+        u = QAtlas.Universality(:Heisenberg)
+        @test QAtlas.fetch(
+            u, QAtlas.MerminGHZBound(), QAtlas.Infinite(); theory=:quantum
+        ) == QAtlas.fetch(
+            u, QAtlas.MerminGHZBound(), QAtlas.Infinite(); theory=:no_signalling
+        )
+    end
+
+    @testset "Classical / quantum ratio = 1/2 (factor of 2 gap)" begin
+        u = QAtlas.Universality(:Ising)
+        c = QAtlas.fetch(u, QAtlas.MerminGHZBound(), QAtlas.Infinite(); theory=:classical)
+        q = QAtlas.fetch(u, QAtlas.MerminGHZBound(), QAtlas.Infinite(); theory=:quantum)
+        @test c / q ≈ 0.5 atol = 1e-12
+    end
+
+    @testset "Universality-class independent" begin
+        vals_q = [
+            QAtlas.fetch(
+                QAtlas.Universality(sym),
+                QAtlas.MerminGHZBound(),
+                QAtlas.Infinite();
+                theory=:quantum,
+            ) for sym in (:Ising, :Heisenberg, :XY, :Potts3, :Potts4)
+        ]
+        @test all(v == 4.0 for v in vals_q)
+    end
+
+    @testset "ArgumentError for unknown theory" begin
+        u = QAtlas.Universality(:Ising)
+        @test_throws ArgumentError QAtlas.fetch(
+            u, QAtlas.MerminGHZBound(), QAtlas.Infinite(); theory=:nonsense
+        )
+        @test_throws ArgumentError QAtlas.fetch(
+            u, QAtlas.MerminGHZBound(), QAtlas.Infinite(); theory=:hidden
+        )
+    end
+end


### PR DESCRIPTION
## Summary

- New universal quantity MerminGHZBound — 3-party generalization of CHSH (Mermin 1990 PRL 65 1838)
- Bounds for the Mermin operator M_3 = X1 Y2 Y3 + Y1 X2 Y3 + Y1 Y2 X3 - X1 X2 X3:
  - classical: 2
  - quantum: 4 (saturated by GHZ state)
  - no-signalling: 4
- Sibling of CHSHBound (PR #598): the QM/no-signalling gap closes at n=3 (unlike CHSH where 2 sqrt(2) < 4)

## Refs

- Refs #579 (universal closed-form quantities track)
- Builds on PR #612 (Heisenberg1D LR + slope)

## Test plan

- 14 assertions: 3 theory values across multiple classes, QM/no-signalling agreement, classical/quantum 1/2 gap ratio, class-independence, ArgumentError on bad theory
