### PR TITLE
feat: wire the AbstractQAtlas dependency edge (#734 step 1)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,15 +1,17 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.25.5"
+version = "0.25.6"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]
+AbstractQAtlas = "dcea2817-62f8-4a75-b498-1b50a9ed1e4d"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
+AbstractQAtlas = "0.3"
 Aqua = "0.8"
 ForwardDiff = "0.10, 1"
 KrylovKit = "0.8, 0.9, 0.10"

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -1,5 +1,16 @@
 module QAtlas
 
+# AbstractQAtlas — the model-independent base this atlas implements, in the
+# AbstractFFTs→FFTW idiom (the dependency never points the other way).  This
+# is the first step of the staged core-vocabulary migration (#734): the
+# abstract type vocabulary (`AbstractQuantity` / `BoundaryCondition` / …) and
+# the universal relations are the single source of truth in AbstractQAtlas,
+# and QAtlas re-exports them for API compatibility.  Only the module name is
+# brought in (no exported names enter scope), so nothing collides yet — the
+# duplicate definitions in `src/core/` still stand until the later per-slice
+# steps replace them.
+using AbstractQAtlas: AbstractQAtlas
+
 export AbstractModel, Model
 export BoundaryCondition, Infinite, PBC, OBC
 export AbstractQuantity, Quantity


### PR DESCRIPTION
## Proposed Changes

First step of the staged core-vocabulary migration onto **AbstractQAtlas** (#734), in the AbstractFFTs→FFTW idiom (the dependency never points the other way). This wires the — now registered — dependency edge and nothing else:

- add `AbstractQAtlas = "0.3"` to `[deps]` + `[compat]` (UUID `dcea2817-…`);
- `import AbstractQAtlas` at the top of the module.

Intentionally **inert**: it is `import`ed (not `using`), so no names enter scope and the duplicate vocabulary definitions in `src/core/` still stand — behaviour is unchanged. This isolates the dependency plumbing from the per-slice surgery that follows, validates that QAtlas precompiles together with AbstractQAtlas, and keeps Aqua `deps_compat` / `stale_deps` green.

## Usage or Results

No public API change. `QAtlas.fetch(...)` and every exported type/name are unchanged; `version` bumped 0.25.5 → 0.25.6 (additive → patch).

Next steps under #734: replace the duplicated core vocabulary (`AbstractQuantity` / `Quantity` / `BoundaryCondition` / `Energy` / universality) with re-exports of the AbstractQAtlas single source of truth, move the model graph onto the shared `KnowledgeGraph` kernel, and re-home the model-specific relations (#730).