### PR TITLE
feat(Heisenberg1D): LiebRobinsonVelocity + EntanglementGrowthSlope wrappers [P3 #612]

### DIFF
--- a/src/models/quantum/Heisenberg/Heisenberg1D_thermal_cft.jl
+++ b/src/models/quantum/Heisenberg/Heisenberg1D_thermal_cft.jl
@@ -246,3 +246,48 @@ function fetch(
         kwargs...,
     )
 end
+
+# -----------------------------------------------------------------------------
+# Lieb-Robinson velocity + entanglement growth slope (des Cloizeaux-Pearson)
+# -----------------------------------------------------------------------------
+
+"""
+    fetch(m::Heisenberg1D, ::LiebRobinsonVelocity, ::Infinite;
+          J = m.J, kwargs...) -> Float64
+
+Maximum group velocity of the des Cloizeaux-Pearson spinon
+dispersion of the spin-1/2 Heisenberg chain. With epsilon(k) =
+(pi/2) |J sin k| the spinon velocity is
+
+    v_s = pi J / 2,
+
+attained at k = 0 and k = pi. This is the standard CC quasi-particle
+velocity that enters the entanglement-spreading formulas.
+"""
+function fetch(m::Heisenberg1D, ::LiebRobinsonVelocity, ::Infinite; J::Real=1.0, kwargs...)
+    return π * abs(J) / 2
+end
+
+"""
+    fetch(m::Heisenberg1D, ::EntanglementGrowthSlope, ::Infinite;
+          beta_eff::Real, kwargs...) -> Float64
+
+Calabrese-Cardy 2005 linear-growth slope of post-quench half-system
+entanglement entropy for the gapless Heisenberg chain (c = 1, v = pi J / 2):
+
+    dS_A / dt = pi c v / (3 beta_eff) = pi^2 J / (6 beta_eff).
+
+Delegates to `Universality(:Heisenberg)`.
+"""
+function fetch(
+    m::Heisenberg1D, ::EntanglementGrowthSlope, ::Infinite; beta_eff::Real, kwargs...
+)
+    return fetch(
+        Universality(:Heisenberg),
+        EntanglementGrowthSlope(),
+        Infinite();
+        v=fetch(m, LiebRobinsonVelocity(), Infinite()),
+        beta_eff=beta_eff,
+        kwargs...,
+    )
+end

--- a/test/models/quantum/Heisenberg/test_heisenberg1d_lr_slope.jl
+++ b/test/models/quantum/Heisenberg/test_heisenberg1d_lr_slope.jl
@@ -1,0 +1,33 @@
+using Test
+using QAtlas
+
+@testset "Heisenberg1D LR velocity + slope (des Cloizeaux-Pearson)" begin
+    m = QAtlas.Heisenberg1D()
+
+    @testset "LiebRobinsonVelocity = π J / 2" begin
+        for J in (0.5, 1.0, 2.0, 5.0)
+            v = QAtlas.fetch(m, QAtlas.LiebRobinsonVelocity(), QAtlas.Infinite(); J=J)
+            @test v ≈ π * J / 2 atol = 1e-12
+        end
+        v_neg = QAtlas.fetch(m, QAtlas.LiebRobinsonVelocity(), QAtlas.Infinite(); J=-3.0)
+        @test v_neg ≈ 3π / 2 atol = 1e-12
+        v_default = QAtlas.fetch(m, QAtlas.LiebRobinsonVelocity(), QAtlas.Infinite())
+        @test v_default ≈ π / 2 atol = 1e-12
+    end
+
+    @testset "EntanglementGrowthSlope = π² J / (6 β_eff)" begin
+        for β in (1.0, 2.0, 5.0)
+            slope = QAtlas.fetch(
+                m, QAtlas.EntanglementGrowthSlope(), QAtlas.Infinite(); beta_eff=β
+            )
+            @test slope ≈ π^2 / (6 * β) atol = 1e-12
+        end
+    end
+
+    @testset "Heisenberg1D ↔ HaldaneShastry LR velocity equivalence at default J" begin
+        m_hs = QAtlas.HaldaneShastry()
+        v_h1 = QAtlas.fetch(m, QAtlas.LiebRobinsonVelocity(), QAtlas.Infinite())
+        v_hs = QAtlas.fetch(m_hs, QAtlas.LiebRobinsonVelocity(), QAtlas.Infinite())
+        @test v_h1 ≈ v_hs atol = 1e-12
+    end
+end


### PR DESCRIPTION
**P3 stack migration — framework-integrated re-author of #612.**

#612 re-integrated on the bound/approx/universal framework (#617 -> #618 -> #619). Skipped-bound baggage (CHSH/Chaos/Bekenstein/Mermin/Cloning — already in bounds/ via #618) dropped during integration. Universality{C} quantities stay fetch-level CFT predictions; concrete-model rows register status=:exact (method=:delegation where they inherit a class value).

Base branch: `feat/p3-heisenberg-triple` (previous in the P3 chain). Verified at the stack tip: cumulative load + universality test suite + registry coherence green.

Re-integration of #612.

[Claude Code]