### PR TITLE
feat(TFIM,HaldaneShastry,XXZ1D): LogarithmicNegativity wrappers [P3 #610]

### DIFF
--- a/src/models/quantum/HaldaneShastry/HaldaneShastry_thermal_cft.jl
+++ b/src/models/quantum/HaldaneShastry/HaldaneShastry_thermal_cft.jl
@@ -308,3 +308,25 @@ function fetch(
         kwargs...,
     )
 end
+
+"""
+    fetch(::HaldaneShastry, ::LogarithmicNegativity, ::Infinite;
+          ℓ_A::Real, ℓ_B::Real, kwargs...) -> Float64
+
+CC-Tonni 2012 logarithmic negativity of two adjacent intervals,
+delegated to `Universality(:Heisenberg)` (c = 1):
+
+    E = (1/4) log[ℓ_A * ℓ_B / (ℓ_A + ℓ_B)].
+"""
+function fetch(
+    ::HaldaneShastry, ::LogarithmicNegativity, ::Infinite; ℓ_A::Real, ℓ_B::Real, kwargs...
+)
+    return fetch(
+        Universality(:Heisenberg),
+        LogarithmicNegativity(),
+        Infinite();
+        ℓ_A=ℓ_A,
+        ℓ_B=ℓ_B,
+        kwargs...,
+    )
+end

--- a/src/models/quantum/TFIM/TFIM_cft_entanglement.jl
+++ b/src/models/quantum/TFIM/TFIM_cft_entanglement.jl
@@ -283,3 +283,38 @@ function fetch(
         kwargs...,
     )
 end
+
+# -----------------------------------------------------------------------------
+# Logarithmic negativity of two adjacent intervals at h = J (CC-Tonni 2012)
+# -----------------------------------------------------------------------------
+
+"""
+    fetch(m::TFIM, ::LogarithmicNegativity, ::Infinite;
+          ℓ_A::Real, ℓ_B::Real, kwargs...) -> Float64
+
+Calabrese-Cardy-Tonni 2012 logarithmic negativity of two adjacent
+intervals at the critical TFIM point `|h| = |J|`:
+
+    E = (c/4) log[ℓ_A · ℓ_B / (ℓ_A + ℓ_B)],   c = 1/2.
+
+Delegates to `Universality(:Ising)`.
+"""
+function fetch(
+    m::TFIM, ::LogarithmicNegativity, ::Infinite; ℓ_A::Real, ℓ_B::Real, kwargs...
+)
+    isapprox(abs(m.h), abs(m.J); atol=1e-12) || throw(
+        DomainError(
+            (m.h, m.J),
+            "TFIM LogarithmicNegativity: closed-form CC-Tonni applies only at " *
+            "the critical point |h| = |J|; got (h, J) = ($(m.h), $(m.J)).",
+        ),
+    )
+    return fetch(
+        Universality(:Ising),
+        LogarithmicNegativity(),
+        Infinite();
+        ℓ_A=ℓ_A,
+        ℓ_B=ℓ_B,
+        kwargs...,
+    )
+end

--- a/src/models/quantum/XXZ/XXZ_thermal.jl
+++ b/src/models/quantum/XXZ/XXZ_thermal.jl
@@ -713,3 +713,46 @@ function fetch(
         )
     end
 end
+
+"""
+    fetch(model::XXZ1D, ::LogarithmicNegativity, ::Infinite;
+          ℓ_A::Real, ℓ_B::Real, kwargs...) -> Float64
+
+CC-Tonni 2012 logarithmic negativity of two adjacent intervals in the
+critical Luttinger-liquid regime `-1 < Δ <= 1`. Delegates to
+`Universality(:XY)` for `-1 < Δ < 1` and `Universality(:Heisenberg)`
+at `Δ = 1`.
+"""
+function fetch(
+    model::XXZ1D, ::LogarithmicNegativity, ::Infinite; ℓ_A::Real, ℓ_B::Real, kwargs...
+)
+    Δ = model.Δ
+    if Δ == 1.0
+        return fetch(
+            Universality(:Heisenberg),
+            LogarithmicNegativity(),
+            Infinite();
+            ℓ_A=ℓ_A,
+            ℓ_B=ℓ_B,
+            kwargs...,
+        )
+    elseif -1.0 < Δ < 1.0
+        return fetch(
+            Universality(:XY),
+            LogarithmicNegativity(),
+            Infinite();
+            ℓ_A=ℓ_A,
+            ℓ_B=ℓ_B,
+            kwargs...,
+        )
+    else
+        throw(
+            DomainError(
+                Δ,
+                "XXZ1D LogarithmicNegativity at Infinite: only the critical " *
+                "Luttinger-liquid regime -1 < Δ <= 1 admits a c = 1 " *
+                "CC-Tonni closed form. Got Δ = $Δ.",
+            ),
+        )
+    end
+end

--- a/test/cross_model/test_three_models_log_negativity.jl
+++ b/test/cross_model/test_three_models_log_negativity.jl
@@ -1,0 +1,67 @@
+using Test
+using QAtlas
+
+@testset "Three-model LogarithmicNegativity wrappers (CC-Tonni 2012)" begin
+    @testset "TFIM h = J: matches Universality(:Ising)" begin
+        for J in (1.0, 2.0)
+            m = QAtlas.TFIM(; h=J, J=J)
+            for (ℓ_A, ℓ_B) in ((5.0, 10.0), (10.0, 20.0), (3.0, 30.0))
+                e = QAtlas.fetch(
+                    m, QAtlas.LogarithmicNegativity(), QAtlas.Infinite(); ℓ_A=ℓ_A, ℓ_B=ℓ_B
+                )
+                ref = (0.5 / 4) * log(ℓ_A * ℓ_B / (ℓ_A + ℓ_B))
+                @test e ≈ ref atol = 1e-12
+            end
+        end
+        m_off = QAtlas.TFIM(; h=0.5, J=1.0)
+        @test_throws DomainError QAtlas.fetch(
+            m_off, QAtlas.LogarithmicNegativity(), QAtlas.Infinite(); ℓ_A=5.0, ℓ_B=5.0
+        )
+    end
+
+    @testset "HaldaneShastry: c = 1" begin
+        m = QAtlas.HaldaneShastry()
+        for (ℓ_A, ℓ_B) in ((5.0, 10.0), (10.0, 20.0))
+            e = QAtlas.fetch(
+                m, QAtlas.LogarithmicNegativity(), QAtlas.Infinite(); ℓ_A=ℓ_A, ℓ_B=ℓ_B
+            )
+            ref = (1.0 / 4) * log(ℓ_A * ℓ_B / (ℓ_A + ℓ_B))
+            @test e ≈ ref atol = 1e-12
+        end
+    end
+
+    @testset "XXZ1D critical regime: c = 1" begin
+        for Δ in (0.0, 0.5, -0.5, 0.9, 1.0)
+            m = QAtlas.XXZ1D(; J=1.0, Δ=Δ)
+            for (ℓ_A, ℓ_B) in ((8.0, 12.0), (15.0, 25.0))
+                e = QAtlas.fetch(
+                    m, QAtlas.LogarithmicNegativity(), QAtlas.Infinite(); ℓ_A=ℓ_A, ℓ_B=ℓ_B
+                )
+                ref = (1.0 / 4) * log(ℓ_A * ℓ_B / (ℓ_A + ℓ_B))
+                @test e ≈ ref atol = 1e-12
+            end
+        end
+    end
+
+    @testset "XXZ1D off-critical (|Δ| > 1) throws DomainError" begin
+        for Δ in (1.5, -1.5, 2.0)
+            m = QAtlas.XXZ1D(; J=1.0, Δ=Δ)
+            @test_throws DomainError QAtlas.fetch(
+                m, QAtlas.LogarithmicNegativity(), QAtlas.Infinite(); ℓ_A=8.0, ℓ_B=12.0
+            )
+        end
+    end
+
+    @testset "Central-charge ratio TFIM/HS = 1/2" begin
+        ℓ_A, ℓ_B = 10.0, 15.0
+        m_tfim = QAtlas.TFIM(; h=1.0, J=1.0)
+        m_hs = QAtlas.HaldaneShastry()
+        e_tfim = QAtlas.fetch(
+            m_tfim, QAtlas.LogarithmicNegativity(), QAtlas.Infinite(); ℓ_A=ℓ_A, ℓ_B=ℓ_B
+        )
+        e_hs = QAtlas.fetch(
+            m_hs, QAtlas.LogarithmicNegativity(), QAtlas.Infinite(); ℓ_A=ℓ_A, ℓ_B=ℓ_B
+        )
+        @test e_tfim / e_hs ≈ 0.5 atol = 1e-12
+    end
+end


### PR DESCRIPTION
**P3 stack migration — framework-integrated re-author of #610.**

#610 re-integrated on the bound/approx/universal framework (#617 -> #618 -> #619). Skipped-bound baggage (CHSH/Chaos/Bekenstein/Mermin/Cloning — already in bounds/ via #618) dropped during integration. Universality{C} quantities stay fetch-level CFT predictions; concrete-model rows register status=:exact (method=:delegation where they inherit a class value).

Base branch: `feat/p3-3models-mutual-info` (previous in the P3 chain). Verified at the stack tip: cumulative load + universality test suite + registry coherence green.

Re-integration of #610.

[Claude Code]