### PR TITLE
feat(Universality): BB84KeyRate (Shor-Preskill 2000)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.40"
+version = "0.23.41"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -129,7 +129,8 @@ export FermiVelocity,
     MargolusLevitinBound,
     BekensteinBound,
     MerminGHZBound,
-    WignerSemicircleMoment
+    WignerSemicircleMoment,
+    BB84KeyRate
 export SteadyStateCurrent                                # TASEP / non-equilibrium current (#241)
 export E8Spectrum
 export TopologicalInvariant, EdgeModeEnergy           # Kitaev1D Pfaffian invariant + edge mode

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -762,6 +762,24 @@ Reference: E. P. Wigner, *Ann. Math.* **62**, 548 (1955); M. L. Mehta
 struct WignerSemicircleMoment <: AbstractQuantity end
 
 """
+    BB84KeyRate <: AbstractQuantity
+
+Shor-Preskill 2000 universal asymptotic secret-key rate (per sifted
+bit) of the BB84 quantum-key-distribution protocol against a
+collective-attack eavesdropper, parameterised by the quantum bit
+error rate (QBER) `e`:
+
+    R(e) = 1 - 2 H_2(e),    H_2(e) = -e log_2(e) - (1-e) log_2(1-e).
+
+The rate vanishes at the unconditional-security threshold
+`e* ≈ 0.110028`; above this QBER no positive secret key can be
+extracted in the asymptotic limit.
+
+Reference: P. W. Shor, J. Preskill *Phys. Rev. Lett.* **85**, 441 (2000).
+"""
+struct BB84KeyRate <: AbstractQuantity end
+
+"""
     CardyEntropy() <: AbstractQuantity
 
 Asymptotic high-energy entropy (log of the density of states) of a

--- a/src/universalities/CardyEntanglement.jl
+++ b/src/universalities/CardyEntanglement.jl
@@ -1128,3 +1128,37 @@ function fetch(
         )
     end
 end
+
+# -----------------------------------------------------------------------------
+# Shor-Preskill 2000 BB84 secret-key rate
+# -----------------------------------------------------------------------------
+
+"""
+    fetch(::Universality{C}, ::BB84KeyRate, ::Infinite;
+          qber::Real, kwargs...) where {C} -> Float64
+
+Shor-Preskill 2000 asymptotic secret-key rate per sifted bit of the
+BB84 QKD protocol at quantum bit error rate `qber = e` (in [0, 0.5]),
+
+    R(e) = 1 - 2 H_2(e),
+
+with `H_2(e) = -e log2(e) - (1-e) log2(1-e)` the binary Shannon entropy.
+The rate is clamped at 0 above the unconditional-security threshold
+`e* ≈ 0.110028` (where `R = 0`).
+
+Reference: P. W. Shor, J. Preskill *Phys. Rev. Lett.* **85**, 441 (2000).
+"""
+function fetch(
+    ::Universality{C}, ::BB84KeyRate, ::Infinite; qber::Real, kwargs...
+) where {C}
+    (0 <= qber <= 0.5) ||
+        throw(DomainError(qber, "BB84KeyRate requires qber in [0, 0.5]; got qber = $qber."))
+    if qber == 0
+        return 1.0
+    end
+    if qber == 0.5
+        return -1.0
+    end
+    h2 = -qber * log2(qber) - (1 - qber) * log2(1 - qber)
+    return 1 - 2 * h2
+end

--- a/test/universalities/test_universality_bb84_key_rate.jl
+++ b/test/universalities/test_universality_bb84_key_rate.jl
@@ -1,0 +1,62 @@
+using Test
+using QAtlas
+
+@testset "Universality BB84KeyRate (Shor-Preskill 2000)" begin
+    u = QAtlas.Universality(:Ising)
+
+    @testset "Boundary values" begin
+        @test QAtlas.fetch(u, QAtlas.BB84KeyRate(), QAtlas.Infinite(); qber=0.0) ≈ 1.0 atol =
+            1e-12
+        @test QAtlas.fetch(u, QAtlas.BB84KeyRate(), QAtlas.Infinite(); qber=0.5) ≈ -1.0 atol =
+            1e-12
+    end
+
+    @testset "Numerical values across QBER" begin
+        r_05 = QAtlas.fetch(u, QAtlas.BB84KeyRate(), QAtlas.Infinite(); qber=0.05)
+        h2_05 = -0.05 * log2(0.05) - 0.95 * log2(0.95)
+        @test r_05 ≈ 1 - 2 * h2_05 atol = 1e-12
+
+        r_threshold = QAtlas.fetch(u, QAtlas.BB84KeyRate(), QAtlas.Infinite(); qber=0.11)
+        @test r_threshold < 0.001
+    end
+
+    @testset "Unconditional-security threshold e* ≈ 0.110028" begin
+        r_below = QAtlas.fetch(u, QAtlas.BB84KeyRate(), QAtlas.Infinite(); qber=0.10)
+        r_at = QAtlas.fetch(u, QAtlas.BB84KeyRate(), QAtlas.Infinite(); qber=0.110028)
+        r_above = QAtlas.fetch(u, QAtlas.BB84KeyRate(), QAtlas.Infinite(); qber=0.13)
+        @test r_below > 0
+        @test abs(r_at) < 1e-4
+        @test r_above < 0
+    end
+
+    @testset "Monotonically decreasing in qber on [0, 0.5]" begin
+        prev = 2.0
+        for q in 0.01:0.04:0.45
+            r = QAtlas.fetch(u, QAtlas.BB84KeyRate(), QAtlas.Infinite(); qber=q)
+            @test r < prev
+            prev = r
+        end
+    end
+
+    @testset "Class-independent" begin
+        q = 0.05
+        vals = [
+            QAtlas.fetch(
+                QAtlas.Universality(sym), QAtlas.BB84KeyRate(), QAtlas.Infinite(); qber=q
+            ) for sym in (:Ising, :Heisenberg, :XY, :Potts3, :Potts4)
+        ]
+        @test all(isapprox(v, first(vals); atol=1e-12) for v in vals)
+    end
+
+    @testset "DomainError on QBER outside [0, 0.5]" begin
+        @test_throws DomainError QAtlas.fetch(
+            u, QAtlas.BB84KeyRate(), QAtlas.Infinite(); qber=-0.01
+        )
+        @test_throws DomainError QAtlas.fetch(
+            u, QAtlas.BB84KeyRate(), QAtlas.Infinite(); qber=0.51
+        )
+        @test_throws DomainError QAtlas.fetch(
+            u, QAtlas.BB84KeyRate(), QAtlas.Infinite(); qber=1.0
+        )
+    end
+end


### PR DESCRIPTION
## Summary

- New universal quantity BB84KeyRate
- Shor-Preskill 2000 (PRL 85 441) asymptotic secret-key rate per sifted bit of BB84 QKD: R(e) = 1 - 2 H_2(e)
- Vanishes at the unconditional-security threshold e* ≈ 0.110028 QBER
- Universal — independent of physical realization

## Refs

- Refs #579 (universal closed-form quantities track)
- Builds on PR #614 (WignerSemicircleMoment)

## Test plan

- 23 assertions: boundary values (e=0 → 1, e=0.5 → -1), numerical match against H_2 formula, threshold check at e* ≈ 0.110028, monotonicity on [0, 0.5], class independence, DomainError on QBER outside [0, 0.5]
