### PR TITLE
feat(TFIM): EntanglementGrowthSlope wrapper at h=J [P3 #595]

### DIFF
--- a/src/models/quantum/TFIM/TFIM.jl
+++ b/src/models/quantum/TFIM/TFIM.jl
@@ -335,3 +335,50 @@ function fetch(
 )
     return 2 * min(abs(J), abs(h))
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# EntanglementGrowthSlope wrapper at h = J critical (#580 / #579 cross)
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    fetch(model::TFIM, ::EntanglementGrowthSlope, ::Infinite;
+          beta_eff::Real, kwargs...) -> Float64
+
+Linear-growth slope of post-quench half-system entanglement entropy
+for the TFIM at the Ising critical point `h = J`. Wires together two
+universality-layer pieces
+
+    c = 1/2          (Universality(:Ising) CentralCharge)
+    v_LR = 2 |J|     (TFIM LiebRobinsonVelocity at h = J critical)
+
+into the Calabrese-Cardy 2005 result
+
+    dS_A/dt = π c v_LR / (3 beta_eff) = π J / (3 beta_eff).
+
+For non-critical TFIM (`h ≠ J`, gapped) the CC linear-growth picture
+does not apply and `DomainError` is thrown.
+
+Reference: Calabrese-Cardy *J. Stat. Mech.* P04010 (2005);
+combines universality-layer dispatches from PR #588 and the TFIM
+LiebRobinsonVelocity from PR #586 / fix #592.
+"""
+function fetch(
+    model::TFIM, ::EntanglementGrowthSlope, ::Infinite; beta_eff::Real, kwargs...
+)
+    isapprox(model.h, model.J; atol=1e-10) || throw(
+        DomainError(
+            (model.J, model.h),
+            "TFIM EntanglementGrowthSlope at Infinite is defined only at the Ising " *
+            "critical point h = J (gapless c = 1/2 CFT); off-critical TFIM is gapped " *
+            "and CC linear-growth does not apply. Got (J, h) = (\$(model.J), \$(model.h)).",
+        ),
+    )
+    return fetch(
+        Universality(:Ising),
+        EntanglementGrowthSlope(),
+        Infinite();
+        v=fetch(model, LiebRobinsonVelocity(), Infinite()),
+        beta_eff=beta_eff,
+        kwargs...,
+    )
+end

--- a/test/models/quantum/TFIM/test_TFIM_entanglement_growth_slope.jl
+++ b/test/models/quantum/TFIM/test_TFIM_entanglement_growth_slope.jl
@@ -1,0 +1,43 @@
+using Test
+using QAtlas
+using QAtlas: TFIM, EntanglementGrowthSlope, Infinite, Universality, LiebRobinsonVelocity
+
+@testset "TFIM EntanglementGrowthSlope wrapper at h=J critical (#580 + #579 cross)" begin
+    @testset "Slope = π J / (3 β_eff) at h = J critical" begin
+        for J in (0.5, 1.0, 2.0, 5.0), β in (1.0, 5.0, 20.0)
+            m = TFIM(; J=J, h=J)
+            slope = QAtlas.fetch(m, EntanglementGrowthSlope(), Infinite(); beta_eff=β)
+            expected = π * J / (3 * β)
+            @test slope ≈ expected atol = 1e-14
+        end
+    end
+
+    @testset "End-to-end chain: c(Ising) · v(TFIM) / (3 β_eff)" begin
+        m = TFIM(; J=1.5, h=1.5)
+        β = 4.0
+        slope_model = QAtlas.fetch(m, EntanglementGrowthSlope(), Infinite(); beta_eff=β)
+        c = float(QAtlas.fetch(Universality(:Ising), QAtlas.CentralCharge(); d=2))
+        v = QAtlas.fetch(m, LiebRobinsonVelocity(), Infinite())
+        slope_chain = π * c * v / (3 * β)
+        @test slope_model ≈ slope_chain atol = 1e-14
+        # Verify the values: c = 1/2, v = 2J = 3.0, expected = π·0.5·3 / 12 = π/8
+        @test slope_chain ≈ π / 8 atol = 1e-14
+    end
+
+    @testset "Off-critical h ≠ J: DomainError" begin
+        for (J, h) in ((1.0, 0.5), (1.0, 2.0), (1.0, 1.5))
+            m = TFIM(; J=J, h=h)
+            @test_throws DomainError QAtlas.fetch(
+                m, EntanglementGrowthSlope(), Infinite(); beta_eff=5.0
+            )
+        end
+    end
+
+    @testset "Critical detection tolerance" begin
+        # Within 1e-10 of criticality should still delegate (not throw).
+        m = TFIM(; J=1.0, h=1.0 + 1e-12)
+        slope = QAtlas.fetch(m, EntanglementGrowthSlope(), Infinite(); beta_eff=1.0)
+        @test isfinite(slope)
+        @test slope > 0
+    end
+end


### PR DESCRIPTION
**P3 stack migration — framework-integrated re-author of #595.**

#595 re-integrated on the bound/approx/universal framework (#617 -> #618 -> #619). Skipped-bound baggage (CHSH/Chaos/Bekenstein/Mermin/Cloning — already in bounds/ via #618) dropped during integration. Universality{C} quantities stay fetch-level CFT predictions; concrete-model rows register status=:exact (method=:delegation where they inherit a class value).

Base branch: `feat/p3-page-entropy` (previous in the P3 chain). Verified at the stack tip: cumulative load + universality test suite + registry coherence green.

Re-integration of #595.

[Claude Code]