### PR TITLE
feat(TightBindingV1D): exact nonlinear response of the ac-driven free-fermion chain

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.25.0"
+version = "0.25.1"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -2338,3 +2338,27 @@
   archivePrefix = {arXiv},
   primaryClass  = {hep-th},
 }
+
+@article{DunlapKenkre1986,
+  title     = {Dynamic localization of a charged particle moving under the influence of an electric field},
+  author    = {Dunlap, D. H. and Kenkre, V. M.},
+  journal   = {Physical Review B},
+  volume    = {34},
+  number    = {6},
+  pages     = {3625--3633},
+  year      = {1986},
+  publisher = {American Physical Society},
+  doi       = {10.1103/PhysRevB.34.3625},
+}
+
+@article{HolthausHone1996,
+  title     = {Localization effects in ac-driven tight-binding lattices},
+  author    = {Holthaus, Martin and Hone, Daniel W.},
+  journal   = {Philosophical Magazine B},
+  volume    = {74},
+  number    = {2},
+  pages     = {105--137},
+  year      = {1996},
+  publisher = {Informa UK Limited},
+  doi       = {10.1080/01418639608240331},
+}

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -175,6 +175,7 @@ export FermiVelocity,
     CFTThermalEntropyDensity,
     WignerSemicircleMoment
 export SteadyStateCurrent                                # TASEP / non-equilibrium current (#241)
+export DynamicLocalization, driven_band_harmonic_weights # ac-driven free-fermion nonlinear response (Dunlap-Kenkre 1986)
 export E8Spectrum
 export LiebRobinsonBound  # status-axis example (:bound)
 export Bound              # universal-bounds namespace: Bound{:QuantumInformation}, …
@@ -371,6 +372,7 @@ include("models/quantum/S1XXZ1D/S1XXZ1D_registry.jl")  # populates REGISTRY for 
 include("models/quantum/Cluster1D/Cluster1D.jl")
 include("models/quantum/Cluster1D/Cluster1D_registry.jl")  # populates REGISTRY for Cluster1D (#301)
 include("models/quantum/TightBindingV1D/TightBindingV1D.jl")
+include("models/quantum/TightBindingV1D/TightBindingV1D_driven.jl")  # ac-driven nonlinear response: DynamicLocalization + harmonics
 include("models/quantum/TightBindingV1D/TightBindingV1D_registry.jl")  # populates REGISTRY for TightBindingV1D (#296)
 include("models/quantum/LongRangeIsing1D/LongRangeIsing1D.jl")
 include("models/quantum/LongRangeIsing1D/LongRangeIsing1D_registry.jl")  # populates REGISTRY for LongRangeIsing1D (#293)

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -1463,6 +1463,26 @@ method returns the smooth-limit prefactor $\sigma$.
 """
 struct CornerEntanglementCoefficient <: AbstractQuantity end
 
+"""
+    DynamicLocalization() <: AbstractQuantity
+
+Cycle-averaged effective-hopping renormalization of a tight-binding band driven
+by a spatially-uniform monochromatic ac electric field (Peierls coupling).  In
+units `e = ℏ = a = 1`, a field `E(τ) = E₀ cos(ωτ)` gives the dimensionless drive
+`K = E₀/ω`, and the hopping is renormalized by the exact, nonperturbative Bessel
+factor
+
+    t_eff / t = J₀(K).
+
+The band collapses — "dynamic localization" — at the zeros of `J₀` (first at
+`K = 2.404826…`), where a static tilt drives no current despite `E₀ ≠ 0`.  This
+is the hallmark exact nonlinear (all-orders-in-field) response of the ac-driven
+free-fermion chain (Dunlap–Kenkre 1986; Holthaus–Hone 1996); the full harmonic
+content of the current is the Bessel spectrum `Jₙ(K)`
+(see `driven_band_harmonic_weights`).
+"""
+struct DynamicLocalization <: AbstractQuantity end
+
 # ─── component trait: concrete methods (#690) ────────────────────────────
 # The component a leaf's type name encodes; `nothing` (the AbstractQuantity
 # default above) everywhere else.  The `…Local` magnetizations deliberately

--- a/src/models/quantum/TightBindingV1D/TightBindingV1D_driven.jl
+++ b/src/models/quantum/TightBindingV1D/TightBindingV1D_driven.jl
@@ -1,0 +1,112 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# TightBindingV1D_driven.jl — exact nonlinear response of the ac-driven
+# free-fermion (V = 0) tight-binding chain.
+#
+# A spatially-uniform monochromatic electric field E(τ) = E₀ cos(ωτ) couples to
+# the chain through the Peierls substitution: the hopping acquires a
+# time-dependent phase t → t e^{±iA(τ)} with the vector potential (e = ℏ = a = 1)
+#
+#     A(τ) = -∫ E dτ = -(E₀/ω) sin(ωτ) ≡ -K sin(ωτ),     K ≡ E₀/ω  (dimensionless).
+#
+# The intraband group-velocity current of a Bloch mode at crystal momentum k is
+# ε'(k) evaluated at the shifted momentum k - A(τ):
+#
+#     j(k, τ) = 2t sin(k - A(τ)) = 2t sin(k + K sin ωτ).
+#
+# Jacobi–Anger (Abramowitz–Stegun 9.1.42-43 / DLMF 10.12) expands this into an
+# EXACT harmonic series whose amplitudes are Bessel functions of the first kind:
+#
+#     j(k, τ) = 2t J₀(K) sin k                                   (dc / 0-th)
+#             + 4t sin k Σ_{m≥1} J_{2m}(K)   cos(2mωτ)           (even harmonics)
+#             + 4t cos k Σ_{m≥0} J_{2m+1}(K) sin((2m+1)ωτ)       (odd  harmonics).
+#
+# Two exact, nonperturbative ("all orders in the field") statements follow, both
+# verified against an independent RK4 real-time simulation in
+# test/identities/test_driven_free_fermion_nonlinear_response.jl:
+#
+#   • DYNAMIC LOCALIZATION (Dunlap–Kenkre 1986; Holthaus–Hone 1996).  The dc /
+#     cycle-averaged current — hence the coherent transport — is renormalized by
+#     the Bessel factor t_eff = t J₀(K).  The band collapses (t_eff → 0) at the
+#     zeros of J₀ (first at K = 2.404826…): a static tilt no longer drives a
+#     current even though E₀ ≠ 0.  Exposed as `fetch(_, DynamicLocalization, _)`.
+#
+#   • HARMONIC SPECTRUM.  The n-th harmonic of the current is exactly ∝ Jₙ(K)
+#     (`driven_band_harmonic_weights`).  For small K, Jₙ(K) ≈ (K/2)ⁿ/n!, so the
+#     n-th harmonic is the order-n (χ⁽ⁿ⁾) nonlinear response and n = 1 recovers
+#     the linear conductivity.
+#
+# NOTE (V = 0 only).  Peierls dressing keeps the chain quadratic only at the
+# free-fermion point; V ≠ 0 (Jordan-Wigner-equivalent to the interacting XXZ
+# chain) is deferred to Phase 2 and raises `DomainError`, matching the rest of
+# this model file.
+#
+# References:
+#   - D. H. Dunlap, V. M. Kenkre, "Dynamic localization of a charged particle
+#     moving under the influence of an electric field", Phys. Rev. B 34, 3625
+#     (1986).
+#   - M. Holthaus, D. W. Hone, "Localization effects in ac-driven tight-binding
+#     lattices", Philos. Mag. B 74, 105 (1996).
+# ─────────────────────────────────────────────────────────────────────────────
+
+using SpecialFunctions: besselj, besselj0
+
+"""
+    fetch(m::TightBindingV1D, ::DynamicLocalization, ::Infinite;
+          drive, t=m.t, V=m.V, kwargs...) -> Float64
+
+Renormalized hopping `t_eff = t · J₀(K)` of the ac-driven free-fermion (V = 0)
+tight-binding chain, where `drive = K = E₀/ω` is the dimensionless field
+amplitude / frequency (Peierls coupling, e = ℏ = a = 1).
+
+`t_eff` sets the collapsed bandwidth `4 t_eff`; dynamic localization is the
+vanishing `t_eff = 0` at the zeros of `J₀` (first at `K ≈ 2.404826`), where a
+static tilt drives no current despite `E₀ ≠ 0` (Dunlap–Kenkre 1986;
+Holthaus–Hone 1996).  The full harmonic spectrum of the current is
+`driven_band_harmonic_weights`.
+
+`V ≠ 0` raises `DomainError` (Phase 2 via JW ↔ XXZ1D).
+"""
+function fetch(
+    m::TightBindingV1D,
+    ::DynamicLocalization,
+    ::Infinite;
+    drive::Real,
+    t::Real=m.t,
+    V::Real=m.V,
+    kwargs...,
+)
+    t > 0 || throw(
+        DomainError(t, "TightBindingV1D DynamicLocalization requires t > 0; got t = $t."),
+    )
+    if !iszero(V)
+        throw(
+            DomainError(
+                V,
+                "TightBindingV1D DynamicLocalization: V ≠ 0 (JW-equivalent to interacting " *
+                "XXZ, Yang-Yang 1966) deferred to Phase 2. Got V = $V.",
+            ),
+        )
+    end
+    return t * besselj0(drive)
+end
+
+"""
+    driven_band_harmonic_weights(drive::Real; nmax::Integer=6) -> Vector{Float64}
+
+Exact Bessel weights `[J₀(K), J₁(K), …, J_nmax(K)]` of the current harmonics of
+a single Bloch mode of the ac-driven free-fermion tight-binding chain, with
+`drive = K = E₀/ω`.
+
+Entry `n+1` is the Bessel weight of the n-th harmonic `n ω` in the Jacobi–Anger
+expansion of `j(k, τ) = 2t sin(k + K sin ωτ)`.  The physical n-th-harmonic
+amplitude of the current is `2t·|J₀(K) sin k|` for `n = 0` and
+`4t·|Jₙ(K)|·(|sin k| if n even else |cos k|)` for `n ≥ 1`.  For small `K`,
+`Jₙ(K) ≈ (K/2)ⁿ/n!`, exhibiting the n-th harmonic as the order-n (χ⁽ⁿ⁾)
+nonlinear response.
+"""
+function driven_band_harmonic_weights(drive::Real; nmax::Integer=6)
+    nmax >= 0 || throw(
+        DomainError(nmax, "driven_band_harmonic_weights requires nmax ≥ 0; got $nmax.")
+    )
+    return Float64[besselj(n, drive) for n in 0:nmax]
+end

--- a/src/models/quantum/TightBindingV1D/TightBindingV1D_registry.jl
+++ b/src/models/quantum/TightBindingV1D/TightBindingV1D_registry.jl
@@ -67,3 +67,17 @@
     references=["Mahan2000"],
     notes="V=0 c_μ(β;t,μ) = (β²/π) ∫₀^π ε² n_F(1-n_F) dk; V≠0 deferred to Phase 2.",
 )
+
+@register(
+    TightBindingV1D,
+    DynamicLocalization,
+    Infinite,
+    method=:analytic,
+    reliability=:high,
+    tested_in="test/identities/test_driven_free_fermion_nonlinear_response.jl",
+    references=["DunlapKenkre1986", "HolthausHone1996"],
+    notes="AC-driven free-fermion (V=0) nonlinear response: renormalized hopping " *
+          "t_eff = t·J₀(E₀/ω); dynamic localization at J₀ zeros (K≈2.4048); harmonic " *
+          "current spectrum = Bessel Jₙ(K) via driven_band_harmonic_weights. " *
+          "V≠0 deferred to Phase 2.",
+)

--- a/test/identities/test_driven_free_fermion_nonlinear_response.jl
+++ b/test/identities/test_driven_free_fermion_nonlinear_response.jl
@@ -1,0 +1,233 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Test: exact nonlinear response of the ac-driven free-fermion tight-binding
+# chain, checked against an INDEPENDENT real-time simulation.
+#
+# The closed form under test (src: TightBindingV1D_driven.jl) is the Jacobi–Anger
+# Bessel spectrum of the Peierls-driven single-band current
+#
+#     j(k, τ) = 2t sin(k + K sin ωτ),        K = E₀/ω  (dimensionless drive),
+#
+#   dc / 0-th:      2t J₀(K) sin k                            (dynamic localization)
+#   n-th harmonic:  4t Jₙ(K) · (sin k if n even, cos k if n odd).
+#
+# The INDEPENDENT route builds the driven chain's current time series FROM
+# SCRATCH — an RK4 integration of the time-dependent Schrödinger / von-Neumann
+# equation with the Peierls Hamiltonian — and a bare discrete Fourier transform
+# extracts each harmonic amplitude.  NOTHING in that route knows about Bessel
+# functions or the Jacobi–Anger identity; if the DFT of the simulated current
+# reproduces `driven_band_harmonic_weights` (= Bessel Jₙ), the closed form is
+# confirmed by genuinely independent means.
+#
+# Pillars:
+#   A. single-mode harmonic spectrum:  DFT of RK4 current == Bessel weights, for
+#      k = π/2 (dc + even harmonics) and k = 0 (odd harmonics) — together these
+#      pin every Jₙ(K).
+#   B. dynamic localization (Dunlap–Kenkre):  cycle-averaged mode current
+#      == 2t J₀(K) sin k across many k, and the whole band localizes at once at
+#      the first Bessel zero K = 2.404826; ties to fetch(_, DynamicLocalization).
+#   C. perturbative order-n limit:  small K ⇒ n-th harmonic ∝ Kⁿ (χ⁽ⁿ⁾), n = 1
+#      recovers the linear conductivity slope 2t.
+#   D. many-body integrator:  RK4 of the half-filled correlation matrix
+#      dC/dτ = -i[H(τ),C] reproduces the summed single-mode current — exercises
+#      the L×L matrix path and the additivity of the nonlinear response.
+#   E. domain guards.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Test, LinearAlgebra
+using QAtlas:
+    TightBindingV1D, DynamicLocalization, Infinite, fetch, driven_band_harmonic_weights
+
+# ── independent machinery: driven ring, RK4, bare DFT ────────────────────────
+# (underscore-prefixed to stay clear of the shared included-test namespace)
+
+# Vector potential of E(τ) = E₀ cos ωτ:  A(τ) = -(E₀/ω) sin ωτ = -K sin ωτ.
+_dffnlr_A(τ, K, ω) = -K * sin(ω * τ)
+
+# Peierls hopping Hamiltonian on an L-site ring: H[j,j+1] = -t e^{-iA}, h.c.
+function _dffnlr_H(L, t, A)
+    H = zeros(ComplexF64, L, L)
+    ph = cis(-A)                       # e^{-iA}
+    @inbounds for j in 1:L
+        k = mod1(j + 1, L)
+        H[j, k] += -t * ph
+        H[k, j] += -t * conj(ph)
+    end
+    return H
+end
+
+# Uniform current operator J = -∂H/∂A: J[j,j+1] = -i t e^{-iA}, J[j+1,j] = +i t e^{+iA}.
+function _dffnlr_J(L, t, A)
+    J = zeros(ComplexF64, L, L)
+    ph = cis(-A)
+    @inbounds for j in 1:L
+        k = mod1(j + 1, L)
+        J[j, k] += -im * t * ph
+        J[k, j] += im * t * conj(ph)
+    end
+    return J
+end
+
+# RK4 for i∂τψ = H(τ)ψ  ⟹  ∂τψ = -i H(τ)ψ.
+function _dffnlr_step_psi(ψ, τ, dt, L, t, K, ω)
+    f(τ, ψ) = -im * (_dffnlr_H(L, t, _dffnlr_A(τ, K, ω)) * ψ)
+    k1 = f(τ, ψ)
+    k2 = f(τ + dt / 2, ψ .+ (dt / 2) .* k1)
+    k3 = f(τ + dt / 2, ψ .+ (dt / 2) .* k2)
+    k4 = f(τ + dt, ψ .+ dt .* k3)
+    return ψ .+ (dt / 6) .* (k1 .+ 2 .* k2 .+ 2 .* k3 .+ k4)
+end
+
+# Current of a single Bloch mode |k0⟩ over one drive period: N samples at τ_m = m T/N.
+function _dffnlr_series(L, t, K, ω, k0, N, S)
+    T = 2π / ω
+    dt = T / (N * S)
+    ψ = ComplexF64[cis(k0 * j) for j in 1:L] ./ sqrt(L)
+    τ = 0.0
+    j = zeros(Float64, N)
+    for m in 0:(N - 1)
+        Jτ = _dffnlr_J(L, t, _dffnlr_A(τ, K, ω))
+        j[m + 1] = real(ψ' * Jτ * ψ)
+        for _ in 1:S
+            ψ = _dffnlr_step_psi(ψ, τ, dt, L, t, K, ω)
+            τ += dt
+        end
+    end
+    return j
+end
+
+# Bare DFT harmonic amplitude of a period-sampled real signal.
+function _dffnlr_amp(sig, n)
+    N = length(sig)
+    n == 0 && return sum(sig) / N                       # signed dc component
+    c = 2 / N * sum(sig[m + 1] * cos(2π * n * m / N) for m in 0:(N - 1))
+    s = 2 / N * sum(sig[m + 1] * sin(2π * n * m / N) for m in 0:(N - 1))
+    return hypot(c, s)                                  # harmonic magnitude
+end
+
+# RK4 of the half-filled correlation matrix dC/dτ = -i[H(τ),C]; total current tr(J C).
+function _dffnlr_series_corr(L, t, K, ω, C0, N, S)
+    T = 2π / ω
+    dt = T / (N * S)
+    C = ComplexF64.(C0)
+    fC(τ, C) = (H=_dffnlr_H(L, t, _dffnlr_A(τ, K, ω)); -im .* (H * C .- C * H))
+    τ = 0.0
+    j = zeros(Float64, N)
+    for m in 0:(N - 1)
+        Jτ = _dffnlr_J(L, t, _dffnlr_A(τ, K, ω))
+        j[m + 1] = real(tr(Jτ * C))
+        for _ in 1:S
+            k1 = fC(τ, C)
+            k2 = fC(τ + dt / 2, C .+ (dt / 2) .* k1)
+            k3 = fC(τ + dt / 2, C .+ (dt / 2) .* k2)
+            k4 = fC(τ + dt, C .+ dt .* k3)
+            C = C .+ (dt / 6) .* (k1 .+ 2 .* k2 .+ 2 .* k3 .+ k4)
+            τ += dt
+        end
+    end
+    return j
+end
+
+const _DFFNLR_J0_ZERO1 = 2.404825557695773   # first zero of J₀ (dynamic localization)
+
+@testset "driven free-fermion nonlinear response — exact Bessel harmonics" begin
+    t = 1.0
+    ω = 1.0
+    L = 16                       # k = 0 (n=0) and k = π/2 (n=L/4) are ring momenta
+    N = 128                      # samples per drive period (Nyquist ≫ nmax)
+    S = 8                        # RK4 substeps between samples
+
+    # ── Pillar A — single-mode harmonic spectrum == Bessel weights ───────────
+    @testset "A: harmonic spectrum == Bessel Jₙ(K)  (K=$K)" for K in (1.0, 2.0)
+        w = driven_band_harmonic_weights(K; nmax=5)          # w[n+1] = Jₙ(K)
+
+        # k = π/2:  sin k = 1, cos k = 0  ⇒  dc + even harmonics, weight 2t / 4t.
+        jhalf = _dffnlr_series(L, t, K, ω, π / 2, N, S)
+        @test isapprox(_dffnlr_amp(jhalf, 0), 2t * w[1]; atol=2e-3)      # dc = 2t J₀
+        @test isapprox(_dffnlr_amp(jhalf, 2), 4t * abs(w[3]); atol=2e-3) # 2ω = 4t J₂
+        @test isapprox(_dffnlr_amp(jhalf, 4), 4t * abs(w[5]); atol=2e-3) # 4ω = 4t J₄
+        @test _dffnlr_amp(jhalf, 1) < 2e-3                               # odd absent
+        @test _dffnlr_amp(jhalf, 3) < 2e-3
+
+        # k = 0:  sin k = 0, cos k = 1  ⇒  odd harmonics only, weight 4t.
+        jzero = _dffnlr_series(L, t, K, ω, 0.0, N, S)
+        @test isapprox(_dffnlr_amp(jzero, 1), 4t * abs(w[2]); atol=2e-3) # 1ω = 4t J₁
+        @test isapprox(_dffnlr_amp(jzero, 3), 4t * abs(w[4]); atol=2e-3) # 3ω = 4t J₃
+        @test isapprox(_dffnlr_amp(jzero, 5), 4t * abs(w[6]); atol=2e-3) # 5ω = 4t J₅
+        @test abs(_dffnlr_amp(jzero, 0)) < 2e-3                          # dc absent
+        @test _dffnlr_amp(jzero, 2) < 2e-3                               # even absent
+    end
+
+    # ── Pillar B — dynamic localization (Dunlap–Kenkre 1986) ─────────────────
+    @testset "B: t_eff = t·J₀(K) and band collapse at first Bessel zero" begin
+        m = TightBindingV1D(; t=t)                      # free-fermion point (V=0)
+
+        # closed-form registered quantity: t_eff = t J₀(K)
+        w0(K) = driven_band_harmonic_weights(K; nmax=0)[1]
+        for K in (0.0, 0.8, 1.5, 2.0, _DFFNLR_J0_ZERO1)
+            @test isapprox(
+                fetch(m, DynamicLocalization(), Infinite(); drive=K), t * w0(K); atol=1e-12
+            )
+        end
+        @test fetch(m, DynamicLocalization(), Infinite(); drive=0.0) == t   # no drive
+        @test abs(fetch(m, DynamicLocalization(), Infinite(); drive=_DFFNLR_J0_ZERO1)) <
+            1e-6                     # localized
+
+        # independent: cycle-averaged mode current == 2t J₀(K) sin k, all modes.
+        for K in (1.0, 2.0), n in (1, 3, 5, 7)          # k = 2π n / L
+            k0 = 2π * n / L
+            dc = _dffnlr_amp(_dffnlr_series(L, t, K, ω, k0, N, S), 0)
+            @test isapprox(dc, 2t * w0(K) * sin(k0); atol=3e-3)
+        end
+        # at K = 2.4048 every mode's dc current collapses → whole band localizes.
+        for n in 1:7
+            k0 = 2π * n / L
+            dc = _dffnlr_amp(_dffnlr_series(L, t, _DFFNLR_J0_ZERO1, ω, k0, N, S), 0)
+            @test abs(dc) < 3e-3
+        end
+    end
+
+    # ── Pillar C — small drive: n-th harmonic is the order-n response ─────────
+    @testset "C: perturbative χ⁽ⁿ⁾ scaling and linear-response slope" begin
+        Ksmall = 0.15
+        w = driven_band_harmonic_weights(Ksmall; nmax=3)
+        # Jₙ(K) ≈ (K/2)ⁿ / n!  ⇒  successive harmonics shrink by ~ K/2.
+        @test isapprox(w[2], Ksmall / 2; rtol=2e-2)              # J₁ ≈ K/2
+        @test isapprox(w[3], (Ksmall / 2)^2 / 2; rtol=3e-2)      # J₂ ≈ (K/2)²/2
+        # linear-response slope of the first harmonic (k=0): amp₁ = 4t J₁ ≈ 2t·K.
+        amp1 = _dffnlr_amp(_dffnlr_series(L, t, Ksmall, ω, 0.0, N, S), 1)
+        @test isapprox(amp1 / Ksmall, 2t; rtol=2e-2)
+        # order separation: 2nd harmonic is O(K) smaller than the 1st.
+        amp2 = _dffnlr_amp(_dffnlr_series(L, t, Ksmall, ω, π / 2, N, S), 2)
+        @test amp2 < amp1 * Ksmall
+    end
+
+    # ── Pillar D — many-body correlation-matrix integrator ───────────────────
+    @testset "D: half-filled correlation-matrix RK4 == summed single-mode" begin
+        Ld = 12
+        K = 1.3
+        Nd, Sd = 96, 8
+        kk = [2π * n / Ld for n in 0:(Ld - 1)]
+        occ = partialsortperm([-2t * cos(k) for k in kk], 1:(Ld ÷ 2))  # lowest ½
+        kocc = kk[occ]
+        # C₀ = Σ_{k∈occ} |k⟩⟨k|,  |k⟩ = L^{-1/2} e^{ikj}
+        C0 = zeros(ComplexF64, Ld, Ld)
+        for k in kocc, a in 1:Ld, b in 1:Ld
+            C0[a, b] += cis(k * (a - b)) / Ld
+        end
+        jrk4 = _dffnlr_series_corr(Ld, t, K, ω, C0, Nd, Sd)
+        T = 2π / ω
+        jref = [
+            sum(2t * sin(k - _dffnlr_A(m * T / Nd, K, ω)) for k in kocc) for m in 0:(Nd - 1)
+        ]
+        @test maximum(abs, jrk4 .- jref) < 5e-3
+    end
+
+    # ── Pillar E — domain guards ─────────────────────────────────────────────
+    @testset "E: guards" begin
+        @test_throws DomainError fetch(
+            TightBindingV1D(; t=1.0, V=0.5), DynamicLocalization(), Infinite(); drive=1.0
+        )
+        @test_throws DomainError driven_band_harmonic_weights(1.0; nmax=-1)
+        @test length(driven_band_harmonic_weights(1.0)) == 7    # nmax=6 default ⇒ 0..6
+    end
+end


### PR DESCRIPTION
# feat(TightBindingV1D): exact nonlinear response of the ac-driven free-fermion chain

## What

Adds the **exact, nonperturbative nonlinear response** of the ac-driven
free-fermion tight-binding chain to the atlas — the one genuinely closed-form
"nonlinear response" available for a free-fermion system.

Under a spatially-uniform monochromatic field `E(τ) = E₀ cos ωτ` (Peierls
coupling, `e = ℏ = a = 1`), the single-band current is

```
j(k, τ) = 2t sin(k + K sin ωτ),      K = E₀/ω   (dimensionless drive)
```

whose Jacobi–Anger expansion has **Bessel-function harmonic amplitudes** to all
orders in the field:

```
j(k,τ) = 2t J₀(K) sin k                                (dc / dynamic localization)
       + 4t sin k Σ_{m≥1} J_{2m}(K)   cos(2mωτ)        (even harmonics)
       + 4t cos k Σ_{m≥0} J_{2m+1}(K) sin((2m+1)ωτ)    (odd  harmonics)
```

- New quantity `DynamicLocalization`: `fetch(TightBindingV1D, DynamicLocalization,
  Infinite; drive=K)` = `t·J₀(K)` — the exact renormalized hopping; the band
  collapses (`t_eff → 0`) at the zeros of `J₀` (first at `K = 2.404826…`).
- New helper `driven_band_harmonic_weights(K; nmax)` = `[J₀(K), …, J_nmax(K)]`,
  the exact Bessel spectrum; small-`K` gives `Jₙ ≈ (K/2)ⁿ/n!`, i.e. the n-th
  harmonic is the order-n (χ⁽ⁿ⁾) response, `n = 1` = linear conductivity.

Free-fermion (`V = 0`) point only; `V ≠ 0` → `DomainError` (Phase 2, JW ↔ XXZ),
matching the rest of the model file.

## Independent-physics test (`test/identities/`)

`test_driven_free_fermion_nonlinear_response.jl` checks the closed form against a
**from-scratch RK4 real-time simulation** of the Peierls-driven chain + a bare
DFT — nothing in that route knows about Bessel functions or Jacobi–Anger, so the
match is genuinely independent:

- **A** single-mode harmonic spectrum == Bessel `Jₙ(K)` (k=π/2 dc+even, k=0 odd).
- **B** dynamic localization: cycle-averaged mode current == `2t J₀(K) sin k`
  across modes; whole band collapses at `K = 2.404826` (Dunlap–Kenkre).
- **C** small drive: n-th harmonic ∝ `Kⁿ` (χ⁽ⁿ⁾); linear slope → `2t`.
- **D** many-body: RK4 of the half-filled correlation matrix `dC/dτ = -i[H,C]`
  reproduces the summed single-mode current.
- **E** domain guards.

50/50 assertions pass.

## References (added to `docs/references.bib`, doiget-verified)

- D. H. Dunlap, V. M. Kenkre, *Dynamic localization of a charged particle moving
  under the influence of an electric field*, Phys. Rev. B **34**, 3625 (1986).
  `10.1103/PhysRevB.34.3625`
- M. Holthaus, D. W. Hone, *Localization effects in ac-driven tight-binding
  lattices*, Philos. Mag. B **74**, 105 (1996). `10.1080/01418639608240331`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
