### PR TITLE
feat: share AbstractQAtlas's fetch generic (#734 step 4b-3)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.25.11"
+version = "0.25.12"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -45,6 +45,11 @@ using AbstractQAtlas:
 # methods in model files, which `using` forbids ("must be explicitly imported to be
 # extended"); it must therefore come in via `import` (#734).
 import AbstractQAtlas: native_energy_granularity
+# `fetch` is AbstractQAtlas's generic function; QAtlas implements the concrete
+# `(model, quantity, bc)` methods (bare-extended in model files, hence `import`
+# not `using`).  Sharing one `fetch` across the ecosystem is the AbstractFFTs
+# idiom — QAtlas is the concrete atlas that implements AbstractQAtlas (#734).
+import AbstractQAtlas: fetch
 
 export AbstractModel, Model
 export BoundaryCondition, Infinite, PBC, OBC

--- a/src/core/type.jl
+++ b/src/core/type.jl
@@ -54,29 +54,11 @@ function Quantity(q::Symbol)
 end
 Quantity(q::AbstractString) = Quantity(Symbol(q))
 
-"""
-    fetch(model, quantity, bc; kwargs...)
-
-Return the stored / computed value of `quantity` for `model` under
-boundary condition `bc`.  The canonical signature takes a concrete
-model struct + concrete quantity struct + BC; a legacy
-`fetch(::Symbol, ::Symbol, bc; kwargs...)` shim is also provided in
-`src/deprecate/legacy_fetch.jl` for backward compatibility.
-
-Each `(model, quantity, bc)` triple must be implemented as a separate
-method; this top-level definition throws an informative error for
-un-implemented triples.
-"""
-function fetch(
-    model::AbstractQAtlasModel, quantity::AbstractQuantity, bc::BoundaryCondition; kwargs...
-)
-    return error(
-        "QAtlas: no fetch method for model=$(typeof(model)), " *
-        "quantity=$(typeof(quantity)), bc=$(typeof(bc)). " *
-        "Define `fetch(::$(typeof(model)), ::$(typeof(quantity)), ::$(typeof(bc)); ...)` " *
-        "in src/models/... to register the implementation.",
-    )
-end
+# `fetch` is AbstractQAtlas's generic function — QAtlas `import`s it (see
+# src/QAtlas.jl) and implements one method per `(model, quantity, bc)` triple in
+# src/models/... (#734).  The generic fallback that errors on an un-implemented
+# triple now lives in AbstractQAtlas; QAtlas no longer defines its own, so the
+# whole ecosystem shares one `fetch` generic (the AbstractFFTs→FFTW idiom).
 
 # Note: the legacy `fetch(::Symbol, ::Symbol, bc; kwargs...)` shim has
 # been moved to `src/deprecate/legacy_fetch.jl` so the deprecation

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -26,7 +26,10 @@ using Aqua
         # fails CI.
         undocumented_names=true,
         persistent_tasks=false,
-        piracies=true,
+        # `fetch` is AbstractQAtlas's generic function; QAtlas is its concrete
+        # implementer, so the legacy `fetch(::Symbol, ::Symbol, ::BC)` deprecation
+        # shim is not piracy in spirit — treat the shared `fetch` as own (#734).
+        piracies=(treat_as_own=[QAtlas.fetch],),
         unbound_args=true,
     )
 


### PR DESCRIPTION
## Proposed Changes

The "share the calling methods" step of #734: QAtlas stops defining its own `fetch` and instead **`import`s AbstractQAtlas's `fetch` generic**, implementing the concrete `(model, quantity, bc)` methods on it — one shared `fetch` across the ecosystem (AbstractFFTs→FFTW idiom).

- `src/core/type.jl`: delete QAtlas's 3-arg abstract fallback (breadcrumb left); AbstractQAtlas's fallback (also `ErrorException`) handles un-implemented triples.
- `src/QAtlas.jl`: `import AbstractQAtlas: fetch` (bare-extended in model files → `import`, not `using`); `export fetch` unchanged.
- `test/test_aqua.jl`: `piracies=(treat_as_own=[QAtlas.fetch],)` — the legacy `fetch(::Symbol, ::Symbol, ::BC)` deprecation shim isn't piracy in spirit (QAtlas is `fetch`'s concrete implementer).
- `version` 0.25.11 → **0.25.12** (non-breaking → patch).

## Usage or Results

No public API change: `QAtlas.fetch(model, quantity, bc; …)` and all 111 model implementations behave identically; `QAtlas.fetch === AbstractQAtlas.fetch` now. The `@test_throws` tests assert error **types** (`ErrorException`/`DomainError`), not the fallback's message string, so switching to AbstractQAtlas's fallback is safe. Format-clean.

Part of #734. The core role-separation (dependency edge, shared vocabulary, shared `fetch`) is now complete; remaining are per-family design calls (structure-factor axis generalization — breaking; dynamic correlations; non-equilibrium/model-specific keeps).