### PR TITLE
feat(query): strict facets (family + axis-derived regimes) + self-describing query_schema (#721)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.25.6"
+version = "0.25.1"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.25.3"
+version = "0.25.4"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.25.5"
+version = "0.25.6"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.25.4"
+version = "0.25.5"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.25.2"
+version = "0.25.3"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -446,6 +446,7 @@ export coherence_report,
 include("core/query.jl")
 export search, search_jsonl, available, relations, relations_jsonl, gaps, gaps_jsonl
 export describe, describe_jsonl, realizing, realizing_jsonl
+export query_schema, query_schema_jsonl, quantity_family, Facet  # self-describing query + family facet
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Precompile workload — bake the hot `fetch` specializations into the package

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -445,6 +445,7 @@ export coherence_report,
 # quantity / bc / regime. Reads REGISTRY + the edge stores, so it comes after they are populated.
 include("core/query.jl")
 export search, search_jsonl, available, relations, relations_jsonl, gaps, gaps_jsonl
+export describe, describe_jsonl, realizing, realizing_jsonl
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Precompile workload — bake the hot `fetch` specializations into the package

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -84,6 +84,7 @@ include("core/alias.jl")
 include("core/type.jl")
 include("core/quantities.jl")
 include("core/universality.jl")  # Universality{C} + CriticalExponents/GrowthExponents (registry design)
+include("core/axes.jl")          # orthogonal thermal/dynamical hub axes (quantity traits + derivation)
 include("core/registry.jl")
 include("core/realizes.jl")  # model <-> universality-class correspondence
 include("core/reduces.jl")   # model -> model reductions (limit / special point)

--- a/src/core/axes.jl
+++ b/src/core/axes.jl
@@ -52,13 +52,18 @@ function _fetch_declares_beta(M::Type, Q::Type, BC::Type)
     return false
 end
 
-# ── quantity family: a TOTAL, regular classification of every quantity into a
-# super-family. This is the regular facet that makes the "use" search complete —
-# correlations / structure factors / magnetization / susceptibility each get a
-# family, so no quantity class can silently fall through the coarse `regime` facet
-# (the design defect the availability review surfaced). Defined on the abstract
-# families in quantities.jl (all loaded before this file, like `thermal_axis`);
-# `:other` is the honest catch-all that keeps the classification total.
+"""
+    quantity_family(Q::Type) -> Symbol
+
+The quantity's super-family — a TOTAL, regular classification into one of
+`:correlation`, `:structure_factor`, `:magnetization`, `:susceptibility`,
+`:thermodynamic`, `:gap`, `:entanglement`, `:velocity`, or `:other`. The `family`
+search facet is keyed on this; because the classification is total (with `:other`
+the honest catch-all), no quantity class can silently fall through the coarse
+`regime` facet — the design defect the availability review surfaced. Defined on
+the abstract quantity families in `quantities.jl` (all loaded before this file,
+like `thermal_axis`), so a concrete quantity dispatches to its family's method.
+"""
 quantity_family(::Type) = :other
 quantity_family(::Type{<:AbstractTwoPointCorrelation}) = :correlation
 quantity_family(::Type{<:AbstractStructureFactor}) = :structure_factor

--- a/src/core/axes.jl
+++ b/src/core/axes.jl
@@ -1,0 +1,53 @@
+# core/axes.jl — orthogonal physical axes for a registered hub, captured at @register time.
+#
+# A single `regime` label conflated several independent physical dimensions, so
+# "finite-temperature dynamics" was inexpressible and velocities masqueraded as "dynamics". These
+# axes decompose that: each hub carries an independent `thermal` and `dynamical` tag, AND-queryable.
+#
+# Derivation priority (applied in register!): explicit @register kwarg > quantity-type trait >
+# fetch-signature introspection (does the method declare a β?) > :unknown. The honest default is
+# :unknown — search abstains rather than guessing, preserving the anti-hallucination property.
+# Because the tags live on the REGISTRY row (not on the quantity type), a hub whose implementation
+# deviates from its quantity's usual axis can be tagged individually via
+# `@register(...; thermal=…, dynamical=…)`.
+
+# ── thermal axis: :zero (T=0 only) / :finite (T>0) / :both / :unknown ──
+thermal_axis(::Type) = :unknown
+thermal_axis(::Type{<:AbstractThermalPotential}) = :finite   # FreeEnergy/SpecificHeat/ThermalEntropy
+thermal_axis(::Type{<:Energy}) = :both                       # ⟨H⟩: ground state (no β) or thermal (β)
+thermal_axis(::Type{<:AbstractGap}) = :zero                  # a gap is a ground-state spectral property
+thermal_axis(::Type{<:AbstractVelocity}) = :zero             # a velocity is a T=0 / low-energy property
+thermal_axis(::Type{<:AbstractEntanglementMeasure}) = :zero  # GS entanglement (quench would override)
+thermal_axis(::Type{<:AbstractMagnetization}) = :both        # spontaneous (T=0) or thermal (T>0)
+thermal_axis(::Type{<:AbstractSusceptibility}) = :both
+thermal_axis(::Type{<:AbstractTwoPointCorrelation}) = :both
+thermal_axis(::Type{<:AbstractStructureFactor}) = :both
+
+# ── dynamical axis: :static / :transport / :dynamic / :unknown ──
+# QAtlas is overwhelmingly equilibrium, so :static is the honest positive default; the few genuinely
+# non-static observables are tagged individually. A velocity is :transport, NOT :dynamic — so
+# `search(dynamical=:dynamic)` honestly returns empty until real spectral/real-time data exists
+# (e.g. a future dynamical critical exponent or A(ω) would be tagged :dynamic here).
+dynamical_axis(::Type) = :static
+dynamical_axis(::Type{<:AbstractVelocity}) = :transport
+
+# ── @register-time derivation: explicit > quantity trait > fetch-introspection > :unknown ──
+function _derive_thermal(explicit, M::Type, Q::Type, BC::Type)
+    explicit === nothing || return explicit
+    t = thermal_axis(Q)
+    t === :unknown || return t
+    return _fetch_declares_beta(M, Q, BC) ? :finite : :unknown
+end
+_derive_dynamical(explicit, Q::Type) = explicit === nothing ? dynamical_axis(Q) : explicit
+
+# Signature introspection: does the (M,Q,BC) fetch method declare a temperature kwarg? Deterministic
+# (thermal fetches declare `; beta::Real, …`), and only a fallback — the quantity trait is primary.
+function _fetch_declares_beta(M::Type, Q::Type, BC::Type)
+    try
+        for mth in methods(fetch, Tuple{M,Q,BC})
+            any(in((:beta, :β, :T, :temperature)), Base.kwarg_decl(mth)) && return true
+        end
+    catch
+    end
+    return false
+end

--- a/src/core/axes.jl
+++ b/src/core/axes.jl
@@ -51,3 +51,21 @@ function _fetch_declares_beta(M::Type, Q::Type, BC::Type)
     end
     return false
 end
+
+# ── quantity family: a TOTAL, regular classification of every quantity into a
+# super-family. This is the regular facet that makes the "use" search complete —
+# correlations / structure factors / magnetization / susceptibility each get a
+# family, so no quantity class can silently fall through the coarse `regime` facet
+# (the design defect the availability review surfaced). Defined on the abstract
+# families in quantities.jl (all loaded before this file, like `thermal_axis`);
+# `:other` is the honest catch-all that keeps the classification total.
+quantity_family(::Type) = :other
+quantity_family(::Type{<:AbstractTwoPointCorrelation}) = :correlation
+quantity_family(::Type{<:AbstractStructureFactor}) = :structure_factor
+quantity_family(::Type{<:AbstractMagnetization}) = :magnetization
+quantity_family(::Type{<:AbstractSusceptibility}) = :susceptibility
+quantity_family(::Type{<:AbstractThermalPotential}) = :thermodynamic
+quantity_family(::Type{<:Energy}) = :thermodynamic
+quantity_family(::Type{<:AbstractGap}) = :gap
+quantity_family(::Type{<:AbstractEntanglementMeasure}) = :entanglement
+quantity_family(::Type{<:AbstractVelocity}) = :velocity

--- a/src/core/query.jl
+++ b/src/core/query.jl
@@ -337,6 +337,58 @@ function gaps(model)
     return out
 end
 
+# ---- describe: the full per-model grounding record (the use-face payoff) ----
+
+"""
+    ModelRecord
+
+Everything the atlas records about one model in a single grounding record: `summary` / `hamiltonian`
+(from the `@about` card — `""` if uncarded, coverage is partial), the distinct `quantities`
+available, the `relations` (graph neighborhood), and aggregated `references`. The structural content
+(quantities + relations) lets an LLM disambiguate a model even when no prose card exists.
+"""
+struct ModelRecord
+    model::String
+    summary::String
+    hamiltonian::String
+    quantities::Vector{String}
+    relations::Vector{Relation}
+    references::Vector{String}
+end
+
+"""
+    describe(model) -> Vector{ModelRecord}
+
+The full record for each model matching `model` (a Type, or a fuzzy Symbol/String): summary +
+Hamiltonian where carded, the distinct quantities available, the graph neighborhood, and the
+aggregated references — the record an LLM grounds a physics statement on. See [`describe_jsonl`](@ref).
+"""
+function describe(model)
+    out = ModelRecord[]
+    for M in _model_types(model)
+        hits = search(; model=M).hits
+        card = about(M)
+        quantities = sort(unique(h.quantity for h in hits))
+        refs = String[]
+        for h in hits
+            append!(refs, h.references)
+        end
+        card === nothing || append!(refs, card.references)
+        push!(
+            out,
+            ModelRecord(
+                _label(M),
+                card === nothing ? "" : card.summary,
+                card === nothing ? "" : card.hamiltonian,
+                quantities,
+                relations(M),
+                sort(unique(refs)),
+            ),
+        )
+    end
+    return out
+end
+
 # ---- JSONL serialization (hand-rolled; fields are clean identifiers / bibkeys) ----
 
 function _json_escape(s::AbstractString)
@@ -507,3 +559,88 @@ function gaps_jsonl(io::IO, model)
     return nothing
 end
 gaps_jsonl(model) = gaps_jsonl(stdout, model)
+
+function _json_record(r::ModelRecord)
+    rels = string('[', join((_json_relation(x) for x in r.relations), ','), ']')
+    return string(
+        "{\"model\":",
+        _jstr(r.model),
+        ",\"summary\":",
+        _jstr(r.summary),
+        ",\"hamiltonian\":",
+        _jstr(r.hamiltonian),
+        ",\"quantities\":",
+        _jarr(r.quantities),
+        ",\"relations\":",
+        rels,
+        ",\"references\":",
+        _jarr(r.references),
+        "}",
+    )
+end
+
+"""
+    describe_jsonl([io=stdout], model) -> nothing
+
+Stream [`describe`](@ref) as JSONL: a `{count, query}` header line then one rich model-record object
+per line (summary, hamiltonian, quantities, relations, references).
+"""
+function describe_jsonl(io::IO, model)
+    recs = describe(model)
+    print(io, "{\"count\":", length(recs), ",\"query\":", _json_query((; model)), "}\n")
+    for r in recs
+        print(io, _json_record(r), "\n")
+    end
+    return nothing
+end
+describe_jsonl(model) = describe_jsonl(stdout, model)
+
+# ---- realizing: the inverse of a model's :realizes edge — which models realize a class ----
+
+"""
+    realizing(class) -> Vector{Relation}
+
+The models that realize a universality `class` (a Symbol/String, case-insensitive exact match) — the
+inverse of the model→class `:realizes` edge `relations` returns. Answers "which physical models can I
+study the Ising / Heisenberg / KPZ / … class with". See [`realizing_jsonl`](@ref).
+"""
+function realizing(class)
+    want = lowercase(string(class))
+    rels = Relation[]
+    for r in REALIZES
+        lowercase(string(r.class)) == want || continue
+        push!(
+            rels,
+            Relation(
+                :realizes, _label(r.model), string(r.class), r.regime, copy(r.references)
+            ),
+        )
+    end
+    sort!(rels; by=x -> x.from)
+    return rels
+end
+
+"""
+    realizing_jsonl([io=stdout], class) -> nothing
+
+Stream [`realizing`](@ref) as JSONL: a `{available, query, count}` summary line then one `:realizes`
+Relation per line.
+"""
+function realizing_jsonl(io::IO, class)
+    rels = realizing(class)
+    print(
+        io,
+        "{\"available\":",
+        !isempty(rels),
+        ",\"query\":",
+        _json_query((; class)),
+        ",\"count\":",
+        length(rels),
+        "}\n",
+    )
+    for r in rels
+        print(io, _json_relation(r), "\n")
+    end
+    return nothing
+end
+realizing_jsonl(class) = realizing_jsonl(stdout, class)

--- a/src/core/query.jl
+++ b/src/core/query.jl
@@ -34,10 +34,19 @@ const REGIMES = (
 """
     Hit
 
-One available (model, quantity, bc) hub, with its provenance: `method` (how the value is obtained),
-`status`, `reliability`, `references`, and `cross_checked` — `true` when the model participates in
-an executable cross-check (a duality, limit, or LSM-symmetry edge), the QAtlas-specific trust signal
-(model-level in this version).
+One available (model, quantity, bc) hub, with its provenance AND how to obtain the
+value. Provenance: `method`, `status`, `reliability`, `references`, `cross_checked`
+(`true` when the model is in an executable cross-check — a duality, limit, or
+LSM-symmetry edge — the QAtlas trust signal, model-level here). Actionability:
+
+- `params` — the fetch's declared keyword arguments (`i`, `j`, `beta`, `N`, `k`,
+  couplings, …): the call signature, so a hit says not just *available* but *how to
+  call it*. A fetch that declares `N`/`finite_N` is evaluable at any finite size
+  (the OBC/PBC hubs are finite-N closed forms; `Infinite` is the thermodynamic
+  limit) — the atlas has no separate `N` dimension, so this is where size shows up.
+- `notes` / `valid_domain` — the closed form's remark and where it holds (from the
+  `Implementation` row), so a consumer can match its numerics to the functional
+  form / validity range. `valid_domain` is `""` when unset.
 """
 struct Hit
     model::String
@@ -50,6 +59,9 @@ struct Hit
     dynamical::Symbol     # orthogonal axis: :static / :transport / :dynamic / :unknown
     cross_checked::Bool
     references::Vector{String}
+    params::Vector{String}  # fetch's declared kwargs — the call signature (how to obtain it)
+    notes::String           # the Implementation row's note (functional form / caveats)
+    valid_domain::String    # where the value holds (:approx rows); "" when unset
 end
 
 """
@@ -97,6 +109,24 @@ function _cross_checked_models()
         push!(s, p.model)
     end
     return s
+end
+
+# The fetch's declared keyword arguments for a (model, quantity, bc) hub — the call
+# signature a consumer needs (i/j sites, beta, N/finite_N, k, couplings…). Same
+# introspection `axes.jl` uses; the `kwargs...` slurp is dropped. Best-effort: an
+# empty vector if no method resolves.
+function _fetch_params(M::Type, Q::Type, BC::Type)
+    ps = String[]
+    try
+        for mth in methods(fetch, Tuple{M,Q,BC})
+            for kw in Base.kwarg_decl(mth)
+                kw === :kwargs && continue
+                push!(ps, String(kw))
+            end
+        end
+    catch
+    end
+    return sort(unique(ps))
 end
 
 """
@@ -162,6 +192,9 @@ function search(;
                 impl.dynamical,
                 xc,
                 copy(impl.references),
+                _fetch_params(impl.model, impl.quantity, impl.bc),
+                impl.notes,
+                impl.valid_domain === nothing ? "" : impl.valid_domain,
             ),
         )
     end
@@ -437,6 +470,12 @@ function _json_hit(h::Hit)
         h.cross_checked,
         ",\"references\":",
         _jarr(h.references),
+        ",\"params\":",
+        _jarr(h.params),
+        ",\"notes\":",
+        _jstr(h.notes),
+        ",\"valid_domain\":",
+        _jstr(h.valid_domain),
         "}",
     )
 end
@@ -457,7 +496,8 @@ end
 Stream a [`search`](@ref) as JSONL. The first line is a summary —
 `{"available":…,"query":…,"count":N,"verified":K}` — so a consumer can branch on it without reading
 the rest; each following line is one hit object (model, quantity, bc, status, reliability,
-cross_checked, references). `verified` counts hits that are cross-checked or exact/universal.
+cross_checked, references, and `params`/`notes`/`valid_domain` — the fetch call signature and
+where the value holds). `verified` counts hits that are cross-checked or exact/universal.
 """
 function search_jsonl(io::IO=stdout; kwargs...)
     r = search(; kwargs...)

--- a/src/core/query.jl
+++ b/src/core/query.jl
@@ -46,6 +46,8 @@ struct Hit
     method::Symbol        # how the value is obtained (:bdg, :bethe_ansatz, :analytic, …)
     status::Symbol        # :exact / :bound / :approx / :universal
     reliability::Symbol   # :high / :medium / :low
+    thermal::Symbol       # orthogonal axis: :zero / :finite / :both / :unknown
+    dynamical::Symbol     # orthogonal axis: :static / :transport / :dynamic / :unknown
     cross_checked::Bool
     references::Vector{String}
 end
@@ -75,6 +77,10 @@ _match(want::Type, @nospecialize(T)) = T <: want
 
 # A reference facet matches if any of a row's bibkeys contains it (case/underscore-insensitive).
 _ref_match(want, refs) = any(r -> occursin(_norm(want), _norm(r)), refs)
+
+# An orthogonal-axis facet matches its stored value; `:both` (a hub spanning T=0 and T>0) matches
+# either `thermal` query.
+_axis_match(want, have) = want === have || have === :both
 
 # Models tied into an executable cross-check (duality / limit / LSM symmetry). Model-level for now.
 function _cross_checked_models()
@@ -122,6 +128,8 @@ function search(;
     method=nothing,
     reference=nothing,
     cross_checked=nothing,
+    thermal=nothing,
+    dynamical=nothing,
 )
     regime === nothing ||
         haskey(REGIMES, regime) ||
@@ -137,6 +145,8 @@ function search(;
         reliability === nothing || impl.reliability === reliability || continue
         method === nothing || _match(method, impl.method) || continue
         reference === nothing || _ref_match(reference, impl.references) || continue
+        thermal === nothing || _axis_match(thermal, impl.thermal) || continue
+        dynamical === nothing || _axis_match(dynamical, impl.dynamical) || continue
         xc = impl.model in xchecked
         cross_checked === nothing || xc === cross_checked || continue
         push!(
@@ -148,6 +158,8 @@ function search(;
                 impl.method,
                 impl.status,
                 impl.reliability,
+                impl.thermal,
+                impl.dynamical,
                 xc,
                 copy(impl.references),
             ),
@@ -165,6 +177,8 @@ function search(;
             method,
             reference,
             cross_checked,
+            thermal,
+            dynamical,
         ),
         !isempty(hits),
         hits,
@@ -363,6 +377,10 @@ function _json_hit(h::Hit)
         _jstr(h.status),
         ",\"reliability\":",
         _jstr(h.reliability),
+        ",\"thermal\":",
+        _jstr(h.thermal),
+        ",\"dynamical\":",
+        _jstr(h.dynamical),
         ",\"cross_checked\":",
         h.cross_checked,
         ",\"references\":",

--- a/src/core/query.jl
+++ b/src/core/query.jl
@@ -16,26 +16,44 @@
 """
     REGIMES
 
-Coarse capability facets, each a predicate over a registry row. Declarative and extensible — add a
-regime by adding a predicate. `:dynamics` is intentionally sparse today (QAtlas has velocities but
-no spectral / real-time data yet); a search for it honestly reports the gap.
+Coarse capability facets, kept as a convenience over the canonical query axes
+(`family` × `thermal` × `dynamical` × `status`). Each predicate is now **derived
+from those axes** rather than a hand-picked quantity list, so a whole quantity
+class can no longer silently fall through: the thermal regimes are keyed on the
+`thermal` axis (so `:ground_state` surfaces T=0-accessible correlations,
+magnetization, … — not only gaps/entanglement), and each predicate is a superset
+of its previous hand-list (no regression). `:dynamics` stays sparse (velocities are
+`:transport`; genuine spectral/real-time data would be `:dynamic`); a search for it
+honestly reports the gap. For a rigorous query, prefer the axes directly.
 """
 const REGIMES = (
     ground_state=impl -> (
+        impl.thermal === :zero ||
+        impl.thermal === :both ||
         impl.quantity <: AbstractGap ||
         impl.quantity <: AbstractEntanglementMeasure ||
         impl.quantity === GroundStateEnergyDensity
     ),
-    finite_temperature=impl -> impl.quantity <: AbstractThermalPotential,
+    finite_temperature=impl -> (
+        impl.thermal === :finite ||
+        impl.thermal === :both ||
+        impl.quantity <: AbstractThermalPotential
+    ),
     universality=impl -> impl.status === :universal,
-    dynamics=impl -> impl.quantity <: AbstractVelocity,
+    dynamics=impl -> (
+        impl.dynamical === :dynamic ||
+        impl.dynamical === :transport ||
+        impl.quantity <: AbstractVelocity
+    ),
 )
 
 """
     Hit
 
-One available (model, quantity, bc) hub, with its provenance AND how to obtain the
-value. Provenance: `method`, `status`, `reliability`, `references`, `cross_checked`
+One available (model, quantity, bc) hub, with its `family` (the quantity's
+super-family — `:correlation`, `:magnetization`, …; total, so it never silently
+drops a class), its provenance, AND how to obtain the value. Provenance: `method`,
+`status`, `reliability`, `references`, `cross_checked`
 (`true` when the model is in an executable cross-check — a duality, limit, or
 LSM-symmetry edge — the QAtlas trust signal, model-level here). Actionability:
 
@@ -52,6 +70,7 @@ struct Hit
     model::String
     quantity::String
     bc::String
+    family::Symbol        # quantity super-family (:correlation, :magnetization, …); TOTAL
     method::Symbol        # how the value is obtained (:bdg, :bethe_ansatz, :analytic, …)
     status::Symbol        # :exact / :bound / :approx / :universal
     reliability::Symbol   # :high / :medium / :low
@@ -137,8 +156,11 @@ given facets are AND-combined.
 
 - `model`/`quantity`/`bc` — a Type (exact, or a family like `AbstractGap`) or a Symbol/String
   (fuzzy: case- and underscore-insensitive substring on the name).
+- `family` — the quantity super-family (`:correlation`, `:structure_factor`, `:magnetization`,
+  `:susceptibility`, `:thermodynamic`, `:gap`, `:entanglement`, `:velocity`, `:other`), exact
+  Symbol match. TOTAL: every quantity has one, so no class silently drops (unlike `regime`).
 - `regime` — one of `keys(REGIMES)` (`:ground_state`, `:finite_temperature`, `:dynamics`,
-  `:universality`).
+  `:universality`), a convenience derived from the axes; prefer `family`/`thermal`/`dynamical`.
 - `status` (`:exact`/`:bound`/`:approx`/`:universal`) and `reliability` (`:high`/`:medium`/`:low`)
   — exact Symbol match.
 - `method` — a Symbol/String, fuzzy (so `:bethe` finds `:bethe_ansatz`).
@@ -152,6 +174,7 @@ function search(;
     model=nothing,
     quantity=nothing,
     bc=nothing,
+    family=nothing,
     regime=nothing,
     status=nothing,
     reliability=nothing,
@@ -170,6 +193,7 @@ function search(;
         _match(model, impl.model) || continue
         _match(quantity, impl.quantity) || continue
         _match(bc, impl.bc) || continue
+        family === nothing || quantity_family(impl.quantity) === family || continue
         regime === nothing || REGIMES[regime](impl) || continue
         status === nothing || impl.status === status || continue
         reliability === nothing || impl.reliability === reliability || continue
@@ -185,6 +209,7 @@ function search(;
                 _label(impl.model),
                 _label(impl.quantity),
                 _label(impl.bc),
+                quantity_family(impl.quantity),
                 impl.method,
                 impl.status,
                 impl.reliability,
@@ -204,6 +229,7 @@ function search(;
             model,
             quantity,
             bc,
+            family,
             regime,
             status,
             reliability,
@@ -456,6 +482,8 @@ function _json_hit(h::Hit)
         _jstr(h.quantity),
         ",\"bc\":",
         _jstr(h.bc),
+        ",\"family\":",
+        _jstr(h.family),
         ",\"method\":",
         _jstr(h.method),
         ",\"status\":",
@@ -684,3 +712,79 @@ function realizing_jsonl(io::IO, class)
     return nothing
 end
 realizing_jsonl(class) = realizing_jsonl(stdout, class)
+
+# ---- query_schema: the query convention, self-describing (discover what you can ask) ----
+
+"""
+    Facet
+
+One searchable facet of [`search`](@ref): its `name`, `kind`
+(`:structural`/`:axis`/`:provenance`/`:derived`), the `match` rule
+(`:type_or_fuzzy`/`:enum`/`:fuzzy`/`:bool`), and the enumerated `values` where the
+domain is finite (`String[]` when open, e.g. free-text model/quantity names).
+"""
+struct Facet
+    name::Symbol
+    kind::Symbol
+    match::Symbol
+    values::Vector{String}
+end
+
+"""
+    query_schema() -> Vector{Facet}
+
+The self-describing catalog of [`search`](@ref)'s facets — every facet, its kind,
+its match rule, and (where finite) its valid values, drawn live from the registry
+(the registered `bc` / `family` / `method` / `reliability` sets) and the fixed
+axis / status vocabularies. Lets a consumer (an LLM, a UI) discover *what it can
+ask, and with which values*, without reading source — the anti-hallucination
+principle applied to the query layer itself. See [`query_schema_jsonl`](@ref).
+"""
+function query_schema()
+    reg_vals(f) = sort(unique(String(f(i)) for i in REGISTRY))
+    return Facet[
+        Facet(:model, :structural, :type_or_fuzzy, String[]),
+        Facet(:quantity, :structural, :type_or_fuzzy, String[]),
+        Facet(
+            :bc, :structural, :type_or_fuzzy, sort(unique(_label(i.bc) for i in REGISTRY))
+        ),
+        Facet(:family, :structural, :enum, reg_vals(i -> quantity_family(i.quantity))),
+        Facet(:thermal, :axis, :enum, ["zero", "finite", "both", "unknown"]),
+        Facet(:dynamical, :axis, :enum, ["static", "transport", "dynamic", "unknown"]),
+        Facet(:regime, :derived, :enum, sort(String.(collect(keys(REGIMES))))),
+        Facet(:status, :provenance, :enum, sort(String.(collect(STATUS_VALUES)))),
+        Facet(:reliability, :provenance, :enum, reg_vals(i -> i.reliability)),
+        Facet(:method, :provenance, :fuzzy, reg_vals(i -> i.method)),
+        Facet(:reference, :provenance, :fuzzy, String[]),
+        Facet(:cross_checked, :provenance, :bool, ["true", "false"]),
+    ]
+end
+
+function _json_facet(f::Facet)
+    return string(
+        "{\"name\":",
+        _jstr(f.name),
+        ",\"kind\":",
+        _jstr(f.kind),
+        ",\"match\":",
+        _jstr(f.match),
+        ",\"values\":",
+        _jarr(f.values),
+        "}",
+    )
+end
+
+"""
+    query_schema_jsonl([io=stdout]) -> nothing
+
+Stream [`query_schema`](@ref) as JSONL: a `{"facets":N}` header then one Facet
+object per line (`name`, `kind`, `match`, `values`).
+"""
+function query_schema_jsonl(io::IO=stdout)
+    fs = query_schema()
+    print(io, "{\"facets\":", length(fs), "}\n")
+    for f in fs
+        print(io, _json_facet(f), "\n")
+    end
+    return nothing
+end

--- a/src/core/registry.jl
+++ b/src/core/registry.jl
@@ -53,6 +53,8 @@ struct Implementation
     tested_in::Union{String,Nothing}
     references::Vector{String}
     notes::String
+    thermal::Symbol                      # orthogonal axis: :zero / :finite / :both / :unknown
+    dynamical::Symbol                    # orthogonal axis: :static / :transport / :dynamic / :unknown
 end
 
 """
@@ -148,6 +150,8 @@ function register!(
     tested_in::Union{String,Nothing}=nothing,
     references::AbstractVector{<:AbstractString}=String[],
     notes::AbstractString="",
+    thermal::Union{Symbol,Nothing}=nothing,
+    dynamical::Union{Symbol,Nothing}=nothing,
 )
     status in STATUS_VALUES || throw(
         ArgumentError("register!: status must be one of $(STATUS_VALUES); got :$(status)"),
@@ -228,6 +232,8 @@ function register!(
             tested_in,
             String[r for r in references],
             String(notes),
+            _derive_thermal(thermal, model_T, quantity_T, bc_T),
+            _derive_dynamical(dynamical, quantity_T),
         ),
     )
     return nothing

--- a/test/core/test_query.jl
+++ b/test/core/test_query.jl
@@ -116,6 +116,42 @@ end
     @test startswith(lines[1], "{\"has_gaps\":")
 end
 
+@testset "query: describe — the full per-model grounding record" begin
+    rs = QAtlas.describe(:TFIM)
+    @test length(rs) == 1
+    r = rs[1]
+    @test r.model == "TFIM"
+    @test !isempty(r.quantities)                 # the observables — disambiguating structural content
+    @test !isempty(r.relations)                  # the graph neighborhood
+    @test r.summary isa String                   # "" if uncarded, honest
+    # the dogfood trap: FibonacciAnyons is uncarded (no prose), but the structure still identifies it
+    fib = QAtlas.describe(:fibonacci)
+    @test length(fib) == 1 && fib[1].model == "FibonacciAnyons"
+    @test fib[1].summary == ""                   # honestly uncarded (no @about card)
+    # JSONL: a header line then one rich record per model
+    io = IOBuffer()
+    QAtlas.describe_jsonl(io, :TFIM)
+    lines = split(strip(String(take!(io))), '\n')
+    @test length(lines) == 2                      # header + 1 record
+    @test startswith(lines[1], "{\"count\":1")
+    @test occursin("\"quantities\":", lines[2]) && occursin("\"relations\":", lines[2])
+end
+
+@testset "query: realizing(class) — inverse edge query (class → models)" begin
+    is = QAtlas.realizing(:Ising)
+    @test !isempty(is)
+    @test all(r -> r.kind === :realizes && r.to == "Ising", is)
+    @test "TFIM" in (r.from for r in is)          # TFIM realizes the Ising class
+    @test [r.from for r in QAtlas.realizing(:ising)] == [r.from for r in is]  # case-insensitive
+    @test all(r -> r.to == "Ising", QAtlas.realizing(:ising))  # exact: does NOT catch IsingSDRG
+    io = IOBuffer()
+    QAtlas.realizing_jsonl(io, :Ising)
+    lines = split(strip(String(take!(io))), '\n')
+    @test length(lines) == length(is) + 1
+    @test startswith(lines[1], "{\"available\":true")
+    @test all(l -> occursin("\"kind\":\"realizes\"", l), lines[2:end])
+end
+
 @testset "query: not-available search → single false summary, no hit lines" begin
     io = IOBuffer()
     QAtlas.search_jsonl(io; model=:NoSuchModelXYZ)

--- a/test/core/test_query.jl
+++ b/test/core/test_query.jl
@@ -55,6 +55,36 @@ end
     @test occursin("\"thermal\":", String(take!(io)))        # axes surface in the JSONL hit
 end
 
+@testset "query: hit carries the fetch call signature + notes/valid_domain" begin
+    r = QAtlas.search(; model=:TFIM)
+    @test r.available
+    # every hit now carries the three actionability fields, well-typed
+    @test all(h -> h.params isa Vector{String}, r.hits)
+    @test all(h -> h.notes isa String && h.valid_domain isa String, r.hits)
+    @test all(h -> h.params == sort(unique(h.params)), r.hits)   # sorted-unique, no `kwargs` slurp
+    @test all(h -> !("kwargs" in h.params), r.hits)
+    @test any(h -> !isempty(h.params), r.hits)                   # the call signature is exposed
+    @test any(h -> !isempty(h.notes), r.hits)                    # notes surface
+    # a finite-temperature quantity exposes its temperature kwarg → "how to call it"
+    sh = QAtlas.search(; model=:TFIM, quantity=:SpecificHeat)
+    @test sh.available
+    @test any(
+        h -> any(
+            p ->
+                occursin("beta", lowercase(p)) || p == "β" || lowercase(p) == "temperature",
+            h.params,
+        ),
+        sh.hits,
+    )
+    # JSONL surfaces the new fields (additive keys)
+    io = IOBuffer()
+    QAtlas.search_jsonl(io; model=:TFIM, quantity=:SpecificHeat)
+    s = String(take!(io))
+    @test occursin("\"params\":", s)
+    @test occursin("\"notes\":", s)
+    @test occursin("\"valid_domain\":", s)
+end
+
 @testset "query: fuzzy facet matching (case/underscore-insensitive)" begin
     @test QAtlas.available(; model=:tfim)                    # lowercase Symbol
     @test QAtlas.available(; quantity=:specific_heat)        # underscore vs SpecificHeat

--- a/test/core/test_query.jl
+++ b/test/core/test_query.jl
@@ -85,6 +85,48 @@ end
     @test occursin("\"valid_domain\":", s)
 end
 
+@testset "query: family facet is total; regime no longer drops correlations" begin
+    # family is a TOTAL classification — every registered hub gets one
+    all_hits = QAtlas.search().hits
+    @test all(h -> h.family isa Symbol && h.family !== Symbol(""), all_hits)
+    # the family facet finds correlations — the class `regime` used to silently drop
+    corr = QAtlas.search(; family=:correlation)
+    @test corr.available && all(h -> h.family === :correlation, corr.hits)
+    @test all(h -> occursin("Correlation", h.quantity), corr.hits)
+    @test QAtlas.available(; model=:Heisenberg, family=:correlation)
+    # THE FIX: regime=:ground_state now surfaces T=0-accessible correlations
+    gs = QAtlas.search(; model=:Heisenberg1D, regime=:ground_state)
+    @test any(h -> occursin("Correlation", h.quantity), gs.hits)
+    # NO REGRESSION: the previous ground_state members are still ground_state
+    @test QAtlas.available(; quantity=:MassGap, regime=:ground_state)                   # <:AbstractGap
+    @test QAtlas.available(; quantity=:GroundStateEnergyDensity, regime=:ground_state)  # thermal=:unknown, kept explicitly
+    # family surfaces in the JSONL hit
+    io = IOBuffer()
+    QAtlas.search_jsonl(io; model=:Heisenberg1D, family=:correlation)
+    @test occursin("\"family\":\"correlation\"", String(take!(io)))
+end
+
+@testset "query: query_schema — the query convention is self-describing" begin
+    sch = QAtlas.query_schema()
+    @test sch isa Vector{QAtlas.Facet}
+    names = [f.name for f in sch]
+    @test all(in(names), (:model, :quantity, :bc, :family, :thermal, :dynamical, :regime))
+    # enumerated facets carry their valid values, drawn live from the registry
+    fam = only(f for f in sch if f.name === :family)
+    @test fam.kind === :structural && "correlation" in fam.values
+    th = only(f for f in sch if f.name === :thermal)
+    @test th.kind === :axis && Set(th.values) == Set(["zero", "finite", "both", "unknown"])
+    bcf = only(f for f in sch if f.name === :bc)
+    @test "OBC" in bcf.values && "Infinite" in bcf.values
+    # JSONL shape: header + one facet per line
+    io = IOBuffer()
+    QAtlas.query_schema_jsonl(io)
+    lines = split(strip(String(take!(io))), '\n')
+    @test startswith(lines[1], "{\"facets\":")
+    @test length(lines) == length(sch) + 1
+    @test all(l -> occursin("\"name\":", l) && occursin("\"values\":", l), lines[2:end])
+end
+
 @testset "query: fuzzy facet matching (case/underscore-insensitive)" begin
     @test QAtlas.available(; model=:tfim)                    # lowercase Symbol
     @test QAtlas.available(; quantity=:specific_heat)        # underscore vs SpecificHeat

--- a/test/core/test_query.jl
+++ b/test/core/test_query.jl
@@ -37,6 +37,24 @@ end
     @test occursin("\"method\":", String(take!(io)))        # method in the JSONL hit
 end
 
+@testset "query: orthogonal axes — thermal × dynamical (captured at @register)" begin
+    ft = QAtlas.search(; thermal=:finite)
+    @test ft.available
+    @test all(h -> h.thermal in (:finite, :both), ft.hits)  # :both spans, matches :finite query
+    @test QAtlas.available(; thermal=:zero)
+    tr = QAtlas.search(; dynamical=:transport)               # velocities are :transport, not :dynamic
+    @test tr.available
+    @test all(h -> h.dynamical === :transport, tr.hits)
+    # THE FIX: real dynamics (:dynamic) is honestly absent → no more velocity overclaim
+    @test !QAtlas.available(; dynamical=:dynamic)
+    @test !QAtlas.available(; thermal=:finite, dynamical=:dynamic)  # the conjunction, honestly empty
+    en = QAtlas.search(; quantity=QAtlas.Energy)             # Energy is :both (T=0 or thermal)
+    @test en.available && any(h -> h.thermal === :both, en.hits)
+    io = IOBuffer()
+    QAtlas.search_jsonl(io; thermal=:finite)
+    @test occursin("\"thermal\":", String(take!(io)))        # axes surface in the JSONL hit
+end
+
 @testset "query: fuzzy facet matching (case/underscore-insensitive)" begin
     @test QAtlas.available(; model=:tfim)                    # lowercase Symbol
     @test QAtlas.available(; quantity=:specific_heat)        # underscore vs SpecificHeat


### PR DESCRIPTION
# feat(query): strict facets (family + axis-derived regimes) + self-describing query_schema

> **Stacked on #723** (`feat/query-hit-enrichment`). Implements items A & B of the
> search design review **#721**. Finalizes the query layer before merge.

## A — no facet silently drops a quantity class (the correctness fix)

The review (#721) showed, empirically, that `regime` silently dropped whole
quantity classes: `search(model=:Heisenberg, regime=:ground_state)` returned 21
hits and **zero correlations**, because `REGIMES` was a hand-picked quantity list
(`ground_state = Gap|Entanglement|GSEnergy`) with no bucket for
correlations/magnetization/susceptibility.

Two changes make the facet model regular:

- **`family` — a TOTAL quantity classification** (`quantity_family` trait in
  `axes.jl`, on the abstract families; `:other` catch-all so it's total):
  `:correlation`, `:structure_factor`, `:magnetization`, `:susceptibility`,
  `:thermodynamic`, `:gap`, `:entanglement`, `:velocity`, `:other`. New `search`
  facet + `Hit.family` + JSONL. Now `search(family=:correlation)` finds every
  correlator, and nothing can fall through.

- **`REGIMES` redefined as axis-derived predicates** (not a hand-list): the thermal
  regimes key on the `thermal` axis, so `:ground_state` now surfaces
  T=0-accessible correlations/magnetization (thermal `:zero`/`:both`), not only
  gaps. Each predicate is a **superset of its old hand-list (no regression** — the
  `AbstractGap`/`GroundStateEnergyDensity` inclusions are kept explicitly, covering
  the `thermal=:unknown` cases the axis alone would miss). Documented as a
  convenience over the canonical `family × thermal × dynamical` axes.

## B — the query convention is self-describing (`query_schema`)

`query_schema()` / `query_schema_jsonl()` return the facet catalog — every facet's
`name`, `kind` (`:structural`/`:axis`/`:provenance`/`:derived`), `match` rule, and
enumerated `values` where finite (drawn **live from the registry**: the actual
`bc` / `family` / `method` / `reliability` sets, plus the fixed axis / status
vocab). An LLM can now discover *what it can ask, and with which values*, without
reading source — the anti-hallucination principle applied to the query layer.

## Test

`test/core/test_query.jl` +2 testsets: family is total; the family facet finds
correlations; **`regime=:ground_state` now surfaces correlations** (the #721 bug,
now a regression guard) with the old members still present (no regression);
`query_schema` shape + live values + JSONL. Existing testsets unchanged.

Version `0.25.5 → 0.25.6`. After this, the query layer is finalized for merge (A/B
of #721 done; the remaining #721 note — per-scheme `dynamical` tagging so a
`{:dynamic}` correlation is `:dynamic` not `:static` — is a small follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
