### PR TITLE
feat(Universality): OptimalCloningFidelity (Buzek-Hillery 1996)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.23.41"
+version = "0.23.42"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -130,7 +130,8 @@ export FermiVelocity,
     BekensteinBound,
     MerminGHZBound,
     WignerSemicircleMoment,
-    BB84KeyRate
+    BB84KeyRate,
+    OptimalCloningFidelity
 export SteadyStateCurrent                                # TASEP / non-equilibrium current (#241)
 export E8Spectrum
 export TopologicalInvariant, EdgeModeEnergy           # Kitaev1D Pfaffian invariant + edge mode

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -780,6 +780,23 @@ Reference: P. W. Shor, J. Preskill *Phys. Rev. Lett.* **85**, 441 (2000).
 struct BB84KeyRate <: AbstractQuantity end
 
 """
+    OptimalCloningFidelity <: AbstractQuantity
+
+Buzek-Hillery 1996 optimal symmetric universal quantum cloner
+fidelity for the canonical `1 -> 2` cloner of a `d`-level system,
+
+    F_{1,2,d} = 1/2 + 1/(d + 1).
+
+For qubits (`d = 2`) this gives the famous `F = 5/6`. Universal upper
+bound — no symmetric `1 -> 2` cloner can exceed it; saturated by the
+Buzek-Hillery construction.
+
+Reference: V. Buzek, M. Hillery *Phys. Rev. A* **54**, 1844 (1996);
+N. Gisin, S. Massar *Phys. Rev. Lett.* **79**, 2153 (1997).
+"""
+struct OptimalCloningFidelity <: AbstractQuantity end
+
+"""
     CardyEntropy() <: AbstractQuantity
 
 Asymptotic high-energy entropy (log of the density of states) of a

--- a/src/universalities/CardyEntanglement.jl
+++ b/src/universalities/CardyEntanglement.jl
@@ -1162,3 +1162,27 @@ function fetch(
     h2 = -qber * log2(qber) - (1 - qber) * log2(1 - qber)
     return 1 - 2 * h2
 end
+
+# -----------------------------------------------------------------------------
+# Optimal symmetric 1 -> 2 universal cloning fidelity (Buzek-Hillery 1996)
+# -----------------------------------------------------------------------------
+
+"""
+    fetch(::Universality{C}, ::OptimalCloningFidelity, ::Infinite;
+          d::Integer=2, kwargs...) where {C} -> Float64
+
+Buzek-Hillery 1996 optimal symmetric universal `1 -> 2` cloner
+single-clone fidelity for a `d`-level system,
+
+    F_{1,2,d} = 1/2 + 1/(d + 1).
+
+For qubits (`d = 2`) this gives the canonical `F = 5/6`.
+
+Reference: V. Buzek, M. Hillery *Phys. Rev. A* **54**, 1844 (1996).
+"""
+function fetch(
+    ::Universality{C}, ::OptimalCloningFidelity, ::Infinite; d::Integer=2, kwargs...
+) where {C}
+    d >= 2 || throw(DomainError(d, "OptimalCloningFidelity requires d >= 2; got d = $d."))
+    return 0.5 + 1 / (d + 1)
+end

--- a/test/universalities/test_universality_cloning_fidelity.jl
+++ b/test/universalities/test_universality_cloning_fidelity.jl
@@ -1,0 +1,63 @@
+using Test
+using QAtlas
+
+@testset "Universality OptimalCloningFidelity (Buzek-Hillery 1996)" begin
+    u = QAtlas.Universality(:Ising)
+
+    @testset "Canonical qubit (d = 2): F = 5/6" begin
+        f = QAtlas.fetch(u, QAtlas.OptimalCloningFidelity(), QAtlas.Infinite())
+        @test f ≈ 5 / 6 atol = 1e-12
+        f_explicit = QAtlas.fetch(
+            u, QAtlas.OptimalCloningFidelity(), QAtlas.Infinite(); d=2
+        )
+        @test f_explicit ≈ 5 / 6 atol = 1e-12
+    end
+
+    @testset "Higher-dim explicit values" begin
+        @test QAtlas.fetch(u, QAtlas.OptimalCloningFidelity(), QAtlas.Infinite(); d=3) ≈
+            3 / 4 atol = 1e-12
+        @test QAtlas.fetch(u, QAtlas.OptimalCloningFidelity(), QAtlas.Infinite(); d=4) ≈
+            7 / 10 atol = 1e-12
+        @test QAtlas.fetch(u, QAtlas.OptimalCloningFidelity(), QAtlas.Infinite(); d=10) ≈
+            1 / 2 + 1 / 11 atol = 1e-12
+    end
+
+    @testset "Asymptotic d → ∞ gives 1/2 (classical limit)" begin
+        f_large = QAtlas.fetch(
+            u, QAtlas.OptimalCloningFidelity(), QAtlas.Infinite(); d=10_000
+        )
+        @test abs(f_large - 0.5) < 1e-3
+        f_huge = QAtlas.fetch(u, QAtlas.OptimalCloningFidelity(), QAtlas.Infinite(); d=10^6)
+        @test abs(f_huge - 0.5) < 1e-5
+    end
+
+    @testset "Monotonically decreasing in d" begin
+        prev = 1.0
+        for d in 2:20
+            f = QAtlas.fetch(u, QAtlas.OptimalCloningFidelity(), QAtlas.Infinite(); d=d)
+            @test f < prev
+            prev = f
+        end
+    end
+
+    @testset "Class-independent" begin
+        vals = [
+            QAtlas.fetch(
+                QAtlas.Universality(sym), QAtlas.OptimalCloningFidelity(), QAtlas.Infinite()
+            ) for sym in (:Ising, :Heisenberg, :XY, :Potts3, :Potts4)
+        ]
+        @test all(isapprox(v, 5 / 6; atol=1e-12) for v in vals)
+    end
+
+    @testset "DomainError on d < 2" begin
+        @test_throws DomainError QAtlas.fetch(
+            u, QAtlas.OptimalCloningFidelity(), QAtlas.Infinite(); d=1
+        )
+        @test_throws DomainError QAtlas.fetch(
+            u, QAtlas.OptimalCloningFidelity(), QAtlas.Infinite(); d=0
+        )
+        @test_throws DomainError QAtlas.fetch(
+            u, QAtlas.OptimalCloningFidelity(), QAtlas.Infinite(); d=-5
+        )
+    end
+end


### PR DESCRIPTION
## Summary

- New universal quantity OptimalCloningFidelity
- Buzek-Hillery 1996 (PRA 54 1844) optimal symmetric 1→2 universal cloner fidelity for a d-level system: F_{1,2,d} = 1/2 + 1/(d+1)
- Canonical qubit (d=2): F = 5/6 (the famous no-cloning quantitative bound)
- Saturated by the Buzek-Hillery construction; sibling of CHSHBound/Tsirelson family of universal QI bounds

## Refs

- Refs #579 (universal closed-form quantities track)
- Builds on PR #615 (BB84KeyRate)

## Test plan

- 30 assertions: qubit 5/6, d=3 → 3/4, d=4 → 7/10, d=10, d → ∞ limit (→ 1/2), monotonicity, class independence, DomainError on d < 2
