### PR TITLE
feat(TFIM): BoundaryEntropy at h=J delegates to Universality(:Ising) [P3 #607]

### DIFF
--- a/src/models/quantum/TFIM/TFIM_cft_entanglement.jl
+++ b/src/models/quantum/TFIM/TFIM_cft_entanglement.jl
@@ -160,3 +160,46 @@ function fetch(model::TFIM, q::RenyiEntropy, ::Infinite; ℓ::Int, beta::Real=In
     end
     return _tfim_cc_entanglement(model.J, model.h, ℓ, beta; α=q.α)
 end
+
+# -----------------------------------------------------------------------------
+# Affleck-Ludwig boundary entropy at criticality (h = J)
+# -----------------------------------------------------------------------------
+
+"""
+    fetch(m::TFIM, ::BoundaryEntropy, ::Infinite;
+          h = m.h, J = m.J, boundary_state::Symbol, kwargs...) -> Float64
+
+Affleck-Ludwig boundary entropy `log g` of the critical TFIM at the
+quantum critical point `h = J`. Delegates to `Universality(:Ising)`
+with the same `boundary_state`, which is dimensionless (independent
+of the sound velocity).
+
+Off-critical (`h != J`) is gapped and Affleck-Ludwig does not apply —
+this dispatch throws `DomainError`.
+
+Reference: Affleck-Ludwig *Phys. Rev. Lett.* **67**, 161 (1991).
+"""
+function fetch(
+    m::TFIM,
+    ::BoundaryEntropy,
+    ::Infinite;
+    h::Real=m.h,
+    J::Real=m.J,
+    boundary_state::Symbol,
+    kwargs...,
+)
+    isapprox(abs(h), abs(J); atol=1e-12) || throw(
+        DomainError(
+            (h, J),
+            "TFIM BoundaryEntropy: closed-form Affleck-Ludwig applies only at " *
+            "the critical point |h| = |J|; got (h, J) = ($h, $J).",
+        ),
+    )
+    return fetch(
+        Universality(:Ising),
+        BoundaryEntropy(),
+        Infinite();
+        boundary_state=boundary_state,
+        kwargs...,
+    )
+end

--- a/test/models/quantum/TFIM/test_tfim_boundary_entropy.jl
+++ b/test/models/quantum/TFIM/test_tfim_boundary_entropy.jl
@@ -1,0 +1,65 @@
+using Test
+using QAtlas
+
+@testset "TFIM BoundaryEntropy at criticality (h = J)" begin
+    @testset "Critical point: matches Universality(:Ising)" begin
+        for J in (0.5, 1.0, 2.0)
+            m = QAtlas.TFIM(; h=J, J=J)
+            for bs in (:identity, :fixed_up, :fixed_down, :epsilon, :sigma, :free)
+                g_model = QAtlas.fetch(
+                    m, QAtlas.BoundaryEntropy(), QAtlas.Infinite(); boundary_state=bs
+                )
+                g_univ = QAtlas.fetch(
+                    QAtlas.Universality(:Ising),
+                    QAtlas.BoundaryEntropy(),
+                    QAtlas.Infinite();
+                    boundary_state=bs,
+                )
+                @test g_model ≈ g_univ atol = 1e-12
+            end
+        end
+    end
+
+    @testset "Specific values at h = J = 1" begin
+        m = QAtlas.TFIM(; h=1.0, J=1.0)
+        @test QAtlas.fetch(
+            m, QAtlas.BoundaryEntropy(), QAtlas.Infinite(); boundary_state=:identity
+        ) ≈ -log(2) / 2 atol = 1e-12
+        @test QAtlas.fetch(
+            m, QAtlas.BoundaryEntropy(), QAtlas.Infinite(); boundary_state=:epsilon
+        ) ≈ -log(2) / 2 atol = 1e-12
+        @test QAtlas.fetch(
+            m, QAtlas.BoundaryEntropy(), QAtlas.Infinite(); boundary_state=:sigma
+        ) ≈ 0.0 atol = 1e-12
+        @test QAtlas.fetch(
+            m, QAtlas.BoundaryEntropy(), QAtlas.Infinite(); boundary_state=:free
+        ) ≈ 0.0 atol = 1e-12
+    end
+
+    @testset "Critical at |h| = |J| (negative J or h)" begin
+        m1 = QAtlas.TFIM(; h=2.0, J=-2.0)
+        @test QAtlas.fetch(
+            m1, QAtlas.BoundaryEntropy(), QAtlas.Infinite(); boundary_state=:sigma
+        ) ≈ 0.0 atol = 1e-12
+        m2 = QAtlas.TFIM(; h=-3.5, J=3.5)
+        @test QAtlas.fetch(
+            m2, QAtlas.BoundaryEntropy(), QAtlas.Infinite(); boundary_state=:identity
+        ) ≈ -log(2) / 2 atol = 1e-12
+    end
+
+    @testset "DomainError off-critical (|h| != |J|)" begin
+        for (h, J) in ((0.5, 1.0), (2.0, 1.0), (0.0, 1.0), (1.0, 0.5))
+            m = QAtlas.TFIM(; h=h, J=J)
+            @test_throws DomainError QAtlas.fetch(
+                m, QAtlas.BoundaryEntropy(), QAtlas.Infinite(); boundary_state=:identity
+            )
+        end
+    end
+
+    @testset "Bad boundary_state propagates from Universality" begin
+        m = QAtlas.TFIM(; h=1.0, J=1.0)
+        @test_throws ArgumentError QAtlas.fetch(
+            m, QAtlas.BoundaryEntropy(), QAtlas.Infinite(); boundary_state=:nonsense
+        )
+    end
+end


### PR DESCRIPTION
**P3 stack migration — framework-integrated re-author of #607.**

#607 re-integrated on the bound/approx/universal framework (#617 -> #618 -> #619). Skipped-bound baggage (CHSH/Chaos/Bekenstein/Mermin/Cloning — already in bounds/ via #618) dropped during integration. Universality{C} quantities stay fetch-level CFT predictions; concrete-model rows register status=:exact (method=:delegation where they inherit a class value).

Base branch: `feat/p3-xxz-lr-xx-point` (previous in the P3 chain). Verified at the stack tip: cumulative load + universality test suite + registry coherence green.

Re-integration of #607.

[Claude Code]