### PR TITLE
feat(Universality): EntanglementGrowthSlope = pi c v/(3 beta_eff) [P3 #588]

### DIFF
--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -112,7 +112,11 @@ export CasimirEnergyCorrection                                              # CF
 export ConformalWeights, PrimaryFields
 export StringOrderParameter
 export FermiVelocity,
-    LuttingerVelocity, SpinWaveVelocity, LiebRobinsonVelocity, MutualInformation
+    LuttingerVelocity,
+    SpinWaveVelocity,
+    LiebRobinsonVelocity,
+    MutualInformation,
+    EntanglementGrowthSlope
 export SteadyStateCurrent                                # TASEP / non-equilibrium current (#241)
 export E8Spectrum
 export LiebRobinsonBound  # status-axis example (:bound)

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -552,6 +552,25 @@ cases. Tracking: #580 entanglement universality catalog.
 struct MutualInformation <: AbstractQuantity end
 
 """
+    EntanglementGrowthSlope() <: AbstractQuantity
+
+Linear-growth slope of the half-system entanglement entropy after a
+global quench from a thermal-like initial state. Calabrese-Cardy 2005
+predicts that, for `t < L / (2 v)`,
+
+    dS_A / dt = (π c v) / (3 β_eff),
+
+where `c` is the central charge of the critical post-quench
+Hamiltonian, `v` is the Lieb-Robinson velocity of correlation
+spreading, and `β_eff` is the effective inverse temperature of the
+generalised-Gibbs steady state set by the initial state. This struct
+is the type tag; concrete dispatches live at the universality layer
+and on model files. Reference: Calabrese-Cardy 2005, *J. Stat. Mech.*
+P04010. Tracking: #580 quench-dynamics phase.
+"""
+struct EntanglementGrowthSlope <: AbstractQuantity end
+
+"""
     E8Spectrum() <: AbstractQuantity
 
 Zamolodchikov E8 mass spectrum (8 stable particles).  Concrete

--- a/src/universalities/CardyEntanglement.jl
+++ b/src/universalities/CardyEntanglement.jl
@@ -535,3 +535,47 @@ function fetch(
     S_AB = fetch(model, VonNeumannEntropy(), Infinite(); ℓ=ℓ_A + ℓ_B, beta=beta, kwargs...)
     return S_A + S_B - S_AB
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Quench-dynamics: linear-growth slope of half-system entanglement (#580)
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    fetch(::Universality{C}, ::EntanglementGrowthSlope, ::Infinite;
+          v::Real, beta_eff::Real, kwargs...) -> Float64
+
+Linear-growth slope `dS_A / dt` of the half-system entanglement entropy
+after a global quench from a thermal-like initial state into a critical
+post-quench Hamiltonian in the same universality class. Calabrese-Cardy
+2005 predicts
+
+    dS_A / dt = (π c v) / (3 beta_eff)            (t < L / (2 v))
+
+where
+
+- `c` is the central charge of the post-quench critical Hamiltonian
+  (provided by the universality dispatch),
+- `v` is the propagation velocity (Lieb-Robinson for free-fermion
+  models; a model-dependent sound velocity in general),
+- `beta_eff` is the effective inverse temperature of the generalised-
+  Gibbs steady state, set by the initial state energy density.
+
+Reference: Calabrese-Cardy J. Stat. Mech. P04010 (2005). Tracking #580.
+"""
+function fetch(
+    model::Universality{C},
+    ::EntanglementGrowthSlope,
+    ::Infinite;
+    v::Real,
+    beta_eff::Real,
+    kwargs...,
+) where {C}
+    v > 0 || throw(ArgumentError("EntanglementGrowthSlope: v must be > 0; got v=$v."))
+    beta_eff > 0 || throw(
+        ArgumentError(
+            "EntanglementGrowthSlope: beta_eff must be > 0; got beta_eff=$beta_eff."
+        ),
+    )
+    c = _cardy_central_charge(model; kwargs...)
+    return π * c * v / (3 * beta_eff)
+end

--- a/test/universalities/test_universality_entanglement_growth_slope.jl
+++ b/test/universalities/test_universality_entanglement_growth_slope.jl
@@ -1,0 +1,86 @@
+using Test
+using QAtlas
+using QAtlas: Universality, EntanglementGrowthSlope, Infinite, CentralCharge
+
+@testset "Universality EntanglementGrowthSlope (Calabrese-Cardy 2005, #580)" begin
+    @testset "Formula πcv/(3β_eff) across 5 universality classes" begin
+        d_for = Dict(:Ising=>2, :XY=>2, :Heisenberg=>1, :Potts3=>2, :Potts4=>2)
+        for class in (:Ising, :XY, :Heisenberg, :Potts3, :Potts4)
+            c = float(QAtlas.fetch(Universality(class), CentralCharge(); d=d_for[class]))
+            for v in (1.0, 2.0, 5.0), β_eff in (1.0, 5.0, 50.0)
+                slope = QAtlas.fetch(
+                    Universality(class),
+                    EntanglementGrowthSlope(),
+                    Infinite();
+                    v=v,
+                    beta_eff=β_eff,
+                )
+                expected = π * c * v / (3 * β_eff)
+                @test slope ≈ expected atol = 1e-14
+            end
+        end
+    end
+
+    @testset "Linearity in v (fixed c, β_eff)" begin
+        for class in (:Ising, :Heisenberg)
+            d = class == :Heisenberg ? 1 : 2
+            β_eff = 4.0
+            s1 = QAtlas.fetch(
+                Universality(class),
+                EntanglementGrowthSlope(),
+                Infinite();
+                v=1.0,
+                beta_eff=β_eff,
+            )
+            s3 = QAtlas.fetch(
+                Universality(class),
+                EntanglementGrowthSlope(),
+                Infinite();
+                v=3.0,
+                beta_eff=β_eff,
+            )
+            @test s3 ≈ 3 * s1 atol = 1e-14
+        end
+    end
+
+    @testset "Inverse linearity in β_eff (fixed c, v)" begin
+        v = 2.5
+        for class in (:Ising, :Heisenberg)
+            s1 = QAtlas.fetch(
+                Universality(class),
+                EntanglementGrowthSlope(),
+                Infinite();
+                v=v,
+                beta_eff=1.0,
+            )
+            s10 = QAtlas.fetch(
+                Universality(class),
+                EntanglementGrowthSlope(),
+                Infinite();
+                v=v,
+                beta_eff=10.0,
+            )
+            @test s10 ≈ s1 / 10 atol = 1e-14
+        end
+    end
+
+    @testset "Argument validation: v > 0, β_eff > 0" begin
+        @test_throws ArgumentError QAtlas.fetch(
+            Universality(:Ising),
+            EntanglementGrowthSlope(),
+            Infinite();
+            v=-1.0,
+            beta_eff=1.0,
+        )
+        @test_throws ArgumentError QAtlas.fetch(
+            Universality(:Ising), EntanglementGrowthSlope(), Infinite(); v=1.0, beta_eff=0.0
+        )
+        @test_throws ArgumentError QAtlas.fetch(
+            Universality(:Heisenberg),
+            EntanglementGrowthSlope(),
+            Infinite();
+            v=0.0,
+            beta_eff=1.0,
+        )
+    end
+end


### PR DESCRIPTION
**P3 stack migration — framework-integrated re-author of #588.**

#588 re-integrated on the bound/approx/universal framework (#617 -> #618 -> #619). Skipped-bound baggage (CHSH/Chaos/Bekenstein/Mermin/Cloning — already in bounds/ via #618) dropped during integration. Universality{C} quantities stay fetch-level CFT predictions; concrete-model rows register status=:exact (method=:delegation where they inherit a class value).

Base branch: `feat/p3-mutual-information` (previous in the P3 chain). Verified at the stack tip: cumulative load + universality test suite + registry coherence green.

Re-integration of #588.

[Claude Code]