### PR TITLE
chore(deps): bump CI actions (checkout v6, cache v5, release-drafter v7) [v0.24.2]

### DIFF
--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,7 +1,9 @@
 name: Format Check
+# Runs on every PR (no path filter): format-check is a *required* status check,
+# so it must always report — a path-filtered required check never reports on
+# PRs that don't touch the filtered paths and blocks the merge forever.
 on:
   pull_request:
-    paths: ['**/*.jl']
 
 jobs:
   format-check:

--- a/.github/workflows/VerifyReferences.yml
+++ b/.github/workflows/VerifyReferences.yml
@@ -41,12 +41,12 @@ jobs:
     # self-hosted Julia runner.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       # Persist the resolver cache (docs/CACHE.md) across runs so an
       # unchanged bibliography resolves with zero network calls — see
       # sotashimozono/doiget#265. Keyed on the .bib so a new ref re-fetches
       # only the delta.
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.cache/doiget
           key: doiget-resolver-${{ hashFiles(env.QATLAS_REFERENCES_BIB) }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,6 +18,6 @@ jobs:
       pull-requests: write  # autolabeler writes labels back to PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.24.1"
+version = "0.24.2"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]


### PR DESCRIPTION
Consolidates the three open Dependabot github-actions bumps into one PR + a Project.toml patch bump so VersionCheck passes (Dependabot PRs don't bump the version, so they were stuck on `check-version`).

- actions/cache 4 → 5 (#649)
- actions/checkout 4 → 6 (#650, last remaining `@v4` in VerifyReferences.yml)
- release-drafter/release-drafter 6 → 7 (#651)

Supersedes #649, #650, #651.