### PR TITLE
feat(query): per-scheme dynamical tagging — dynamic correlations/quench are :dynamic (#721)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.25.2"
+version = "0.25.3"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/core/axes.jl
+++ b/src/core/axes.jl
@@ -25,11 +25,32 @@ thermal_axis(::Type{<:AbstractStructureFactor}) = :both
 
 # ── dynamical axis: :static / :transport / :dynamic / :unknown ──
 # QAtlas is overwhelmingly equilibrium, so :static is the honest positive default; the few genuinely
-# non-static observables are tagged individually. A velocity is :transport, NOT :dynamic — so
-# `search(dynamical=:dynamic)` honestly returns empty until real spectral/real-time data exists
-# (e.g. a future dynamical critical exponent or A(ω) would be tagged :dynamic here).
+# non-static observables are tagged individually. A velocity is :transport, NOT :dynamic.
+# Real-time / non-equilibrium SCHEMES (the type parameter of a scheme-tagged quantity) make a hub
+# :dynamic — so a `{:dynamic}`/`{:lightcone}` correlation, a `{:quench}` entanglement/magnetization,
+# or a Loschmidt echo is honestly surfaced by `search(dynamical=:dynamic)` (the availability-review
+# follow-up). Equilibrium schemes (:static / :connected / :equilibrium) stay :static; extend the set
+# by adding a scheme to `_dynamic_scheme`.
 dynamical_axis(::Type) = :static
 dynamical_axis(::Type{<:AbstractVelocity}) = :transport
+
+_dynamic_scheme(s) = s in (:dynamic, :lightcone, :quench)
+function dynamical_axis(::Type{<:XXCorrelation{M}}) where {M}
+    return _dynamic_scheme(M) ? :dynamic : :static
+end
+function dynamical_axis(::Type{<:YYCorrelation{M}}) where {M}
+    return _dynamic_scheme(M) ? :dynamic : :static
+end
+function dynamical_axis(::Type{<:ZZCorrelation{M}}) where {M}
+    return _dynamic_scheme(M) ? :dynamic : :static
+end
+function dynamical_axis(::Type{<:VonNeumannEntropy{M}}) where {M}
+    return _dynamic_scheme(M) ? :dynamic : :static
+end
+function dynamical_axis(::Type{<:MagnetizationXLocal{M}}) where {M}
+    return _dynamic_scheme(M) ? :dynamic : :static
+end
+dynamical_axis(::Type{<:LoschmidtEcho}) = :dynamic  # Loschmidt echo is a real-time quench quantity
 
 # ── @register-time derivation: explicit > quantity trait > fetch-introspection > :unknown ──
 function _derive_thermal(explicit, M::Type, Q::Type, BC::Type)

--- a/test/core/test_query.jl
+++ b/test/core/test_query.jl
@@ -45,14 +45,36 @@ end
     tr = QAtlas.search(; dynamical=:transport)               # velocities are :transport, not :dynamic
     @test tr.available
     @test all(h -> h.dynamical === :transport, tr.hits)
-    # THE FIX: real dynamics (:dynamic) is honestly absent → no more velocity overclaim
-    @test !QAtlas.available(; dynamical=:dynamic)
-    @test !QAtlas.available(; thermal=:finite, dynamical=:dynamic)  # the conjunction, honestly empty
+    # per-scheme tagging: real-time correlations / quench observables ARE :dynamic now
+    dyn = QAtlas.search(; dynamical=:dynamic)
+    @test dyn.available && all(h -> h.dynamical === :dynamic, dyn.hits)
+    @test QAtlas.available(; thermal=:finite, dynamical=:dynamic)   # dynamic correlations are thermal=:both
     en = QAtlas.search(; quantity=QAtlas.Energy)             # Energy is :both (T=0 or thermal)
     @test en.available && any(h -> h.thermal === :both, en.hits)
     io = IOBuffer()
     QAtlas.search_jsonl(io; thermal=:finite)
     @test occursin("\"thermal\":", String(take!(io)))        # axes surface in the JSONL hit
+end
+
+@testset "query: per-scheme dynamical tagging (dynamic correlations / quench)" begin
+    da = QAtlas.dynamical_axis
+    @test da(QAtlas.ZZCorrelation{:dynamic}) === :dynamic
+    @test da(QAtlas.ZZCorrelation{:lightcone}) === :dynamic
+    @test da(QAtlas.ZZCorrelation{:static}) === :static
+    @test da(QAtlas.ZZCorrelation{:connected}) === :static
+    @test da(QAtlas.VonNeumannEntropy{:quench}) === :dynamic
+    @test da(QAtlas.VonNeumannEntropy{:equilibrium}) === :static
+    @test da(QAtlas.LoschmidtEcho{:amplitude}) === :dynamic
+    # search now surfaces the dynamic hubs; equilibrium schemes stay out
+    dyn = QAtlas.search(; dynamical=:dynamic)
+    @test dyn.available
+    @test any(h -> occursin("Correlation", h.quantity), dyn.hits)   # e.g. XXCorrelation{:dynamic}
+    @test !any(
+        h -> endswith(h.quantity, "{:static}") || endswith(h.quantity, "{:connected}"),
+        dyn.hits,
+    )
+    # the axis-derived `regime=:dynamics` convenience now surfaces them too
+    @test QAtlas.available(; regime=:dynamics)
 end
 
 @testset "query: hit carries the fetch call signature + notes/valid_domain" begin


### PR DESCRIPTION
# feat(query): per-scheme dynamical tagging — dynamic correlations / quench are `:dynamic`

Closes the follow-up noted in the search design review (#721): a real-time
correlation such as `ZZCorrelation{:dynamic}` (or `{:lightcone}`) was still tagged
`dynamical=:static` on the orthogonal axis, so `search(dynamical=:dynamic)` and
`regime=:dynamics` returned empty despite the data existing (TFIM has dynamic
correlations).

## What

`dynamical_axis` (`src/core/axes.jl`) becomes **scheme-aware**: the type parameter
of a scheme-tagged quantity now drives the axis. Real-time / non-equilibrium
schemes → `:dynamic`; equilibrium schemes stay `:static`.

- `_dynamic_scheme(s) = s in (:dynamic, :lightcone, :quench)` — the one place to
  extend.
- `XXCorrelation{M}` / `YYCorrelation{M}` / `ZZCorrelation{M}`,
  `VonNeumannEntropy{M}`, `MagnetizationXLocal{M}` → `:dynamic` iff `M` is a dynamic
  scheme, else `:static`.
- `LoschmidtEcho` → `:dynamic` (a real-time quench quantity for any scheme).

Because the axis is derived at `@register` time from the quantity type, every
existing registry row picks up the correct value on the next module load — no
per-row edits. Equilibrium hubs (`{:static}`/`{:connected}`/`{:equilibrium}`) are
unchanged.

## Effect

- `search(dynamical=:dynamic)` now surfaces the dynamic correlations / quench
  observables (was empty).
- `regime=:dynamics` (axis-derived since #725) surfaces them too, alongside
  velocities (`:transport`).
- `search(dynamical=:static)` no longer over-claims the dynamic ones.

## Test

`test/core/test_query.jl`: updated the axes testset (the old
`!available(dynamical=:dynamic)` honest-empty assertions → now available), and a
new testset pinning the trait (`ZZCorrelation{:dynamic}`→`:dynamic`,
`{:static}`→`:static`, `VonNeumannEntropy{:quench}`→`:dynamic`, `LoschmidtEcho`→
`:dynamic`) + that `search`/`regime=:dynamics` surface them while equilibrium
schemes stay out.

Version `0.25.2 → 0.25.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
