### PR TITLE
feat: orthogonal thermal/dynamical axes at @register (fixes the dynamics overclaim)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.25.2"
+version = "0.25.3"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -84,6 +84,7 @@ include("core/alias.jl")
 include("core/type.jl")
 include("core/quantities.jl")
 include("core/universality.jl")  # Universality{C} + CriticalExponents/GrowthExponents (registry design)
+include("core/axes.jl")          # orthogonal thermal/dynamical hub axes (quantity traits + derivation)
 include("core/registry.jl")
 include("core/realizes.jl")  # model <-> universality-class correspondence
 include("core/reduces.jl")   # model -> model reductions (limit / special point)

--- a/src/core/axes.jl
+++ b/src/core/axes.jl
@@ -1,0 +1,53 @@
+# core/axes.jl — orthogonal physical axes for a registered hub, captured at @register time.
+#
+# A single `regime` label conflated several independent physical dimensions, so
+# "finite-temperature dynamics" was inexpressible and velocities masqueraded as "dynamics". These
+# axes decompose that: each hub carries an independent `thermal` and `dynamical` tag, AND-queryable.
+#
+# Derivation priority (applied in register!): explicit @register kwarg > quantity-type trait >
+# fetch-signature introspection (does the method declare a β?) > :unknown. The honest default is
+# :unknown — search abstains rather than guessing, preserving the anti-hallucination property.
+# Because the tags live on the REGISTRY row (not on the quantity type), a hub whose implementation
+# deviates from its quantity's usual axis can be tagged individually via
+# `@register(...; thermal=…, dynamical=…)`.
+
+# ── thermal axis: :zero (T=0 only) / :finite (T>0) / :both / :unknown ──
+thermal_axis(::Type) = :unknown
+thermal_axis(::Type{<:AbstractThermalPotential}) = :finite   # FreeEnergy/SpecificHeat/ThermalEntropy
+thermal_axis(::Type{<:Energy}) = :both                       # ⟨H⟩: ground state (no β) or thermal (β)
+thermal_axis(::Type{<:AbstractGap}) = :zero                  # a gap is a ground-state spectral property
+thermal_axis(::Type{<:AbstractVelocity}) = :zero             # a velocity is a T=0 / low-energy property
+thermal_axis(::Type{<:AbstractEntanglementMeasure}) = :zero  # GS entanglement (quench would override)
+thermal_axis(::Type{<:AbstractMagnetization}) = :both        # spontaneous (T=0) or thermal (T>0)
+thermal_axis(::Type{<:AbstractSusceptibility}) = :both
+thermal_axis(::Type{<:AbstractTwoPointCorrelation}) = :both
+thermal_axis(::Type{<:AbstractStructureFactor}) = :both
+
+# ── dynamical axis: :static / :transport / :dynamic / :unknown ──
+# QAtlas is overwhelmingly equilibrium, so :static is the honest positive default; the few genuinely
+# non-static observables are tagged individually. A velocity is :transport, NOT :dynamic — so
+# `search(dynamical=:dynamic)` honestly returns empty until real spectral/real-time data exists
+# (e.g. a future dynamical critical exponent or A(ω) would be tagged :dynamic here).
+dynamical_axis(::Type) = :static
+dynamical_axis(::Type{<:AbstractVelocity}) = :transport
+
+# ── @register-time derivation: explicit > quantity trait > fetch-introspection > :unknown ──
+function _derive_thermal(explicit, M::Type, Q::Type, BC::Type)
+    explicit === nothing || return explicit
+    t = thermal_axis(Q)
+    t === :unknown || return t
+    return _fetch_declares_beta(M, Q, BC) ? :finite : :unknown
+end
+_derive_dynamical(explicit, Q::Type) = explicit === nothing ? dynamical_axis(Q) : explicit
+
+# Signature introspection: does the (M,Q,BC) fetch method declare a temperature kwarg? Deterministic
+# (thermal fetches declare `; beta::Real, …`), and only a fallback — the quantity trait is primary.
+function _fetch_declares_beta(M::Type, Q::Type, BC::Type)
+    try
+        for mth in methods(fetch, Tuple{M,Q,BC})
+            any(in((:beta, :β, :T, :temperature)), Base.kwarg_decl(mth)) && return true
+        end
+    catch
+    end
+    return false
+end

--- a/src/core/query.jl
+++ b/src/core/query.jl
@@ -46,6 +46,8 @@ struct Hit
     method::Symbol        # how the value is obtained (:bdg, :bethe_ansatz, :analytic, …)
     status::Symbol        # :exact / :bound / :approx / :universal
     reliability::Symbol   # :high / :medium / :low
+    thermal::Symbol       # orthogonal axis: :zero / :finite / :both / :unknown
+    dynamical::Symbol     # orthogonal axis: :static / :transport / :dynamic / :unknown
     cross_checked::Bool
     references::Vector{String}
 end
@@ -75,6 +77,10 @@ _match(want::Type, @nospecialize(T)) = T <: want
 
 # A reference facet matches if any of a row's bibkeys contains it (case/underscore-insensitive).
 _ref_match(want, refs) = any(r -> occursin(_norm(want), _norm(r)), refs)
+
+# An orthogonal-axis facet matches its stored value; `:both` (a hub spanning T=0 and T>0) matches
+# either `thermal` query.
+_axis_match(want, have) = want === have || have === :both
 
 # Models tied into an executable cross-check (duality / limit / LSM symmetry). Model-level for now.
 function _cross_checked_models()
@@ -122,6 +128,8 @@ function search(;
     method=nothing,
     reference=nothing,
     cross_checked=nothing,
+    thermal=nothing,
+    dynamical=nothing,
 )
     regime === nothing ||
         haskey(REGIMES, regime) ||
@@ -137,6 +145,8 @@ function search(;
         reliability === nothing || impl.reliability === reliability || continue
         method === nothing || _match(method, impl.method) || continue
         reference === nothing || _ref_match(reference, impl.references) || continue
+        thermal === nothing || _axis_match(thermal, impl.thermal) || continue
+        dynamical === nothing || _axis_match(dynamical, impl.dynamical) || continue
         xc = impl.model in xchecked
         cross_checked === nothing || xc === cross_checked || continue
         push!(
@@ -148,6 +158,8 @@ function search(;
                 impl.method,
                 impl.status,
                 impl.reliability,
+                impl.thermal,
+                impl.dynamical,
                 xc,
                 copy(impl.references),
             ),
@@ -165,6 +177,8 @@ function search(;
             method,
             reference,
             cross_checked,
+            thermal,
+            dynamical,
         ),
         !isempty(hits),
         hits,
@@ -363,6 +377,10 @@ function _json_hit(h::Hit)
         _jstr(h.status),
         ",\"reliability\":",
         _jstr(h.reliability),
+        ",\"thermal\":",
+        _jstr(h.thermal),
+        ",\"dynamical\":",
+        _jstr(h.dynamical),
         ",\"cross_checked\":",
         h.cross_checked,
         ",\"references\":",

--- a/src/core/registry.jl
+++ b/src/core/registry.jl
@@ -53,6 +53,8 @@ struct Implementation
     tested_in::Union{String,Nothing}
     references::Vector{String}
     notes::String
+    thermal::Symbol                      # orthogonal axis: :zero / :finite / :both / :unknown
+    dynamical::Symbol                    # orthogonal axis: :static / :transport / :dynamic / :unknown
 end
 
 """
@@ -148,6 +150,8 @@ function register!(
     tested_in::Union{String,Nothing}=nothing,
     references::AbstractVector{<:AbstractString}=String[],
     notes::AbstractString="",
+    thermal::Union{Symbol,Nothing}=nothing,
+    dynamical::Union{Symbol,Nothing}=nothing,
 )
     status in STATUS_VALUES || throw(
         ArgumentError("register!: status must be one of $(STATUS_VALUES); got :$(status)"),
@@ -228,6 +232,8 @@ function register!(
             tested_in,
             String[r for r in references],
             String(notes),
+            _derive_thermal(thermal, model_T, quantity_T, bc_T),
+            _derive_dynamical(dynamical, quantity_T),
         ),
     )
     return nothing

--- a/test/core/test_query.jl
+++ b/test/core/test_query.jl
@@ -37,6 +37,24 @@ end
     @test occursin("\"method\":", String(take!(io)))        # method in the JSONL hit
 end
 
+@testset "query: orthogonal axes — thermal × dynamical (captured at @register)" begin
+    ft = QAtlas.search(; thermal=:finite)
+    @test ft.available
+    @test all(h -> h.thermal in (:finite, :both), ft.hits)  # :both spans, matches :finite query
+    @test QAtlas.available(; thermal=:zero)
+    tr = QAtlas.search(; dynamical=:transport)               # velocities are :transport, not :dynamic
+    @test tr.available
+    @test all(h -> h.dynamical === :transport, tr.hits)
+    # THE FIX: real dynamics (:dynamic) is honestly absent → no more velocity overclaim
+    @test !QAtlas.available(; dynamical=:dynamic)
+    @test !QAtlas.available(; thermal=:finite, dynamical=:dynamic)  # the conjunction, honestly empty
+    en = QAtlas.search(; quantity=QAtlas.Energy)             # Energy is :both (T=0 or thermal)
+    @test en.available && any(h -> h.thermal === :both, en.hits)
+    io = IOBuffer()
+    QAtlas.search_jsonl(io; thermal=:finite)
+    @test occursin("\"thermal\":", String(take!(io)))        # axes surface in the JSONL hit
+end
+
 @testset "query: fuzzy facet matching (case/underscore-insensitive)" begin
     @test QAtlas.available(; model=:tfim)                    # lowercase Symbol
     @test QAtlas.available(; quantity=:specific_heat)        # underscore vs SpecificHeat


### PR DESCRIPTION
## What (stacked on #711)

Fixes the overclaim the dogfood exposed: `regime` jammed several **orthogonal physical axes** into
one label, so "finite-temperature dynamics" couldn't be expressed and velocities were mislabeled
"dynamics". This splits the conflated axis into two independent, AND-queryable axes — `thermal` and
`dynamical` — **captured per hub at `@register` time**.

```julia
search(; thermal=:finite, dynamical=:dynamic)   # the conjunction is now native — and honestly empty
```

### Derivation (in `register!`), priority order
**explicit `@register` kwarg > quantity-type trait > fetch-signature introspection (`kwarg_decl`:
does the method declare a `β`?) > `:unknown`** (abstain — search never guesses, preserving the
anti-hallucination property). The ~12 trait declarations live on the quantity type hierarchy
(`thermal_axis` / `dynamical_axis`); because the result is stored on the `Implementation` row, a hub
that deviates from its quantity's usual axis can be overridden individually:
`@register(...; thermal=:zero)`.

### The honest fix
A velocity is `:transport`, **not** `:dynamic` — so `search(dynamical=:dynamic)` returns empty until
real spectral/real-time data exists. The finite-T-dynamics overclaim is gone.

Verified on `main`: **coherence errors 0** (the core `register!` change is safe); FreeEnergy→`:finite`,
velocity→(`:zero`,`:transport`), Energy→`:both`; `dynamical=:dynamic` and `thermal=:finite ∧
dynamical=:dynamic` both honestly empty. **55 assertions** green.

`version 0.25.2 → 0.25.3` (vs this PR's base, `feat/availability-search`).

> **Do not merge** — stacked on #711, held for design review. `regime` is kept for now (back-compat);
> `thermal × dynamical` is its honest successor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)