### PR TITLE
feat: adopt AbstractQAtlas's parametric Susceptibility for the static names (#734 step 4b-2)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.25.10"
+version = "0.25.11"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -39,7 +39,8 @@ using AbstractQAtlas:
     TopologicalEntanglementEntropy,
     TopologicalInvariant,
     UniversalityClass,
-    Magnetization
+    Magnetization,
+    Susceptibility
 # `native_energy_granularity` is extended by bare `native_energy_granularity(::M, ::BC) = …`
 # methods in model files, which `using` forbids ("must be explicitly imported to be
 # extended"); it must therefore come in via `import` (#734).
@@ -194,6 +195,7 @@ export Magnetization  # axis-parametric (AbstractQAtlas); MagnetizationX/Y/Z are
 export MagnetizationX, MagnetizationY, MagnetizationZ
 export Polarization
 export MagnetizationXLocal, MagnetizationYLocal, MagnetizationZLocal, EnergyLocal
+export Susceptibility  # index-parametric (AbstractQAtlas); SusceptibilityXX/YY/ZZ are deprecated aliases
 export SusceptibilityXX, SusceptibilityYY, SusceptibilityZZ
 export XXCorrelation, YYCorrelation, ZZCorrelation
 export XXStructureFactor, YYStructureFactor, ZZStructureFactor

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -254,28 +254,33 @@ struct EnergyLocal <: AbstractQuantity end
 
 # ─── Susceptibilities (axis pair) ────────────────────────────────────────
 
+# The static axis-pair susceptibilities adopt AbstractQAtlas's index-parametric
+# `Susceptibility{I}` (#734).  The fused `SusceptibilityXX/YY/ZZ` names stay as
+# deprecated aliases so existing fetch methods, registry rows, and downstream
+# code keep working; new code should use `Susceptibility(:x, :x)` etc.
+
 """
-    SusceptibilityXX() <: AbstractQuantity
+    const SusceptibilityXX = Susceptibility{(:x, :x)}   # deprecated alias
 
 Static transverse susceptibility,
-`χ_xx(β) = β · (⟨M_x²⟩ − ⟨M_x⟩²) / N`.
+`χ_xx(β) = β · (⟨M_x²⟩ − ⟨M_x⟩²) / N`.  **Deprecated** — use `Susceptibility(:x, :x)`.
 """
-struct SusceptibilityXX <: AbstractSusceptibility end
+const SusceptibilityXX = Susceptibility{(:x, :x)}
 
 """
-    SusceptibilityYY() <: AbstractQuantity
+    const SusceptibilityYY = Susceptibility{(:y, :y)}   # deprecated alias
 
-Analogue for the y-axis.
+Analogue for the y-axis.  **Deprecated** — use `Susceptibility(:y, :y)`.
 """
-struct SusceptibilityYY <: AbstractSusceptibility end
+const SusceptibilityYY = Susceptibility{(:y, :y)}
 
 """
-    SusceptibilityZZ() <: AbstractQuantity
+    const SusceptibilityZZ = Susceptibility{(:z, :z)}   # deprecated alias
 
 Uniform longitudinal susceptibility,
-`χ_zz(β) = β · (⟨M_z²⟩ − ⟨M_z⟩²) / N`.
+`χ_zz(β) = β · (⟨M_z²⟩ − ⟨M_z⟩²) / N`.  **Deprecated** — use `Susceptibility(:z, :z)`.
 """
-struct SusceptibilityZZ <: AbstractSusceptibility end
+const SusceptibilityZZ = Susceptibility{(:z, :z)}
 
 # ─── Real-space two-point correlators ───────────────────────────────────
 #


### PR DESCRIPTION
## Proposed Changes

Second parametric-adoption slice of #734: QAtlas adopts AbstractQAtlas's index-parametric `Susceptibility{I}` for the static axis-pair susceptibilities.

- `src/core/quantities.jl`: replace `struct SusceptibilityXX/YY/ZZ` with deprecated `const` aliases — `const SusceptibilityXX = Susceptibility{(:x, :x)}` (and `:y`, `:z`).
- `src/QAtlas.jl`: `import` + `export Susceptibility`; keep exporting the fused names (now aliases).
- `version` 0.25.10 → **0.25.11** (non-breaking → patch).

`SusceptibilityXX === Susceptibility(:x, :x)`, so fetch methods on `::SusceptibilityXX`, registry rows, and `component(::Type{SusceptibilityXX})` traits keep working with no rewrite. New code should use `Susceptibility(:x, :x)`.

## Usage or Results

No public API change — the fused names are now the same types as `Susceptibility(:x,:x)` etc. Verified: no Base-method piracy, format-clean.

Part of #734. Next: structure factors (needs a spin-axis generalization on AbstractQAtlas's `StructureFactor`) and the correlations (static→`SpinCorrelation`, dynamic split).