### PR TITLE
feat(XXZ1D): grand-canonical (μ≠0) OBC thermal Energy & MagnetizationZ

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.25.4"
+version = "0.25.5"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/models/quantum/XXZ/XXZ.jl
+++ b/src/models/quantum/XXZ/XXZ.jl
@@ -236,10 +236,27 @@ METTS).
 Convention matches [`fetch(::TFIM, ::Energy, ::OBC)`](@ref): finite-size
 boundary conditions return total energy; only `Infinite()` returns per-site
 (`⟨H⟩/N`, the only finite quantity in the thermodynamic limit).
+
+## Grand-canonical (`mu`)
+
+With `mu ≠ 0` the average is taken in the **grand-canonical ensemble** of the
+shifted generator `Ĥ_μ = Ĥ - μ N̂`, `N̂ = Ŝᶻ_tot = Σᵢ Sᶻᵢ` (spin-½ units):
+
+    ⟨Ĥ⟩_{β,μ} = Tr(Ĥ exp(-β(Ĥ - μ N̂))) / Tr(exp(-β(Ĥ - μ N̂))).
+
+The measured operator is still the **unshifted** `Ĥ`; only the ensemble is
+reweighted (`XXZ1D` conserves `N̂`, so `μ` shifts the magnetisation sector).
+This is the independent reference for grand-canonical TPQ (gTPQ, Hyuga et al.,
+PRB 90, 121110(R) (2014)); pair it with `fetch(model, MagnetizationZ(), OBC(N);
+beta, mu)` for `⟨N̂⟩`. `mu = 0` (default) is the canonical energy above.
 """
-function fetch(model::XXZ1D, ::Energy{:total}, bc::OBC; beta::Real, kwargs...)
-    H = _xxz1d_hamiltonian_matrix(model, bc.N)
-    return _ed_thermal_energy(H, beta)
+function fetch(model::XXZ1D, ::Energy{:total}, bc::OBC; beta::Real, mu::Real=0.0, kwargs...)
+    if iszero(mu)
+        H = _xxz1d_hamiltonian_matrix(model, bc.N)
+        return _ed_thermal_energy(H, beta)
+    end
+    F = _xxz1d_grand_kernel(model, bc.N, beta, mu)
+    return _xxz1d_thermal_expectation_op(F, F.H)
 end
 
 # ── NMR relaxation exponent (critical Luttinger liquid) ───────────────

--- a/src/models/quantum/XXZ/XXZ_thermal.jl
+++ b/src/models/quantum/XXZ/XXZ_thermal.jl
@@ -64,6 +64,37 @@ function _xxz1d_thermal_kernel(model::XXZ1D, N::Int, β::Real)
 end
 
 """
+    _xxz1d_grand_kernel(model, N, beta, mu) -> NamedTuple
+
+Grand-canonical counterpart of [`_xxz1d_thermal_kernel`](@ref): diagonalise the
+**shifted generator** `Ĥ_μ = Ĥ - μ N̂` and return the Boltzmann weights of
+`Ĥ_μ`, so that
+
+    ⟨A⟩_{β,μ} = Σₙ wₙ ⟨n|A|n⟩,   wₙ ∝ exp(-β Eₙ^{(μ)}),  |n⟩, Eₙ^{(μ)} of Ĥ_μ.
+
+The conserved charge is the total spin-z `N̂ = Ŝᶻ_tot = Σᵢ Sᶻᵢ` in **spin-½
+units** (`Sᶻ = σᶻ/2`), so `μ` is the chemical potential / uniform longitudinal
+field conjugate to it; `Ĥ_μ = Ĥ - (μ/2) Σᵢ σᶻᵢ`. `XXZ1D` has U(1) `Ŝᶻ_tot`
+conservation, so `[Ĥ, N̂] = 0` and `μ` merely reweights the magnetisation
+sectors. Fields: `evals`/`evecs`/`weights` of `Ĥ_μ`, plus the **unshifted**
+`H` (= `Ĥ`) and `Sz` (= `N̂`) matrices so callers can read off `⟨Ĥ⟩` and
+`⟨N̂⟩` under the grand ensemble. `mu = 0` reproduces
+[`_xxz1d_thermal_kernel`](@ref) up to the returned extra fields.
+"""
+function _xxz1d_grand_kernel(model::XXZ1D, N::Int, β::Real, μ::Real)
+    H = _xxz1d_hamiltonian_matrix(model, N)
+    Sz = 0.5 .* _xxz1d_total_M(N, _σz)      # N̂ = Σ Sᶻ_i = (1/2) Σ σᶻ_i (spin-½ units)
+    Hμ = H .- μ .* Sz                        # grand-canonical generator Ĥ - μ N̂
+    F = eigen(Hermitian(Hμ))
+    evals = F.values
+    evecs = F.vectors
+    emin = minimum(evals)
+    ws = exp.(-β .* (evals .- emin))
+    weights = ws ./ sum(ws)
+    return (; evals=evals, evecs=evecs, weights=weights, H=H, Sz=Sz)
+end
+
+"""
     _xxz1d_thermal_expectation_op(F::NamedTuple, A::AbstractMatrix) -> Float64
 
 Compute `⟨A⟩_β = Σₙ wₙ ⟨n|A|n⟩` for a Hermitian operator `A`, using a
@@ -189,18 +220,30 @@ function fetch(model::XXZ1D, ::MagnetizationY, bc::OBC; beta::Real, kwargs...)
 end
 
 """
-    fetch(model::XXZ1D, ::MagnetizationZ, ::OBC; beta) -> Float64
+    fetch(model::XXZ1D, ::MagnetizationZ, ::OBC; beta, mu=0.0) -> Float64
 
-Per-site bulk magnetisation `⟨Σᵢ σᶻᵢ⟩_β / N`.  Σᵢ σᶻᵢ commutes with `H`
-(U(1) symmetry), so the thermal average is `Tr(M_z exp(-βH))/Z`; for
-even `N` and any real `β` the σᶻ-product basis groups symmetrically
-between sectors of opposite total Sᶻ and the average is zero.
-For odd `N` the unique smallest-Sᶻ-magnitude sector is half-filled
-±½ (still S_z = ±½), so the average is again zero up to round-off.
+Per-site bulk magnetisation `⟨Σᵢ σᶻᵢ⟩_β / N` (Pauli convention). Σᵢ σᶻᵢ
+commutes with `H` (U(1) symmetry), so the thermal average is
+`Tr(M_z exp(-βH))/Z`; at `mu = 0`, for even `N` and any real `β` the
+σᶻ-product basis groups symmetrically between sectors of opposite total Sᶻ and
+the average is zero (odd `N` likewise up to round-off).
+
+## Grand-canonical (`mu`)
+
+With `mu ≠ 0` the average is taken in the grand-canonical ensemble of
+`Ĥ_μ = Ĥ - μ N̂`, `N̂ = Ŝᶻ_tot = Σᵢ Sᶻᵢ` (spin-½ units) — a uniform
+longitudinal field that polarises the chain, so the magnetisation is non-zero
+and increases with `μ`. Returned in the **Pauli** convention `⟨Σᵢ σᶻᵢ⟩/N`; the
+total spin-z charge is `⟨N̂⟩ = (N/2)·` this value (`Sᶻ = σᶻ/2`). Reference for
+gTPQ's particle-number / magnetisation estimator.
 """
-function fetch(model::XXZ1D, ::MagnetizationZ, bc::OBC; beta::Real, kwargs...)
+function fetch(model::XXZ1D, ::MagnetizationZ, bc::OBC; beta::Real, mu::Real=0.0, kwargs...)
     N = _bc_size(bc, kwargs)
-    F = _xxz1d_thermal_kernel(model, N, beta)
+    F = if iszero(mu)
+        _xxz1d_thermal_kernel(model, N, beta)
+    else
+        _xxz1d_grand_kernel(model, N, beta, mu)
+    end
     Mz = _xxz1d_total_M(N, _σz)
     return _xxz1d_thermal_expectation_op(F, Mz) / N
 end

--- a/test/models/quantum/XXZ/test_xxz1d_grand_canonical.jl
+++ b/test/models/quantum/XXZ/test_xxz1d_grand_canonical.jl
@@ -1,0 +1,107 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# test/models/quantum/XXZ/test_xxz1d_grand_canonical.jl
+#
+# Grand-canonical (`mu`) extension of XXZ1D OBC Energy / MagnetizationZ:
+#
+#   ⟨A⟩_{β,μ} = Tr(A exp(-β(Ĥ - μ N̂))) / Tr(exp(-β(Ĥ - μ N̂))),
+#   N̂ = Ŝᶻ_tot = Σᵢ Sᶻᵢ = (1/2) Σᵢ σᶻᵢ   (spin-½ units).
+#
+# Independent verification route: a fully self-contained dense-ED built here
+# from bare kron Pauli strings (NO QAtlas internals), plus analytic limits
+# (μ = 0 anchor, μ ↔ -μ symmetry, μ → ∞ saturation). Reference for grand-
+# canonical TPQ (gTPQ, Hyuga et al., PRB 90, 121110(R) (2014)). Refs #737.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using QAtlas, Test, LinearAlgebra
+
+# --- Independent dense-ED grand-canonical helpers (do NOT use QAtlas internals) ---
+
+const _SXg = ComplexF64[0 1; 1 0]
+const _SYg = ComplexF64[0 -im; im 0]
+const _SZg = ComplexF64[1 0; 0 -1]
+const _I2g = ComplexF64[1 0; 0 1]
+
+_g_pauli(N, i, σ) = reduce(kron, [j == i ? σ : _I2g for j in 1:N])
+_g_pair(N, i, j, σ) = reduce(kron, [(k == i || k == j) ? σ : _I2g for k in 1:N])
+
+function _g_xxz_H(N, J, Δ)
+    D = 2^N
+    H = zeros(ComplexF64, D, D)
+    for i in 1:(N - 1)
+        H .+= (J / 4) .* _g_pair(N, i, i + 1, _SXg)
+        H .+= (J / 4) .* _g_pair(N, i, i + 1, _SYg)
+        H .+= (J * Δ / 4) .* _g_pair(N, i, i + 1, _SZg)
+    end
+    return H
+end
+
+_g_Sz_tot(N) = 0.5 .* sum(_g_pauli(N, i, _SZg) for i in 1:N)   # N̂ = Σ Sᶻ = ½ Σ σᶻ
+_g_Mz(N) = sum(_g_pauli(N, i, _SZg) for i in 1:N)              # Pauli Σ σᶻ
+
+# ⟨A⟩ under the grand ensemble exp(-β(H - μ N̂))
+function _g_expect(A, H, Sz, β, μ)
+    F = eigen(Hermitian(H .- μ .* Sz))
+    emin = minimum(F.values)
+    ws = exp.(-β .* (F.values .- emin))
+    ws ./= sum(ws)
+    Ad = real.(diag(F.vectors' * A * F.vectors))
+    return sum(ws .* Ad)
+end
+
+@testset "XXZ1D grand-canonical Energy/MagnetizationZ vs independent ED" begin
+    # Exact to ED round-off: same operators, theoretically distinct route (bare
+    # kron ED here vs QAtlas's own eigen kernel). atol tracks the dense-ED noise
+    # floor, matching the canonical XXZ1D observable tests.
+    for (J, Δ) in ((1.0, 0.5), (1.0, 1.0), (1.0, -0.7)), N in (4, 6)
+        m = XXZ1D(; J=J, Δ=Δ)
+        H = _g_xxz_H(N, J, Δ)
+        Sz = _g_Sz_tot(N)
+        Mz = _g_Mz(N)
+        for β in (0.5, 2.0), μ in (0.3, 1.5, -0.8)
+            E_ref = _g_expect(H, H, Sz, β, μ)
+            Mz_ref = _g_expect(Mz, H, Sz, β, μ) / N
+            @test QAtlas.fetch(m, Energy(), OBC(N); beta=β, mu=μ) ≈ E_ref atol = 1e-10
+            @test QAtlas.fetch(m, MagnetizationZ(), OBC(N); beta=β, mu=μ) ≈ Mz_ref atol =
+                1e-10
+        end
+    end
+end
+
+@testset "XXZ1D grand-canonical: μ = 0 anchor, μ↔-μ symmetry, saturation" begin
+    for (J, Δ) in ((1.0, 0.5), (1.0, 1.0)), N in (4, 6)
+        m = XXZ1D(; J=J, Δ=Δ)
+
+        # μ = 0 reduces to the canonical quantities (default-mu path).
+        for β in (0.5, 2.0)
+            @test QAtlas.fetch(m, Energy(), OBC(N); beta=β, mu=0.0) ≈
+                QAtlas.fetch(m, Energy(), OBC(N); beta=β) atol = 1e-12
+            @test abs(QAtlas.fetch(m, MagnetizationZ(), OBC(N); beta=β, mu=0.0)) < 1e-10
+        end
+
+        # Spin-flip symmetry of the XXZ Hamiltonian ⇒ E even in μ, M_z odd in μ.
+        β = 1.3
+        for μ in (0.4, 1.1)
+            @test QAtlas.fetch(m, Energy(), OBC(N); beta=β, mu=μ) ≈
+                QAtlas.fetch(m, Energy(), OBC(N); beta=β, mu=(-μ)) atol = 1e-10
+            @test QAtlas.fetch(m, MagnetizationZ(), OBC(N); beta=β, mu=μ) ≈
+                -QAtlas.fetch(m, MagnetizationZ(), OBC(N); beta=β, mu=(-μ)) atol = 1e-10
+        end
+
+        # Monotone polarisation: M_z increases with μ at fixed β.
+        β = 1.0
+        mz = [
+            QAtlas.fetch(m, MagnetizationZ(), OBC(N); beta=β, mu=μ) for
+            μ in (0.0, 0.5, 1.0, 2.0)
+        ]
+        @test issorted(mz)
+        @test all(diff(mz) .> 0)
+
+        # Saturation (μ, β → large): the field selects the all-up state, so
+        # ⟨σᶻ⟩/site → 1 and ⟨Ĥ⟩ → the all-up energy J·Δ·(N-1)/4 (only the σᶻσᶻ
+        # bond term survives on |↑…↑⟩). Purely analytic, no ED.
+        E_allup = J * Δ * (N - 1) / 4
+        @test QAtlas.fetch(m, MagnetizationZ(), OBC(N); beta=50.0, mu=10.0) ≈ 1.0 atol =
+            1e-8
+        @test QAtlas.fetch(m, Energy(), OBC(N); beta=50.0, mu=10.0) ≈ E_allup atol = 1e-8
+    end
+end


### PR DESCRIPTION
Closes #737.

## Summary

Adds a `mu` kwarg to the `XXZ1D` OBC dense-ED thermal `Energy` and
`MagnetizationZ` fetches. With `mu ≠ 0` the average is taken in the
**grand-canonical ensemble** of the shifted generator

    Ĥ_μ = Ĥ - μ N̂ ,   N̂ = Ŝᶻ_tot = Σᵢ Sᶻᵢ = (½) Σᵢ σᶻᵢ   (spin-½ units),

i.e. `⟨A⟩_{β,μ} = Tr(A e^{-β(Ĥ-μN̂)}) / Tr(e^{-β(Ĥ-μN̂)})`. The **measured
operator stays the unshifted** `Ĥ` (resp. `Σσᶻ`); only the ensemble is
reweighted (`XXZ1D` conserves `N̂`, so `μ` shifts the magnetisation sector).
`mu = 0` (default) is byte-for-byte the existing canonical path — no behavior
change for current callers.

New helper `_xxz1d_grand_kernel` mirrors `_xxz1d_thermal_kernel` on `Ĥ_μ`.

## Motivation

Independent reference for **grand-canonical TPQ** (gTPQ,
Hyuga–Sugiura–Sakai–Shimizu, *Thermal Pure Quantum States of Many-Particle
Systems*, PRB **90**, 121110(R) (2014)). Consumed by
`lab-sotashimozono/ThermalMPS.jl` to validate a `GrandTPQ` flavor.

## Verification (theoretically independent route)

`test/models/quantum/XXZ/test_xxz1d_grand_canonical.jl` (120 assertions):

- **Independent kron dense-ED** built from bare Pauli strings (NO QAtlas
  internals) over `(J,Δ) × N × β × μ` grids — exact to ED round-off (`atol
  1e-10`).
- **Analytic limits**: `μ=0` anchor = canonical; `μ↔-μ` spin-flip symmetry
  (`E` even, `M_z` odd); monotone polarisation `∂M_z/∂μ > 0`; `μ,β→∞`
  saturation to the all-up state (`M_z→1`, `⟨Ĥ⟩→J·Δ·(N-1)/4`).

Full XXZ thermal/magnetization suite stays green (**463/463** locally).
Patch bump `0.25.4 → 0.25.5` (additive, non-breaking; stays within ThermalMPS's
`0.25` compat).