### PR TITLE
feat(Universality): ConformalCasimirEnergy = -pi c/(6 L) [P3 #590]

### DIFF
--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -117,7 +117,8 @@ export FermiVelocity,
     LiebRobinsonVelocity,
     MutualInformation,
     EntanglementGrowthSlope,
-    CardyEntropy
+    CardyEntropy,
+    ConformalCasimirEnergy
 export SteadyStateCurrent                                # TASEP / non-equilibrium current (#241)
 export E8Spectrum
 export LiebRobinsonBound  # status-axis example (:bound)

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -586,6 +586,22 @@ Cardy-Verlinde / black-hole-entropy correspondences. Tracking: #580.
 struct CardyEntropy <: AbstractQuantity end
 
 """
+    ConformalCasimirEnergy() <: AbstractQuantity
+
+Universal Casimir (ground-state) energy of a 1+1D CFT on a cylinder
+of circumference `L` (PBC). Cardy 1986 / Blote-Cardy-Nightingale 1986
+/ Affleck 1986 showed it is determined entirely by the central charge:
+
+    E_0(L) = -π c / (6 L).
+
+This is the strict thermodynamic-limit subtraction `lim_{L->∞}
+(E_GS(L) - L * e_∞) * L` that extracts the universal finite-size
+correction.  Sign convention follows the original PRL: `E_0 < 0` for
+unitary CFTs with `c > 0`. Tracking: #580.
+"""
+struct ConformalCasimirEnergy <: AbstractQuantity end
+
+"""
     E8Spectrum() <: AbstractQuantity
 
 Zamolodchikov E8 mass spectrum (8 stable particles).  Concrete

--- a/src/universalities/CardyEntanglement.jl
+++ b/src/universalities/CardyEntanglement.jl
@@ -606,3 +606,34 @@ function fetch(
     c = _cardy_central_charge(model; kwargs...)
     return 2 * π * sqrt(c * E / 6)
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Conformal Casimir energy on a cylinder (#580)
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    fetch(::Universality{C}, ::ConformalCasimirEnergy, ::Infinite;
+          L::Real, kwargs...) -> Float64
+
+Universal Casimir ground-state energy of a 1+1D CFT on a cylinder of
+circumference `L` (Cardy 1986 / Blote-Cardy-Nightingale 1986 /
+Affleck 1986):
+
+    E_0(L) = -π c / (6 L).
+
+The sign convention follows the original PRLs (`E_0 < 0` for unitary
+CFTs with `c > 0`). Identified empirically by subtracting `L * e_∞`
+from the lattice ground-state energy on a periodic chain of `L` sites
+and rescaling by `L`.
+
+Reference: Cardy *Nucl. Phys. B* **270**, 186 (1986); Blote-Cardy-
+Nightingale *Phys. Rev. Lett.* **56**, 742 (1986); Affleck *Phys. Rev.
+Lett.* **56**, 746 (1986).
+"""
+function fetch(
+    model::Universality{C}, ::ConformalCasimirEnergy, ::Infinite; L::Real, kwargs...
+) where {C}
+    L > 0 || throw(ArgumentError("ConformalCasimirEnergy: L must be > 0; got L=$L."))
+    c = _cardy_central_charge(model; kwargs...)
+    return -π * c / (6 * L)
+end

--- a/test/universalities/test_universality_conformal_casimir_energy.jl
+++ b/test/universalities/test_universality_conformal_casimir_energy.jl
@@ -1,0 +1,66 @@
+using Test
+using QAtlas
+using QAtlas: Universality, ConformalCasimirEnergy, Infinite, CentralCharge
+
+@testset "Universality ConformalCasimirEnergy = -π c / (6 L) Cardy 1986 (#580)" begin
+    @testset "Formula across 5 universality classes" begin
+        d_for = Dict(:Ising=>2, :XY=>2, :Heisenberg=>1, :Potts3=>2, :Potts4=>2)
+        for class in (:Ising, :XY, :Heisenberg, :Potts3, :Potts4)
+            c = float(QAtlas.fetch(Universality(class), CentralCharge(); d=d_for[class]))
+            for L in (1.0, 5.0, 20.0, 100.0, 1000.0)
+                E0 = QAtlas.fetch(
+                    Universality(class), ConformalCasimirEnergy(), Infinite(); L=L
+                )
+                expected = -π * c / (6 * L)
+                @test E0 ≈ expected atol = 1e-14
+            end
+        end
+    end
+
+    @testset "E_0 < 0 for unitary classes (c > 0)" begin
+        for class in (:Ising, :XY, :Heisenberg, :Potts3, :Potts4)
+            E0 = QAtlas.fetch(
+                Universality(class), ConformalCasimirEnergy(), Infinite(); L=10.0
+            )
+            @test E0 < 0
+        end
+    end
+
+    @testset "E_0(L) decays as 1/L" begin
+        for class in (:Ising, :Heisenberg)
+            E1 = QAtlas.fetch(
+                Universality(class), ConformalCasimirEnergy(), Infinite(); L=1.0
+            )
+            E10 = QAtlas.fetch(
+                Universality(class), ConformalCasimirEnergy(), Infinite(); L=10.0
+            )
+            E100 = QAtlas.fetch(
+                Universality(class), ConformalCasimirEnergy(), Infinite(); L=100.0
+            )
+            @test E10 ≈ E1 / 10 atol = 1e-14
+            @test E100 ≈ E1 / 100 atol = 1e-14
+        end
+    end
+
+    @testset "E_0 linear in c at fixed L" begin
+        L = 5.0
+        E_Ising = QAtlas.fetch(
+            Universality(:Ising), ConformalCasimirEnergy(), Infinite(); L=L
+        )
+        E_Heis = QAtlas.fetch(
+            Universality(:Heisenberg), ConformalCasimirEnergy(), Infinite(); L=L
+        )
+        c_I = float(QAtlas.fetch(Universality(:Ising), CentralCharge(); d=2))
+        c_H = float(QAtlas.fetch(Universality(:Heisenberg), CentralCharge(); d=1))
+        @test E_Heis / E_Ising ≈ c_H / c_I atol = 1e-12
+    end
+
+    @testset "Argument validation" begin
+        @test_throws ArgumentError QAtlas.fetch(
+            Universality(:Ising), ConformalCasimirEnergy(), Infinite(); L=0.0
+        )
+        @test_throws ArgumentError QAtlas.fetch(
+            Universality(:Heisenberg), ConformalCasimirEnergy(), Infinite(); L=-1.0
+        )
+    end
+end


### PR DESCRIPTION
**P3 stack migration — framework-integrated re-author of #590.**

#590 re-integrated on the bound/approx/universal framework (#617 -> #618 -> #619). Skipped-bound baggage (CHSH/Chaos/Bekenstein/Mermin/Cloning — already in bounds/ via #618) dropped during integration. Universality{C} quantities stay fetch-level CFT predictions; concrete-model rows register status=:exact (method=:delegation where they inherit a class value).

Base branch: `feat/p3-cardy-entropy` (previous in the P3 chain). Verified at the stack tip: cumulative load + universality test suite + registry coherence green.

Re-integration of #590.

[Claude Code]