### PR TITLE
feat: thorough atlas search (node / edge / gap, JSONL) — the LLM use face

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.25.0"
+version = "0.25.2"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -443,7 +443,7 @@ export coherence_report,
 # Availability search (the "use" face): "does the atlas have X?" → yes/no + JSONL, by model /
 # quantity / bc / regime. Reads REGISTRY + the edge stores, so it comes after they are populated.
 include("core/query.jl")
-export search, search_jsonl, available, relations, relations_jsonl
+export search, search_jsonl, available, relations, relations_jsonl, gaps, gaps_jsonl
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Precompile workload — bake the hot `fetch` specializations into the package

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -443,7 +443,7 @@ export coherence_report,
 # Availability search (the "use" face): "does the atlas have X?" → yes/no + JSONL, by model /
 # quantity / bc / regime. Reads REGISTRY + the edge stores, so it comes after they are populated.
 include("core/query.jl")
-export search, search_jsonl, available
+export search, search_jsonl, available, relations, relations_jsonl
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Precompile workload — bake the hot `fetch` specializations into the package

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -440,6 +440,11 @@ export predicts, predicted_by, bounds_on, cited_by, delegations, implementations
 export coherence_report,
     coherence_errors, coherence_gaps, CoherenceFinding, check_realization_agreement
 
+# Availability search (the "use" face): "does the atlas have X?" → yes/no + JSONL, by model /
+# quantity / bc / regime. Reads REGISTRY + the edge stores, so it comes after they are populated.
+include("core/query.jl")
+export search, search_jsonl, available
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Precompile workload — bake the hot `fetch` specializations into the package
 # image so the test suite (and downstream callers) do not re-pay type inference

--- a/src/core/query.jl
+++ b/src/core/query.jl
@@ -178,6 +178,115 @@ The bare yes/no: does the atlas have anything matching the facets? Convenience o
 """
 available(; kwargs...) = search(; kwargs...).available
 
+# ---- edge / relation search: a model's graph neighborhood ----
+
+"""
+    Relation
+
+One edge in a model's graph neighborhood: `kind`
+(`:dual`/`:limit_to`/`:limit_from`/`:reduces_to`/`:reduces_from`/`:realizes`/`:symmetry`), the
+`from`/`to` endpoints (model names; a universality class for `:realizes`; `""` for `:symmetry`), a
+`detail` summary, and `references`.
+"""
+struct Relation
+    kind::Symbol
+    from::String
+    to::String
+    detail::String
+    references::Vector{String}
+end
+
+# The registered model Types matching a facet (a Type, or a fuzzy Symbol/String).
+function _model_types(facet)
+    seen = Type[]
+    for impl in REGISTRY
+        impl.model in seen && continue
+        _match(facet, impl.model) || continue
+        push!(seen, impl.model)
+    end
+    return seen
+end
+
+"""
+    relations(model) -> Vector{Relation}
+
+The graph neighborhood of `model` (a Type, or a fuzzy Symbol/String facet): every duality, limit,
+reduction, realization, and symmetry edge it participates in, one `Relation` each. See
+[`relations_jsonl`](@ref) for JSONL output.
+"""
+function relations(model)
+    rels = Relation[]
+    for M in _model_types(model)
+        nm = _label(M)
+        for d in DUALITIES
+            (d.source === M || d.target === M) || continue
+            partner = d.source === M ? d.target : d.source
+            push!(
+                rels,
+                Relation(
+                    :dual,
+                    nm,
+                    _label(partner),
+                    "kind=$(d.kind); $(d.regime)",
+                    copy(d.references),
+                ),
+            )
+        end
+        for l in LIMIT_EDGES
+            l.source === M && push!(
+                rels,
+                Relation(
+                    :limit_to,
+                    nm,
+                    _label(l.target),
+                    "param=$(l.param); $(l.regime)",
+                    copy(l.references),
+                ),
+            )
+            l.target === M && push!(
+                rels,
+                Relation(
+                    :limit_from,
+                    _label(l.source),
+                    nm,
+                    "param=$(l.param); $(l.regime)",
+                    copy(l.references),
+                ),
+            )
+        end
+        for r in REDUCES
+            r.source === M && push!(
+                rels,
+                Relation(:reduces_to, nm, _label(r.target), r.regime, copy(r.references)),
+            )
+            r.target === M && push!(
+                rels,
+                Relation(:reduces_from, _label(r.source), nm, r.regime, copy(r.references)),
+            )
+        end
+        for r in REALIZES
+            r.model === M && push!(
+                rels,
+                Relation(:realizes, nm, string(r.class), r.regime, copy(r.references)),
+            )
+        end
+        for p in SYMMETRY_PROFILES
+            p.model === M && push!(
+                rels,
+                Relation(
+                    :symmetry,
+                    nm,
+                    "",
+                    "internal=$(p.internal), translation=$(p.translation)",
+                    copy(p.references),
+                ),
+            )
+        end
+    end
+    sort!(rels; by=r -> (string(r.kind), r.from, r.to))
+    return rels
+end
+
 # ---- JSONL serialization (hand-rolled; fields are clean identifiers / bibkeys) ----
 
 function _json_escape(s::AbstractString)
@@ -266,3 +375,44 @@ function search_jsonl(io::IO=stdout; kwargs...)
     end
     return nothing
 end
+
+function _json_relation(r::Relation)
+    return string(
+        "{\"kind\":",
+        _jstr(r.kind),
+        ",\"from\":",
+        _jstr(r.from),
+        ",\"to\":",
+        _jstr(r.to),
+        ",\"detail\":",
+        _jstr(r.detail),
+        ",\"references\":",
+        _jarr(r.references),
+        "}",
+    )
+end
+
+"""
+    relations_jsonl([io=stdout], model) -> nothing
+
+Stream [`relations`](@ref) as JSONL: a `{available, query, count}` summary line then one Relation
+object per line.
+"""
+function relations_jsonl(io::IO, model)
+    rels = relations(model)
+    print(
+        io,
+        "{\"available\":",
+        !isempty(rels),
+        ",\"query\":",
+        _json_query((; model)),
+        ",\"count\":",
+        length(rels),
+        "}\n",
+    )
+    for r in rels
+        print(io, _json_relation(r), "\n")
+    end
+    return nothing
+end
+relations_jsonl(model) = relations_jsonl(stdout, model)

--- a/src/core/query.jl
+++ b/src/core/query.jl
@@ -34,14 +34,16 @@ const REGIMES = (
 """
     Hit
 
-One available (model, quantity, bc) hub, with its provenance. `cross_checked` is `true` when the
-model participates in an executable cross-check (a duality, limit, or LSM-symmetry edge) — the
-QAtlas-specific trust signal (model-level in this version).
+One available (model, quantity, bc) hub, with its provenance: `method` (how the value is obtained),
+`status`, `reliability`, `references`, and `cross_checked` — `true` when the model participates in
+an executable cross-check (a duality, limit, or LSM-symmetry edge), the QAtlas-specific trust signal
+(model-level in this version).
 """
 struct Hit
     model::String
     quantity::String
     bc::String
+    method::Symbol        # how the value is obtained (:bdg, :bethe_ansatz, :analytic, …)
     status::Symbol        # :exact / :bound / :approx / :universal
     reliability::Symbol   # :high / :medium / :low
     cross_checked::Bool
@@ -71,6 +73,9 @@ _match(want::Symbol, @nospecialize(T)) = occursin(_norm(want), _norm(_label(T)))
 _match(want::AbstractString, @nospecialize(T)) = occursin(_norm(want), _norm(_label(T)))
 _match(want::Type, @nospecialize(T)) = T <: want
 
+# A reference facet matches if any of a row's bibkeys contains it (case/underscore-insensitive).
+_ref_match(want, refs) = any(r -> occursin(_norm(want), _norm(r)), refs)
+
 # Models tied into an executable cross-check (duality / limit / LSM symmetry). Model-level for now.
 function _cross_checked_models()
     s = Set{Type}()
@@ -89,15 +94,35 @@ function _cross_checked_models()
 end
 
 """
-    search(; model=nothing, quantity=nothing, bc=nothing, regime=nothing) -> QueryResult
+    search(; model, quantity, bc, regime, status, reliability, method, reference, cross_checked) -> QueryResult
 
-Does the atlas have data matching the given facets? Any facet left `nothing` is unconstrained.
-`model`/`quantity`/`bc` accept a Type (exact / family) or a Symbol/String (fuzzy substring on the
-name); `regime` is one of `keys(REGIMES)` (`:ground_state`, `:finite_temperature`, `:dynamics`,
-`:universality`). Returns a [`QueryResult`](@ref) — see [`search_jsonl`](@ref) for JSONL output and
-[`available`](@ref) for just the boolean.
+Does the atlas have data matching the given facets? Any facet left `nothing` is unconstrained; all
+given facets are AND-combined.
+
+- `model`/`quantity`/`bc` — a Type (exact, or a family like `AbstractGap`) or a Symbol/String
+  (fuzzy: case- and underscore-insensitive substring on the name).
+- `regime` — one of `keys(REGIMES)` (`:ground_state`, `:finite_temperature`, `:dynamics`,
+  `:universality`).
+- `status` (`:exact`/`:bound`/`:approx`/`:universal`) and `reliability` (`:high`/`:medium`/`:low`)
+  — exact Symbol match.
+- `method` — a Symbol/String, fuzzy (so `:bethe` finds `:bethe_ansatz`).
+- `reference` — a bibkey substring, fuzzy (so `"Pfeuty"` finds `"Pfeuty1970"`).
+- `cross_checked` — `true`/`false`, the trust filter.
+
+Returns a [`QueryResult`](@ref) — see [`search_jsonl`](@ref) for JSONL and [`available`](@ref) for
+just the boolean.
 """
-function search(; model=nothing, quantity=nothing, bc=nothing, regime=nothing)
+function search(;
+    model=nothing,
+    quantity=nothing,
+    bc=nothing,
+    regime=nothing,
+    status=nothing,
+    reliability=nothing,
+    method=nothing,
+    reference=nothing,
+    cross_checked=nothing,
+)
     regime === nothing ||
         haskey(REGIMES, regime) ||
         throw(ArgumentError("unknown regime $(repr(regime)); known: $(keys(REGIMES))"))
@@ -108,21 +133,42 @@ function search(; model=nothing, quantity=nothing, bc=nothing, regime=nothing)
         _match(quantity, impl.quantity) || continue
         _match(bc, impl.bc) || continue
         regime === nothing || REGIMES[regime](impl) || continue
+        status === nothing || impl.status === status || continue
+        reliability === nothing || impl.reliability === reliability || continue
+        method === nothing || _match(method, impl.method) || continue
+        reference === nothing || _ref_match(reference, impl.references) || continue
+        xc = impl.model in xchecked
+        cross_checked === nothing || xc === cross_checked || continue
         push!(
             hits,
             Hit(
                 _label(impl.model),
                 _label(impl.quantity),
                 _label(impl.bc),
+                impl.method,
                 impl.status,
                 impl.reliability,
-                impl.model in xchecked,
+                xc,
                 copy(impl.references),
             ),
         )
     end
     sort!(hits; by=h -> (h.model, h.quantity, h.bc))
-    return QueryResult((; model, quantity, bc, regime), !isempty(hits), hits)
+    return QueryResult(
+        (;
+            model,
+            quantity,
+            bc,
+            regime,
+            status,
+            reliability,
+            method,
+            reference,
+            cross_checked,
+        ),
+        !isempty(hits),
+        hits,
+    )
 end
 
 """
@@ -166,6 +212,8 @@ function _json_hit(h::Hit)
         _jstr(h.quantity),
         ",\"bc\":",
         _jstr(h.bc),
+        ",\"method\":",
+        _jstr(h.method),
         ",\"status\":",
         _jstr(h.status),
         ",\"reliability\":",
@@ -182,7 +230,8 @@ function _json_query(q::NamedTuple)
     parts = String[]
     for (k, v) in pairs(q)
         v === nothing && continue
-        push!(parts, string(_jstr(k), ":", _jstr(v isa Type ? _label(v) : v)))
+        val = v isa Bool ? string(v) : _jstr(v isa Type ? _label(v) : v)
+        push!(parts, string(_jstr(k), ":", val))
     end
     return string('{', join(parts, ','), '}')
 end

--- a/src/core/query.jl
+++ b/src/core/query.jl
@@ -1,0 +1,219 @@
+# core/query.jl — availability search over the atlas (the "use" face)
+#
+# `implementation_status()` returns every registry row, but there was no way to ask "does the atlas
+# HAVE X?" and get a yes/no. `search` answers that — by model, quantity, boundary condition, and/or
+# a coarse `regime` facet (ground-state / finite-temperature / dynamics / universality) — and
+# `search_jsonl` streams the answer as JSONL: a summary line `{available, query, count, verified}`
+# then one object per hit. A consumer (an LLM, or a shell pipeline) can ask "is there
+# finite-temperature TFIM data?" and branch on the first line alone.
+#
+# Each hit carries its provenance (status, reliability, references) and whether the model is tied
+# into QAtlas's executable cross-checks (`cross_checked`) — so "available" is qualified by "and how
+# trustworthy", not a bare bool. The live pass/fail verdict (running the numerics) is a deeper,
+# on-demand query, deliberately NOT run here so search stays fast. JSON is hand-rolled (the fields
+# are clean identifiers / bibkeys) to keep the core dependency-free.
+
+"""
+    REGIMES
+
+Coarse capability facets, each a predicate over a registry row. Declarative and extensible — add a
+regime by adding a predicate. `:dynamics` is intentionally sparse today (QAtlas has velocities but
+no spectral / real-time data yet); a search for it honestly reports the gap.
+"""
+const REGIMES = (
+    ground_state=impl -> (
+        impl.quantity <: AbstractGap ||
+        impl.quantity <: AbstractEntanglementMeasure ||
+        impl.quantity === GroundStateEnergyDensity
+    ),
+    finite_temperature=impl -> impl.quantity <: AbstractThermalPotential,
+    universality=impl -> impl.status === :universal,
+    dynamics=impl -> impl.quantity <: AbstractVelocity,
+)
+
+"""
+    Hit
+
+One available (model, quantity, bc) hub, with its provenance. `cross_checked` is `true` when the
+model participates in an executable cross-check (a duality, limit, or LSM-symmetry edge) — the
+QAtlas-specific trust signal (model-level in this version).
+"""
+struct Hit
+    model::String
+    quantity::String
+    bc::String
+    status::Symbol        # :exact / :bound / :approx / :universal
+    reliability::Symbol   # :high / :medium / :low
+    cross_checked::Bool
+    references::Vector{String}
+end
+
+"""
+    QueryResult
+
+The result of a [`search`](@ref): the echoed `query`, an `available` flag, and the matching `hits`.
+"""
+struct QueryResult
+    query::NamedTuple
+    available::Bool
+    hits::Vector{Hit}
+end
+
+_label(@nospecialize T) = replace(string(T), "QAtlas." => "")
+_norm(s) = lowercase(replace(string(s), "_" => ""))
+
+# Facet matching: `nothing` matches anything; a Symbol/String matches by case- and
+# underscore-insensitive substring on the type name (so `:specific_heat` finds `SpecificHeat`,
+# `:ising` finds every Ising* model); a Type matches as a supertype (so `quantity=AbstractGap`
+# catches the whole family).
+_match(::Nothing, @nospecialize(T)) = true
+_match(want::Symbol, @nospecialize(T)) = occursin(_norm(want), _norm(_label(T)))
+_match(want::AbstractString, @nospecialize(T)) = occursin(_norm(want), _norm(_label(T)))
+_match(want::Type, @nospecialize(T)) = T <: want
+
+# Models tied into an executable cross-check (duality / limit / LSM symmetry). Model-level for now.
+function _cross_checked_models()
+    s = Set{Type}()
+    for d in DUALITIES
+        push!(s, d.source)
+        push!(s, d.target)
+    end
+    for l in LIMIT_EDGES
+        push!(s, l.source)
+        push!(s, l.target)
+    end
+    for p in SYMMETRY_PROFILES
+        push!(s, p.model)
+    end
+    return s
+end
+
+"""
+    search(; model=nothing, quantity=nothing, bc=nothing, regime=nothing) -> QueryResult
+
+Does the atlas have data matching the given facets? Any facet left `nothing` is unconstrained.
+`model`/`quantity`/`bc` accept a Type (exact / family) or a Symbol/String (fuzzy substring on the
+name); `regime` is one of `keys(REGIMES)` (`:ground_state`, `:finite_temperature`, `:dynamics`,
+`:universality`). Returns a [`QueryResult`](@ref) — see [`search_jsonl`](@ref) for JSONL output and
+[`available`](@ref) for just the boolean.
+"""
+function search(; model=nothing, quantity=nothing, bc=nothing, regime=nothing)
+    regime === nothing ||
+        haskey(REGIMES, regime) ||
+        throw(ArgumentError("unknown regime $(repr(regime)); known: $(keys(REGIMES))"))
+    xchecked = _cross_checked_models()
+    hits = Hit[]
+    for impl in REGISTRY
+        _match(model, impl.model) || continue
+        _match(quantity, impl.quantity) || continue
+        _match(bc, impl.bc) || continue
+        regime === nothing || REGIMES[regime](impl) || continue
+        push!(
+            hits,
+            Hit(
+                _label(impl.model),
+                _label(impl.quantity),
+                _label(impl.bc),
+                impl.status,
+                impl.reliability,
+                impl.model in xchecked,
+                copy(impl.references),
+            ),
+        )
+    end
+    sort!(hits; by=h -> (h.model, h.quantity, h.bc))
+    return QueryResult((; model, quantity, bc, regime), !isempty(hits), hits)
+end
+
+"""
+    available(; model=nothing, quantity=nothing, bc=nothing, regime=nothing) -> Bool
+
+The bare yes/no: does the atlas have anything matching the facets? Convenience over [`search`](@ref).
+"""
+available(; kwargs...) = search(; kwargs...).available
+
+# ---- JSONL serialization (hand-rolled; fields are clean identifiers / bibkeys) ----
+
+function _json_escape(s::AbstractString)
+    buf = IOBuffer()
+    for c in s
+        if c == '"'
+            print(buf, "\\\"")
+        elseif c == '\\'
+            print(buf, "\\\\")
+        elseif c == '\n'
+            print(buf, "\\n")
+        elseif c == '\t'
+            print(buf, "\\t")
+        elseif c == '\r'
+            print(buf, "\\r")
+        elseif c < ' '
+            print(buf, "\\u", lpad(string(UInt16(c); base=16), 4, '0'))
+        else
+            print(buf, c)
+        end
+    end
+    return String(take!(buf))
+end
+_jstr(s) = string('"', _json_escape(string(s)), '"')
+_jarr(v) = string('[', join((_jstr(x) for x in v), ','), ']')
+
+function _json_hit(h::Hit)
+    return string(
+        "{\"model\":",
+        _jstr(h.model),
+        ",\"quantity\":",
+        _jstr(h.quantity),
+        ",\"bc\":",
+        _jstr(h.bc),
+        ",\"status\":",
+        _jstr(h.status),
+        ",\"reliability\":",
+        _jstr(h.reliability),
+        ",\"cross_checked\":",
+        h.cross_checked,
+        ",\"references\":",
+        _jarr(h.references),
+        "}",
+    )
+end
+
+function _json_query(q::NamedTuple)
+    parts = String[]
+    for (k, v) in pairs(q)
+        v === nothing && continue
+        push!(parts, string(_jstr(k), ":", _jstr(v isa Type ? _label(v) : v)))
+    end
+    return string('{', join(parts, ','), '}')
+end
+
+"""
+    search_jsonl([io=stdout]; model, quantity, bc, regime) -> nothing
+
+Stream a [`search`](@ref) as JSONL. The first line is a summary —
+`{"available":…,"query":…,"count":N,"verified":K}` — so a consumer can branch on it without reading
+the rest; each following line is one hit object (model, quantity, bc, status, reliability,
+cross_checked, references). `verified` counts hits that are cross-checked or exact/universal.
+"""
+function search_jsonl(io::IO=stdout; kwargs...)
+    r = search(; kwargs...)
+    nverified = count(
+        h -> h.cross_checked || h.status === :exact || h.status === :universal, r.hits
+    )
+    print(
+        io,
+        "{\"available\":",
+        r.available,
+        ",\"query\":",
+        _json_query(r.query),
+        ",\"count\":",
+        length(r.hits),
+        ",\"verified\":",
+        nverified,
+        "}\n",
+    )
+    for h in r.hits
+        print(io, _json_hit(h), "\n")
+    end
+    return nothing
+end

--- a/src/core/query.jl
+++ b/src/core/query.jl
@@ -287,6 +287,42 @@ function relations(model)
     return rels
 end
 
+# ---- gap / absence search: a model's coverage holes ----
+
+"""
+    Gap
+
+A coverage hole — something the atlas does NOT have. `kind` is `:regime` (a `REGIMES` capability the
+`model` does not cover); `subject` names what is missing. Atlas-wide structural gaps are separate —
+see `coherence_gaps()`.
+"""
+struct Gap
+    kind::Symbol
+    subject::String
+    model::String
+end
+
+"""
+    gaps(model) -> Vector{Gap}
+
+What the atlas does NOT have for `model` (a Type, or a fuzzy Symbol/String facet): for each `regime`
+in `REGIMES` the model does not cover, a `Gap(:regime, regime, model)`. The grounded negative of
+[`search`](@ref) — no guessed "expected set", just the known capability facets the model lacks. See
+[`gaps_jsonl`](@ref) for JSONL.
+"""
+function gaps(model)
+    out = Gap[]
+    for M in _model_types(model)
+        nm = _label(M)
+        for regime in keys(REGIMES)
+            isempty(search(; model=M, regime=regime).hits) &&
+                push!(out, Gap(:regime, string(regime), nm))
+        end
+    end
+    sort!(out; by=g -> (g.model, g.subject))
+    return out
+end
+
 # ---- JSONL serialization (hand-rolled; fields are clean identifiers / bibkeys) ----
 
 function _json_escape(s::AbstractString)
@@ -416,3 +452,40 @@ function relations_jsonl(io::IO, model)
     return nothing
 end
 relations_jsonl(model) = relations_jsonl(stdout, model)
+
+function _json_gap(g::Gap)
+    return string(
+        "{\"kind\":",
+        _jstr(g.kind),
+        ",\"subject\":",
+        _jstr(g.subject),
+        ",\"model\":",
+        _jstr(g.model),
+        "}",
+    )
+end
+
+"""
+    gaps_jsonl([io=stdout], model) -> nothing
+
+Stream [`gaps`](@ref) as JSONL: a `{has_gaps, query, count}` summary line then one Gap object per
+line.
+"""
+function gaps_jsonl(io::IO, model)
+    gs = gaps(model)
+    print(
+        io,
+        "{\"has_gaps\":",
+        !isempty(gs),
+        ",\"query\":",
+        _json_query((; model)),
+        ",\"count\":",
+        length(gs),
+        "}\n",
+    )
+    for g in gs
+        print(io, _json_gap(g), "\n")
+    end
+    return nothing
+end
+gaps_jsonl(model) = gaps_jsonl(stdout, model)

--- a/test/core/test_query.jl
+++ b/test/core/test_query.jl
@@ -1,0 +1,56 @@
+using QAtlas, Test
+
+# Availability search (core/query.jl): "does the atlas have X?" → yes/no + JSONL, by
+# model / quantity / bc / regime. These tests pin the contract the LLM "use" face depends on.
+
+@testset "query: search + available agree; facets narrow" begin
+    r = QAtlas.search(; model=:TFIM, regime=:finite_temperature)
+    @test r isa QAtlas.QueryResult
+    @test r.available
+    @test !isempty(r.hits)
+    @test QAtlas.available(; model=:TFIM, regime=:finite_temperature) == r.available
+    @test all(h -> occursin("TFIM", h.model), r.hits)        # every hit really is TFIM
+end
+
+@testset "query: regime taxonomy filters correctly" begin
+    uni = QAtlas.search(; regime=:universality)
+    @test uni.available
+    @test all(h -> h.status === :universal, uni.hits)        # :universality ⇒ only :universal rows
+    @test QAtlas.search(; regime=:finite_temperature).available
+    @test_throws ArgumentError QAtlas.search(; regime=:not_a_regime)
+end
+
+@testset "query: fuzzy facet matching (case/underscore-insensitive)" begin
+    @test QAtlas.available(; model=:tfim)                    # lowercase Symbol
+    @test QAtlas.available(; quantity=:specific_heat)        # underscore vs SpecificHeat
+    @test QAtlas.available(; quantity="FreeEnergy")          # String facet
+    @test !QAtlas.available(; model=:NoSuchModelXYZ)         # honest "not available"
+end
+
+@testset "query: a Type facet matches a whole family; a concrete type narrows" begin
+    fam = QAtlas.search(; quantity=QAtlas.AbstractThermalPotential)
+    fe = QAtlas.search(; quantity=QAtlas.FreeEnergy)
+    @test fam.available && fe.available
+    @test all(h -> h.quantity == "FreeEnergy", fe.hits)
+    @test length(fe.hits) <= length(fam.hits)
+end
+
+@testset "query: search_jsonl shape (summary line + one object per hit)" begin
+    r = QAtlas.search(; model=:TFIM, regime=:finite_temperature)
+    io = IOBuffer()
+    QAtlas.search_jsonl(io; model=:TFIM, regime=:finite_temperature)
+    lines = split(strip(String(take!(io))), '\n')
+    @test length(lines) == length(r.hits) + 1                # summary + one per hit
+    @test startswith(lines[1], "{\"available\":true")        # branchable first line
+    @test occursin("\"count\":$(length(r.hits))", lines[1])
+    @test all(l -> startswith(l, "{\"model\":"), lines[2:end])
+    @test all(l -> occursin("\"cross_checked\":", l), lines[2:end])
+end
+
+@testset "query: not-available search → single false summary, no hit lines" begin
+    io = IOBuffer()
+    QAtlas.search_jsonl(io; model=:NoSuchModelXYZ)
+    lines = split(strip(String(take!(io))), '\n')
+    @test length(lines) == 1
+    @test startswith(lines[1], "{\"available\":false")
+end

--- a/test/core/test_query.jl
+++ b/test/core/test_query.jl
@@ -20,6 +20,23 @@ end
     @test_throws ArgumentError QAtlas.search(; regime=:not_a_regime)
 end
 
+@testset "query: rich node facets — status / reliability / method / reference / cross_checked" begin
+    ex = QAtlas.search(; model=:TFIM, status=:exact)
+    @test ex.available
+    @test all(h -> h.status === :exact, ex.hits)            # exact Symbol match
+    @test all(h -> h.method isa Symbol, ex.hits)            # method now surfaces in the hit
+    pf = QAtlas.search(; reference="Pfeuty")                 # bibkey substring (fuzzy)
+    @test pf.available
+    @test all(h -> any(r -> occursin("pfeuty", lowercase(r)), h.references), pf.hits)
+    @test QAtlas.available(; method=:bethe)                 # fuzzy → finds :bethe_ansatz
+    xc = QAtlas.search(; model=:TFIM, cross_checked=true)   # the trust filter
+    @test xc.available && all(h -> h.cross_checked, xc.hits)
+    @test !QAtlas.available(; model=:TFIM, status=:no_such_status)  # AND-combined, honest miss
+    io = IOBuffer()
+    QAtlas.search_jsonl(io; model=:TFIM, status=:exact)
+    @test occursin("\"method\":", String(take!(io)))        # method in the JSONL hit
+end
+
 @testset "query: fuzzy facet matching (case/underscore-insensitive)" begin
     @test QAtlas.available(; model=:tfim)                    # lowercase Symbol
     @test QAtlas.available(; quantity=:specific_heat)        # underscore vs SpecificHeat

--- a/test/core/test_query.jl
+++ b/test/core/test_query.jl
@@ -64,6 +64,25 @@ end
     @test all(l -> occursin("\"cross_checked\":", l), lines[2:end])
 end
 
+@testset "query: relations — a model's graph neighborhood (edge search)" begin
+    rs = QAtlas.relations(:TFIM)
+    @test !isempty(rs)
+    @test :dual in (r.kind for r in rs)                      # TFIM is Kramers–Wannier self-dual
+    @test all(r -> r.from == "TFIM" || r.to == "TFIM", rs)   # every relation touches TFIM
+    @test all(r -> r.references isa Vector, rs)
+    io = IOBuffer()
+    QAtlas.relations_jsonl(io, :TFIM)
+    lines = split(strip(String(take!(io))), '\n')
+    @test length(lines) == length(rs) + 1                    # summary + one per relation
+    @test startswith(lines[1], "{\"available\":true")
+    @test all(l -> occursin("\"kind\":", l), lines[2:end])
+    io2 = IOBuffer()
+    QAtlas.relations_jsonl(io2, :NoSuchModelXYZ)             # no such model → false summary, no lines
+    out2 = strip(String(take!(io2)))
+    @test startswith(out2, "{\"available\":false")
+    @test !occursin('\n', out2)
+end
+
 @testset "query: not-available search → single false summary, no hit lines" begin
     io = IOBuffer()
     QAtlas.search_jsonl(io; model=:NoSuchModelXYZ)

--- a/test/core/test_query.jl
+++ b/test/core/test_query.jl
@@ -83,6 +83,21 @@ end
     @test !occursin('\n', out2)
 end
 
+@testset "query: gaps — per-model coverage holes (absence search)" begin
+    g = QAtlas.gaps(:TFIM)
+    @test all(x -> x.kind === :regime && x.model == "TFIM", g)
+    # grounded: gaps + covered regimes partition all REGIMES (no guessed "expected set")
+    covered = count(r -> QAtlas.available(; model=:TFIM, regime=r), keys(QAtlas.REGIMES))
+    @test length(g) + covered == length(QAtlas.REGIMES)
+    # each reported gap is genuinely absent
+    @test all(x -> !QAtlas.available(; model=:TFIM, regime=Symbol(x.subject)), g)
+    io = IOBuffer()
+    QAtlas.gaps_jsonl(io, :TFIM)
+    lines = split(strip(String(take!(io))), '\n')
+    @test length(lines) == length(g) + 1
+    @test startswith(lines[1], "{\"has_gaps\":")
+end
+
 @testset "query: not-available search → single false summary, no hit lines" begin
     io = IOBuffer()
     QAtlas.search_jsonl(io; model=:NoSuchModelXYZ)


### PR DESCRIPTION
## What

A **thorough, machine-readable search over the atlas** — the LLM "use" face. `implementation_status()`
dumps every row, but there was no way to ask targeted questions and get a structured answer an LLM
(or a shell pipeline) can branch on. Three orthogonal layers, all emitting JSONL:

### Layer 1 — node search
`search(; model, quantity, bc, regime, status, reliability, method, reference, cross_checked) → QueryResult`,
`available(; …) → Bool`, `search_jsonl([io]; …)`. Facets are a Type (exact / a family like
`AbstractGap`) or a fuzzy Symbol/String (case- & underscore-insensitive). Each hit carries provenance
(status, reliability, method, references) + `cross_checked` — the model is tied into an executable
duality/limit/symmetry edge, the QAtlas-specific trust signal.

### Layer 2 — edge/relation search
`relations(model) → Vector{Relation}`, `relations_jsonl([io], model)`. A model's graph neighborhood
(dualities, limits, reductions, realizations, symmetry) as a uniform flat list.

### Layer 3 — gap/absence search
`gaps(model) → Vector{Gap}`, `gaps_jsonl([io], model)`. The grounded negative — which `REGIMES` a
model lacks (gaps + covered = REGIMES).

JSONL is hand-rolled (clean identifier/bibkey fields) to keep the core dependency-free.

**46 assertions** in `test/core/test_query.jl`, green on `main`; Aqua-clean (0 ambiguities, exports OK).
`version 0.25.0 → 0.25.2`.

> **Do not merge yet** — held for design review (maintainer will merge only once confirmed stable +
> minimal). A stacked PR (orthogonal thermal/dynamical axes) builds on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)