### PR TITLE
refactor(core): extract shared _forward_kw_macro for the 4 declarative-store macros

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.24.6"
+version = "0.24.8"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/core/about.jl
+++ b/src/core/about.jl
@@ -73,11 +73,7 @@ type; the remaining `key=value` pairs are forwarded as keyword arguments.  Use
 ```
 """
 macro about(model_T, kwargs...)
-    kw = map(kwargs) do k
-        k isa Expr && k.head === :(=) || error("@about: expected key=value, got $k")
-        return Expr(:kw, k.args[1], esc(k.args[2]))
-    end
-    return Expr(:call, about!, Expr(:parameters, kw...), esc(model_T))
+    return _forward_kw_macro(about!, :about, (model_T,), kwargs)
 end
 
 """

--- a/src/core/realizes.jl
+++ b/src/core/realizes.jl
@@ -72,11 +72,7 @@ type and `:class` as the class symbol; the remaining `key=value` pairs are
 forwarded as keyword arguments.
 """
 macro realizes(model_T, class, kwargs...)
-    kw = map(kwargs) do k
-        k isa Expr && k.head === :(=) || error("@realizes: expected key=value, got $k")
-        return Expr(:kw, k.args[1], esc(k.args[2]))
-    end
-    return Expr(:call, realizes!, Expr(:parameters, kw...), esc(model_T), esc(class))
+    return _forward_kw_macro(realizes!, :realizes, (model_T, class), kwargs)
 end
 
 """

--- a/src/core/reduces.jl
+++ b/src/core/reduces.jl
@@ -69,11 +69,7 @@ keyword arguments.
 ```
 """
 macro reduces(source_T, target_T, kwargs...)
-    kw = map(kwargs) do k
-        k isa Expr && k.head === :(=) || error("@reduces: expected key=value, got $k")
-        return Expr(:kw, k.args[1], esc(k.args[2]))
-    end
-    return Expr(:call, reduces!, Expr(:parameters, kw...), esc(source_T), esc(target_T))
+    return _forward_kw_macro(reduces!, :reduces, (source_T, target_T), kwargs)
 end
 
 """

--- a/src/core/registry.jl
+++ b/src/core/registry.jl
@@ -228,18 +228,21 @@ The three positional arguments are spliced as types; the remaining
 [`register!`](@ref).
 """
 macro register(model_T, quantity_T, bc_T, kwargs...)
-    kw_exprs = map(kwargs) do kw
-        kw isa Expr && kw.head === :(=) || error("@register: expected key=value, got $kw")
-        return Expr(:kw, kw.args[1], esc(kw.args[2]))
+    return _forward_kw_macro(register!, :register, (model_T, quantity_T, bc_T), kwargs)
+end
+
+# Shared body of the four declarative-store macros (@register / @realizes /
+# @reduces / @about): validate each `key=value` arg, build the keyword
+# parameters, and return the `backend(; kw...) (positionals...)` forwarding call.
+# `name` is only for the error message.  All four macros expand at include time of
+# the `*_registry.jl` files (long after this is defined), so the forward reference
+# from `@register` above is fine.
+function _forward_kw_macro(backend, name::Symbol, positionals, kwargs)
+    kw = map(kwargs) do k
+        (k isa Expr && k.head === :(=)) || error("@$(name): expected key=value, got $(k)")
+        return Expr(:kw, k.args[1], esc(k.args[2]))
     end
-    return Expr(
-        :call,
-        register!,
-        Expr(:parameters, kw_exprs...),
-        esc(model_T),
-        esc(quantity_T),
-        esc(bc_T),
-    )
+    return Expr(:call, backend, Expr(:parameters, kw...), map(esc, positionals)...)
 end
 
 # ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Follow-up from the v0.24.4 design review (#660). Pure de-duplication, no behavior change.

## What
`@register` / `@realizes` / `@reduces` / `@about` had **verbatim-identical** bodies — validate each `key=value` arg, build the keyword parameters, forward to the backend with `esc`'d positionals — differing only in the backend function and the positional count. This PR extracts that body into one helper:

```julia
function _forward_kw_macro(backend, name::Symbol, positionals, kwargs)
    kw = map(kwargs) do k
        (k isa Expr && k.head === :(=)) || error("@$(name): expected key=value, got $(k)")
        return Expr(:kw, k.args[1], esc(k.args[2]))
    end
    return Expr(:call, backend, Expr(:parameters, kw...), map(esc, positionals)...)
end
```

…and reduces each macro to a one-liner, e.g. `@register` → `_forward_kw_macro(register!, :register, (model_T, quantity_T, bc_T), kwargs)`. The helper lives in `registry.jl`, which loads before `realizes.jl`/`reduces.jl`/`about.jl`; all four expand at include time of the `*_registry.jl` files, so the forward reference is fine. The expanded `Expr` is **identical** to before.

## Scope (per the review)
Only the macro layer is collapsed. The docs-harness static-scan twins (`scan_registry`/`scan_realizes`/`scan_about`) are **deliberately left alone** — the weigh-lens flagged that collapsing them is over-engineering (they're non-uniform: raw-string unwrap, QuoteNode special-case, 9-field assembly, and only 3-way). The store factoring itself is sound; this is just the one cheap duplicated layer.

## Validation
- Successful load is the macro-expansion test: every `@register`/`@realizes`/`@reduces`/`@about` across the codebase still produces correct rows (`REGISTRY`/`REALIZES`/`REDUCES` populated).
- `coherence_report()` = **0 errors / 0 gaps** (clean session).
- Per-store tests pass: `test_registry` / `test_realizes` / `test_reduces` / `test_about`.
- JuliaFormatter v2 clean; 5 files, net −9 lines.

## Versioning
Bumps to **0.24.8**, sequenced after #665 (0.24.7). Intended merge order: **#665 → #660**. If merged out of order, a trivial re-bump satisfies VersionCheck. Off `main`; no file conflict with #665.

Review & merge is yours (no auto-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)