### PR TITLE
feat(XXZ1D): LiebRobinsonVelocity + EntanglementGrowthSlope at XX point [P3 #606]

### DIFF
--- a/src/models/quantum/XXZ/XXZ_xx_quench.jl
+++ b/src/models/quantum/XXZ/XXZ_xx_quench.jl
@@ -244,3 +244,69 @@ function fetch(
     # See `(♣) / (♠)` in the file header for the full derivation.
     return 0.0
 end
+
+# -----------------------------------------------------------------------------
+# Lieb-Robinson velocity + entanglement growth slope at the XX point (Delta = 0)
+# -----------------------------------------------------------------------------
+
+"""
+    fetch(model::XXZ1D, ::LiebRobinsonVelocity, ::Infinite;
+          J = model.J, Delta = model.Δ, kwargs...) -> Float64
+
+Maximum group velocity of the free-fermion XX chain (`Delta = 0`).
+The single-particle dispersion is `epsilon(k) = -2 J cos k`, and its
+group-velocity maximum is
+
+    v_LR = 2 |J|,
+
+attained at `k = pi / 2`. For `Delta != 0` the LR bound is more
+involved (interacting regime) and is deferred — this dispatch throws
+`DomainError`.
+"""
+function fetch(
+    model::XXZ1D,
+    ::LiebRobinsonVelocity,
+    ::Infinite;
+    J::Real=model.J,
+    Delta::Real=model.Δ,
+    kwargs...,
+)
+    isapprox(Delta, 0.0; atol=1e-12) || throw(
+        DomainError(
+            Delta,
+            "XXZ1D LiebRobinsonVelocity: closed form only at the XX point (Delta = 0); got Delta = $Delta.",
+        ),
+    )
+    return 2 * abs(J)
+end
+
+"""
+    fetch(model::XXZ1D, ::EntanglementGrowthSlope, ::Infinite;
+          beta_eff::Real, kwargs...) -> Float64
+
+Calabrese-Cardy 2005 linear-growth slope of half-system entanglement
+after a quench at the XX point of the XXZ chain. The chain is
+gapless with central charge `c = 1` and LR velocity `v = 2 |J|`, so
+
+    dS_A / dt = pi c v / (3 beta_eff) = 2 pi |J| / (3 beta_eff).
+
+Delegates to `Universality(:XY)` (c = 1).
+"""
+function fetch(
+    model::XXZ1D, ::EntanglementGrowthSlope, ::Infinite; beta_eff::Real, kwargs...
+)
+    isapprox(model.Δ, 0.0; atol=1e-12) || throw(
+        DomainError(
+            model.Δ,
+            "XXZ1D EntanglementGrowthSlope: closed form only at the XX point (Delta = 0); got Delta = $(model.Δ).",
+        ),
+    )
+    return fetch(
+        Universality(:XY),
+        EntanglementGrowthSlope(),
+        Infinite();
+        v=fetch(model, LiebRobinsonVelocity(), Infinite()),
+        beta_eff=beta_eff,
+        kwargs...,
+    )
+end

--- a/test/models/quantum/XXZ/test_xxz_xx_lr_slope.jl
+++ b/test/models/quantum/XXZ/test_xxz_xx_lr_slope.jl
@@ -1,0 +1,41 @@
+using Test
+using QAtlas
+
+@testset "XXZ1D LR velocity + slope at XX point (Δ = 0)" begin
+    @testset "LiebRobinsonVelocity = 2|J|" begin
+        for J in (0.5, 1.0, 2.0, 5.0)
+            m = QAtlas.XXZ1D(; J=J, Δ=0.0)
+            v = QAtlas.fetch(m, QAtlas.LiebRobinsonVelocity(), QAtlas.Infinite())
+            @test v ≈ 2 * abs(J) atol = 1e-12
+        end
+        m_neg = QAtlas.XXZ1D(; J=1.0, Δ=0.0)
+        v_neg = QAtlas.fetch(
+            m_neg, QAtlas.LiebRobinsonVelocity(), QAtlas.Infinite(); J=-3.7
+        )
+        @test v_neg ≈ 2 * 3.7 atol = 1e-12
+    end
+
+    @testset "EntanglementGrowthSlope = πcv/(3β_eff) with c=1, v=2|J|" begin
+        for J in (1.0, 2.0)
+            m = QAtlas.XXZ1D(; J=J, Δ=0.0)
+            for β in (1.0, 2.0, 5.0, 10.0)
+                slope = QAtlas.fetch(
+                    m, QAtlas.EntanglementGrowthSlope(), QAtlas.Infinite(); beta_eff=β
+                )
+                @test slope ≈ 2π * abs(J) / (3 * β) atol = 1e-12
+            end
+        end
+    end
+
+    @testset "DomainError off the XX point (Δ != 0)" begin
+        for Δ in (0.1, 0.5, 1.0, -0.5)
+            m = QAtlas.XXZ1D(; J=1.0, Δ=Δ)
+            @test_throws DomainError QAtlas.fetch(
+                m, QAtlas.LiebRobinsonVelocity(), QAtlas.Infinite()
+            )
+            @test_throws DomainError QAtlas.fetch(
+                m, QAtlas.EntanglementGrowthSlope(), QAtlas.Infinite(); beta_eff=1.0
+            )
+        end
+    end
+end


### PR DESCRIPTION
**P3 stack migration — framework-integrated re-author of #606.**

#606 re-integrated on the bound/approx/universal framework (#617 -> #618 -> #619). Skipped-bound baggage (CHSH/Chaos/Bekenstein/Mermin/Cloning — already in bounds/ via #618) dropped during integration. Universality{C} quantities stay fetch-level CFT predictions; concrete-model rows register status=:exact (method=:delegation where they inherit a class value).

Base branch: `feat/p3-thermal-entropy-density` (previous in the P3 chain). Verified at the stack tip: cumulative load + universality test suite + registry coherence green.

Re-integration of #606.

[Claude Code]