### PR TITLE
feat(query): enrich Hit with fetch call signature + notes/valid_domain (#721)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.25.4"
+version = "0.25.5"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/core/query.jl
+++ b/src/core/query.jl
@@ -34,10 +34,19 @@ const REGIMES = (
 """
     Hit
 
-One available (model, quantity, bc) hub, with its provenance: `method` (how the value is obtained),
-`status`, `reliability`, `references`, and `cross_checked` — `true` when the model participates in
-an executable cross-check (a duality, limit, or LSM-symmetry edge), the QAtlas-specific trust signal
-(model-level in this version).
+One available (model, quantity, bc) hub, with its provenance AND how to obtain the
+value. Provenance: `method`, `status`, `reliability`, `references`, `cross_checked`
+(`true` when the model is in an executable cross-check — a duality, limit, or
+LSM-symmetry edge — the QAtlas trust signal, model-level here). Actionability:
+
+- `params` — the fetch's declared keyword arguments (`i`, `j`, `beta`, `N`, `k`,
+  couplings, …): the call signature, so a hit says not just *available* but *how to
+  call it*. A fetch that declares `N`/`finite_N` is evaluable at any finite size
+  (the OBC/PBC hubs are finite-N closed forms; `Infinite` is the thermodynamic
+  limit) — the atlas has no separate `N` dimension, so this is where size shows up.
+- `notes` / `valid_domain` — the closed form's remark and where it holds (from the
+  `Implementation` row), so a consumer can match its numerics to the functional
+  form / validity range. `valid_domain` is `""` when unset.
 """
 struct Hit
     model::String
@@ -50,6 +59,9 @@ struct Hit
     dynamical::Symbol     # orthogonal axis: :static / :transport / :dynamic / :unknown
     cross_checked::Bool
     references::Vector{String}
+    params::Vector{String}  # fetch's declared kwargs — the call signature (how to obtain it)
+    notes::String           # the Implementation row's note (functional form / caveats)
+    valid_domain::String    # where the value holds (:approx rows); "" when unset
 end
 
 """
@@ -97,6 +109,24 @@ function _cross_checked_models()
         push!(s, p.model)
     end
     return s
+end
+
+# The fetch's declared keyword arguments for a (model, quantity, bc) hub — the call
+# signature a consumer needs (i/j sites, beta, N/finite_N, k, couplings…). Same
+# introspection `axes.jl` uses; the `kwargs...` slurp is dropped. Best-effort: an
+# empty vector if no method resolves.
+function _fetch_params(M::Type, Q::Type, BC::Type)
+    ps = String[]
+    try
+        for mth in methods(fetch, Tuple{M,Q,BC})
+            for kw in Base.kwarg_decl(mth)
+                kw === :kwargs && continue
+                push!(ps, String(kw))
+            end
+        end
+    catch
+    end
+    return sort(unique(ps))
 end
 
 """
@@ -162,6 +192,9 @@ function search(;
                 impl.dynamical,
                 xc,
                 copy(impl.references),
+                _fetch_params(impl.model, impl.quantity, impl.bc),
+                impl.notes,
+                impl.valid_domain === nothing ? "" : impl.valid_domain,
             ),
         )
     end
@@ -437,6 +470,12 @@ function _json_hit(h::Hit)
         h.cross_checked,
         ",\"references\":",
         _jarr(h.references),
+        ",\"params\":",
+        _jarr(h.params),
+        ",\"notes\":",
+        _jstr(h.notes),
+        ",\"valid_domain\":",
+        _jstr(h.valid_domain),
         "}",
     )
 end
@@ -457,7 +496,8 @@ end
 Stream a [`search`](@ref) as JSONL. The first line is a summary —
 `{"available":…,"query":…,"count":N,"verified":K}` — so a consumer can branch on it without reading
 the rest; each following line is one hit object (model, quantity, bc, status, reliability,
-cross_checked, references). `verified` counts hits that are cross-checked or exact/universal.
+cross_checked, references, and `params`/`notes`/`valid_domain` — the fetch call signature and
+where the value holds). `verified` counts hits that are cross-checked or exact/universal.
 """
 function search_jsonl(io::IO=stdout; kwargs...)
     r = search(; kwargs...)

--- a/test/core/test_query.jl
+++ b/test/core/test_query.jl
@@ -55,6 +55,36 @@ end
     @test occursin("\"thermal\":", String(take!(io)))        # axes surface in the JSONL hit
 end
 
+@testset "query: hit carries the fetch call signature + notes/valid_domain" begin
+    r = QAtlas.search(; model=:TFIM)
+    @test r.available
+    # every hit now carries the three actionability fields, well-typed
+    @test all(h -> h.params isa Vector{String}, r.hits)
+    @test all(h -> h.notes isa String && h.valid_domain isa String, r.hits)
+    @test all(h -> h.params == sort(unique(h.params)), r.hits)   # sorted-unique, no `kwargs` slurp
+    @test all(h -> !("kwargs" in h.params), r.hits)
+    @test any(h -> !isempty(h.params), r.hits)                   # the call signature is exposed
+    @test any(h -> !isempty(h.notes), r.hits)                    # notes surface
+    # a finite-temperature quantity exposes its temperature kwarg → "how to call it"
+    sh = QAtlas.search(; model=:TFIM, quantity=:SpecificHeat)
+    @test sh.available
+    @test any(
+        h -> any(
+            p ->
+                occursin("beta", lowercase(p)) || p == "β" || lowercase(p) == "temperature",
+            h.params,
+        ),
+        sh.hits,
+    )
+    # JSONL surfaces the new fields (additive keys)
+    io = IOBuffer()
+    QAtlas.search_jsonl(io; model=:TFIM, quantity=:SpecificHeat)
+    s = String(take!(io))
+    @test occursin("\"params\":", s)
+    @test occursin("\"notes\":", s)
+    @test occursin("\"valid_domain\":", s)
+end
+
 @testset "query: fuzzy facet matching (case/underscore-insensitive)" begin
     @test QAtlas.available(; model=:tfim)                    # lowercase Symbol
     @test QAtlas.available(; quantity=:specific_heat)        # underscore vs SpecificHeat


### PR DESCRIPTION
# feat(query): enrich `Hit` with the fetch call signature + notes/valid_domain

> **Stacked on #713** (`feat/describe`). Addresses part 1 (the cheap, high-value
> half) of the search design review in **#721**.

## Why

Driving the availability-search as an LLM agent (see #721) showed that a `Hit`
answers *"is it available?"* but not *"how do I obtain it?"* or *"where does it
hold?"* — even though that information is already recorded. To actually **measure**
a Heisenberg spin-spin correlation for finite-size validation, a consumer needs
the fetch's call signature (`i`, `j`, `beta`, `N`, …) and the closed form's
validity — none of which `Hit` surfaced.

## What

`Hit` (and the JSONL hit object) gain three additive fields:

- **`params`** — the fetch's declared keyword arguments, i.e. the **call
  signature**: "available" → "available *and here is how to call it*". Introspected
  via `Base.kwarg_decl` (the same mechanism `axes.jl` already uses for the thermal
  axis); the `kwargs...` slurp is dropped, result is sorted-unique. This also
  answers the **system-size** question: a fetch that declares `N`/`finite_N` is
  evaluable at any finite size (OBC/PBC hubs are finite-N closed forms; `Infinite`
  is the TDL) — otherwise invisible, as the atlas has no `N` registry dimension.
- **`notes`** / **`valid_domain`** — the `Implementation` row's remark and where
  the value holds (`""` when unset), so a consumer can match its numerics to the
  functional form / validity range.

Example (JSONL, `search_jsonl(; model=:TFIM, quantity=:SpecificHeat)`): each hit
now carries `"params":["beta",…]`, `"notes":"…"`, `"valid_domain":"…"` alongside
the existing provenance keys.

## Test

Extends `test/core/test_query.jl`: every hit has well-typed `params`/`notes`/
`valid_domain`; `params` is sorted-unique with no `kwargs` slurp; a
finite-temperature quantity exposes its temperature kwarg; JSONL surfaces the new
keys. Purely additive — existing keys/shape unchanged.

## Scope

This is item 1 of #721. The consistency fix (regularize `regime` ↔ axes so no
quantity class silently drops — the `regime=:ground_state` returns-no-correlations
trap) and the self-describing `query_schema()` are proposed in #721 for discussion
before implementing.

Version `0.25.4 → 0.25.5` (vs the `feat/describe` base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
