### PR TITLE
feat: collapse the BoundaryCondition vocab onto AbstractQAtlas (#734 step 2)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.25.6"
+version = "0.25.7"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -1,15 +1,14 @@
 module QAtlas
 
 # AbstractQAtlas — the model-independent base this atlas implements, in the
-# AbstractFFTs→FFTW idiom (the dependency never points the other way).  This
-# is the first step of the staged core-vocabulary migration (#734): the
-# abstract type vocabulary (`AbstractQuantity` / `BoundaryCondition` / …) and
-# the universal relations are the single source of truth in AbstractQAtlas,
-# and QAtlas re-exports them for API compatibility.  Only the module name is
-# brought in (no exported names enter scope), so nothing collides yet — the
-# duplicate definitions in `src/core/` still stand until the later per-slice
-# steps replace them.
-using AbstractQAtlas: AbstractQAtlas
+# AbstractFFTs→FFTW idiom (the dependency never points the other way).  The
+# staged core-vocabulary migration (#734) makes AbstractQAtlas the single
+# source of truth for the shared type vocabulary; QAtlas imports and
+# re-exports each slice for API compatibility.  Migrated so far: the
+# BoundaryCondition family (`BoundaryCondition` / `Infinite` / `OBC` / `PBC`)
+# and the `_bc_size` helper.  Remaining duplicate definitions in `src/core/`
+# are replaced in later per-slice steps.
+using AbstractQAtlas: BoundaryCondition, Infinite, OBC, PBC, _bc_size
 
 export AbstractModel, Model
 export BoundaryCondition, Infinite, PBC, OBC

--- a/src/core/type.jl
+++ b/src/core/type.jl
@@ -38,74 +38,10 @@ function Model(name::Symbol; kwargs...)
     return Model{canon}(Dict{Symbol,Any}(kwargs))
 end
 
-"""
-    BoundaryCondition
-
-Abstract parent type.  The three concrete subtypes carry system-size
-information where applicable, so `fetch` can read it from the
-BC instead of `kwargs`.
-
-- `Infinite` — thermodynamic limit; no size.
-- `PBC(N::Int)` — periodic boundary conditions at finite `N`.
-- `OBC(N::Int)` — open boundary conditions at finite `N`.
-
-For backward compatibility, the zero-argument constructors `PBC()` and
-`OBC()` exist and set `N = 0`, which signals "caller will pass `N` via
-kwargs" — legacy fetch methods still look at `kwargs[:N]`.  New fetch
-methods read `bc.N` directly.
-"""
-abstract type BoundaryCondition end
-
-"""
-    Infinite()
-
-Thermodynamic-limit boundary condition — no finite size.
-"""
-struct Infinite <: BoundaryCondition end
-
-"""
-    OBC(N::Int)
-    OBC(; N::Int = 0)
-
-Open boundary condition.  `N` is the chain length.  `N = 0` is a legacy
-sentinel meaning "size unspecified — caller passes it via kwargs";
-`fetch` methods that accept `OBC(0)` must look up `kwargs[:N]`.
-"""
-struct OBC <: BoundaryCondition
-    N::Int
-end
-OBC(; N::Int=0) = OBC(N)
-
-"""
-    PBC(N::Int)
-    PBC(; N::Int = 0)
-
-Periodic boundary condition.  See [`OBC`](@ref) for the `N = 0`
-sentinel.
-"""
-struct PBC <: BoundaryCondition
-    N::Int
-end
-PBC(; N::Int=0) = PBC(N)
-
-"""
-    _bc_size(bc::BoundaryCondition, kwargs) -> Int
-
-Return the effective system size for `bc`.  Prefers `bc.N` when it is
-positive; otherwise looks up `kwargs[:N]`; otherwise throws.  Legacy
-fetch methods can use this helper to accept both `OBC(N=24)` and
-`OBC(); N=24` call forms.
-"""
-function _bc_size end
-
-function _bc_size(::Infinite, kwargs)
-    return error("_bc_size called on Infinite; call a size-free fetch method instead")
-end
-function _bc_size(bc::Union{OBC,PBC}, kwargs)
-    bc.N > 0 && return bc.N
-    haskey(kwargs, :N) && return Int(kwargs[:N])
-    return error("$(typeof(bc)): N unspecified — pass via OBC(N=...) or kwargs N=...")
-end
+# `BoundaryCondition` / `Infinite` / `OBC` / `PBC` and the `_bc_size` helper are
+# defined once in AbstractQAtlas (the single source of truth) and imported +
+# re-exported at the top of `QAtlas.jl` (#734).  Concrete-model `fetch` methods
+# dispatch on the same shared BC types, so behaviour is unchanged.
 
 """
     AbstractQuantity


### PR DESCRIPTION
## Proposed Changes

Second step of the staged migration onto AbstractQAtlas (#734): the first **core-vocabulary slice**. QAtlas's `BoundaryCondition` / `Infinite` / `OBC` / `PBC` and the `_bc_size` helper are **byte-identical** to AbstractQAtlas's, so this deletes the duplicates and imports + re-exports them from AbstractQAtlas (the single source of truth).

- `src/core/type.jl`: remove the duplicated BC definitions + `_bc_size` (−72 lines, breadcrumb left).
- `src/QAtlas.jl`: `using AbstractQAtlas: BoundaryCondition, Infinite, OBC, PBC, _bc_size`; the existing `export BoundaryCondition, Infinite, PBC, OBC` re-exports them.
- `version` 0.25.6 → **0.25.7** (non-breaking re-export → patch).

## Usage or Results

No public API change: `QAtlas.OBC(24)`, `fetch(model, q, OBC(24))`, `Infinite()` etc. all behave identically — the BC types are now the *same* objects as `AbstractQAtlas.OBC` etc., so dispatch across the ecosystem unifies. Verified no type piracy (every BC-dispatching method carries a QAtlas-owned arg; `_bc_size` is defined only here and moves wholesale). Locally format-clean under JuliaFormatter 2.10.2.

Part of #734. Next slice: the abstract roots (`AbstractQAtlasModel` / `AbstractQuantity`).