### PR TITLE
chore(ci): track latest JuliaFormatter + reformat repo to 2.10.1

### DIFF
--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           version: '1'
       - name: Install JuliaFormatter
-        run: julia -e 'using Pkg; Pkg.add(name="JuliaFormatter", version="2"); using JuliaFormatter; @info "JuliaFormatter $(pkgversion(JuliaFormatter))"'
+        run: julia -e 'using Pkg; Pkg.add("JuliaFormatter"); using JuliaFormatter; @info "JuliaFormatter $(pkgversion(JuliaFormatter))"'
       - name: Check formatting
         run: |
           julia -e '

--- a/docs/atlas/generate.jl
+++ b/docs/atlas/generate.jl
@@ -618,7 +618,11 @@ function render_model_index(model_name::AbstractString)
         get(levcounts, AtlasInventory.UNIVERSALITY_CORROBORATED, 0),
         " |",
     )
-    P("| 🟢 corroborated-at-p | ", get(levcounts, AtlasInventory.CORROBORATED_AT_P, 0), " |")
+    P(
+        "| 🟢 corroborated-at-p | ",
+        get(levcounts, AtlasInventory.CORROBORATED_AT_P, 0),
+        " |",
+    )
     P("| 🔵 coherent | ", get(levcounts, AtlasInventory.COHERENT, 0), " |")
     P("| ⚪ cited-only | ", get(levcounts, AtlasInventory.CITED_ONLY, 0), " |")
     P(
@@ -855,7 +859,9 @@ function render_model_list()
         "name to drill into its `Quantity × BC` matrix.",
     )
     P("")
-    P("| Model | Universality | #K | Methods | 🟣 | 🟢 | 🔵 | ⚪ | 🟠 | ED | Regimes (top 3) |")
+    P(
+        "| Model | Universality | #K | Methods | 🟣 | 🟢 | 🔵 | ⚪ | 🟠 | ED | Regimes (top 3) |",
+    )
     P("|---|---|---|---|---|---|---|---|---|---|---|")
     for m in models
         hs = sort(filter(h -> modelof(h) == m, claimed))

--- a/src/core/constraints.jl
+++ b/src/core/constraints.jl
@@ -300,7 +300,7 @@ function _bc_instance(::Type{BC}; finite_N::Int) where {BC<:BoundaryCondition}
     BC === Infinite && return Infinite()
     BC === OBC && return OBC(finite_N)
     BC === PBC && return PBC(; N=finite_N)
-    throw(ArgumentError("_bc_instance: unsupported boundary-condition type $(BC)"))
+    return throw(ArgumentError("_bc_instance: unsupported boundary-condition type $(BC)"))
 end
 
 """

--- a/src/models/quantum/AKLT/AKLT1D.jl
+++ b/src/models/quantum/AKLT/AKLT1D.jl
@@ -452,7 +452,7 @@ fetches for finite gap-suppressed values, or HeisenbergS1.jl's
 ED-based path for finite-N numerical references.
 """
 function fetch(::AKLT1D, ::SusceptibilityZZ, ::OBC; beta::Real, kwargs...)
-    throw(
+    return throw(
         DomainError(
             beta,
             "AKLT1D OBC SusceptibilityZZ diverges at β = Inf (edge-mode Curie tail; " *

--- a/src/models/quantum/AKLT/AKLT1D_thermal.jl
+++ b/src/models/quantum/AKLT/AKLT1D_thermal.jl
@@ -59,7 +59,7 @@ end
 # Generic fallback: unknown scheme (or a quantity without an :htse definition,
 # e.g. SusceptibilityZZ — its HTSE needs separate magnetisation cumulants).
 function _aklt_thermo_infinite_scheme(::AKLT1D, q, ::Val{S}; beta) where {S}
-    throw(
+    return throw(
         ArgumentError(
             "AKLT1D $(typeof(q)) Infinite: no scheme :$(S) (only :canonical + :htse)"
         ),

--- a/src/universalities/RMT/RMT.jl
+++ b/src/universalities/RMT/RMT.jl
@@ -76,7 +76,7 @@ function fetch(::Universality{:RMT}, ::MeanRatio; β::Int, kwargs...)
     elseif β == 4
         return 0.6744
     end
-    throw(DomainError(β, "Universality(:RMT)/MeanRatio: β must be in {1, 2, 4}"))
+    return throw(DomainError(β, "Universality(:RMT)/MeanRatio: β must be in {1, 2, 4}"))
 end
 
 # ─── Tracy-Widom F_β(x) — tabulated + tail asymptotics ───────────────────────

--- a/test/verification/universality/test_universality_cross_check.jl
+++ b/test/verification/universality/test_universality_cross_check.jl
@@ -519,8 +519,7 @@ end
     x̄ = sum(invN) / n
     ȳ = sum(corrN) / n
     c1 =
-        sum((invN[i] - x̄) * (corrN[i] - ȳ) for i in 1:n) /
-        sum((invN[i] - x̄)^2 for i in 1:n)
+        sum((invN[i] - x̄) * (corrN[i] - ȳ) for i in 1:n) / sum((invN[i] - x̄)^2 for i in 1:n)
     c0 = ȳ - c1 * x̄
     @test isapprox(c0, corrN[end]; atol=5e-4)
     @test c1 < 0  # corrN approaches its limit from below at OBC critical TFIM


### PR DESCRIPTION
Fixes the repo-wide format-check red (all open PRs) after JuliaFormatter 2.10.1 became the latest 2.x.

## What
- `FormatCheck.yml`: `Pkg.add(name="JuliaFormatter", version="2")` → `Pkg.add("JuliaFormatter")` (**latest**, per request).
- Reformat the 6 files 2.10.1 drifted (formatting-only, no behaviour change): `docs/atlas/generate.jl`, `src/core/constraints.jl`, `AKLT1D.jl`, `AKLT1D_thermal.jl`, `RMT.jl`, `test_universality_cross_check.jl`.

## Why it was red
CI floats to the latest 2.x; 2.10.1 adds `return` before tail `throw`/one-line bodies and wraps long calls. Main hadn't been reformatted, so **every** open PR failed format-check regardless of its diff (verified: #711 and #713 also red).

## Merge note
Open PRs (#711–#713 stack, #718/#719) must **rebase onto main** after this merges to pick up the reformat and go green. Tracking `latest` (unpinned) means future JuliaFormatter releases may require another sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)