### PR TITLE
feat(Universality:RMT): WignerSemicircleMoment (Wigner 1955, Catalan numbers)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.39"
+version = "0.23.40"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -128,7 +128,8 @@ export FermiVelocity,
     MandelstamTammBound,
     MargolusLevitinBound,
     BekensteinBound,
-    MerminGHZBound
+    MerminGHZBound,
+    WignerSemicircleMoment
 export SteadyStateCurrent                                # TASEP / non-equilibrium current (#241)
 export E8Spectrum
 export TopologicalInvariant, EdgeModeEnergy           # Kitaev1D Pfaffian invariant + edge mode

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -739,6 +739,29 @@ Use `theory` kwarg (`:classical`, `:quantum`, `:no_signalling`).
 struct MerminGHZBound <: AbstractQuantity end
 
 """
+    WignerSemicircleMoment <: AbstractQuantity
+
+Moments of the Wigner semicircle distribution
+
+    rho(x) = (1 / (2 pi)) sqrt(4 - x^2),   x in [-2, 2],
+
+the universal large-N eigenvalue density of Gaussian random matrix
+ensembles (GOE / GUE / GSE) under Wigner-Mehta normalisation.
+
+The even moments are Catalan numbers,
+
+    m_{2k} = C_k = (2k)! / (k! (k+1)!),
+
+and the odd moments vanish by symmetry. These are the universal large-N
+free-probability moments underlying RMT spectral statistics; they also
+count rooted plane trees / non-crossing pair partitions.
+
+Reference: E. P. Wigner, *Ann. Math.* **62**, 548 (1955); M. L. Mehta
+*Random Matrices* (1991).
+"""
+struct WignerSemicircleMoment <: AbstractQuantity end
+
+"""
     CardyEntropy() <: AbstractQuantity
 
 Asymptotic high-energy entropy (log of the density of states) of a

--- a/src/universalities/RMT.jl
+++ b/src/universalities/RMT.jl
@@ -256,3 +256,36 @@ function fetch(
     end
     return 1.0  # GUE late-time plateau (Mehta 2004 §16; CHM 2016)
 end
+
+# -----------------------------------------------------------------------------
+# Wigner-semicircle moments (Wigner 1955, Mehta)
+# -----------------------------------------------------------------------------
+
+"""
+    fetch(::Universality{:RMT}, ::WignerSemicircleMoment, ::Infinite;
+          n::Integer, kwargs...) -> Float64
+
+Universal moment `m_n = E[x^n]` of the Wigner semicircle distribution
+on `[-2, 2]`. Even moments are Catalan numbers
+
+    m_{2k} = C_k = binomial(2k, k) / (k + 1),
+
+odd moments vanish. The large-N eigenvalue density of all three Gaussian
+ensembles (GOE, GUE, GSE) converges to the same semicircle, so the
+moments are class-independent within RMT.
+"""
+function fetch(
+    ::Universality{:RMT}, ::WignerSemicircleMoment, ::Infinite; n::Integer, kwargs...
+)
+    n >= 0 ||
+        throw(DomainError(n, "WignerSemicircleMoment: n must be non-negative; got n = $n."))
+    if isodd(n)
+        return 0.0
+    end
+    k = div(n, 2)
+    return Float64(binomial(big(2 * k), big(k)) / (k + 1))
+end
+
+function fetch(m::Universality{:RMT}, q::WignerSemicircleMoment; n::Integer, kwargs...)
+    fetch(m, q, Infinite(); n=n, kwargs...)
+end

--- a/test/universalities/test_universality_wigner_moment.jl
+++ b/test/universalities/test_universality_wigner_moment.jl
@@ -1,0 +1,53 @@
+using Test
+using QAtlas
+
+@testset "Universality(:RMT) WignerSemicircleMoment" begin
+    u = QAtlas.Universality(:RMT)
+
+    @testset "Catalan number even moments" begin
+        catalan_ref = (1.0, 1.0, 2.0, 5.0, 14.0, 42.0, 132.0, 429.0)
+        for (k, ref) in enumerate(catalan_ref)
+            n = 2 * (k - 1)
+            m_n = QAtlas.fetch(u, QAtlas.WignerSemicircleMoment(), QAtlas.Infinite(); n=n)
+            @test m_n ≈ ref atol = 1e-12
+        end
+    end
+
+    @testset "Odd moments vanish" begin
+        for n in (1, 3, 5, 7, 9, 11, 13)
+            @test QAtlas.fetch(
+                u, QAtlas.WignerSemicircleMoment(), QAtlas.Infinite(); n=n
+            ) == 0.0
+        end
+    end
+
+    @testset "Catalan recursion C_{k+1} = sum_i C_i C_{k-i}" begin
+        moments = [
+            QAtlas.fetch(u, QAtlas.WignerSemicircleMoment(), QAtlas.Infinite(); n=2k) for
+            k in 0:5
+        ]
+        for k in 1:5
+            recursion = sum(moments[i + 1] * moments[k - i] for i in 0:(k - 1))
+            @test moments[k + 1] ≈ recursion atol = 1e-10
+        end
+    end
+
+    @testset "Without explicit Infinite() also dispatches" begin
+        @test QAtlas.fetch(u, QAtlas.WignerSemicircleMoment(); n=4) == 2.0
+        @test QAtlas.fetch(u, QAtlas.WignerSemicircleMoment(); n=6) == 5.0
+    end
+
+    @testset "DomainError for negative n" begin
+        @test_throws DomainError QAtlas.fetch(
+            u, QAtlas.WignerSemicircleMoment(), QAtlas.Infinite(); n=-1
+        )
+        @test_throws DomainError QAtlas.fetch(
+            u, QAtlas.WignerSemicircleMoment(), QAtlas.Infinite(); n=-10
+        )
+    end
+
+    @testset "Large n still works (BigInt internally)" begin
+        m_40 = QAtlas.fetch(u, QAtlas.WignerSemicircleMoment(), QAtlas.Infinite(); n=40)
+        @test m_40 ≈ 6564120420.0 atol = 1e-2
+    end
+end


### PR DESCRIPTION
## Summary

- New universal quantity WignerSemicircleMoment at Universality(:RMT)
- Even moments m_{2k} = Catalan_k = C(2k, k) / (k+1); odd moments vanish
- Wigner 1955 / Mehta — universal large-N moments of GOE/GUE/GSE eigenvalue density, also counts non-crossing pair partitions in free probability
- Sibling of existing WignerSurmise, MeanRatio, SpectralFormFactor at Universality(:RMT)

## Refs

- Refs #579 (universal closed-form quantities track)
- Builds on PR #613 (MerminGHZBound)

## Test plan

- 25 assertions: first 8 Catalan numbers (1, 1, 2, 5, 14, 42, 132, 429), odd moments zero, Catalan recursion C_{k+1} = sum C_i C_{k-i}, scale-tag-free dispatch, DomainError on n < 0, BigInt safety at n = 40 (C_20 = 6,564,120,420)
