### PR TITLE
fix(docs+bounds): correct stale source= selector + coherence over-claim

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.24.4"
+version = "0.24.5"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/docs/src/atlas/quantities/CHSHBound.md
+++ b/docs/src/atlas/quantities/CHSHBound.md
@@ -7,7 +7,7 @@ All `(Model, BC)` hubs `src` claims for the **`CHSHBound`** observable.  Empty c
 
 ## Definition
 
-The CHSH (Bell-inequality) correlator bound — the maximum of `S = E(a,b) + E(a,b′) + E(a′,b) − E(a′,b′)` admissible in a given physical theory.  A `status=:bound` quantity with the historical name (like ``LiebRobinsonBound``); fetched against a ``Bound`` domain (not a model), with a `source=` selector choosing *whose* bound (`:bell` → 2, `:tsirelson` → 2√2, `:popescu_rohrlich` → 4).
+The CHSH (Bell-inequality) correlator bound — the maximum of `S = E(a,b) + E(a,b′) + E(a′,b) − E(a′,b′)` admissible in a given physical theory.  A `status=:bound` quantity with the historical name (like ``LiebRobinsonBound``); fetched against a ``Bound`` domain (not a model), with a `scheme=` selector choosing the theory regime (`:classical` → 2, `:quantum` → 2√2, `:no_signalling` → 4).
 
 _(extracted from `src/core/quantities.jl` docstring.)_
 

--- a/docs/src/atlas/quantities/MerminGHZBound.md
+++ b/docs/src/atlas/quantities/MerminGHZBound.md
@@ -7,7 +7,7 @@ All `(Model, BC)` hubs `src` claims for the **`MerminGHZBound`** observable.  Em
 
 ## Definition
 
-The Mermin 3-party Bell-type bound — the maximum of the Mermin operator `|⟨M₃⟩|` admissible in a given theory.  A `status=:bound` quantity (Mermin 1990); fetched against a ``Bound`` domain with `source=` choosing the bound (`:classical` → 2 local-realistic, `:mermin` → 4 quantum, saturated by the GHZ state).
+The Mermin 3-party Bell-type bound — the maximum of the Mermin operator `|⟨M₃⟩|` admissible in a given theory.  A `status=:bound` quantity (Mermin 1990); fetched against a ``Bound`` domain with `scheme=` choosing the theory regime (`:classical` → 2 local-realistic, `:quantum` → 4 quantum, saturated by the GHZ state).
 
 _(extracted from `src/core/quantities.jl` docstring.)_
 

--- a/src/bounds/Bounds.jl
+++ b/src/bounds/Bounds.jl
@@ -4,7 +4,7 @@
 # A *bound* is NOT a universality class.  It is pinned by three things:
 #   * what physical quantity it bounds  — the registry `quantity`,
 #   * which way it constrains           — `direction = :upper / :lower`,
-#   * whose bound it is                 — `references` (+ a `source=` selector
+#   * whose bound it is                 — `references` (+ a `scheme=` selector
 #                                          when several bounds share a quantity).
 #
 # Universal (model-independent) bounds — Tsirelson, Bekenstein,
@@ -28,8 +28,8 @@ A universal bound has no home model, so it is fetched against a `Bound`
 domain rather than a Hamiltonian:
 
 ```julia
-QAtlas.fetch(Bound(:QuantumInformation), CHSHBound(), Infinite())                # 2√2 (Tsirelson)
-QAtlas.fetch(Bound(:QuantumInformation), CHSHBound(), Infinite(); source=:bell)  # 2   (local-hidden-variable)
+QAtlas.fetch(Bound(:QuantumInformation), CHSHBound(), Infinite())                     # 2√2 (Tsirelson)
+QAtlas.fetch(Bound(:QuantumInformation), CHSHBound(), Infinite(); scheme=:classical)  # 2   (local-hidden-variable)
 ```
 
 Every bound is registered with `status=:bound` and a `direction`

--- a/src/bounds/QuantumInformation/QuantumInformation.jl
+++ b/src/bounds/QuantumInformation/QuantumInformation.jl
@@ -31,6 +31,12 @@ function fetch(
     scheme::Symbol=:quantum,
     kwargs...,
 )
+    haskey(kwargs, :source) && throw(
+        ArgumentError(
+            "CHSHBound: `source=` is not a selector; use `scheme=` " *
+            "(:classical / :quantum / :no_signalling)",
+        ),
+    )
     if scheme === :quantum
         return 2 * sqrt(2)
     elseif scheme === :classical
@@ -66,6 +72,12 @@ function fetch(
     scheme::Symbol=:quantum,
     kwargs...,
 )
+    haskey(kwargs, :source) && throw(
+        ArgumentError(
+            "MerminGHZBound: `source=` is not a selector; use `scheme=` " *
+            "(:classical / :quantum)",
+        ),
+    )
     if scheme === :quantum
         return 4.0
     elseif scheme === :classical

--- a/src/core/coherence.jl
+++ b/src/core/coherence.jl
@@ -1,17 +1,26 @@
-# core/coherence.jl — verification DERIVED from the knowledge graph.
+# core/coherence.jl — STRUCTURAL verification DERIVED from the knowledge graph.
 #
-# The thesis: correctness and comprehensiveness are properties of the *network*,
-# not of isolated rows.  Each implementation is constrained by several
+# The thesis: structural correctness and comprehensiveness are properties of the
+# *network*, not of isolated rows.  Each implementation is constrained by several
 # independent cross-paths (its class's universal prediction, the bounds on its
 # quantity, its cited literature, agreement with sibling models).  A wrong or
-# missing implementation violates at least one cross-path; satisfying them all
-# is a far stronger guarantee than any single unit test.  Missing edges are
-# self-reported as coverage gaps.
+# missing edge violates at least one cross-path; missing edges are self-reported
+# as coverage gaps.  This layer is COMPLEMENTARY to — not a replacement for — the
+# physical verify-card tests: it catches graph-level defects (dangling refs,
+# kind/namespace desync, undeclared delegation targets, overlapping loci) that a
+# per-row unit test cannot see, while the *physical values* are checked in
+# `test/verification/` and `test/bounds/` via `verify` / `verify_bound`.
 #
 # Each `check_*` walks `REGISTRY` / `REALIZES` (+ `links.jl`) and returns
-# `CoherenceFinding`s.  `coherence_report` runs the structural suite.  Physical
-# cross-checks (realization-agreement C5, bound-satisfaction C7) need per-quantity
-# invocation probes and are layered on top via `check_realization_agreement`.
+# `CoherenceFinding`s.  `coherence_report` runs the STRUCTURAL suite wired today:
+# C1 reference integrity, C2 namespace⟺kind, C3 canonical/scheme coherence,
+# C4 delegation targets, C6 coverage, C8 realization loci.  Two further checks
+# are DESIGNED but not auto-run: C5 realization-agreement
+# (`check_realization_agreement`) is an opt-in physical probe — the model↔class
+# agreement it asserts is already covered concretely by the verify-card
+# cross-checks (`test/verification/universality/`); C7 bound-satisfaction is a
+# reserved slot with no generic implementation yet — bound saturation is checked
+# per-bound by `verify_bound` in `test/bounds/`.
 
 """
     CoherenceFinding(check, severity, message)
@@ -168,6 +177,12 @@ For each `method=:delegation` row whose `quantity` has an entry in `probes`
 (a `Dict` quantity-instance ⇒ NamedTuple of fetch kwargs), assert the model's
 value equals the realized class's prediction at the probe point — the physical
 cross-validation that makes a delegation edge *true*, not just declared.
+
+!!! note
+    This C5 probe is **not** run by [`coherence_report`](@ref) (which is
+    structural-only): it requires a per-quantity probe dict, so call it directly.
+    The same model↔class agreement is already verified concretely in the
+    verify-card layer (`test/verification/universality/`).
 """
 function check_realization_agreement(probes::AbstractDict; rtol=1e-8)
     out = CoherenceFinding[]

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -1191,8 +1191,8 @@ The CHSH (Bell-inequality) correlator bound — the maximum of
 `S = E(a,b) + E(a,b′) + E(a′,b) − E(a′,b′)` admissible in a given physical
 theory.  A `status=:bound` quantity with the historical name (like
 [`LiebRobinsonBound`](@ref)); fetched against a [`Bound`](@ref) domain
-(not a model), with a `source=` selector choosing *whose* bound
-(`:bell` → 2, `:tsirelson` → 2√2, `:popescu_rohrlich` → 4).
+(not a model), with a `scheme=` selector choosing the theory regime
+(`:classical` → 2, `:quantum` → 2√2, `:no_signalling` → 4).
 """
 struct CHSHBound <: AbstractQuantity end
 
@@ -1201,9 +1201,9 @@ struct CHSHBound <: AbstractQuantity end
 
 The Mermin 3-party Bell-type bound — the maximum of the Mermin operator
 `|⟨M₃⟩|` admissible in a given theory.  A `status=:bound` quantity
-(Mermin 1990); fetched against a [`Bound`](@ref) domain with `source=`
-choosing the bound (`:classical` → 2 local-realistic, `:mermin` → 4
-quantum, saturated by the GHZ state).
+(Mermin 1990); fetched against a [`Bound`](@ref) domain with `scheme=`
+choosing the theory regime (`:classical` → 2 local-realistic, `:quantum`
+→ 4 quantum, saturated by the GHZ state).
 """
 struct MerminGHZBound <: AbstractQuantity end
 

--- a/test/bounds/test_chsh_bound.jl
+++ b/test/bounds/test_chsh_bound.jl
@@ -28,6 +28,9 @@ using QAtlas: Bound, CHSHBound, Infinite
 
     @testset "argument validation" begin
         @test_throws ArgumentError QAtlas.fetch(qi, CHSHBound(), Infinite(); scheme=:bogus)
+        # the removed `source=` selector is rejected loudly, not silently swallowed
+        # (regression: it used to fall through to the default scheme and return 2√2)
+        @test_throws ArgumentError QAtlas.fetch(qi, CHSHBound(), Infinite(); source=:bell)
     end
 
     @testset "verify_bound — quantum bound saturated by the optimal Bell state" begin

--- a/test/bounds/test_mermin_ghz_bound.jl
+++ b/test/bounds/test_mermin_ghz_bound.jl
@@ -14,6 +14,8 @@ using QAtlas: Bound, MerminGHZBound, Infinite
     @test QAtlas.fetch(qi, MerminGHZBound(), Infinite(); scheme=:quantum) ≈ 4.0 atol = 1e-14
     @test QAtlas.fetch(qi, MerminGHZBound(), Infinite()) ≈ 4.0 atol = 1e-14   # default = quantum
     @test_throws ArgumentError QAtlas.fetch(qi, MerminGHZBound(), Infinite(); scheme=:bogus)
+    # the removed `source=` selector is rejected loudly, not silently swallowed
+    @test_throws ArgumentError QAtlas.fetch(qi, MerminGHZBound(), Infinite(); source=:bell)
 
     @testset "GHZ state saturates the quantum bound" begin
         s = verify_bound(


### PR DESCRIPTION
The two **[do-now]** items from the v0.24.4 new-regime design review (22-agent adversarial pass). Both are documentation-currency defects — the docs described a slightly different library than the one shipped.

## 1. bounds `source=` foot-gun — silent wrong value (Closes #657)

The CHSH/Mermin bound docstrings (`quantities.jl`, `Bounds.jl`) advertised a `source=` selector (`:bell`/`:tsirelson`/`:popescu_rohrlich`) that was **never implemented** — the real kwarg is `scheme=` (`:classical`/`:quantum`/`:no_signalling`). Because the fetch methods slurp `kwargs...`, a documented call

```julia
fetch(Bound(:QuantumInformation), CHSHBound(), Infinite(); source=:bell)  # docs claimed 2
```

silently fell through to the default `scheme=:quantum` and returned **2√2 instead of 2** — the wrong physical constant, no error. Fix:
- corrected the source-of-truth docstrings + regenerated the two affected atlas pages (`docs/src/atlas/quantities/{CHSHBound,MerminGHZBound}.md`);
- added a **localized** guard in the two terminal CHSH/Mermin methods that throws `ArgumentError` pointing at `scheme=` (deliberately *not* a global kwarg reject — that would conflict with the 600+ `kwargs...` pass-throughs and the `Energy{:per_site}` delegation);
- added regression `@test_throws` in `test/bounds/`.

## 2. coherence over-claim (Closes #656)

`coherence.jl`'s header sold an 8-check "stronger than any single unit test" suite, but `coherence_report` runs only the **6 structural checks** (C1–C4, C6, C8). C5 (`check_realization_agreement`) is defined+exported but never auto-run; C7 (bound-satisfaction) is named in a comment only and unimplemented. The physics they would assert is already covered in the verify-card layer (`test/verification/`, `test/bounds/`). Fix: reworded the header + `coherence_report` docstring to state honestly what runs and point at the verify-card layer; annotated C5 as an opt-in probe. (Comment/docstring only — no behavior change.)

## Validation
- `coherence_report()` = **0 errors / 0 gaps**
- `test/bounds/test_chsh_bound.jl` (18) + `test_mermin_ghz_bound.jl` (11) pass, including the new `source=` guard
- formatted with JuliaFormatter **v2** (CI-pinned); 9 files, no doc line-ending churn

## Follow-ups (filed, not in this PR)
#658 (C4 porous delegation gate / falsely-green zero-gaps), #659 (`:universal` double-encoding by construction), #660 (macro helper extraction), #661 (cheap coherence walks), #662 (single-Claim north star — deferred, trigger documented).

Review & merge is yours (no auto-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)