### PR TITLE
feat: collapse the abstract root types onto AbstractQAtlas (#734 step 3)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.25.7"
+version = "0.25.8"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -4,11 +4,14 @@ module QAtlas
 # AbstractFFTs→FFTW idiom (the dependency never points the other way).  The
 # staged core-vocabulary migration (#734) makes AbstractQAtlas the single
 # source of truth for the shared type vocabulary; QAtlas imports and
-# re-exports each slice for API compatibility.  Migrated so far: the
-# BoundaryCondition family (`BoundaryCondition` / `Infinite` / `OBC` / `PBC`)
-# and the `_bc_size` helper.  Remaining duplicate definitions in `src/core/`
-# are replaced in later per-slice steps.
-using AbstractQAtlas: BoundaryCondition, Infinite, OBC, PBC, _bc_size
+# re-exports each slice for API compatibility.  Migrated so far: the abstract
+# roots (`AbstractQAtlasModel` / `AbstractQuantity`) and the BoundaryCondition
+# family (`BoundaryCondition` / `Infinite` / `OBC` / `PBC`) with `_bc_size`.
+# QAtlas keeps the deprecation surface (`AbstractModel` alias, `Model{M}` /
+# `Quantity{Q}` wrappers), which now subtype the shared roots.  Remaining
+# duplicate definitions in `src/core/` are replaced in later per-slice steps.
+using AbstractQAtlas:
+    AbstractQAtlasModel, AbstractQuantity, BoundaryCondition, Infinite, OBC, PBC, _bc_size
 
 export AbstractModel, Model
 export BoundaryCondition, Infinite, PBC, OBC

--- a/src/core/type.jl
+++ b/src/core/type.jl
@@ -1,16 +1,8 @@
 
-"""
-    AbstractQAtlasModel
-
-Abstract parent type for every QAtlas model.  Concrete subtypes carry
-their physics parameters as typed fields (e.g.
-`struct TFIM <: AbstractQAtlasModel; J::Float64; h::Float64; end`).
-
-The older `Model{S}(params::Dict)` phantom-typed wrapper is still an
-`AbstractQAtlasModel` (via the deprecated alias below) but new models
-must use concrete structs.
-"""
-abstract type AbstractQAtlasModel end
+# `AbstractQAtlasModel` (the root model type) is defined once in AbstractQAtlas
+# and imported + re-exported at the top of `QAtlas.jl` (#734).  The deprecation
+# surface below (`AbstractModel` alias, `Model{M}` wrapper) stays in QAtlas and
+# subtypes the shared root.
 
 """
     const AbstractModel = AbstractQAtlasModel
@@ -43,16 +35,10 @@ end
 # re-exported at the top of `QAtlas.jl` (#734).  Concrete-model `fetch` methods
 # dispatch on the same shared BC types, so behaviour is unchanged.
 
-"""
-    AbstractQuantity
-
-Abstract parent type for quantities.  New code defines concrete structs
-(e.g. `struct MagnetizationX <: AbstractQuantity end`) so dispatch is
-static and naming is explicit (axis, entropy variant, …).  The older
-`Quantity{S}` phantom-type wrapper is retained for legacy symbol-based
-dispatch; see the `Quantity(::Symbol)` shim below.
-"""
-abstract type AbstractQuantity end
+# `AbstractQuantity` (the root quantity type) is defined once in AbstractQAtlas
+# and imported + re-exported at the top of `QAtlas.jl` (#734).  The legacy
+# `Quantity{Q}` phantom wrapper below stays in QAtlas and subtypes the shared
+# root.
 
 """
     Quantity{Q} <: AbstractQuantity  (deprecated)


### PR DESCRIPTION
## Proposed Changes

Third step of the staged migration (#734): collapse the two **abstract root types**. QAtlas's `abstract type AbstractQAtlasModel` and `abstract type AbstractQuantity` are byte-identical to AbstractQAtlas's roots, so this deletes the duplicates and imports + re-exports them.

- `src/core/type.jl`: remove the two duplicate `abstract type` definitions (breadcrumbs left).
- `src/QAtlas.jl`: add `AbstractQAtlasModel`, `AbstractQuantity` to the `using AbstractQAtlas: …` import; existing exports re-export `AbstractQuantity`.
- `version` 0.25.7 → **0.25.8** (non-breaking re-export → patch).

QAtlas keeps its **deprecation surface** — the `AbstractModel` alias and the `Model{M}` / `Quantity{Q}` phantom wrappers — which now subtype the shared roots. So the entire QAtlas model and quantity hierarchy re-roots onto AbstractQAtlas without any consumer-visible change.

## Usage or Results

No public API change: `struct TFIM <: AbstractQAtlasModel`, `x isa AbstractQuantity`, `Model(:TFIM; …)`, dispatch on `::AbstractQuantity` all behave identically. QAtlas's `fetch` and trait functions are its own generic functions, so methods dispatching on the (now shared) roots are not piracy — verified no `Base.*` method dispatches solely on the roots. Format-clean under JuliaFormatter 2.10.2.

Part of #734. Next slice: the quantity taxonomy (`Energy{G}` — mind the granularity convention — and the response/thermal families) + `universality`.