### PR TITLE
fix(registry): derive :universal status by construction (kill double-encoding)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.24.6"
+version = "0.24.7"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.24.5"
+version = "0.24.6"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/core/links.jl
+++ b/src/core/links.jl
@@ -11,7 +11,7 @@
 # state.  `_as_type` is shared with registry.jl / realizes.jl.
 
 # ── node-type helpers ────────────────────────────────────────────────────────
-_is_universality(::Type{T}) where {T} = T <: Universality
+# `_is_universality` lives in core/universality.jl (register! needs it earlier).
 _is_bound(::Type{T}) where {T} = T <: Bound
 _class_of(::Type{T}) where {T} = T <: Universality ? T.parameters[1]::Symbol : nothing
 _domain_of(::Type{T}) where {T} = T <: Bound ? T.parameters[1]::Symbol : nothing

--- a/src/core/registry.jl
+++ b/src/core/registry.jl
@@ -152,6 +152,28 @@ function register!(
     status in STATUS_VALUES || throw(
         ArgumentError("register!: status must be one of $(STATUS_VALUES); got :$(status)"),
     )
+    # `:universal` is fixed by the namespace, not a free choice: a Universality
+    # node is :universal by construction (so the (namespace, status) pair cannot
+    # desync), and :universal is rejected on anything else.  NOTE: deliberately
+    # NOT symmetric with Bound — a concrete model may legitimately carry
+    # status=:bound (e.g. a Lieb–Robinson velocity), so the Bound side stays
+    # one-way and is checked (not enforced) by coherence C2.
+    if _is_universality(model_T)
+        status === :exact && (status = :universal)   # :exact is the unset default
+        status === :universal || throw(
+            ArgumentError(
+                "register!: $(model_T) is a Universality node — status is :universal " *
+                "by construction, not :$(status)",
+            ),
+        )
+    elseif status === :universal
+        throw(
+            ArgumentError(
+                "register!: status=:universal is only for Universality nodes; " *
+                "$(model_T) is not one",
+            ),
+        )
+    end
     # A bound must pin which way it constrains; a non-bound must not.
     if status === :bound
         direction in BOUND_DIRECTIONS || throw(

--- a/src/core/universality.jl
+++ b/src/core/universality.jl
@@ -36,6 +36,11 @@ QAtlas.fetch(Universality(:Ising), CriticalExponents(); d=4)   # mean-field
 struct Universality{C} <: AbstractQAtlasModel end
 Universality(name::Symbol) = Universality{name}()
 
+# Namespace predicate: is `T` a Universality node?  Defined here (not in
+# links.jl) so `register!` can derive `status=:universal` by construction — the
+# universality `*_registry.jl` files run long before links.jl is included.
+_is_universality(::Type{T}) where {T} = T <: Universality
+
 """
     CriticalExponents() <: AbstractQuantity
 

--- a/src/universalities/KPZ/KPZ_registry.jl
+++ b/src/universalities/KPZ/KPZ_registry.jl
@@ -5,8 +5,7 @@ register!(
     Universality{:KPZ},
     GrowthExponents,
     Infinite;
-    status=:universal,
-    method=:analytic,
+    method=:analytic,  # status=:universal derived by construction (register!)
     reliability=:high,
     notes="KPZ scaling exponents (β_growth, α_rough, z) — Kardar-Parisi-Zhang 1986; exact in d=1, numerical d=2,3.",
 )

--- a/src/universalities/MeanField/MeanField_registry.jl
+++ b/src/universalities/MeanField/MeanField_registry.jl
@@ -5,8 +5,7 @@ register!(
     Universality{:MeanField},
     CriticalExponents,
     Infinite;
-    status=:universal,
-    method=:analytic,
+    method=:analytic,  # status=:universal derived by construction (register!)
     reliability=:high,
     notes="Landau mean-field critical exponents (α=0, β=1/2, γ=1, δ=3, ν=1/2, η=0); exact for d >= d_c = 4.",
 )

--- a/src/universalities/behaviour/CardyEntanglement_registry.jl
+++ b/src/universalities/behaviour/CardyEntanglement_registry.jl
@@ -60,8 +60,7 @@ for C in _CFT_CLASSES, (q, refs, note) in _CFT_PREDICTIONS
         Universality{C},
         q,
         Infinite;
-        status=:universal,
-        method=:analytic,
+        method=:analytic,  # status=:universal derived by construction (register!)
         reliability=:high,
         references=refs,
         notes=note,

--- a/test/core/test_registry.jl
+++ b/test/core/test_registry.jl
@@ -268,3 +268,30 @@ end
     )
     @test all_tfim == expected
 end
+
+@testset "register! derives :universal for Universality nodes by construction (#659)" begin
+    # A Universality node is :universal by construction — no explicit status= needed,
+    # so the (namespace, status) pair cannot desync (the old double-encoding).
+    n_before = length(REGISTRY)
+    QAtlas.register!(
+        QAtlas.Universality{:__test659},
+        QAtlas.CriticalExponents,
+        Infinite;
+        method=:analytic,
+    )
+    @test REGISTRY[end].status === :universal
+    pop!(REGISTRY)                                   # undo the probe row
+    @test length(REGISTRY) == n_before
+
+    # A disagreeing explicit status on a Universality node is rejected (no row added).
+    @test_throws ArgumentError QAtlas.register!(
+        QAtlas.Universality{:__test659},
+        QAtlas.CriticalExponents,
+        Infinite;
+        status=:bound,
+        direction=:upper,
+    )
+    # :universal on a non-Universality node is rejected (the reverse half).
+    @test_throws ArgumentError QAtlas.register!(TFIM, MassGap, Infinite; status=:universal)
+    @test length(REGISTRY) == n_before
+end


### PR DESCRIPTION
Follow-up from the v0.24.4 design review (#659).

## The defect
`status=:universal` is 100% determined by the **namespace** — it appears only on `Universality{C}` nodes — yet it was hand-stamped on every such registration, and `register!` had no guard. Coherence **C2** *detected* a `(namespace, status)` desync after the fact; its very existence proved two writable sources of truth for the same fact. This is the old "status double-encoding" weakness in miniature.

## The fix (prevention by construction)
- `register!` now **derives** `status=:universal` for Universality nodes (omit it, or it's forced) and **rejects a disagreeing explicit status**; `:universal` on a non-Universality node is likewise rejected.
- **Deliberately NOT symmetric with Bound.** A concrete model may legitimately carry `status=:bound` (e.g. TFIM's Lieb–Robinson velocity), so the Bound side stays one-way — checked, not enforced, by C2. (This is the design-review correction to the naive "make it symmetric" idea, which would have produced false positives.)
- Moved `_is_universality` to `core/universality.jl` so `register!` can call it at include time — the universality `*_registry.jl` files run long before `links.jl` (its old home). The other node-type helpers stay in `links.jl`.
- Dropped the now-redundant hand-written `status=:universal` from the three registration sites (CardyEntanglement loop → 40 rows, KPZ, MeanField).
- Added the **targeted C2 test that never existed**: `register!` derives `:universal`, rejects a disagreeing status on a Universality node, and rejects `:universal` on a non-Universality node.

## Validation
- Successful package load is itself the include-order test (register! resolves `_is_universality` while the universality registries run).
- All universality REGISTRY rows remain `:universal` (now derived, not stamped).
- `coherence_report()` = **0 errors / 0 gaps**; `test/core/test_registry.jl` passes (incl. the new #659 testset).
- JuliaFormatter v2 clean; 8 files.

## Note on versioning
This bumps 0.24.5→**0.24.6**, the same target as the in-flight #664. They're independent off `main` and touch `links.jl` on different lines (no merge conflict). If #664 merges first, this one will need a trivial re-bump to 0.24.7 (or a rebase) to satisfy VersionCheck.

Review & merge is yours (no auto-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)