### PR TITLE
fix(coherence): recognize variant delegation tags in C4/C5 (close falsely-green zero-gaps)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.24.5"
+version = "0.24.6"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/core/coherence.jl
+++ b/src/core/coherence.jl
@@ -122,8 +122,16 @@ function check_canonical_coherence()
     return out
 end
 
+# A delegation row's method is `:delegation` or a descriptive `:<target>_delegation`
+# variant (e.g. `:kitaev_delegation`, `:minimal_model_delegation`); the C4/C5
+# checks and the `delegations` query recognise all of them via `_is_delegation`,
+# else a variant-tagged delegation silently bypasses the gate (a falsely-green gap).
+function _is_delegation(method::Symbol)
+    return method === :delegation || endswith(String(method), "_delegation")
+end
+
 # ── C4 — delegation has a typed target ───────────────────────────────────────
-# `method=:delegation` covers two cases, both typed by an edge store: a
+# A delegation covers two cases, both typed by an edge store: a
 # model→class delegation is backed by a `REALIZES` edge (model realizes the
 # class it delegates to), a model→model reduction by a `REDUCES` edge (model
 # becomes the target model in a limit).  This is a *presence* check — it asks
@@ -135,7 +143,7 @@ end
 function check_delegation_targets()
     out = CoherenceFinding[]
     for e in REGISTRY
-        e.method === :delegation || continue
+        _is_delegation(e.method) || continue
         realizes_class = any(r -> r.model === e.model, REALIZES)
         reduces_model = any(r -> r.source === e.model, REDUCES)
         (realizes_class || reduces_model) || push!(
@@ -187,7 +195,7 @@ cross-validation that makes a delegation edge *true*, not just declared.
 function check_realization_agreement(probes::AbstractDict; rtol=1e-8)
     out = CoherenceFinding[]
     for e in REGISTRY
-        e.method === :delegation || continue
+        _is_delegation(e.method) || continue
         q = nothing
         for (qi, _) in probes
             typeof(qi) === e.quantity && (q = qi)

--- a/src/core/links.jl
+++ b/src/core/links.jl
@@ -96,7 +96,7 @@ function delegations(model)
     targets = Type[r.target for r in REDUCES if r.source === m_T]
     return [
         (quantity=e.quantity, bc=e.bc, classes=classes, targets=targets) for
-        e in REGISTRY if e.model === m_T && e.method === :delegation
+        e in REGISTRY if e.model === m_T && _is_delegation(e.method)
     ]
 end
 

--- a/src/reduces_registry.jl
+++ b/src/reduces_registry.jl
@@ -15,3 +15,8 @@
 @reduces ExtendedHubbard1D Hubbard1D regime = "nearest-neighbour interaction V = 0; the extended Hubbard chain reduces to the Hubbard model"
 @reduces RandomBondIsing2D MinimalModel regime = "pure (zero-disorder) point; 2D Ising CFT, the M(4,3) minimal model, c = 1/2"
 @reduces ZnClock MinimalModel regime = "self-dual critical point of the Z_n clock model maps onto a minimal-model CFT (e.g. n = 4 → M(4,3))"
+@reduces TricriticalPotts3 MinimalModel regime = "tricritical 3-state Potts CFT is the unitary minimal model M(7,6), c = 6/7; CFT data (central charge, conformal weights, primary fields) delegated"
+@reduces YangLee MinimalModel regime = "Yang–Lee edge singularity is the non-unitary minimal model M(5,2), c = -22/5; CFT data delegated"
+@reduces KitaevHeisenberg KitaevHoneycomb regime = "K-only limit J = Γ = 0; the K-J-Γ honeycomb model becomes the exactly-solvable Kitaev honeycomb model"
+@reduces S1XXZ1D S1Heisenberg1D regime = "isotropic point Δ = 1; the spin-1 XXZ chain becomes the spin-1 Heisenberg (Haldane) chain"
+@reduces S1AnisotropicD1D S1Heisenberg1D regime = "zero single-ion anisotropy D = 0; the anisotropic spin-1 chain becomes the spin-1 Heisenberg (Haldane) chain"

--- a/test/core/test_reduces.jl
+++ b/test/core/test_reduces.jl
@@ -9,6 +9,14 @@ using QAtlas:
     MajumdarGhosh,
     J1J2Heisenberg1D,
     MixedFieldIsing1D,
+    TricriticalPotts3,
+    YangLee,
+    KitaevHeisenberg,
+    KitaevHoneycomb,
+    S1XXZ1D,
+    S1AnisotropicD1D,
+    S1Heisenberg1D,
+    MinimalModel,
     reductions,
     reduced_from
 
@@ -45,4 +53,31 @@ end
     @test isempty(QAtlas.coherence_errors(fs))
     deleg_gaps = filter(g -> g.check === :delegation_target, QAtlas.coherence_gaps(fs))
     @test isempty(deleg_gaps)
+end
+
+# #658 — the C4/C5 gate and the `delegations` query must recognise descriptive
+# `:<target>_delegation` method tags, not just the literal `:delegation`. Before
+# this fix those rows silently bypassed C4, making the zero-gaps assertion above
+# falsely green.
+@testset "delegation gate recognizes variant method tags (#658)" begin
+    @test QAtlas._is_delegation(:delegation)
+    @test QAtlas._is_delegation(:kitaev_delegation)
+    @test QAtlas._is_delegation(:minimal_model_delegation)
+    @test QAtlas._is_delegation(:s1_heisenberg_delegation)
+    @test !QAtlas._is_delegation(:analytic)
+    @test !QAtlas._is_delegation(:closed_form)
+end
+
+@testset "variant-tagged model→model delegations are backed by @reduces (#658)" begin
+    # each delegates via a :*_delegation tag and was previously invisible to C4;
+    # the @reduces edge now types the delegation target.
+    for (src, tgt) in (
+        (TricriticalPotts3, MinimalModel),
+        (YangLee, MinimalModel),
+        (KitaevHeisenberg, KitaevHoneycomb),
+        (S1XXZ1D, S1Heisenberg1D),
+        (S1AnisotropicD1D, S1Heisenberg1D),
+    )
+        @test tgt in [r.target for r in reductions(src)]
+    end
 end


### PR DESCRIPTION
Follow-up from the v0.24.4 design review (#658).

## The defect
C4 (`check_delegation_targets`) and C5 (`check_realization_agreement`) gated on the **literal** `e.method === :delegation`. But delegations are tagged descriptively across the registry, and the variant tags **bypassed the gate**:
- `:kitaev_delegation`, `:minimal_model_delegation`, `:s1_heisenberg_delegation`

So **8 model→model delegations across 5 models** were invisible to C4 — and `test/core/test_reduces.jl`'s "zero delegation gaps" assertion was **falsely green** (it asserted the absence of gaps it couldn't see). `delegations()` missed them too.

Empirically (fixed gate, before adding edges):
```
TricriticalPotts3/CentralCharge      YangLee/CentralCharge      YangLee/ConformalWeights
KitaevHeisenberg/MassGap             S1XXZ1D/MassGap            S1XXZ1D/Energy{:per_site}
S1AnisotropicD1D/MassGap             S1AnisotropicD1D/Energy{:per_site}
```

## The fix
- `_is_delegation(method)` = `:delegation` **or** any `:*_delegation` variant; used in C4, C5, and the `delegations` link query (single source of truth for "is this a delegation row").
- Back the 8 now-visible delegations with `@reduces` edges — all are genuine **model→model reductions** stated verbatim in each model's own docstring (verified against the fetch implementations, e.g. `KitaevHeisenberg` fetches `KitaevHoneycomb(Kx=K,Ky=K,Kz=K)` at J=Γ=0):

| source | target | regime |
|---|---|---|
| TricriticalPotts3 | MinimalModel | M(7,6) tricritical 3-state Potts CFT, c=6/7 |
| YangLee | MinimalModel | non-unitary M(5,2) Yang–Lee edge, c=-22/5 |
| KitaevHeisenberg | KitaevHoneycomb | K-only limit J=Γ=0 |
| S1XXZ1D | S1Heisenberg1D | isotropic point Δ=1 |
| S1AnisotropicD1D | S1Heisenberg1D | zero anisotropy D=0 |

(`@reduces` keys on the source TYPE, so 5 edges back all 8 rows.)

## Validation
- New tests: `_is_delegation` recognizes the variant tags + rejects `:analytic`/`:closed_form`; the 5 sources are backed by `@reduces`. The zero-gaps assertion is now **genuinely** green.
- `coherence_report()` = **0 errors / 0 gaps**; `test_reduces.jl` passes (9+2+6+5).
- JuliaFormatter v2 clean; 5 files.

Review & merge is yours (no auto-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)