### PR TITLE
feat: describe(model) + realizing(class) — richer use-face read queries

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.25.3"
+version = "0.25.4"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -445,6 +445,7 @@ export coherence_report,
 # quantity / bc / regime. Reads REGISTRY + the edge stores, so it comes after they are populated.
 include("core/query.jl")
 export search, search_jsonl, available, relations, relations_jsonl, gaps, gaps_jsonl
+export describe, describe_jsonl, realizing, realizing_jsonl
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Precompile workload — bake the hot `fetch` specializations into the package

--- a/src/core/query.jl
+++ b/src/core/query.jl
@@ -337,6 +337,58 @@ function gaps(model)
     return out
 end
 
+# ---- describe: the full per-model grounding record (the use-face payoff) ----
+
+"""
+    ModelRecord
+
+Everything the atlas records about one model in a single grounding record: `summary` / `hamiltonian`
+(from the `@about` card — `""` if uncarded, coverage is partial), the distinct `quantities`
+available, the `relations` (graph neighborhood), and aggregated `references`. The structural content
+(quantities + relations) lets an LLM disambiguate a model even when no prose card exists.
+"""
+struct ModelRecord
+    model::String
+    summary::String
+    hamiltonian::String
+    quantities::Vector{String}
+    relations::Vector{Relation}
+    references::Vector{String}
+end
+
+"""
+    describe(model) -> Vector{ModelRecord}
+
+The full record for each model matching `model` (a Type, or a fuzzy Symbol/String): summary +
+Hamiltonian where carded, the distinct quantities available, the graph neighborhood, and the
+aggregated references — the record an LLM grounds a physics statement on. See [`describe_jsonl`](@ref).
+"""
+function describe(model)
+    out = ModelRecord[]
+    for M in _model_types(model)
+        hits = search(; model=M).hits
+        card = about(M)
+        quantities = sort(unique(h.quantity for h in hits))
+        refs = String[]
+        for h in hits
+            append!(refs, h.references)
+        end
+        card === nothing || append!(refs, card.references)
+        push!(
+            out,
+            ModelRecord(
+                _label(M),
+                card === nothing ? "" : card.summary,
+                card === nothing ? "" : card.hamiltonian,
+                quantities,
+                relations(M),
+                sort(unique(refs)),
+            ),
+        )
+    end
+    return out
+end
+
 # ---- JSONL serialization (hand-rolled; fields are clean identifiers / bibkeys) ----
 
 function _json_escape(s::AbstractString)
@@ -507,3 +559,88 @@ function gaps_jsonl(io::IO, model)
     return nothing
 end
 gaps_jsonl(model) = gaps_jsonl(stdout, model)
+
+function _json_record(r::ModelRecord)
+    rels = string('[', join((_json_relation(x) for x in r.relations), ','), ']')
+    return string(
+        "{\"model\":",
+        _jstr(r.model),
+        ",\"summary\":",
+        _jstr(r.summary),
+        ",\"hamiltonian\":",
+        _jstr(r.hamiltonian),
+        ",\"quantities\":",
+        _jarr(r.quantities),
+        ",\"relations\":",
+        rels,
+        ",\"references\":",
+        _jarr(r.references),
+        "}",
+    )
+end
+
+"""
+    describe_jsonl([io=stdout], model) -> nothing
+
+Stream [`describe`](@ref) as JSONL: a `{count, query}` header line then one rich model-record object
+per line (summary, hamiltonian, quantities, relations, references).
+"""
+function describe_jsonl(io::IO, model)
+    recs = describe(model)
+    print(io, "{\"count\":", length(recs), ",\"query\":", _json_query((; model)), "}\n")
+    for r in recs
+        print(io, _json_record(r), "\n")
+    end
+    return nothing
+end
+describe_jsonl(model) = describe_jsonl(stdout, model)
+
+# ---- realizing: the inverse of a model's :realizes edge — which models realize a class ----
+
+"""
+    realizing(class) -> Vector{Relation}
+
+The models that realize a universality `class` (a Symbol/String, case-insensitive exact match) — the
+inverse of the model→class `:realizes` edge `relations` returns. Answers "which physical models can I
+study the Ising / Heisenberg / KPZ / … class with". See [`realizing_jsonl`](@ref).
+"""
+function realizing(class)
+    want = lowercase(string(class))
+    rels = Relation[]
+    for r in REALIZES
+        lowercase(string(r.class)) == want || continue
+        push!(
+            rels,
+            Relation(
+                :realizes, _label(r.model), string(r.class), r.regime, copy(r.references)
+            ),
+        )
+    end
+    sort!(rels; by=x -> x.from)
+    return rels
+end
+
+"""
+    realizing_jsonl([io=stdout], class) -> nothing
+
+Stream [`realizing`](@ref) as JSONL: a `{available, query, count}` summary line then one `:realizes`
+Relation per line.
+"""
+function realizing_jsonl(io::IO, class)
+    rels = realizing(class)
+    print(
+        io,
+        "{\"available\":",
+        !isempty(rels),
+        ",\"query\":",
+        _json_query((; class)),
+        ",\"count\":",
+        length(rels),
+        "}\n",
+    )
+    for r in rels
+        print(io, _json_relation(r), "\n")
+    end
+    return nothing
+end
+realizing_jsonl(class) = realizing_jsonl(stdout, class)

--- a/test/core/test_query.jl
+++ b/test/core/test_query.jl
@@ -116,6 +116,42 @@ end
     @test startswith(lines[1], "{\"has_gaps\":")
 end
 
+@testset "query: describe — the full per-model grounding record" begin
+    rs = QAtlas.describe(:TFIM)
+    @test length(rs) == 1
+    r = rs[1]
+    @test r.model == "TFIM"
+    @test !isempty(r.quantities)                 # the observables — disambiguating structural content
+    @test !isempty(r.relations)                  # the graph neighborhood
+    @test r.summary isa String                   # "" if uncarded, honest
+    # the dogfood trap: FibonacciAnyons is uncarded (no prose), but the structure still identifies it
+    fib = QAtlas.describe(:fibonacci)
+    @test length(fib) == 1 && fib[1].model == "FibonacciAnyons"
+    @test fib[1].summary == ""                   # honestly uncarded (no @about card)
+    # JSONL: a header line then one rich record per model
+    io = IOBuffer()
+    QAtlas.describe_jsonl(io, :TFIM)
+    lines = split(strip(String(take!(io))), '\n')
+    @test length(lines) == 2                      # header + 1 record
+    @test startswith(lines[1], "{\"count\":1")
+    @test occursin("\"quantities\":", lines[2]) && occursin("\"relations\":", lines[2])
+end
+
+@testset "query: realizing(class) — inverse edge query (class → models)" begin
+    is = QAtlas.realizing(:Ising)
+    @test !isempty(is)
+    @test all(r -> r.kind === :realizes && r.to == "Ising", is)
+    @test "TFIM" in (r.from for r in is)          # TFIM realizes the Ising class
+    @test [r.from for r in QAtlas.realizing(:ising)] == [r.from for r in is]  # case-insensitive
+    @test all(r -> r.to == "Ising", QAtlas.realizing(:ising))  # exact: does NOT catch IsingSDRG
+    io = IOBuffer()
+    QAtlas.realizing_jsonl(io, :Ising)
+    lines = split(strip(String(take!(io))), '\n')
+    @test length(lines) == length(is) + 1
+    @test startswith(lines[1], "{\"available\":true")
+    @test all(l -> occursin("\"kind\":\"realizes\"", l), lines[2:end])
+end
+
 @testset "query: not-available search → single false summary, no hit lines" begin
     io = IOBuffer()
     QAtlas.search_jsonl(io; model=:NoSuchModelXYZ)


### PR DESCRIPTION
## What (stacked on #712)

Two richer use-face read queries — the LLM's grounding + disambiguation surface.

### `describe(model)` — the full per-model grounding record
`describe(model) -> Vector{ModelRecord}` / `describe_jsonl([io], model)`. For each matching model:
`{summary, hamiltonian, quantities, relations, references}` — everything the atlas records, in one
record an LLM grounds a physics statement on. Composes the `@about` card + the search/relations layers.

**Disambiguation via structure** (the dogfood FibonacciAnyons trap): about-cards are sparse (23/80)
and FibonacciAnyons has none — but its record
`{summary:"", quantities:["TopologicalEntanglementEntropy"], references:[FreedmanKitaevLarsenWang2003, KitaevPreskill2006, ReadRezayi1999]}`
identifies it as a topological anyon model, **not** a Fibonacci quasicrystal. The structural content
disambiguates where prose is absent. (Universal one-line summaries = a separate `@about` coverage task.)

### `realizing(class)` — the class→models inverse
`realizing(class) -> Vector{Relation}` / `realizing_jsonl([io], class)`. The inverse of a model's
`:realizes` edge: which physical models realize a universality class — the dogfood scenario-4 question,
answered directly. `realizing(:Ising)` → TFIM / IsingSquare / IsingTriangular / Kitaev1D / ZnClock /
ZnParafermion, each with its critical locus + CFT data + references. Case-insensitive exact class match
(does not catch `IsingSDRG`).

**73 assertions** green on `main` (describe 10, realizing 8). `version 0.25.3 → 0.25.4`.

> Do not merge — stacked on #712, held for design review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)