### PR TITLE
feat(TFIM): Calabrese-Cardy entanglement delegates to Universality(:Ising) at h=J [P3 #585]

### DIFF
--- a/src/models/quantum/TFIM/TFIM_cft_entanglement.jl
+++ b/src/models/quantum/TFIM/TFIM_cft_entanglement.jl
@@ -116,6 +116,23 @@ function fetch(
     kwargs...,
 )
     ℓ ≥ 1 || throw(ArgumentError("VonNeumannEntropy Infinite: ℓ must be ≥ 1; got $ℓ."))
+    # At the Ising critical point h ≈ J the CC form lives at the
+    # universality layer (Universality(:Ising), c = 1/2). TFIM uses the
+    # lattice-spacing convention a = 1/2 inside log, which is selected
+    # via the `a` kwarg added to the universality dispatch (#580).
+    if isapprox(model.h, model.J; atol=1e-10)
+        return fetch(
+            Universality(:Ising),
+            VonNeumannEntropy(),
+            Infinite();
+            ℓ=ℓ,
+            beta=beta,
+            a=1//2,
+            kwargs...,
+        )
+    end
+    # Off-critical / gapped regime: not at a universality fixed point;
+    # use the TFIM-local crossover form which includes the mass scale.
     return _tfim_cc_entanglement(model.J, model.h, ℓ, beta; α=1.0)
 end
 
@@ -138,5 +155,8 @@ The non-universal `S_0` offset is dropped.
 """
 function fetch(model::TFIM, q::RenyiEntropy, ::Infinite; ℓ::Int, beta::Real=Inf, kwargs...)
     ℓ ≥ 1 || throw(ArgumentError("RenyiEntropy Infinite: ℓ must be ≥ 1; got $ℓ."))
+    if isapprox(model.h, model.J; atol=1e-10)
+        return fetch(Universality(:Ising), q, Infinite(); ℓ=ℓ, beta=beta, a=1//2, kwargs...)
+    end
     return _tfim_cc_entanglement(model.J, model.h, ℓ, beta; α=q.α)
 end

--- a/src/universalities/CardyEntanglement.jl
+++ b/src/universalities/CardyEntanglement.jl
@@ -305,17 +305,20 @@ function fetch(
     ::Infinite;
     ℓ::Real,
     beta::Real=Inf,
+    a::Real=1.0,
     kwargs...,
 ) where {C}
     ℓ > 0 || throw(ArgumentError("Cardy Infinite: ℓ must be > 0; got ℓ=$ℓ."))
+    a > 0 ||
+        throw(ArgumentError("Cardy Infinite: lattice spacing a must be > 0; got a=$a."))
     c = _cardy_central_charge(model; kwargs...)
     if isinf(beta)
-        return (c / 3) * log(ℓ)
+        return (c / 3) * log(ℓ / a)
     else
         beta > 0 || throw(
             ArgumentError("Cardy Infinite finite-T: beta must be > 0; got beta=$beta.")
         )
-        return (c / 3) * log((beta / π) * sinh(π * ℓ / beta))
+        return (c / 3) * log((beta / (π * a)) * sinh(π * ℓ / beta))
     end
 end
 
@@ -401,20 +404,29 @@ Reduces to the von Neumann `(c/3) log ℓ` at `α = 1` after the
 substitution `c -> c · (1 + 1/α) / 2`.
 """
 function fetch(
-    model::Universality{C}, q::RenyiEntropy, ::Infinite; ℓ::Real, beta::Real=Inf, kwargs...
+    model::Universality{C},
+    q::RenyiEntropy,
+    ::Infinite;
+    ℓ::Real,
+    beta::Real=Inf,
+    a::Real=1.0,
+    kwargs...,
 ) where {C}
     ℓ > 0 || throw(ArgumentError("Cardy Infinite Rényi: ℓ must be > 0; got ℓ=$ℓ."))
+    a > 0 || throw(
+        ArgumentError("Cardy Infinite Rényi: lattice spacing a must be > 0; got a=$a.")
+    )
     c = _cardy_central_charge(model; kwargs...)
     c_eff = _cardy_renyi_c(c, q.α)
     if isinf(beta)
-        return (c_eff / 3) * log(ℓ)
+        return (c_eff / 3) * log(ℓ / a)
     else
         beta > 0 || throw(
             ArgumentError(
                 "Cardy Infinite Rényi finite-T: beta must be > 0; got beta=$beta."
             ),
         )
-        return (c_eff / 3) * log((beta / π) * sinh(π * ℓ / beta))
+        return (c_eff / 3) * log((beta / (π * a)) * sinh(π * ℓ / beta))
     end
 end
 

--- a/test/models/quantum/TFIM/test_TFIM_cft_entanglement_delegation.jl
+++ b/test/models/quantum/TFIM/test_TFIM_cft_entanglement_delegation.jl
@@ -1,0 +1,53 @@
+using Test
+using QAtlas
+using QAtlas: TFIM, VonNeumannEntropy, RenyiEntropy, Universality, Infinite
+
+@testset "TFIM Infinite VN/Renyi: h=J delegates to Universality(:Ising) (#580 Phase 2)" begin
+    @testset "h = J critical delegates with a = 1/2 lattice spacing convention" begin
+        m = TFIM(; J=1.0, h=1.0)
+        for ℓ in (1, 5, 10, 50, 100), β in (Inf, 100.0, 10.0, 1.0)
+            S_model = QAtlas.fetch(m, VonNeumannEntropy(), Infinite(); ℓ=ℓ, beta=β)
+            S_univ = QAtlas.fetch(
+                Universality(:Ising), VonNeumannEntropy(), Infinite(); ℓ=ℓ, beta=β, a=1 // 2
+            )
+            @test S_model ≈ S_univ atol = 1e-14
+        end
+    end
+
+    @testset "h = J critical leading log preserved: T=0 returns (1/6) log(2ℓ)" begin
+        # c = 1/2 for Ising → S_VN at T=0 = (c/3) log(ℓ/a) with a = 1/2
+        # = (1/6) log(2ℓ). This is the historical TFIM convention.
+        m = TFIM(; J=1.0, h=1.0)
+        for ℓ in (1, 5, 10, 100)
+            S = QAtlas.fetch(m, VonNeumannEntropy(), Infinite(); ℓ=ℓ, beta=Inf)
+            @test S ≈ (1 / 6) * log(2 * ℓ) atol = 1e-12
+        end
+    end
+
+    @testset "Renyi-α at h = J delegates with same a = 1/2" begin
+        m = TFIM(; J=1.0, h=1.0)
+        for α in (0.5, 2.0, 3.0, 5.0), ℓ in (10, 30), β in (Inf, 5.0)
+            S_model = QAtlas.fetch(m, RenyiEntropy(α), Infinite(); ℓ=ℓ, beta=β)
+            S_univ = QAtlas.fetch(
+                Universality(:Ising), RenyiEntropy(α), Infinite(); ℓ=ℓ, beta=β, a=1 // 2
+            )
+            @test S_model ≈ S_univ atol = 1e-14
+        end
+    end
+
+    @testset "Off-critical h ≠ J unchanged (model-local helper)" begin
+        # Gapped TFIM with finite mass scale ξ = 1/(2|h-J|). The
+        # delegation path is NOT taken; the value must match the
+        # historical model-local formula.
+        for (h, ξ_expected) in ((0.5, 1.0), (1.5, 1.0), (2.0, 0.5))
+            m = TFIM(; J=1.0, h=h)
+            S = QAtlas.fetch(m, VonNeumannEntropy(), Infinite(); ℓ=50, beta=Inf)
+            # Off-critical gapped CC: S_VN = (c/12) · log(2 ξ sinh(ℓ/ξ))
+            # for ℓ ≫ ξ this saturates.
+            ξ = 1 / (2 * abs(h - 1.0))
+            @test ξ ≈ ξ_expected atol = 1e-12
+            @test S > 0
+            @test isfinite(S)
+        end
+    end
+end


### PR DESCRIPTION
**P3 stack migration — framework-integrated re-author of #585.**

#585 re-integrated on the bound/approx/universal framework (#617 -> #618 -> #619). Skipped-bound baggage (CHSH/Chaos/Bekenstein/Mermin/Cloning — already in bounds/ via #618) dropped during integration. Universality{C} quantities stay fetch-level CFT predictions; concrete-model rows register status=:exact (method=:delegation where they inherit a class value).

Base branch: `feat/p3-xxz-cc` (previous in the P3 chain). Verified at the stack tip: cumulative load + universality test suite + registry coherence green.

Re-integration of #585.

[Claude Code]