### PR TITLE
feat(Universality): TopologicalEntanglementEntropy Kitaev-Preskill 2006 [P3 #596]

### DIFF
--- a/src/universalities/CardyEntanglement.jl
+++ b/src/universalities/CardyEntanglement.jl
@@ -776,3 +776,58 @@ function fetch(
     end
     return s - (m - 1) / (2.0 * n)
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Topological entanglement entropy via total quantum dimension (#580)
+#
+# Kitaev-Preskill 2006 (DOI 10.1103/PhysRevLett.96.110404) and Levin-Wen
+# 2006 (DOI 10.1103/PhysRevLett.96.110405) showed that the subleading
+# constant in the entanglement entropy of a topologically ordered
+# 2D ground state is the universal piece
+#
+#     gamma = log D,      D = sqrt(sum_a d_a^2),
+#
+# where {d_a} are the quantum dimensions of the anyon types and D is
+# the total quantum dimension. Examples:
+#
+#     ToricCode:      anyons {1, e, m, eps},  d_a = (1,1,1,1) -> D = 2  -> gamma = log 2
+#     Ising anyon:    anyons {1, sigma, psi},  d_a = (1, sqrt 2, 1) -> D = 2 -> gamma = log 2
+#     Fibonacci:      anyons {1, tau},  d_a = (1, phi),  phi = (1+sqrt 5)/2 -> D = sqrt(2+phi)
+#
+# Tracking: #580.
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    fetch(::Universality{:TopologicalOrder}, ::TopologicalEntanglementEntropy,
+          ::Infinite; quantum_dimensions::AbstractVector{<:Real}, kwargs...)
+        -> Float64
+
+Universal topological entanglement entropy of a 2D topologically
+ordered ground state in the Kitaev-Preskill / Levin-Wen convention,
+
+    gamma = log D,    D = sqrt(sum_a d_a^2),
+
+with `quantum_dimensions = [d_a]` the vector of anyon quantum
+dimensions. References: Kitaev-Preskill 2006 (PRL 96, 110404);
+Levin-Wen 2006 (PRL 96, 110405).
+"""
+function fetch(
+    ::Universality{:TopologicalOrder},
+    ::TopologicalEntanglementEntropy,
+    ::Infinite;
+    quantum_dimensions::AbstractVector{<:Real},
+    kwargs...,
+)
+    isempty(quantum_dimensions) && throw(
+        ArgumentError(
+            "TopologicalEntanglementEntropy: quantum_dimensions must be non-empty."
+        ),
+    )
+    all(d -> d > 0, quantum_dimensions) || throw(
+        ArgumentError(
+            "TopologicalEntanglementEntropy: all quantum dimensions d_a must be > 0."
+        ),
+    )
+    D_sq = sum(d -> d^2, quantum_dimensions)
+    return 0.5 * log(D_sq)
+end

--- a/test/universalities/test_universality_topological_entanglement_entropy.jl
+++ b/test/universalities/test_universality_topological_entanglement_entropy.jl
@@ -1,0 +1,94 @@
+using Test
+using QAtlas
+using QAtlas: Universality, TopologicalEntanglementEntropy, Infinite, ToricCode
+
+@testset "Universality(:TopologicalOrder) TopologicalEntanglementEntropy Kitaev-Preskill 2006 (#580)" begin
+    @testset "Abelian Z_2 (Toric Code, 4 anyons of d=1): gamma = log 2" begin
+        γ = QAtlas.fetch(
+            Universality(:TopologicalOrder),
+            TopologicalEntanglementEntropy(),
+            Infinite();
+            quantum_dimensions=[1.0, 1.0, 1.0, 1.0],
+        )
+        @test γ ≈ log(2) atol = 1e-14
+    end
+
+    @testset "Ising anyon (3 sectors d=1,sqrt(2),1): gamma = log 2" begin
+        γ = QAtlas.fetch(
+            Universality(:TopologicalOrder),
+            TopologicalEntanglementEntropy(),
+            Infinite();
+            quantum_dimensions=[1.0, sqrt(2.0), 1.0],
+        )
+        @test γ ≈ log(2) atol = 1e-14
+    end
+
+    @testset "Fibonacci (2 sectors, golden ratio): gamma = (1/2) log(1 + phi^2)" begin
+        ϕ = (1 + sqrt(5)) / 2
+        γ = QAtlas.fetch(
+            Universality(:TopologicalOrder),
+            TopologicalEntanglementEntropy(),
+            Infinite();
+            quantum_dimensions=[1.0, ϕ],
+        )
+        @test γ ≈ 0.5 * log(1 + ϕ^2) atol = 1e-14
+    end
+
+    @testset "Cross-check with existing ToricCode model dispatch" begin
+        # Existing model-side fetch should agree (γ = log 2).
+        γ_model = QAtlas.fetch(ToricCode(), TopologicalEntanglementEntropy(), Infinite())
+        γ_univ = QAtlas.fetch(
+            Universality(:TopologicalOrder),
+            TopologicalEntanglementEntropy(),
+            Infinite();
+            quantum_dimensions=[1.0, 1.0, 1.0, 1.0],
+        )
+        @test γ_model ≈ γ_univ atol = 1e-14
+    end
+
+    @testset "Trivial state (single trivial sector): gamma = 0" begin
+        γ = QAtlas.fetch(
+            Universality(:TopologicalOrder),
+            TopologicalEntanglementEntropy(),
+            Infinite();
+            quantum_dimensions=[1.0],
+        )
+        @test γ ≈ 0.0 atol = 1e-14
+    end
+
+    @testset "D_n discrete gauge theory: gamma = log n" begin
+        # Z_n gauge theory has n^2 abelian anyons all with d_a = 1,
+        # so D = sqrt(n^2) = n -> gamma = log n.
+        for n in (2, 3, 4, 5, 10)
+            dims = ones(n^2)
+            γ = QAtlas.fetch(
+                Universality(:TopologicalOrder),
+                TopologicalEntanglementEntropy(),
+                Infinite();
+                quantum_dimensions=dims,
+            )
+            @test γ ≈ log(n) atol = 1e-14
+        end
+    end
+
+    @testset "Argument validation" begin
+        @test_throws ArgumentError QAtlas.fetch(
+            Universality(:TopologicalOrder),
+            TopologicalEntanglementEntropy(),
+            Infinite();
+            quantum_dimensions=Float64[],
+        )
+        @test_throws ArgumentError QAtlas.fetch(
+            Universality(:TopologicalOrder),
+            TopologicalEntanglementEntropy(),
+            Infinite();
+            quantum_dimensions=[1.0, 0.0, 1.0],
+        )
+        @test_throws ArgumentError QAtlas.fetch(
+            Universality(:TopologicalOrder),
+            TopologicalEntanglementEntropy(),
+            Infinite();
+            quantum_dimensions=[1.0, -2.0, 1.0],
+        )
+    end
+end


### PR DESCRIPTION
**P3 stack migration — framework-integrated re-author of #596.**

#596 re-integrated on the bound/approx/universal framework (#617 -> #618 -> #619). Skipped-bound baggage (CHSH/Chaos/Bekenstein/Mermin/Cloning — already in bounds/ via #618) dropped during integration. Universality{C} quantities stay fetch-level CFT predictions; concrete-model rows register status=:exact (method=:delegation where they inherit a class value).

Base branch: `feat/p3-tfim-egs-wrapper` (previous in the P3 chain). Verified at the stack tip: cumulative load + universality test suite + registry coherence green.

Re-integration of #596.

[Claude Code]