### PR TITLE
feat(TFIM,HaldaneShastry,XXZ1D): EntanglementSaturationDensity wrappers [P3 #608]

### DIFF
--- a/src/models/quantum/HaldaneShastry/HaldaneShastry_thermal_cft.jl
+++ b/src/models/quantum/HaldaneShastry/HaldaneShastry_thermal_cft.jl
@@ -260,3 +260,24 @@ function fetch(
         kwargs...,
     )
 end
+
+"""
+    fetch(::HaldaneShastry, ::EntanglementSaturationDensity, ::Infinite;
+          beta_eff::Real, kwargs...) -> Float64
+
+Long-time saturation `S_A(infty)/L = pi c / (6 beta_eff)` after a
+global quench. Haldane-Shastry is gapless with `c = 1`, so the
+formula gives `pi / (6 beta_eff)`. Delegates to
+`Universality(:Heisenberg)`.
+"""
+function fetch(
+    ::HaldaneShastry, ::EntanglementSaturationDensity, ::Infinite; beta_eff::Real, kwargs...
+)
+    return fetch(
+        Universality(:Heisenberg),
+        EntanglementSaturationDensity(),
+        Infinite();
+        beta_eff=beta_eff,
+        kwargs...,
+    )
+end

--- a/src/models/quantum/TFIM/TFIM_cft_entanglement.jl
+++ b/src/models/quantum/TFIM/TFIM_cft_entanglement.jl
@@ -203,3 +203,41 @@ function fetch(
         kwargs...,
     )
 end
+
+# -----------------------------------------------------------------------------
+# Post-quench entanglement saturation density at h = J (Calabrese-Cardy 2005)
+# -----------------------------------------------------------------------------
+
+"""
+    fetch(m::TFIM, ::EntanglementSaturationDensity, ::Infinite;
+          beta_eff::Real, h = m.h, J = m.J, kwargs...) -> Float64
+
+Long-time saturation `S_A(infty)/L = pi c / (6 beta_eff)` of the
+half-system entanglement entropy after a global quench at the
+critical TFIM point `|h| = |J|`. Delegates to `Universality(:Ising)`
+(c = 1/2).
+"""
+function fetch(
+    m::TFIM,
+    ::EntanglementSaturationDensity,
+    ::Infinite;
+    beta_eff::Real,
+    h::Real=m.h,
+    J::Real=m.J,
+    kwargs...,
+)
+    isapprox(abs(h), abs(J); atol=1e-12) || throw(
+        DomainError(
+            (h, J),
+            "TFIM EntanglementSaturationDensity: closed form applies only at the " *
+            "critical point |h| = |J|; got (h, J) = ($h, $J).",
+        ),
+    )
+    return fetch(
+        Universality(:Ising),
+        EntanglementSaturationDensity(),
+        Infinite();
+        beta_eff=beta_eff,
+        kwargs...,
+    )
+end

--- a/src/models/quantum/XXZ/XXZ_xx_quench.jl
+++ b/src/models/quantum/XXZ/XXZ_xx_quench.jl
@@ -310,3 +310,33 @@ function fetch(
         kwargs...,
     )
 end
+
+"""
+    fetch(model::XXZ1D, ::EntanglementSaturationDensity, ::Infinite;
+          beta_eff::Real, kwargs...) -> Float64
+
+Long-time saturation of post-quench half-system entanglement entropy
+at the XX point (`Delta = 0`). The XX chain is gapless with c = 1,
+so delegates to `Universality(:XY)` returning `pi / (6 beta_eff)`.
+
+Off-XX (`Delta != 0`) throws `DomainError` -- interacting regime
+deferred.
+"""
+function fetch(
+    model::XXZ1D, ::EntanglementSaturationDensity, ::Infinite; beta_eff::Real, kwargs...
+)
+    isapprox(model.Δ, 0.0; atol=1e-12) || throw(
+        DomainError(
+            model.Δ,
+            "XXZ1D EntanglementSaturationDensity: closed form only at the XX " *
+            "point (Delta = 0); got Delta = $(model.Δ).",
+        ),
+    )
+    return fetch(
+        Universality(:XY),
+        EntanglementSaturationDensity(),
+        Infinite();
+        beta_eff=beta_eff,
+        kwargs...,
+    )
+end

--- a/test/ci/universe.jl
+++ b/test/ci/universe.jl
@@ -12,6 +12,7 @@ const ALL_DIRS = [
     "util_verify/",
     "universalities/",
     "bounds/",
+    "cross_model/",
     "models/classical/",
     "models/quantum/TFIM/",
     "models/quantum/XXZ/",

--- a/test/cross_model/test_three_models_saturation_density.jl
+++ b/test/cross_model/test_three_models_saturation_density.jl
@@ -1,0 +1,69 @@
+using Test
+using QAtlas
+
+@testset "Three-model EntanglementSaturationDensity wrappers" begin
+    @testset "TFIM h = J critical → Universality(:Ising) (c = 1/2)" begin
+        for J in (1.0, 2.0)
+            m = QAtlas.TFIM(; h=J, J=J)
+            for β in (1.0, 2.0, 5.0)
+                s = QAtlas.fetch(
+                    m, QAtlas.EntanglementSaturationDensity(), QAtlas.Infinite(); beta_eff=β
+                )
+                ref = π * 0.5 / (6 * β)
+                @test s ≈ ref atol = 1e-12
+            end
+        end
+        m_off = QAtlas.TFIM(; h=0.5, J=1.0)
+        @test_throws DomainError QAtlas.fetch(
+            m_off, QAtlas.EntanglementSaturationDensity(), QAtlas.Infinite(); beta_eff=1.0
+        )
+    end
+
+    @testset "HaldaneShastry → Universality(:Heisenberg) (c = 1)" begin
+        for J in (0.5, 1.0, 2.0)
+            m = QAtlas.HaldaneShastry(; J=J)
+            for β in (1.0, 2.0, 5.0)
+                s = QAtlas.fetch(
+                    m, QAtlas.EntanglementSaturationDensity(), QAtlas.Infinite(); beta_eff=β
+                )
+                ref = π / (6 * β)
+                @test s ≈ ref atol = 1e-12
+            end
+        end
+    end
+
+    @testset "XXZ1D at XX (Δ = 0) → Universality(:XY) (c = 1)" begin
+        for J in (0.5, 1.0, 2.0)
+            m = QAtlas.XXZ1D(; J=J, Δ=0.0)
+            for β in (1.0, 2.0, 5.0)
+                s = QAtlas.fetch(
+                    m, QAtlas.EntanglementSaturationDensity(), QAtlas.Infinite(); beta_eff=β
+                )
+                ref = π / (6 * β)
+                @test s ≈ ref atol = 1e-12
+            end
+        end
+        for Δ in (0.5, 1.0, -0.5)
+            m_off = QAtlas.XXZ1D(; J=1.0, Δ=Δ)
+            @test_throws DomainError QAtlas.fetch(
+                m_off,
+                QAtlas.EntanglementSaturationDensity(),
+                QAtlas.Infinite();
+                beta_eff=1.0,
+            )
+        end
+    end
+
+    @testset "Universality central-charge ratio reflected in 3 models" begin
+        β = 3.0
+        m_tfim = QAtlas.TFIM(; h=1.0, J=1.0)
+        m_hs = QAtlas.HaldaneShastry(; J=1.0)
+        s_tfim = QAtlas.fetch(
+            m_tfim, QAtlas.EntanglementSaturationDensity(), QAtlas.Infinite(); beta_eff=β
+        )
+        s_hs = QAtlas.fetch(
+            m_hs, QAtlas.EntanglementSaturationDensity(), QAtlas.Infinite(); beta_eff=β
+        )
+        @test s_tfim / s_hs ≈ 0.5 atol = 1e-12
+    end
+end


### PR DESCRIPTION
**P3 stack migration — framework-integrated re-author of #608.**

#608 re-integrated on the bound/approx/universal framework (#617 -> #618 -> #619). Skipped-bound baggage (CHSH/Chaos/Bekenstein/Mermin/Cloning — already in bounds/ via #618) dropped during integration. Universality{C} quantities stay fetch-level CFT predictions; concrete-model rows register status=:exact (method=:delegation where they inherit a class value).

Base branch: `feat/p3-tfim-boundary-entropy` (previous in the P3 chain). Verified at the stack tip: cumulative load + universality test suite + registry coherence green.

Re-integration of #608.

[Claude Code]