### PR TITLE
feat(coherence): C9 orphan-class check + C1 edge-store reference integrity

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.24.7"
+version = "0.24.9"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/core/coherence.jl
+++ b/src/core/coherence.jl
@@ -14,7 +14,8 @@
 # Each `check_*` walks `REGISTRY` / `REALIZES` (+ `links.jl`) and returns
 # `CoherenceFinding`s.  `coherence_report` runs the STRUCTURAL suite wired today:
 # C1 reference integrity, C2 namespace⟺kind, C3 canonical/scheme coherence,
-# C4 delegation targets, C6 coverage, C8 realization loci.  Two further checks
+# C4 delegation targets, C6 coverage, C8 realization loci, C9 orphan classes
+# (C1 scans every edge store, not just REGISTRY).  Two further checks
 # are DESIGNED but not auto-run: C5 realization-agreement
 # (`check_realization_agreement`) is an opt-in physical probe — the model↔class
 # agreement it asserts is already covered concretely by the verify-card
@@ -39,18 +40,32 @@ function Base.show(io::IO, f::CoherenceFinding)
 end
 
 # ── C1 — reference integrity: every cited bibkey exists ──────────────────────
+# Scans every edge store that carries `references` — not just REGISTRY
+# (@register) but also REALIZES (@realizes), REDUCES (@reduces) and ABOUT
+# (@about) — so a dangling bibkey anywhere in the graph is caught, not only in
+# the implementation rows.
 function check_reference_integrity(bibkeys)
     keys = Set(string.(bibkeys))
     out = CoherenceFinding[]
-    for e in REGISTRY, r in e.references
-        r in keys || push!(
+    function _flag(loc, k)
+        return k in keys || push!(
             out,
             CoherenceFinding(
-                :reference_integrity,
-                :error,
-                "dangling reference '$(r)' in $(_kgshort(e.model))/$(_kgshort(e.quantity))",
+                :reference_integrity, :error, "dangling reference '$(k)' in $(loc)"
             ),
         )
+    end
+    for e in REGISTRY, r in e.references
+        _flag("$(_kgshort(e.model))/$(_kgshort(e.quantity))", r)
+    end
+    for r in REALIZES, k in r.references
+        _flag("realizes $(_kgshort(r.model))→:$(r.class)", k)
+    end
+    for r in REDUCES, k in r.references
+        _flag("reduces $(_kgshort(r.source))→$(_kgshort(r.target))", k)
+    end
+    for c in ABOUT, k in c.references
+        _flag("about $(_kgshort(c.model))", k)
     end
     return out
 end
@@ -177,6 +192,33 @@ function coverage_report()
     return out
 end
 
+# ── C9 — orphan universality classes ─────────────────────────────────────────
+# The inverse of C6: a class that *predicts* universal quantities (has
+# `status=:universal` rows) but is realized by NO model.  The atlas knows the
+# universal class yet has no concrete model flowing to it — a coverage hole, so
+# a `:gap` (a missing-but-expected edge, not an invariant violation): the class
+# is a candidate for a future `@realizes`, or is knowingly carried unrealized.
+function check_orphan_classes()
+    out = CoherenceFinding[]
+    predicting = unique(
+        c for c in (_class_of(e.model) for e in REGISTRY if e.status === :universal) if
+        c !== nothing
+    )
+    realized = Set(r.class for r in REALIZES)
+    for c in sort(predicting)
+        c in realized || push!(
+            out,
+            CoherenceFinding(
+                :orphan_class,
+                :gap,
+                "class :$(c) predicts universal quantities but is realized by no model — " *
+                "add an @realizes (a model flowing to :$(c)) or carry it as unrealized",
+            ),
+        )
+    end
+    return out
+end
+
 # ── C5 — realization agreement (physical) ────────────────────────────────────
 """
     check_realization_agreement(probes; rtol=1e-8) -> Vector{CoherenceFinding}
@@ -283,8 +325,9 @@ end
     coherence_report(; bibkeys=String[]) -> Vector{CoherenceFinding}
 
 Run the structural graph-coherence suite (C1–C4, C6 coverage, C8 realization
-loci). Pass `bibkeys` (the set of keys in references.bib) to include C1.
-`:error` findings must be empty; `:gap` findings are self-reported holes.
+loci, C9 orphan classes). Pass `bibkeys` (the set of keys in references.bib) to
+include C1. `:error` findings must be empty; `:gap` findings are self-reported
+holes (coverage / orphan classes) and need not be empty.
 """
 function coherence_report(; bibkeys=String[])
     findings = CoherenceFinding[]
@@ -294,6 +337,7 @@ function coherence_report(; bibkeys=String[])
     append!(findings, check_delegation_targets())
     append!(findings, coverage_report())
     append!(findings, check_realization_loci())
+    append!(findings, check_orphan_classes())
     return findings
 end
 

--- a/test/core/test_reduces.jl
+++ b/test/core/test_reduces.jl
@@ -81,3 +81,27 @@ end
         @test tgt in [r.target for r in reductions(src)]
     end
 end
+
+# #661 — orphan universality classes: a class that predicts (has :universal rows)
+# but is realized by no model is a coverage hole the network now self-reports (C9).
+@testset "orphan universality classes surface as coverage gaps (#661)" begin
+    fs = QAtlas.coherence_report()
+    @test isempty(QAtlas.coherence_errors(fs))            # still no invariant violations
+    orphans = filter(g -> g.check === :orphan_class, QAtlas.coherence_gaps(fs))
+    msgs = join((g.message for g in orphans), " ")
+    # :Potts3 / :Potts4 carry CardyEntanglement :universal rows but no model realizes them
+    @test occursin(":Potts3", msgs)
+    @test occursin(":Potts4", msgs)
+    # a realized class (Ising — TFIM / IsingSquare / …) must never be flagged orphan
+    @test !occursin(":Ising", msgs)
+end
+
+# #661 — C1 reference integrity now scans the edge stores, not just @register rows.
+@testset "C1 reference integrity catches a dangling edge-store bibkey (#661)" begin
+    n = length(QAtlas.REDUCES)
+    QAtlas.reduces!(HeisenbergXYZ, TFIM; regime="ref-test", references=["__NoSuchKey2026"])
+    fs = QAtlas.check_reference_integrity(["SomeRealKey"])   # bibkey set lacking the bogus key
+    @test any(f -> f.severity === :error && occursin("__NoSuchKey2026", f.message), fs)
+    pop!(QAtlas.REDUCES)                                     # undo the probe row
+    @test length(QAtlas.REDUCES) == n
+end


### PR DESCRIPTION
Follow-up from the v0.24.4 design review (#661). Strengthens the coherence layer's self-reporting — the layer whose whole value proposition is reporting holes.

## What

**C9 — orphan universality classes** (`check_orphan_classes`): the inverse of C6. A class that *predicts* universal quantities (has `status=:universal` rows) but is realized by **no** model. The atlas knows the universal class yet has no concrete model flowing to it. Surfaces:
- `:Potts3` and `:Potts4` — both carry CardyEntanglement `:universal` rows (they're valid 1+1D CFTs with central charge) but no model `@realizes` them.

**C1 extended** (`check_reference_integrity`): now scans `REALIZES` / `REDUCES` / `ABOUT` references, not just `REGISTRY`. A dangling bibkey in any edge store is now caught (latent today — the edge stores carry no references yet — but no longer a blind spot when they do).

## ⚠️ Behavior change: `coherence_report()` is now 0 errors / **2 gaps**

This is the **feature working as intended** — `:gap` findings are self-reported coverage holes and (per the convention in `CoherenceFinding`) **need not be empty**; only `:error` findings are the hard invariant (still 0). The 2 gaps are the `:Potts3`/`:Potts4` orphans.

The decision you delegated ("loosen the 0-gap baseline or address the orphans") is resolved here as: **surface them as `:gap`** (knowingly-carried unrealized classes), rather than `:error` or hiding them. If you'd rather they not appear, the alternatives are (a) add a model that realizes `:Potts3`/`:Potts4`, or (b) drop those two from `_CFT_CLASSES` in CardyEntanglement. Easy to flip later.

(The test that filters to `:delegation_target` gaps is unaffected; no test asserted global 0-gaps.)

## Scope
Skipped the `:universal`-fetch-coverage walk also listed in #661 — it's already enforced by the existing `has_native_fetch` drift guard in `test_registry.jl` (every row, including `:universal`, must have a native fetch). Adding it to coherence would duplicate that test.

## Validation
- `coherence_report()` = 0 errors / 2 gaps (`:Potts3`, `:Potts4`); errors are the hard invariant.
- Tests: orphan gaps surface `:Potts3`/`:Potts4` and never a realized class (`:Ising`); C1 catches a dangling edge-store bibkey (via a probe `@reduces` row).
- JuliaFormatter v2 clean; 3 files.

## Versioning
Bumps to **0.24.9**, sequenced after #666 (0.24.8). Intended merge order: **#666 → #661**. Off `main`; touches only `coherence.jl` (no conflict with #666's macro files).

Review & merge is yours (no auto-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)