### PR TITLE
feat(Universality): ThermalEnergyDensity = pi c/(6 beta^2) Affleck 1986 [P3 #600]

### DIFF
--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -121,7 +121,9 @@ export FermiVelocity,
     ConformalCasimirEnergy,
     LogarithmicNegativity,
     BoundaryEntropy,
-    PageEntropy
+    PageEntropy,
+    EntanglementSaturationDensity,
+    ThermalEnergyDensity
 export SteadyStateCurrent                                # TASEP / non-equilibrium current (#241)
 export E8Spectrum
 export LiebRobinsonBound  # status-axis example (:bound)

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -589,6 +589,23 @@ linear regime). Reference: Calabrese-Cardy J. Stat. Mech. P04010
 struct EntanglementSaturationDensity <: AbstractQuantity end
 
 """
+    ThermalEnergyDensity <: AbstractQuantity
+
+Leading low-temperature thermal energy density of a (1+1)D
+conformal field theory above its ground state,
+
+    e(T) - e_0 = pi c T^2 / 6 = pi c / (6 beta^2),
+
+where  is the central charge and  (Affleck 1986;
+Bloete-Cardy-Nightingale 1986). This is the universal counterpart of
+[](@ref): the same  prefactor that
+controls the Casimir term in finite size also fixes the leading
+thermal-excitation density in finite temperature, via modular
+invariance.
+"""
+struct ThermalEnergyDensity <: AbstractQuantity end
+
+"""
     CardyEntropy() <: AbstractQuantity
 
 Asymptotic high-energy entropy (log of the density of states) of a

--- a/src/universalities/CardyEntanglement.jl
+++ b/src/universalities/CardyEntanglement.jl
@@ -867,3 +867,34 @@ function fetch(
     c = _cardy_central_charge(model; kwargs...)
     return π * c / (6 * beta_eff)
 end
+
+# -----------------------------------------------------------------------------
+# Thermal energy density (Affleck 1986; Bloete-Cardy-Nightingale 1986)
+# -----------------------------------------------------------------------------
+
+"""
+    fetch(::Universality{C}, ::ThermalEnergyDensity, ::Infinite;
+          beta::Real, kwargs...) where {C} -> Float64
+
+Leading thermal energy density above the ground state for a
+(1+1)D CFT with central charge ,
+
+    e(T) - e_0 = pi c / (6 beta^2).
+
+This is the universal complement of
+[](@ref): modular invariance interchanges the
+finite-size Casimir energy and the finite-temperature thermal energy
+with identical coefficient .
+
+Reference: I. Affleck *Phys. Rev. Lett.* **56**, 746 (1986);
+Bloete-Cardy-Nightingale *Phys. Rev. Lett.* **56**, 742 (1986).
+"""
+function fetch(
+    ::Universality{C}, ::ThermalEnergyDensity, ::Infinite; beta::Real, kwargs...
+) where {C}
+    beta > 0 || throw(
+        DomainError(beta, "ThermalEnergyDensity requires beta > 0; got beta = $beta.")
+    )
+    c = _cardy_central_charge(Universality(C))
+    return π * c / (6 * beta^2)
+end

--- a/test/universalities/test_universality_thermal_energy_density.jl
+++ b/test/universalities/test_universality_thermal_energy_density.jl
@@ -1,0 +1,42 @@
+using Test
+using QAtlas
+
+@testset "Universality ThermalEnergyDensity (Affleck 1986)" begin
+    for sym in (:Ising, :Heisenberg, :XY, :Potts3, :Potts4)
+        u = QAtlas.Universality(sym)
+        c = QAtlas._cardy_central_charge(u)
+        for β in (1.0, 2.0, 5.0, 10.0, 0.5)
+            e_th = QAtlas.fetch(u, QAtlas.ThermalEnergyDensity(), QAtlas.Infinite(); beta=β)
+            ref = π * Float64(c) / (6 * β^2)
+            @test e_th ≈ ref atol = 1e-12
+        end
+    end
+
+    @testset "DomainError on non-positive beta" begin
+        u = QAtlas.Universality(:Ising)
+        @test_throws DomainError QAtlas.fetch(
+            u, QAtlas.ThermalEnergyDensity(), QAtlas.Infinite(); beta=0.0
+        )
+        @test_throws DomainError QAtlas.fetch(
+            u, QAtlas.ThermalEnergyDensity(), QAtlas.Infinite(); beta=-1.0
+        )
+    end
+
+    @testset "Linear in c (Ising vs Heisenberg ratio = 1/2)" begin
+        β = 3.0
+        u_is = QAtlas.Universality(:Ising)
+        u_he = QAtlas.Universality(:Heisenberg)
+        e_is = QAtlas.fetch(u_is, QAtlas.ThermalEnergyDensity(), QAtlas.Infinite(); beta=β)
+        e_he = QAtlas.fetch(u_he, QAtlas.ThermalEnergyDensity(), QAtlas.Infinite(); beta=β)
+        @test e_is / e_he ≈ 0.5 atol = 1e-12
+    end
+
+    @testset "Scales as 1/beta^2" begin
+        u = QAtlas.Universality(:Heisenberg)
+        e_b1 = QAtlas.fetch(u, QAtlas.ThermalEnergyDensity(), QAtlas.Infinite(); beta=1.0)
+        e_b2 = QAtlas.fetch(u, QAtlas.ThermalEnergyDensity(), QAtlas.Infinite(); beta=2.0)
+        e_b4 = QAtlas.fetch(u, QAtlas.ThermalEnergyDensity(), QAtlas.Infinite(); beta=4.0)
+        @test e_b1 / e_b2 ≈ 4.0 atol = 1e-12
+        @test e_b2 / e_b4 ≈ 4.0 atol = 1e-12
+    end
+end


### PR DESCRIPTION
**P3 stack migration — framework-integrated re-author of #600.**

#600 re-integrated on the bound/approx/universal framework (#617 -> #618 -> #619). Skipped-bound baggage (CHSH/Chaos/Bekenstein/Mermin/Cloning — already in bounds/ via #618) dropped during integration. Universality{C} quantities stay fetch-level CFT predictions; concrete-model rows register status=:exact (method=:delegation where they inherit a class value).

Base branch: `feat/p3-hs-lr-slope` (previous in the P3 chain). Verified at the stack tip: cumulative load + universality test suite + registry coherence green.

Re-integration of #600.

[Claude Code]