### PR TITLE
refs: add cMPS/cMPO references (Verstraete–Cirac 2010, Haegeman 2013, Tang 2020)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.25.0"
+version = "0.25.1"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -2338,3 +2338,35 @@
   archivePrefix = {arXiv},
   primaryClass  = {hep-th},
 }
+
+% Continuous matrix product states / operators (cMPS / cMPO) — shared with ITensorcMPS.jl.
+
+@misc{VerstraeteCirac2010,
+  title         = {Continuous Matrix Product States for Quantum Fields},
+  author        = {Verstraete, F. and Cirac, J. I.},
+  year          = {2010},
+  eprint        = {1002.1824},
+  archivePrefix = {arXiv},
+  primaryClass  = {cond-mat.str-el},
+  doi           = {10.1103/PhysRevLett.104.190405},
+}
+
+@misc{Haegeman2013,
+  title         = {Calculus of continuous matrix product states},
+  author        = {Haegeman, Jutho and Cirac, J. Ignacio and Osborne, Tobias J. and Verstraete, Frank},
+  year          = {2013},
+  eprint        = {1211.3935},
+  archivePrefix = {arXiv},
+  primaryClass  = {quant-ph},
+  doi           = {10.1103/PhysRevB.88.085118},
+}
+
+@misc{Tang2020,
+  title         = {Continuous matrix product operator approach to finite temperature quantum states},
+  author        = {Tang, Wei and Tu, Hong-Hao and Wang, Lei},
+  year          = {2020},
+  eprint        = {2004.12928},
+  archivePrefix = {arXiv},
+  primaryClass  = {cond-mat.str-el},
+  doi           = {10.1103/PhysRevLett.125.170604},
+}


### PR DESCRIPTION
Add the continuous matrix product state / operator foundational references to the canonical QAtlas bibliography, so they are the **single source of truth** shared with `ITensorcMPS.jl` — which will resolve its reproduction-test bibkeys against this file (via `pkgdir(QAtlas)/docs/references.bib`) rather than keeping a local duplicate.

- `VerstraeteCirac2010` — Continuous Matrix Product States for Quantum Fields (PRL 104, 190405)
- `Haegeman2013` — Calculus of continuous matrix product states (PRB 88, 085118)
- `Tang2020` — Continuous matrix product operator approach to finite-T quantum states (PRL 125, 170604)

All three DOIs / arXiv ids are verified by `VerifyReferences` (doiget). Uncited-by-QAtlas entries are fine (the key-consistency test checks cited ⊆ bib). Patch bump 0.25.0 → 0.25.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
