### PR TITLE
feat(Heisenberg1D): MI + LN + EntanglementSaturationDensity wrappers [P3 #611]

### DIFF
--- a/src/models/quantum/Heisenberg/Heisenberg1D_thermal_cft.jl
+++ b/src/models/quantum/Heisenberg/Heisenberg1D_thermal_cft.jl
@@ -169,3 +169,80 @@ function fetch(
     end
     return _heisenberg1d_cft_specific_heat(J, beta)
 end
+
+# -----------------------------------------------------------------------------
+# Adjacent-interval quantum-information triple at the gapless point
+# (Calabrese-Cardy 2009 MI / CC-Tonni 2012 LN / CC 2005 saturation)
+# -----------------------------------------------------------------------------
+
+"""
+    fetch(::Heisenberg1D, ::MutualInformation, ::Infinite;
+          ℓ_A::Real, ℓ_B::Real, beta::Real=Inf, kwargs...) -> Float64
+
+Calabrese-Cardy mutual information of two adjacent intervals,
+delegated to `Universality(:Heisenberg)` (c = 1). The chain is gapless
+SU(2)-invariant Luttinger liquid, so the Universality formula applies
+directly.
+"""
+function fetch(
+    ::Heisenberg1D,
+    ::MutualInformation,
+    ::Infinite;
+    ℓ_A::Real,
+    ℓ_B::Real,
+    beta::Real=Inf,
+    kwargs...,
+)
+    return fetch(
+        Universality(:Heisenberg),
+        MutualInformation(),
+        Infinite();
+        ℓ_A=ℓ_A,
+        ℓ_B=ℓ_B,
+        beta=beta,
+        kwargs...,
+    )
+end
+
+"""
+    fetch(::Heisenberg1D, ::LogarithmicNegativity, ::Infinite;
+          ℓ_A::Real, ℓ_B::Real, kwargs...) -> Float64
+
+Calabrese-Cardy-Tonni 2012 logarithmic negativity of two adjacent
+intervals, delegated to `Universality(:Heisenberg)`:
+
+    E = (1/4) log[ℓ_A * ℓ_B / (ℓ_A + ℓ_B)].
+"""
+function fetch(
+    ::Heisenberg1D, ::LogarithmicNegativity, ::Infinite; ℓ_A::Real, ℓ_B::Real, kwargs...
+)
+    return fetch(
+        Universality(:Heisenberg),
+        LogarithmicNegativity(),
+        Infinite();
+        ℓ_A=ℓ_A,
+        ℓ_B=ℓ_B,
+        kwargs...,
+    )
+end
+
+"""
+    fetch(::Heisenberg1D, ::EntanglementSaturationDensity, ::Infinite;
+          beta_eff::Real, kwargs...) -> Float64
+
+Long-time post-quench saturation of half-system entanglement entropy
+per unit length, delegated to `Universality(:Heisenberg)`:
+
+    S_A(infty) / L = pi / (6 beta_eff).
+"""
+function fetch(
+    ::Heisenberg1D, ::EntanglementSaturationDensity, ::Infinite; beta_eff::Real, kwargs...
+)
+    return fetch(
+        Universality(:Heisenberg),
+        EntanglementSaturationDensity(),
+        Infinite();
+        beta_eff=beta_eff,
+        kwargs...,
+    )
+end

--- a/test/models/quantum/Heisenberg/test_heisenberg1d_entanglement_triple.jl
+++ b/test/models/quantum/Heisenberg/test_heisenberg1d_entanglement_triple.jl
@@ -1,0 +1,78 @@
+using Test
+using QAtlas
+
+@testset "Heisenberg1D entanglement triple" begin
+    m = QAtlas.Heisenberg1D()
+
+    @testset "MutualInformation matches Universality(:Heisenberg)" begin
+        for (ℓ_A, ℓ_B) in ((5.0, 10.0), (10.0, 20.0), (3.0, 30.0))
+            for β in (Inf, 5.0, 1.0)
+                mi = QAtlas.fetch(
+                    m,
+                    QAtlas.MutualInformation(),
+                    QAtlas.Infinite();
+                    ℓ_A=ℓ_A,
+                    ℓ_B=ℓ_B,
+                    beta=β,
+                )
+                ref = QAtlas.fetch(
+                    QAtlas.Universality(:Heisenberg),
+                    QAtlas.MutualInformation(),
+                    QAtlas.Infinite();
+                    ℓ_A=ℓ_A,
+                    ℓ_B=ℓ_B,
+                    beta=β,
+                )
+                @test mi ≈ ref atol = 1e-12
+            end
+        end
+    end
+
+    @testset "LogarithmicNegativity = (1/4) log[ℓ_A ℓ_B / (ℓ_A + ℓ_B)]" begin
+        for (ℓ_A, ℓ_B) in ((5.0, 10.0), (10.0, 20.0))
+            e = QAtlas.fetch(
+                m, QAtlas.LogarithmicNegativity(), QAtlas.Infinite(); ℓ_A=ℓ_A, ℓ_B=ℓ_B
+            )
+            ref = (1.0 / 4) * log(ℓ_A * ℓ_B / (ℓ_A + ℓ_B))
+            @test e ≈ ref atol = 1e-12
+        end
+    end
+
+    @testset "EntanglementSaturationDensity = π / (6 β_eff)" begin
+        for β in (1.0, 2.0, 5.0, 10.0)
+            s = QAtlas.fetch(
+                m, QAtlas.EntanglementSaturationDensity(), QAtlas.Infinite(); beta_eff=β
+            )
+            @test s ≈ π / (6 * β) atol = 1e-12
+        end
+    end
+
+    @testset "Heisenberg1D ↔ HaldaneShastry agreement (both c = 1)" begin
+        m_hs = QAtlas.HaldaneShastry()
+        for (ℓ_A, ℓ_B) in ((8.0, 12.0), (5.0, 20.0))
+            mi_h1 = QAtlas.fetch(
+                m, QAtlas.MutualInformation(), QAtlas.Infinite(); ℓ_A=ℓ_A, ℓ_B=ℓ_B
+            )
+            mi_hs = QAtlas.fetch(
+                m_hs, QAtlas.MutualInformation(), QAtlas.Infinite(); ℓ_A=ℓ_A, ℓ_B=ℓ_B
+            )
+            @test mi_h1 ≈ mi_hs atol = 1e-12
+            ln_h1 = QAtlas.fetch(
+                m, QAtlas.LogarithmicNegativity(), QAtlas.Infinite(); ℓ_A=ℓ_A, ℓ_B=ℓ_B
+            )
+            ln_hs = QAtlas.fetch(
+                m_hs, QAtlas.LogarithmicNegativity(), QAtlas.Infinite(); ℓ_A=ℓ_A, ℓ_B=ℓ_B
+            )
+            @test ln_h1 ≈ ln_hs atol = 1e-12
+        end
+        for β in (1.0, 5.0)
+            s_h1 = QAtlas.fetch(
+                m, QAtlas.EntanglementSaturationDensity(), QAtlas.Infinite(); beta_eff=β
+            )
+            s_hs = QAtlas.fetch(
+                m_hs, QAtlas.EntanglementSaturationDensity(), QAtlas.Infinite(); beta_eff=β
+            )
+            @test s_h1 ≈ s_hs atol = 1e-12
+        end
+    end
+end


### PR DESCRIPTION
**P3 stack migration — framework-integrated re-author of #611.**

#611 re-integrated on the bound/approx/universal framework (#617 -> #618 -> #619). Skipped-bound baggage (CHSH/Chaos/Bekenstein/Mermin/Cloning — already in bounds/ via #618) dropped during integration. Universality{C} quantities stay fetch-level CFT predictions; concrete-model rows register status=:exact (method=:delegation where they inherit a class value).

Base branch: `feat/p3-3models-log-neg` (previous in the P3 chain). Verified at the stack tip: cumulative load + universality test suite + registry coherence green.

Re-integration of #611.

[Claude Code]