### PR TITLE
feat: split fused real-space correlators onto AbstractQAtlas's typed quantities (#734 step 4b-5)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]
@@ -11,7 +11,7 @@ QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
-AbstractQAtlas = "0.3.29"
+AbstractQAtlas = "0.3.31"
 Aqua = "0.8"
 ForwardDiff = "0.10, 1"
 KrylovKit = "0.8, 0.9, 0.10"

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -42,7 +42,10 @@ using AbstractQAtlas:
     Magnetization,
     Susceptibility,
     SpinStructureFactor,
-    DynamicalSpinStructureFactor
+    DynamicalSpinStructureFactor,
+    SpinCorrelation,
+    ConnectedSpinCorrelation,
+    DynamicalCorrelation
 # `native_energy_granularity` is extended by bare `native_energy_granularity(::M, ::BC) = …`
 # methods in model files, which `using` forbids ("must be explicitly imported to be
 # extended"); it must therefore come in via `import` (#734).
@@ -204,7 +207,9 @@ export Polarization
 export MagnetizationXLocal, MagnetizationYLocal, MagnetizationZLocal, EnergyLocal
 export Susceptibility  # index-parametric (AbstractQAtlas); SusceptibilityXX/YY/ZZ are deprecated aliases
 export SusceptibilityXX, SusceptibilityYY, SusceptibilityZZ
-export XXCorrelation, YYCorrelation, ZZCorrelation
+export SpinCorrelation, ConnectedSpinCorrelation, DynamicalCorrelation  # axis-parametric (AbstractQAtlas)
+export LightconeSpinCorrelation  # QAtlas-side matrix-valued diagnostic
+export XXCorrelation, YYCorrelation, ZZCorrelation  # deprecated fused-name constructor functions
 export SpinStructureFactor, DynamicalSpinStructureFactor  # axis-parametric (AbstractQAtlas)
 export XXStructureFactor, YYStructureFactor, ZZStructureFactor  # deprecated static aliases
 export CentralCharge, LuttingerParameter, CorrelationLength, UniversalityClass

--- a/src/core/axes.jl
+++ b/src/core/axes.jl
@@ -35,15 +35,11 @@ dynamical_axis(::Type) = :static
 dynamical_axis(::Type{<:AbstractVelocity}) = :transport
 
 _dynamic_scheme(s) = s in (:dynamic, :lightcone, :quench)
-function dynamical_axis(::Type{<:XXCorrelation{M}}) where {M}
-    return _dynamic_scheme(M) ? :dynamic : :static
-end
-function dynamical_axis(::Type{<:YYCorrelation{M}}) where {M}
-    return _dynamic_scheme(M) ? :dynamic : :static
-end
-function dynamical_axis(::Type{<:ZZCorrelation{M}}) where {M}
-    return _dynamic_scheme(M) ? :dynamic : :static
-end
+# Real-space correlators are now split by scheme onto distinct types (#734):
+# the retarded (dynamic) and light-cone spreading correlators are :dynamic; the
+# static / connected equal-time correlators fall through to the :static default.
+dynamical_axis(::Type{<:DynamicalCorrelation}) = :dynamic
+dynamical_axis(::Type{<:LightconeSpinCorrelation}) = :dynamic
 function dynamical_axis(::Type{<:VonNeumannEntropy{M}}) where {M}
     return _dynamic_scheme(M) ? :dynamic : :static
 end

--- a/src/core/quantities.jl
+++ b/src/core/quantities.jl
@@ -282,54 +282,69 @@ Uniform longitudinal susceptibility,
 """
 const SusceptibilityZZ = Susceptibility{(:z, :z)}
 
-# ─── Real-space two-point correlators ───────────────────────────────────
-#
-# `XXCorrelation` / `YYCorrelation` / `ZZCorrelation` all carry a `mode`
-# field so the same type dispatches static / dynamic / light-cone / …
-# variants.  A model may implement only a subset of modes; `fetch`
-# methods should error explicitly for unsupported modes.
+# Real-space two-point correlators adopt AbstractQAtlas's parametric quantities
+# (#734): SpinCorrelation{A,B} (:static, full ⟨SS⟩), ConnectedSpinCorrelation{A,B}
+# (:connected, ⟨SS⟩_c), and DynamicalCorrelation{(A,B)} (:dynamic, retarded
+# ⟨S(t)S⟩).  The :lightcone mode is a matrix-valued numerical diagnostic and
+# stays QAtlas-side as `LightconeSpinCorrelation{A,B}` below.  The fused
+# `ZZ/XX/YYCorrelation` names become deprecated constructor functions mapping
+# the old `mode` kwarg onto these types (the type is parametric, so no `const`
+# alias is possible; dispatch on `ZZCorrelation{:m}` is removed).
 
 """
-    ZZCorrelation{M}() <: AbstractQuantity
-    ZZCorrelation(; mode::Symbol = :static)
+    LightconeSpinCorrelation{A,B}() <: AbstractTwoPointCorrelation
+    LightconeSpinCorrelation(a::Symbol, b::Symbol)
 
-Real-space 2-point correlator `⟨σᶻ_i σᶻ_j⟩`.  The mode `M::Symbol` is
-a phantom type parameter so dispatch can specialise on it.
-
-Supported `mode` values (by convention; individual models need only
-implement the ones they support):
-
-- `:static` — equal-time, thermal or zero-temperature value
-- `:connected` — `⟨σᶻ_i σᶻ_j⟩ − ⟨σᶻ_i⟩⟨σᶻ_j⟩`
-- `:dynamic` — retarded real-time correlator `⟨σᶻ_i(t) σᶻ_j(0)⟩`
-- `:lightcone` — space-time spreading `⟨σᶻ_i(t) σᶻ_j(0)⟩` as a
-  matrix over (site, time)
-
-The companion type for Fourier-space structure factors is
-[`ZZStructureFactor`](@ref), kept separate because it carries (q, ω)
-arguments instead of (i, j, t).
+Light-cone spreading of the real-time spin correlator `⟨S^A_i(t) S^B_j(0)⟩`
+as a **matrix over (site, time)** — a QAtlas-specific numerical diagnostic
+(returns an array, not a scalar), kept here rather than in AbstractQAtlas's
+scalar-quantity vocabulary.  `LightconeSpinCorrelation(:z, :z)` is the σᶻ cone.
 """
-struct ZZCorrelation{M} <: AbstractTwoPointCorrelation end
-ZZCorrelation(; mode::Symbol=:static) = ZZCorrelation{mode}()
+struct LightconeSpinCorrelation{A,B} <: AbstractTwoPointCorrelation
+    function LightconeSpinCorrelation{A,B}() where {A,B}
+        (A isa Symbol && B isa Symbol) ||
+            error("LightconeSpinCorrelation axes must be Symbols, got ($A, $B)")
+        return new{A,B}()
+    end
+end
+LightconeSpinCorrelation(a::Symbol, b::Symbol) = LightconeSpinCorrelation{a,b}()
 
-"""
-    XXCorrelation{M}() <: AbstractQuantity
-    XXCorrelation(; mode::Symbol = :static)
-
-Real-space 2-point `⟨σˣ_i σˣ_j⟩` correlator.  See
-[`ZZCorrelation`](@ref) for the `mode` semantics.
-"""
-struct XXCorrelation{M} <: AbstractTwoPointCorrelation end
-XXCorrelation(; mode::Symbol=:static) = XXCorrelation{mode}()
+# Deprecated fused-name constructor functions (#734): map the old `mode` onto
+# the new typed quantities.  New code should use the target types directly.
+function _spin_correlation_by_mode(a::Symbol, b::Symbol, mode::Symbol)
+    mode === :static && return SpinCorrelation(a, b)
+    mode === :connected && return ConnectedSpinCorrelation(a, b)
+    mode === :dynamic && return DynamicalCorrelation(a, b)
+    mode === :lightcone && return LightconeSpinCorrelation(a, b)
+    return error(
+        "unknown correlation mode :$mode; expected :static, :connected, " *
+        ":dynamic, or :lightcone",
+    )
+end
 
 """
-    YYCorrelation{M}() <: AbstractQuantity
-    YYCorrelation(; mode::Symbol = :static)
+    ZZCorrelation(; mode = :static)   (deprecated)
 
-Real-space 2-point `⟨σʸ_i σʸ_j⟩` correlator.
+Deprecated — returns the axis-parametric quantity for `⟨σᶻ σᶻ⟩` in `mode`
+(`:static`→[`SpinCorrelation`](@ref), `:connected`→[`ConnectedSpinCorrelation`](@ref),
+`:dynamic`→[`DynamicalCorrelation`](@ref), `:lightcone`→[`LightconeSpinCorrelation`](@ref)).
+Use those types directly in new code.
 """
-struct YYCorrelation{M} <: AbstractTwoPointCorrelation end
-YYCorrelation(; mode::Symbol=:static) = YYCorrelation{mode}()
+ZZCorrelation(; mode::Symbol=:static) = _spin_correlation_by_mode(:z, :z, mode)
+
+"""
+    XXCorrelation(; mode = :static)   (deprecated)
+
+`⟨σˣ σˣ⟩`; see [`ZZCorrelation`](@ref) for the mode mapping.
+"""
+XXCorrelation(; mode::Symbol=:static) = _spin_correlation_by_mode(:x, :x, mode)
+
+"""
+    YYCorrelation(; mode = :static)   (deprecated)
+
+`⟨σʸ σʸ⟩`; see [`ZZCorrelation`](@ref) for the mode mapping.
+"""
+YYCorrelation(; mode::Symbol=:static) = _spin_correlation_by_mode(:y, :y, mode)
 
 # ─── Fourier-space structure factors (q, ω) ────────────────────────────
 
@@ -1270,9 +1285,13 @@ component(::Type{MagnetizationZ}) = :z
 component(::Type{SusceptibilityXX}) = :xx
 component(::Type{SusceptibilityYY}) = :yy
 component(::Type{SusceptibilityZZ}) = :zz
-component(::Type{<:XXCorrelation}) = :xx
-component(::Type{<:YYCorrelation}) = :yy
-component(::Type{<:ZZCorrelation}) = :zz
+# Correlators are now axis-parametric (#734): the component is the diagonal
+# axis pair read off the type parameters (e.g. SpinCorrelation{:z,:z} -> :zz),
+# preserving the old fused-name mapping across all four correlator types.
+component(::Type{<:SpinCorrelation{A,B}}) where {A,B} = Symbol(A, B)
+component(::Type{<:ConnectedSpinCorrelation{A,B}}) where {A,B} = Symbol(A, B)
+component(::Type{<:LightconeSpinCorrelation{A,B}}) where {A,B} = Symbol(A, B)
+component(::Type{<:DynamicalCorrelation{I}}) where {I} = Symbol(I...)
 component(::Type{XXStructureFactor}) = :xx
 component(::Type{YYStructureFactor}) = :yy
 component(::Type{ZZStructureFactor}) = :zz

--- a/src/deprecate/legacy_tfim.jl
+++ b/src/deprecate/legacy_tfim.jl
@@ -103,11 +103,12 @@ for (qsym, QTy) in _LEGACY_TFIM_LOCAL_MAP
 end
 
 # ── Dynamics / correlators / structure factors (TFIM_dynamics.jl) ──────
-# These use parametric ZZCorrelation{:mode} dispatch in the new API.
+# These route the old Symbol-keyed quantities onto the new axis-parametric
+# correlator types (#734).
 function fetch(m::Model{:TFIM}, ::Quantity{:sz_sz_correlation}, bc::OBC; kwargs...)
     return fetch(
         _tfim_from_legacy_model(m),
-        ZZCorrelation{:dynamic}(),
+        DynamicalCorrelation(:z, :z),
         _bc_with_legacy_N(bc, m);
         kwargs...,
     )
@@ -115,7 +116,7 @@ end
 function fetch(m::Model{:TFIM}, ::Quantity{:sx_sx_correlation}, bc::OBC; kwargs...)
     return fetch(
         _tfim_from_legacy_model(m),
-        XXCorrelation{:dynamic}(),
+        DynamicalCorrelation(:x, :x),
         _bc_with_legacy_N(bc, m);
         kwargs...,
     )
@@ -123,7 +124,7 @@ end
 function fetch(m::Model{:TFIM}, ::Quantity{:sz_sz_spreading}, bc::OBC; kwargs...)
     return fetch(
         _tfim_from_legacy_model(m),
-        ZZCorrelation{:lightcone}(),
+        LightconeSpinCorrelation(:z, :z),
         _bc_with_legacy_N(bc, m);
         kwargs...,
     )
@@ -131,7 +132,7 @@ end
 function fetch(m::Model{:TFIM}, ::Quantity{:zz_static_thermal}, bc::OBC; kwargs...)
     return fetch(
         _tfim_from_legacy_model(m),
-        ZZCorrelation{:static}(),
+        SpinCorrelation(:z, :z),
         _bc_with_legacy_N(bc, m);
         kwargs...,
     )

--- a/src/models/classical/IsingTriangular/IsingTriangular.jl
+++ b/src/models/classical/IsingTriangular/IsingTriangular.jl
@@ -168,7 +168,7 @@ function fetch(m::IsingTriangular, ::ResidualEntropy, ::Infinite; J::Real=m.J)
 end
 
 """
-    fetch(::IsingTriangular, ::ZZCorrelation{:static}, ::Infinite; r=1, J=m.J) -> Float64
+    fetch(::IsingTriangular, ::SpinCorrelation{:z,:z}, ::Infinite; r=1, J=m.J) -> Float64
 
 Zero-temperature nearest-neighbour spin–spin correlation `⟨σ_i σ_j⟩` of the
 classical triangular Ising model (Wannier 1950 convention `H = +J Σ σσ`).
@@ -187,7 +187,7 @@ ferromagnetic branch are not implemented here.
 - G. H. Wannier, *Phys. Rev.* **79**, 357 (1950).
 """
 function fetch(
-    m::IsingTriangular, ::ZZCorrelation{:static}, ::Infinite; r::Integer=1, J::Real=m.J
+    m::IsingTriangular, ::SpinCorrelation{:z,:z}, ::Infinite; r::Integer=1, J::Real=m.J
 )
     J > 0 || throw(
         DomainError(

--- a/src/models/classical/IsingTriangular/IsingTriangular_registry.jl
+++ b/src/models/classical/IsingTriangular/IsingTriangular_registry.jl
@@ -95,7 +95,7 @@
 
 @register(
     IsingTriangular,
-    ZZCorrelation{:static},
+    SpinCorrelation{:z,:z},
     Infinite,
     method=:analytic,
     reliability=:high,

--- a/src/models/quantum/AKLT/AKLT1D.jl
+++ b/src/models/quantum/AKLT/AKLT1D.jl
@@ -279,7 +279,7 @@ end
 #     doi:10.1103/PhysRevLett.60.531
 
 """
-    fetch(model::AKLT1D, ::ZZCorrelation{:static}, ::Infinite; r::Integer) -> Float64
+    fetch(model::AKLT1D, ::SpinCorrelation{:z,:z}, ::Infinite; r::Integer) -> Float64
 
 Exact equal-time spin-z two-point function of the AKLT VBS ground
 state at separation `r`:
@@ -293,7 +293,7 @@ with [`fetch(::AKLT1D, ::CorrelationLength, ::Infinite)`](@ref)
 `ξ = 1/log 3`.  Since `⟨Sᶻ⟩ = 0` in the VBS this equal-time value is
 already the connected correlation.
 """
-function fetch(::AKLT1D, ::ZZCorrelation{:static}, ::Infinite; r::Integer, kwargs...)
+function fetch(::AKLT1D, ::SpinCorrelation{:z,:z}, ::Infinite; r::Integer, kwargs...)
     r == 0 && return 2.0 / 3.0
     a = abs(r)
     return (iseven(a) ? 1.0 : -1.0) * (4.0 / 3.0) * 3.0^(-a)
@@ -309,7 +309,7 @@ Exact static (equal-time) spin-z structure factor of the AKLT chain,
 (Arovas–Auerbach–Haldane 1988).  `S_zz(0) = 0` by total-`Sᶻ`
 conservation; antiferromagnetic peak `S_zz(π) = 2`.  `J`-independent.
 This is the lattice-Fourier sum of the closed-form
-[`ZZCorrelation`](@ref) `(−1)^r (4/3) 3^{−|r|}`.
+[`SpinCorrelation`](@ref) `(−1)^r (4/3) 3^{−|r|}`.
 """
 function fetch(::AKLT1D, ::ZZStructureFactor, ::Infinite; q::Real, kwargs...)
     c = cos(q)

--- a/src/models/quantum/AKLT/AKLT1D_registry.jl
+++ b/src/models/quantum/AKLT/AKLT1D_registry.jl
@@ -75,7 +75,7 @@
 # ── VBS ground-state correlations (Infinite, closed form) ────────────
 @register(
     AKLT1D,
-    ZZCorrelation{:static},
+    SpinCorrelation{:z,:z},
     Infinite,
     method=:analytic,
     reliability=:high,

--- a/src/models/quantum/Heisenberg/Heisenberg.jl
+++ b/src/models/quantum/Heisenberg/Heisenberg.jl
@@ -261,12 +261,13 @@ function fetch(
     return fetch(XXZ1D(; J=J, Δ=1.0), MagnetizationXLocal(), bc; beta=beta, kwargs...)
 end
 
-# Two-point correlators (static + connected).
-for CorrTy in (:XXCorrelation, :YYCorrelation, :ZZCorrelation)
-    for mode in (:static, :connected)
+# Two-point correlators (static + connected).  #734: dispatch on and delegate
+# to the new axis-parametric correlator types (Heisenberg1D = XXZ1D at Δ = 1).
+for axis in (:x, :y, :z)
+    for CorrT in (SpinCorrelation{axis,axis}, ConnectedSpinCorrelation{axis,axis})
         @eval function fetch(
             ::Heisenberg1D,
-            ::$CorrTy{$(QuoteNode(mode))},
+            ::$CorrT,
             bc::OBC;
             beta::Real,
             i::Int,
@@ -274,15 +275,7 @@ for CorrTy in (:XXCorrelation, :YYCorrelation, :ZZCorrelation)
             J::Real=1.0,
             kwargs...,
         )
-            return fetch(
-                XXZ1D(; J=J, Δ=1.0),
-                $CorrTy{$(QuoteNode(mode))}(),
-                bc;
-                beta=beta,
-                i=i,
-                j=j,
-                kwargs...,
-            )
+            return fetch(XXZ1D(; J=J, Δ=1.0), $CorrT(), bc; beta=beta, i=i, j=j, kwargs...)
         end
     end
 end

--- a/src/models/quantum/Heisenberg/HeisenbergS1_observables.jl
+++ b/src/models/quantum/Heisenberg/HeisenbergS1_observables.jl
@@ -109,9 +109,13 @@ end
 
 for (Q, axis_sym) in ((:XXCorrelation, :x), (:YYCorrelation, :y), (:ZZCorrelation, :z))
     axis_str = string(axis_sym)
+    # #734: dispatch on the new axis-parametric correlator types; `Q` is kept
+    # only for the (unchanged) error-message text that names the old fused type.
+    StaticT = SpinCorrelation{axis_sym,axis_sym}
+    ConnectedT = ConnectedSpinCorrelation{axis_sym,axis_sym}
     @eval begin
         """
-            fetch(model::S1Heisenberg1D, ::$($Q){:static}, ::OBC;
+            fetch(model::S1Heisenberg1D, ::$($StaticT), ::OBC;
                   beta, i::Int, j::Int) -> Float64
 
         Static thermal correlator `⟨S^$($axis_str)_i S^$($axis_str)_j⟩_β`
@@ -120,7 +124,7 @@ for (Q, axis_sym) in ((:XXCorrelation, :x), (:YYCorrelation, :y), (:ZZCorrelatio
         """
         function fetch(
             model::S1Heisenberg1D,
-            ::$Q{:static},
+            ::$StaticT,
             bc::OBC;
             beta::Real,
             i::Int,
@@ -140,7 +144,7 @@ for (Q, axis_sym) in ((:XXCorrelation, :x), (:YYCorrelation, :y), (:ZZCorrelatio
         end
 
         """
-            fetch(model::S1Heisenberg1D, ::$($Q){:connected}, ::OBC;
+            fetch(model::S1Heisenberg1D, ::$($ConnectedT), ::OBC;
                   beta, i::Int, j::Int) -> Float64
 
         Connected (cumulant) correlator
@@ -149,7 +153,7 @@ for (Q, axis_sym) in ((:XXCorrelation, :x), (:YYCorrelation, :y), (:ZZCorrelatio
         """
         function fetch(
             model::S1Heisenberg1D,
-            ::$Q{:connected},
+            ::$ConnectedT,
             bc::OBC;
             beta::Real,
             i::Int,

--- a/src/models/quantum/Heisenberg/HeisenbergS1_registry.jl
+++ b/src/models/quantum/Heisenberg/HeisenbergS1_registry.jl
@@ -96,7 +96,7 @@
 # ── Two-point correlators (static / connected, OBC) ───────────────────
 @register(
     S1Heisenberg1D,
-    XXCorrelation{:static},
+    SpinCorrelation{:x,:x},
     OBC,
     method=:dense_ed,
     reliability=:high,
@@ -104,7 +104,7 @@
 )
 @register(
     S1Heisenberg1D,
-    YYCorrelation{:static},
+    SpinCorrelation{:y,:y},
     OBC,
     method=:dense_ed,
     reliability=:high,
@@ -112,7 +112,7 @@
 )
 @register(
     S1Heisenberg1D,
-    ZZCorrelation{:static},
+    SpinCorrelation{:z,:z},
     OBC,
     method=:dense_ed,
     reliability=:high,
@@ -120,7 +120,7 @@
 )
 @register(
     S1Heisenberg1D,
-    XXCorrelation{:connected},
+    ConnectedSpinCorrelation{:x,:x},
     OBC,
     method=:dense_ed,
     reliability=:high,
@@ -128,7 +128,7 @@
 )
 @register(
     S1Heisenberg1D,
-    YYCorrelation{:connected},
+    ConnectedSpinCorrelation{:y,:y},
     OBC,
     method=:dense_ed,
     reliability=:high,
@@ -136,7 +136,7 @@
 )
 @register(
     S1Heisenberg1D,
-    ZZCorrelation{:connected},
+    ConnectedSpinCorrelation{:z,:z},
     OBC,
     method=:dense_ed,
     reliability=:high,

--- a/src/models/quantum/Heisenberg/Heisenberg_registry.jl
+++ b/src/models/quantum/Heisenberg/Heisenberg_registry.jl
@@ -162,10 +162,17 @@
 )
 
 # ── Two-point correlators (static + connected) ────────────────────────
-for CorrTy in (XXCorrelation, YYCorrelation, ZZCorrelation), mode in (:static, :connected)
+for CorrT in (
+    SpinCorrelation{:x,:x},
+    SpinCorrelation{:y,:y},
+    SpinCorrelation{:z,:z},
+    ConnectedSpinCorrelation{:x,:x},
+    ConnectedSpinCorrelation{:y,:y},
+    ConnectedSpinCorrelation{:z,:z},
+)
     register!(
         Heisenberg1D,
-        CorrTy{mode},
+        CorrT,
         OBC;
         method=:dense_ed,
         reliability=:high,

--- a/src/models/quantum/TFIM/TFIM_dynamics.jl
+++ b/src/models/quantum/TFIM/TFIM_dynamics.jl
@@ -377,7 +377,7 @@ end
 # ═══════════════════════════════════════════════════════════════════════════════
 
 """
-    fetch(model::TFIM, ::ZZCorrelation{:dynamic}, bc::OBC;
+    fetch(model::TFIM, ::DynamicalCorrelation{(:z, :z)}, bc::OBC;
           i::Int, j::Int, t::Float64, beta::Float64 = Inf) -> ComplexF64
 
 Exact `⟨σᶻ_i(t) σᶻ_j(0)⟩_β` for the OBC TFIM.  `beta = Inf` (the default)
@@ -385,7 +385,7 @@ gives the ground-state result.  `N` comes from `bc.N`.
 """
 function fetch(
     model::TFIM,
-    ::ZZCorrelation{:dynamic},
+    ::DynamicalCorrelation{(:z, :z)},
     bc::OBC;
     i::Int,
     j::Int,
@@ -398,14 +398,14 @@ function fetch(
 end
 
 """
-    fetch(model::TFIM, ::XXCorrelation{:dynamic}, bc::OBC;
+    fetch(model::TFIM, ::DynamicalCorrelation{(:x, :x)}, bc::OBC;
           i::Int, j::Int, t::Float64, beta::Float64 = Inf) -> ComplexF64
 
 Exact `⟨σˣ_i(t) σˣ_j(0)⟩_β` for the OBC TFIM.
 """
 function fetch(
     model::TFIM,
-    ::XXCorrelation{:dynamic},
+    ::DynamicalCorrelation{(:x, :x)},
     bc::OBC;
     i::Int,
     j::Int,
@@ -418,7 +418,7 @@ function fetch(
 end
 
 """
-    fetch(model::TFIM, ::ZZCorrelation{:lightcone}, bc::OBC;
+    fetch(model::TFIM, ::LightconeSpinCorrelation{:z,:z}, bc::OBC;
           center::Int, times::AbstractVector{<:Real}, beta::Float64 = Inf) -> Matrix{ComplexF64}
 
 Exact spreading correlation `C[it, ix] = ⟨σᶻ_ix(t_it) σᶻ_center(0)⟩_β` for all
@@ -426,7 +426,7 @@ sites `ix ∈ 1:N` and `t_it ∈ times`.
 """
 function fetch(
     model::TFIM,
-    ::ZZCorrelation{:lightcone},
+    ::LightconeSpinCorrelation{:z,:z},
     bc::OBC;
     center::Int,
     times::AbstractVector{<:Real},
@@ -438,7 +438,7 @@ function fetch(
 end
 
 """
-    fetch(model::TFIM, ::ZZCorrelation{:static}, bc::OBC;
+    fetch(model::TFIM, ::SpinCorrelation{:z,:z}, bc::OBC;
           beta::Float64, [i::Int, j::Int]) -> Matrix{Float64} or Float64
 
 Static (equal-time) thermal correlator `⟨σᶻ_i σᶻ_j⟩_β` for the OBC TFIM.
@@ -447,7 +447,7 @@ N×N matrix.
 """
 function fetch(
     model::TFIM,
-    ::ZZCorrelation{:static},
+    ::SpinCorrelation{:z,:z},
     bc::OBC;
     beta::Float64,
     i::Union{Int,Nothing}=nothing,
@@ -462,7 +462,7 @@ function fetch(
 end
 
 """
-    fetch(model::TFIM, ::ZZCorrelation{:connected}, bc::OBC;
+    fetch(model::TFIM, ::ConnectedSpinCorrelation{:z,:z}, bc::OBC;
           beta::Float64, [i::Int, j::Int]) -> Matrix{Float64} or Float64
 
 Connected static thermal correlator
@@ -483,7 +483,7 @@ in the source.
 """
 function fetch(
     model::TFIM,
-    ::ZZCorrelation{:connected},
+    ::ConnectedSpinCorrelation{:z,:z},
     bc::OBC;
     beta::Float64,
     i::Union{Int,Nothing}=nothing,
@@ -494,7 +494,7 @@ function fetch(
     # returns the connected correlator under that assumption.  Wire to it
     # directly; if a future TFIM variant adds explicit symmetry breaking,
     # subtract `mz[i] * mz[j]` here using `MagnetizationZLocal`.
-    return fetch(model, ZZCorrelation{:static}(), bc; beta=beta, i=i, j=j, kwargs...)
+    return fetch(model, SpinCorrelation(:z, :z), bc; beta=beta, i=i, j=j, kwargs...)
 end
 
 """

--- a/src/models/quantum/TFIM/TFIM_registry.jl
+++ b/src/models/quantum/TFIM/TFIM_registry.jl
@@ -232,7 +232,7 @@
 )
 @register(
     TFIM,
-    ZZCorrelation{:static},
+    SpinCorrelation{:z,:z},
     OBC,
     method=:bdg,
     reliability=:high,
@@ -240,7 +240,7 @@
 )
 @register(
     TFIM,
-    ZZCorrelation{:dynamic},
+    DynamicalCorrelation{(:z, :z)},
     OBC,
     method=:bdg,
     reliability=:high,
@@ -249,7 +249,7 @@
 )
 @register(
     TFIM,
-    ZZCorrelation{:lightcone},
+    LightconeSpinCorrelation{:z,:z},
     OBC,
     method=:bdg,
     reliability=:high,
@@ -258,7 +258,7 @@
 )
 @register(
     TFIM,
-    XXCorrelation{:dynamic},
+    DynamicalCorrelation{(:x, :x)},
     OBC,
     method=:bdg,
     reliability=:high,
@@ -391,7 +391,7 @@
 # ── ZZ correlator connected mode (OBC) ───────────────────────────────
 @register(
     TFIM,
-    ZZCorrelation{:connected},
+    ConnectedSpinCorrelation{:z,:z},
     OBC,
     method=:bdg,
     reliability=:high,
@@ -402,7 +402,7 @@
 # ── Tier 2: XX static + connected via Pfaffian Wick contraction ─────
 @register(
     TFIM,
-    XXCorrelation{:static},
+    SpinCorrelation{:x,:x},
     OBC,
     method=:pfaffian,
     reliability=:high,
@@ -412,7 +412,7 @@
 )
 @register(
     TFIM,
-    XXCorrelation{:connected},
+    ConnectedSpinCorrelation{:x,:x},
     OBC,
     method=:pfaffian,
     reliability=:high,
@@ -420,7 +420,7 @@
 )
 @register(
     TFIM,
-    XXCorrelation{:static},
+    SpinCorrelation{:x,:x},
     Infinite,
     method=:pfaffian,
     reliability=:medium,
@@ -429,7 +429,7 @@
 )
 @register(
     TFIM,
-    XXCorrelation{:connected},
+    ConnectedSpinCorrelation{:x,:x},
     Infinite,
     method=:pfaffian,
     reliability=:medium,
@@ -488,7 +488,7 @@
 # (defined in TFIM_yy.jl; closes the YY gap left by PR #130 Tier 2)
 @register(
     TFIM,
-    YYCorrelation{:static},
+    SpinCorrelation{:y,:y},
     OBC,
     method=:pfaffian,
     reliability=:high,
@@ -497,7 +497,7 @@
 )
 @register(
     TFIM,
-    YYCorrelation{:connected},
+    ConnectedSpinCorrelation{:y,:y},
     OBC,
     method=:pfaffian,
     reliability=:high,
@@ -506,7 +506,7 @@
 )
 @register(
     TFIM,
-    YYCorrelation{:dynamic},
+    DynamicalCorrelation{(:y, :y)},
     OBC,
     method=:pfaffian,
     reliability=:high,

--- a/src/models/quantum/TFIM/TFIM_xx_static.jl
+++ b/src/models/quantum/TFIM/TFIM_xx_static.jl
@@ -4,8 +4,8 @@
 # Companion to `TFIM_dynamics.jl`.  All the heavy lifting (Majorana
 # Hamiltonian assembly, BdG-thermal Majorana 2-point function, Wick / Pfaffian
 # evaluation) is already provided there; this file only adds equal-time
-# (`t = 0`) `fetch` dispatches for `XXCorrelation{:static}` /
-# `XXCorrelation{:connected}` and an `Infinite`-proxy variant that re-uses
+# (`t = 0`) `fetch` dispatches for `SpinCorrelation{:x,:x}` /
+# `ConnectedSpinCorrelation{:x,:x}` and an `Infinite`-proxy variant that re-uses
 # the OBC routine at a large N.
 #
 # Conventions:
@@ -33,7 +33,7 @@
 # ═══════════════════════════════════════════════════════════════════════════════
 
 """
-    fetch(model::TFIM, ::XXCorrelation{:static}, bc::OBC;
+    fetch(model::TFIM, ::SpinCorrelation{:x,:x}, bc::OBC;
           beta::Real = Inf, i::Int, j::Int, kwargs...) -> Float64
 
 Static (equal-time) thermal transverse correlator
@@ -49,7 +49,7 @@ At `i = j`, `⟨(σˣ)²⟩ = ⟨I⟩ = 1` regardless of (β, J, h).
 """
 function fetch(
     model::TFIM,
-    ::XXCorrelation{:static},
+    ::SpinCorrelation{:x,:x},
     bc::OBC;
     beta::Real=Inf,
     i::Int,
@@ -63,13 +63,13 @@ function fetch(
 end
 
 """
-    fetch(model::TFIM, ::XXCorrelation{:connected}, bc::OBC;
+    fetch(model::TFIM, ::ConnectedSpinCorrelation{:x,:x}, bc::OBC;
           beta::Real = Inf, i::Int, j::Int, kwargs...) -> Float64
 
 Connected static thermal transverse correlator
 `⟨σˣ_i σˣ_j⟩_β − ⟨σˣ_i⟩_β ⟨σˣ_j⟩_β` for the OBC TFIM.
 
-Unlike `ZZCorrelation{:connected}` (where ⟨σᶻ⟩ = 0 by Z₂ on OBC and the
+Unlike `ConnectedSpinCorrelation{:z,:z}` (where ⟨σᶻ⟩ = 0 by Z₂ on OBC and the
 connected and bare correlators coincide), `⟨σˣ⟩_β ≠ 0` in general — σˣ
 is the field-coupled order parameter and acquires a non-zero
 expectation `Σ[2i-1, 2i]` from the BdG-thermal covariance.
@@ -83,7 +83,7 @@ evolution `R = I` at `t = 0`, the 4×4 Pfaffian for `⟨σˣ_i σˣ_j⟩_β`.
 """
 function fetch(
     model::TFIM,
-    ::XXCorrelation{:connected},
+    ::ConnectedSpinCorrelation{:x,:x},
     bc::OBC;
     beta::Real=Inf,
     i::Int,
@@ -114,7 +114,7 @@ end
 # ═══════════════════════════════════════════════════════════════════════════════
 
 """
-    fetch(model::TFIM, ::XXCorrelation{:static}, ::Infinite;
+    fetch(model::TFIM, ::SpinCorrelation{:x,:x}, ::Infinite;
           beta::Real = Inf, i::Int, j::Int,
           N_proxy::Int = 80, kwargs...) -> Float64
 
@@ -133,7 +133,7 @@ Raise `N_proxy` if more accuracy is needed; the cost is the single
 """
 function fetch(
     model::TFIM,
-    ::XXCorrelation{:static},
+    ::SpinCorrelation{:x,:x},
     ::Infinite;
     beta::Real=Inf,
     i::Int,
@@ -141,20 +141,20 @@ function fetch(
     N_proxy::Int=80,
     kwargs...,
 )
-    return fetch(model, XXCorrelation{:static}(), OBC(N_proxy); beta=beta, i=i, j=j)
+    return fetch(model, SpinCorrelation(:x, :x), OBC(N_proxy); beta=beta, i=i, j=j)
 end
 
 """
-    fetch(model::TFIM, ::XXCorrelation{:connected}, ::Infinite;
+    fetch(model::TFIM, ::ConnectedSpinCorrelation{:x,:x}, ::Infinite;
           beta::Real = Inf, i::Int, j::Int,
           N_proxy::Int = 80, kwargs...) -> Float64
 
 Connected static `⟨σˣ_i σˣ_j⟩_β,c` in the thermodynamic limit, via the
-same OBC large-N proxy as `XXCorrelation{:static}, Infinite()`.
+same OBC large-N proxy as `SpinCorrelation{:x,:x}, Infinite()`.
 """
 function fetch(
     model::TFIM,
-    ::XXCorrelation{:connected},
+    ::ConnectedSpinCorrelation{:x,:x},
     ::Infinite;
     beta::Real=Inf,
     i::Int,
@@ -162,5 +162,5 @@ function fetch(
     N_proxy::Int=80,
     kwargs...,
 )
-    return fetch(model, XXCorrelation{:connected}(), OBC(N_proxy); beta=beta, i=i, j=j)
+    return fetch(model, ConnectedSpinCorrelation(:x, :x), OBC(N_proxy); beta=beta, i=i, j=j)
 end

--- a/src/models/quantum/TFIM/TFIM_yy.jl
+++ b/src/models/quantum/TFIM/TFIM_yy.jl
@@ -90,16 +90,16 @@ end
 # ═══════════════════════════════════════════════════════════════════════════════
 
 """
-    fetch(model::TFIM, ::YYCorrelation{:static}, bc::OBC;
+    fetch(model::TFIM, ::SpinCorrelation{:y,:y}, bc::OBC;
           beta=Inf, i, j) -> Float64
 
 Static thermal correlator `⟨σʸ_i σʸ_j⟩_β` on the OBC TFIM.  Equivalent
-to the `t = 0` slice of [`YYCorrelation`](@ref) with `mode = :dynamic`,
+to the `t = 0` slice of [`DynamicalCorrelation`](@ref)`(:y, :y)`,
 returned as `Float64` (the imaginary part is round-off only at t = 0).
 """
 function fetch(
     model::TFIM,
-    ::YYCorrelation{:static},
+    ::SpinCorrelation{:y,:y},
     bc::OBC;
     beta::Real=Inf,
     i::Int,
@@ -116,7 +116,7 @@ function fetch(
 end
 
 """
-    fetch(model::TFIM, ::YYCorrelation{:connected}, bc::OBC;
+    fetch(model::TFIM, ::ConnectedSpinCorrelation{:y,:y}, bc::OBC;
           beta=Inf, i, j) -> Float64
 
 Connected thermal correlator `⟨σʸ_i σʸ_j⟩_β − ⟨σʸ_i⟩ ⟨σʸ_j⟩`.  Since
@@ -126,7 +126,7 @@ returns `1 - 0² = 1`.
 """
 function fetch(
     model::TFIM,
-    ::YYCorrelation{:connected},
+    ::ConnectedSpinCorrelation{:y,:y},
     bc::OBC;
     beta::Real=Inf,
     i::Int,
@@ -134,11 +134,11 @@ function fetch(
     kwargs...,
 )
     N = _bc_size(bc, kwargs)
-    return fetch(model, YYCorrelation{:static}(), bc; beta=beta, i=i, j=j, N=N)
+    return fetch(model, SpinCorrelation(:y, :y), bc; beta=beta, i=i, j=j, N=N)
 end
 
 """
-    fetch(model::TFIM, ::YYCorrelation{:dynamic}, bc::OBC;
+    fetch(model::TFIM, ::DynamicalCorrelation{(:y, :y)}, bc::OBC;
           beta=Inf, i, j, t) -> ComplexF64
 
 Real-time correlator `⟨σʸ_i(t) σʸ_j(0)⟩_β`.  Returns `ComplexF64`; the
@@ -148,7 +148,7 @@ odd in t — see the time-domain identity tests in
 """
 function fetch(
     model::TFIM,
-    ::YYCorrelation{:dynamic},
+    ::DynamicalCorrelation{(:y, :y)},
     bc::OBC;
     i::Int,
     j::Int,

--- a/src/models/quantum/XXZ/XXZ_registry.jl
+++ b/src/models/quantum/XXZ/XXZ_registry.jl
@@ -206,15 +206,22 @@
 )
 
 # ── Two-point correlators (static + connected) ────────────────────────
-for CorrTy in (XXCorrelation, YYCorrelation, ZZCorrelation), mode in (:static, :connected)
+for CorrT in (
+    SpinCorrelation{:x,:x},
+    SpinCorrelation{:y,:y},
+    SpinCorrelation{:z,:z},
+    ConnectedSpinCorrelation{:x,:x},
+    ConnectedSpinCorrelation{:y,:y},
+    ConnectedSpinCorrelation{:z,:z},
+)
     register!(
         XXZ1D,
-        CorrTy{mode},
+        CorrT,
         OBC;
         method=:dense_ed,
         reliability=:high,
         tested_in="test/models/test_XXZ1D_observables.jl",
-        notes="(i,j) ⟨σᵅᵢ σᵅⱼ⟩_β; mode=:connected subtracts the disconnected piece.",
+        notes="(i,j) ⟨σᵅᵢ σᵅⱼ⟩_β; the connected variant subtracts the disconnected piece.",
     )
 end
 

--- a/src/models/quantum/XXZ/XXZ_thermal.jl
+++ b/src/models/quantum/XXZ/XXZ_thermal.jl
@@ -450,13 +450,18 @@ function _xxz1d_static_corr(
     return c2 - ci * cj
 end
 
-# Generate fetch methods for the four (mode, axis) combinations we support.
-const _XXZ1D_CORR_AXES = ((XXCorrelation, _σx), (YYCorrelation, _σy), (ZZCorrelation, _σz))
+# Generate fetch methods for the two modes × three axes we support.  #734: the
+# static / connected correlators are now the axis-parametric AbstractQAtlas types.
+const _XXZ1D_CORR_AXES = (
+    (SpinCorrelation{:x,:x}, ConnectedSpinCorrelation{:x,:x}, _σx),
+    (SpinCorrelation{:y,:y}, ConnectedSpinCorrelation{:y,:y}, _σy),
+    (SpinCorrelation{:z,:z}, ConnectedSpinCorrelation{:z,:z}, _σz),
+)
 
-for (CorrTy, σα) in _XXZ1D_CORR_AXES
+for (StaticT, ConnectedT, σα) in _XXZ1D_CORR_AXES
     @eval begin
         function fetch(
-            model::XXZ1D, ::$CorrTy{:static}, bc::OBC; beta::Real, i::Int, j::Int, kwargs...
+            model::XXZ1D, ::$StaticT, bc::OBC; beta::Real, i::Int, j::Int, kwargs...
         )
             N = _bc_size(bc, kwargs)
             F = _xxz1d_thermal_kernel(model, N, beta)
@@ -464,13 +469,7 @@ for (CorrTy, σα) in _XXZ1D_CORR_AXES
         end
 
         function fetch(
-            model::XXZ1D,
-            ::$CorrTy{:connected},
-            bc::OBC;
-            beta::Real,
-            i::Int,
-            j::Int,
-            kwargs...,
+            model::XXZ1D, ::$ConnectedT, bc::OBC; beta::Real, i::Int, j::Int, kwargs...
         )
             N = _bc_size(bc, kwargs)
             F = _xxz1d_thermal_kernel(model, N, beta)

--- a/test/core/test_query.jl
+++ b/test/core/test_query.jl
@@ -58,17 +58,17 @@ end
 
 @testset "query: per-scheme dynamical tagging (dynamic correlations / quench)" begin
     da = QAtlas.dynamical_axis
-    @test da(QAtlas.ZZCorrelation{:dynamic}) === :dynamic
-    @test da(QAtlas.ZZCorrelation{:lightcone}) === :dynamic
-    @test da(QAtlas.ZZCorrelation{:static}) === :static
-    @test da(QAtlas.ZZCorrelation{:connected}) === :static
+    @test da(QAtlas.DynamicalCorrelation{(:z, :z)}) === :dynamic
+    @test da(QAtlas.LightconeSpinCorrelation{:z,:z}) === :dynamic
+    @test da(QAtlas.SpinCorrelation{:z,:z}) === :static
+    @test da(QAtlas.ConnectedSpinCorrelation{:z,:z}) === :static
     @test da(QAtlas.VonNeumannEntropy{:quench}) === :dynamic
     @test da(QAtlas.VonNeumannEntropy{:equilibrium}) === :static
     @test da(QAtlas.LoschmidtEcho{:amplitude}) === :dynamic
     # search now surfaces the dynamic hubs; equilibrium schemes stay out
     dyn = QAtlas.search(; dynamical=:dynamic)
     @test dyn.available
-    @test any(h -> occursin("Correlation", h.quantity), dyn.hits)   # e.g. XXCorrelation{:dynamic}
+    @test any(h -> occursin("Correlation", h.quantity), dyn.hits)   # e.g. DynamicalCorrelation{(:x, :x)}
     @test !any(
         h -> endswith(h.quantity, "{:static}") || endswith(h.quantity, "{:connected}"),
         dyn.hits,

--- a/test/identities/test_TFIM_dynamic_symmetries.jl
+++ b/test/identities/test_TFIM_dynamic_symmetries.jl
@@ -33,10 +33,10 @@ using LinearAlgebra: norm
         N = 8
         for i in (3, 4, 5), t in (0.4, 1.2, 2.5)
             c_pos = QAtlas.fetch(
-                model, ZZCorrelation{:dynamic}(), OBC(N); i=i, j=i, t=t, beta=β
+                model, DynamicalCorrelation(:z, :z), OBC(N); i=i, j=i, t=t, beta=β
             )
             c_neg = QAtlas.fetch(
-                model, ZZCorrelation{:dynamic}(), OBC(N); i=i, j=i, t=(-t), beta=β
+                model, DynamicalCorrelation(:z, :z), OBC(N); i=i, j=i, t=(-t), beta=β
             )
             @test real(c_pos) ≈ real(c_neg) atol = 1e-10
             @test imag(c_pos) ≈ -imag(c_neg) atol = 1e-10
@@ -49,10 +49,10 @@ end
     model = TFIM(; J=1.0, h=h)
     for i in (3, 4, 5), t in (0.4, 1.5)
         c_pos = QAtlas.fetch(
-            model, XXCorrelation{:dynamic}(), OBC(N); i=i, j=i, t=t, beta=β
+            model, DynamicalCorrelation(:x, :x), OBC(N); i=i, j=i, t=t, beta=β
         )
         c_neg = QAtlas.fetch(
-            model, XXCorrelation{:dynamic}(), OBC(N); i=i, j=i, t=(-t), beta=β
+            model, DynamicalCorrelation(:x, :x), OBC(N); i=i, j=i, t=(-t), beta=β
         )
         @test real(c_pos) ≈ real(c_neg) atol = 1e-10
         @test imag(c_pos) ≈ -imag(c_neg) atol = 1e-10
@@ -69,10 +69,10 @@ end
     model = TFIM(; J=1.0, h=h)
     for (i, j) in ((3, 5), (2, 6), (3, 7)), t in (0.5, 1.7)
         c_ij_pos = QAtlas.fetch(
-            model, ZZCorrelation{:dynamic}(), OBC(N); i=i, j=j, t=t, beta=β
+            model, DynamicalCorrelation(:z, :z), OBC(N); i=i, j=j, t=t, beta=β
         )
         c_ji_neg = QAtlas.fetch(
-            model, ZZCorrelation{:dynamic}(), OBC(N); i=j, j=i, t=(-t), beta=β
+            model, DynamicalCorrelation(:z, :z), OBC(N); i=j, j=i, t=(-t), beta=β
         )
         @test conj(c_ij_pos) ≈ c_ji_neg atol = 1e-10
     end
@@ -85,10 +85,10 @@ end
     model = TFIM(; J=1.0, h=h)
     for (i, j) in ((3, 5), (4, 7)), t in (0.6, 1.4)
         c_ij_pos = QAtlas.fetch(
-            model, ZZCorrelation{:dynamic}(), OBC(N); i=i, j=j, t=t, beta=β
+            model, DynamicalCorrelation(:z, :z), OBC(N); i=i, j=j, t=t, beta=β
         )
         c_ji_neg = QAtlas.fetch(
-            model, ZZCorrelation{:dynamic}(), OBC(N); i=j, j=i, t=(-t), beta=β
+            model, DynamicalCorrelation(:z, :z), OBC(N); i=j, j=i, t=(-t), beta=β
         )
         @test conj(c_ij_pos) ≈ c_ji_neg atol = 1e-10
     end
@@ -104,9 +104,9 @@ end
         N = 8
         for i in 2:(N - 1), j in i:(N - 1)
             c_dyn = QAtlas.fetch(
-                model, ZZCorrelation{:dynamic}(), OBC(N); i=i, j=j, t=0.0, beta=β
+                model, DynamicalCorrelation(:z, :z), OBC(N); i=i, j=j, t=0.0, beta=β
             )
-            c_stat = QAtlas.fetch(model, ZZCorrelation{:static}(), OBC(N); i=i, j=j, beta=β)
+            c_stat = QAtlas.fetch(model, SpinCorrelation(:z, :z), OBC(N); i=i, j=j, beta=β)
             @test imag(c_dyn) ≈ 0 atol = 1e-12
             @test real(c_dyn) ≈ c_stat atol = 1e-10
         end
@@ -118,9 +118,9 @@ end
     model = TFIM(; J=1.0, h=h)
     for i in 2:(N - 1), j in i:(N - 1)
         c_dyn = QAtlas.fetch(
-            model, XXCorrelation{:dynamic}(), OBC(N); i=i, j=j, t=0.0, beta=β
+            model, DynamicalCorrelation(:x, :x), OBC(N); i=i, j=j, t=0.0, beta=β
         )
-        c_stat = QAtlas.fetch(model, XXCorrelation{:static}(), OBC(N); i=i, j=j, beta=β)
+        c_stat = QAtlas.fetch(model, SpinCorrelation(:x, :x), OBC(N); i=i, j=j, beta=β)
         @test imag(c_dyn) ≈ 0 atol = 1e-12
         @test real(c_dyn) ≈ c_stat atol = 1e-10
     end
@@ -142,21 +142,22 @@ end
     i, j = 4, 12
     Δr = j - i  # = 8
 
-    c_static = QAtlas.fetch(model, ZZCorrelation{:static}(), OBC(N); i=i, j=j, beta=Inf)
+    c_static = QAtlas.fetch(model, SpinCorrelation(:z, :z), OBC(N); i=i, j=j, beta=Inf)
 
     # Just outside lightcone: t = Δr/(4 v_max) → exponential decay.
     t_out = Δr / (4 * v_max)
     c_out = abs(
         QAtlas.fetch(
-            model, ZZCorrelation{:dynamic}(), OBC(N); i=i, j=j, t=t_out, beta=Inf
+            model, DynamicalCorrelation(:z, :z), OBC(N); i=i, j=j, t=t_out, beta=Inf
         ) - c_static,
     )
 
     # Well inside lightcone: t = 4 Δr / v_max → O(1) deviation.
     t_in = 4 * Δr / v_max
     c_in = abs(
-        QAtlas.fetch(model, ZZCorrelation{:dynamic}(), OBC(N); i=i, j=j, t=t_in, beta=Inf) -
-        c_static,
+        QAtlas.fetch(
+            model, DynamicalCorrelation(:z, :z), OBC(N); i=i, j=j, t=t_in, beta=Inf
+        ) - c_static,
     )
 
     @test c_out < c_in    # outside-lightcone deviation is smaller
@@ -181,9 +182,11 @@ end
     δ = 1e-4
     for i in (3, 5)
         j = i + 1   # nearest neighbour, well inside the bulk
-        c_p = QAtlas.fetch(model, XXCorrelation{:dynamic}(), OBC(N); i=i, j=j, t=δ, beta=β)
+        c_p = QAtlas.fetch(
+            model, DynamicalCorrelation(:x, :x), OBC(N); i=i, j=j, t=δ, beta=β
+        )
         c_m = QAtlas.fetch(
-            model, XXCorrelation{:dynamic}(), OBC(N); i=i, j=j, t=(-δ), beta=β
+            model, DynamicalCorrelation(:x, :x), OBC(N); i=i, j=j, t=(-δ), beta=β
         )
         re_slope = (real(c_p) - real(c_m)) / (2δ)
         im_slope = (imag(c_p) - imag(c_m)) / (2δ)
@@ -195,8 +198,10 @@ end
         @test abs(im_slope) > 1e-4
     end
     # Locality check: at |i − j| = 3 the slope is identically 0.
-    c_p = QAtlas.fetch(model, XXCorrelation{:dynamic}(), OBC(N); i=3, j=6, t=δ, beta=β)
-    c_m = QAtlas.fetch(model, XXCorrelation{:dynamic}(), OBC(N); i=3, j=6, t=(-δ), beta=β)
+    c_p = QAtlas.fetch(model, DynamicalCorrelation(:x, :x), OBC(N); i=3, j=6, t=δ, beta=β)
+    c_m = QAtlas.fetch(
+        model, DynamicalCorrelation(:x, :x), OBC(N); i=3, j=6, t=(-δ), beta=β
+    )
     far_im_slope = (imag(c_p) - imag(c_m)) / (2δ)
     @test abs(far_im_slope) < 1e-10
 end

--- a/test/identities/test_property_invariants.jl
+++ b/test/identities/test_property_invariants.jl
@@ -235,10 +235,10 @@ end
         i = rand(2:(N - 1))
         j = rand(2:(N - 1))
         c_zz = QAtlas.fetch(
-            TFIM(; J=1.0, h=h), ZZCorrelation{:static}(), OBC(N); beta=β, i=i, j=j
+            TFIM(; J=1.0, h=h), SpinCorrelation(:z, :z), OBC(N); beta=β, i=i, j=j
         )
         c_xx = QAtlas.fetch(
-            TFIM(; J=1.0, h=h), XXCorrelation{:static}(), OBC(N); beta=β, i=i, j=j
+            TFIM(; J=1.0, h=h), SpinCorrelation(:x, :x), OBC(N); beta=β, i=i, j=j
         )
         @test abs(c_zz) ≤ 1 + 1e-10
         @test abs(c_xx) ≤ 1 + 1e-10

--- a/test/models/quantum/TFIM/test_TFIM_dynamics_critical.jl
+++ b/test/models/quantum/TFIM/test_TFIM_dynamics_critical.jl
@@ -25,7 +25,7 @@
         v1 = real(
             QAtlas.fetch(
                 TFIM(; J=J, h=h),
-                ZZCorrelation{:dynamic}(),
+                DynamicalCorrelation(:z, :z),
                 OBC(; N=N);
                 i=i0,
                 j=i0 + 10,
@@ -35,7 +35,7 @@
         v2 = real(
             QAtlas.fetch(
                 TFIM(; J=J, h=h),
-                ZZCorrelation{:dynamic}(),
+                DynamicalCorrelation(:z, :z),
                 OBC(; N=N);
                 i=i0,
                 j=i0 + 20,
@@ -60,7 +60,7 @@ end
     envelope = Float64[
         abs(
             QAtlas.fetch(
-                TFIM(; J=J, h=h), ZZCorrelation{:dynamic}(), OBC(; N=N); i=i0, j=i0, t=t
+                TFIM(; J=J, h=h), DynamicalCorrelation(:z, :z), OBC(; N=N); i=i0, j=i0, t=t
             ),
         ) for t in ts
     ]

--- a/test/models/quantum/TFIM/test_TFIM_dynamics_disordered.jl
+++ b/test/models/quantum/TFIM/test_TFIM_dynamics_disordered.jl
@@ -31,7 +31,7 @@
             v1 = real(
                 QAtlas.fetch(
                     TFIM(; J=J, h=h),
-                    ZZCorrelation{:dynamic}(),
+                    DynamicalCorrelation(:z, :z),
                     OBC(; N=N);
                     i=i0,
                     j=i0 + r1,
@@ -41,7 +41,7 @@
             v2 = real(
                 QAtlas.fetch(
                     TFIM(; J=J, h=h),
-                    ZZCorrelation{:dynamic}(),
+                    DynamicalCorrelation(:z, :z),
                     OBC(; N=N);
                     i=i0,
                     j=i0 + r2,

--- a/test/models/quantum/TFIM/test_TFIM_dynamics_ed_small.jl
+++ b/test/models/quantum/TFIM/test_TFIM_dynamics_ed_small.jl
@@ -26,7 +26,12 @@
             ED = real(gs' * _op_site(_SZ, i, N) * _op_site(_SZ, j, N) * gs)
             QAT = real(
                 QAtlas.fetch(
-                    TFIM(; J=J, h=h), ZZCorrelation{:dynamic}(), OBC(; N=N); i=i, j=j, t=0.0
+                    TFIM(; J=J, h=h),
+                    DynamicalCorrelation(:z, :z),
+                    OBC(; N=N);
+                    i=i,
+                    j=j,
+                    t=0.0,
                 ),
             )
             @test QAT ≈ ED atol=1e-10
@@ -37,7 +42,12 @@
             ED = real(gs' * _op_site(_SX, i, N) * _op_site(_SX, j, N) * gs)
             QAT = real(
                 QAtlas.fetch(
-                    TFIM(; J=J, h=h), XXCorrelation{:dynamic}(), OBC(; N=N); i=i, j=j, t=0.0
+                    TFIM(; J=J, h=h),
+                    DynamicalCorrelation(:x, :x),
+                    OBC(; N=N);
+                    i=i,
+                    j=j,
+                    t=0.0,
                 ),
             )
             @test QAT ≈ ED atol=1e-10
@@ -51,7 +61,7 @@
                 exp(im * E[1] * t) *
                 (gs' * _op_site(_SZ, i, N) * Ut * _op_site(_SZ, j, N) * gs)
             QAT = QAtlas.fetch(
-                TFIM(; J=J, h=h), ZZCorrelation{:dynamic}(), OBC(; N=N); i=i, j=j, t=t
+                TFIM(; J=J, h=h), DynamicalCorrelation(:z, :z), OBC(; N=N); i=i, j=j, t=t
             )
             @test real(QAT) ≈ real(ED) atol=1e-10
             @test imag(QAT) ≈ imag(ED) atol=1e-10
@@ -63,7 +73,7 @@
         N, J, h = 12, 1.0, 0.7
         for i in (1, 4, 8, 12)
             v = QAtlas.fetch(
-                TFIM(; J=J, h=h), ZZCorrelation{:dynamic}(), OBC(; N=N); i=i, j=i, t=0.0
+                TFIM(; J=J, h=h), DynamicalCorrelation(:z, :z), OBC(; N=N); i=i, j=i, t=0.0
             )
             @test real(v) ≈ 1.0 atol=1e-10
             @test abs(imag(v)) < 1e-10
@@ -77,7 +87,7 @@
         times = [0.0, 0.5, 1.0]
         C = QAtlas.fetch(
             TFIM(; J=J, h=h),
-            ZZCorrelation{:lightcone}(),
+            LightconeSpinCorrelation(:z, :z),
             OBC(; N=N);
             center=center,
             times=times,
@@ -87,7 +97,12 @@
         # Each entry should match an individual call.
         for (it, t) in enumerate(times), ix in 1:N
             ref = QAtlas.fetch(
-                TFIM(; J=J, h=h), ZZCorrelation{:dynamic}(), OBC(; N=N); i=ix, j=center, t=t
+                TFIM(; J=J, h=h),
+                DynamicalCorrelation(:z, :z),
+                OBC(; N=N);
+                i=ix,
+                j=center,
+                t=t,
             )
             @test C[it, ix] ≈ ref atol=1e-10
         end

--- a/test/models/quantum/TFIM/test_TFIM_dynamics_ordered.jl
+++ b/test/models/quantum/TFIM/test_TFIM_dynamics_ordered.jl
@@ -19,7 +19,7 @@ function mean_far(N::Int, J::Float64, h::Float64, i0::Int)
         s += real(
             QAtlas.fetch(
                 TFIM(; J=J, h=h),
-                ZZCorrelation{:dynamic}(),
+                DynamicalCorrelation(:z, :z),
                 OBC(; N=N);
                 i=i0,
                 j=i0 + r,

--- a/test/models/quantum/TFIM/test_TFIM_local.jl
+++ b/test/models/quantum/TFIM/test_TFIM_local.jl
@@ -59,7 +59,7 @@
         N, J, h, β = 8, 1.0, 1.2, 1.0
         ε_loc = QAtlas.fetch(TFIM(; J=J, h=h), EnergyLocal(), OBC(; N=N); beta=β)
         mx_loc = QAtlas.fetch(TFIM(; J=J, h=h), MagnetizationXLocal(), OBC(; N=N); beta=β)
-        C = QAtlas.fetch(TFIM(; J=J, h=h), ZZCorrelation{:static}(), OBC(; N=N); beta=β)
+        C = QAtlas.fetch(TFIM(; J=J, h=h), SpinCorrelation(:z, :z), OBC(; N=N); beta=β)
 
         # ε_i reconstructed from the Pfaffian nearest-neighbour correlator.
         ε_ref = Vector{Float64}(undef, N)

--- a/test/models/quantum/TFIM/test_TFIM_thermal.jl
+++ b/test/models/quantum/TFIM/test_TFIM_thermal.jl
@@ -88,7 +88,7 @@ end
             for r in 1:4
                 v_th = QAtlas.fetch(
                     TFIM(; J=1.0, h=h_phase),
-                    ZZCorrelation{:static}(),
+                    SpinCorrelation(:z, :z),
                     OBC(; N=10);
                     beta=Inf,
                     i=2,
@@ -97,7 +97,7 @@ end
                 v_gs = real(
                     QAtlas.fetch(
                         TFIM(; J=1.0, h=h_phase),
-                        ZZCorrelation{:dynamic}(),
+                        DynamicalCorrelation(:z, :z),
                         OBC(; N=10);
                         i=2,
                         j=2 + r,
@@ -224,7 +224,7 @@ end
                 op = _op_site(_SZ, i, N) * _op_site(_SZ, j, N)
                 ed_val = real(tr(ρ * op))
                 qa_val = QAtlas.fetch(
-                    TFIM(; J=J, h=h), ZZCorrelation{:static}(), OBC(; N=N); beta=β, i=i, j=j
+                    TFIM(; J=J, h=h), SpinCorrelation(:z, :z), OBC(; N=N); beta=β, i=i, j=j
                 )
                 @test qa_val ≈ ed_val atol=1e-10
             end

--- a/test/models/quantum/TFIM/test_TFIM_xx_static.jl
+++ b/test/models/quantum/TFIM/test_TFIM_xx_static.jl
@@ -3,8 +3,8 @@
 # (`src/models/quantum/TFIM/TFIM_xx_static.jl`).
 #
 # Layers:
-#   1. T = 0 self-consistency: the new `XXCorrelation{:static}` equals the
-#      real part of the existing `XXCorrelation{:dynamic}` evaluated at
+#   1. T = 0 self-consistency: the new `SpinCorrelation{:x,:x}` equals the
+#      real part of the existing `DynamicalCorrelation{(:x, :x)}` evaluated at
 #      `t = 0`.
 #   2. Boundary conditions of σˣ algebra:
 #        ⟨(σˣ_i)²⟩ = 1  (since (σˣ)² = I)  ⇒ static at i = j returns 1.
@@ -25,9 +25,11 @@ using QAtlas, Test, LinearAlgebra
         for h in (0.5, 1.0, 1.5), N in (8, 12)
             model = TFIM(; J=1.0, h=h)
             for i in 2:(N - 1), j in i:(N - 1)
-                v_static = QAtlas.fetch(model, XXCorrelation{:static}(), OBC(N); i=i, j=j)
+                v_static = QAtlas.fetch(model, SpinCorrelation(:x, :x), OBC(N); i=i, j=j)
                 v_dynamic_re = real(
-                    QAtlas.fetch(model, XXCorrelation{:dynamic}(), OBC(N); i=i, j=j, t=0.0)
+                    QAtlas.fetch(
+                        model, DynamicalCorrelation(:x, :x), OBC(N); i=i, j=j, t=0.0
+                    ),
                 )
                 @test v_static ≈ v_dynamic_re atol=1e-10
             end
@@ -37,7 +39,7 @@ using QAtlas, Test, LinearAlgebra
     @testset "i = j returns ⟨(σˣ)²⟩ = 1" begin
         for h in (0.5, 1.5), β in (Inf, 1.0)
             model = TFIM(; J=1.0, h=h)
-            v = QAtlas.fetch(model, XXCorrelation{:static}(), OBC(8); beta=β, i=4, j=4)
+            v = QAtlas.fetch(model, SpinCorrelation(:x, :x), OBC(8); beta=β, i=4, j=4)
             @test v ≈ 1.0 atol=1e-10
         end
     end
@@ -47,9 +49,9 @@ using QAtlas, Test, LinearAlgebra
         model = TFIM(; J=1.0, h=h)
         mx_local = QAtlas.fetch(model, MagnetizationXLocal(), OBC(N); beta=β)
         for i in 3:(N - 2), j in (i + 1):(N - 2)
-            v_st = QAtlas.fetch(model, XXCorrelation{:static}(), OBC(N); beta=β, i=i, j=j)
+            v_st = QAtlas.fetch(model, SpinCorrelation(:x, :x), OBC(N); beta=β, i=i, j=j)
             v_cn = QAtlas.fetch(
-                model, XXCorrelation{:connected}(), OBC(N); beta=β, i=i, j=j
+                model, ConnectedSpinCorrelation(:x, :x), OBC(N); beta=β, i=i, j=j
             )
             @test v_cn ≈ v_st - mx_local[i] * mx_local[j] atol=1e-10
         end
@@ -61,7 +63,7 @@ using QAtlas, Test, LinearAlgebra
         mx_local = QAtlas.fetch(model, MagnetizationXLocal(), OBC(N); beta=β)
         for i in 2:(N - 1)
             v_cn = QAtlas.fetch(
-                model, XXCorrelation{:connected}(), OBC(N); beta=β, i=i, j=i
+                model, ConnectedSpinCorrelation(:x, :x), OBC(N); beta=β, i=i, j=i
             )
             @test v_cn ≈ 1.0 - mx_local[i]^2 atol=1e-10
         end
@@ -85,7 +87,7 @@ using QAtlas, Test, LinearAlgebra
                 op = _op_site(_SX, i, N) * _op_site(_SX, j, N)
                 ed_val = real(tr(ρ * op))
                 qa_val = QAtlas.fetch(
-                    TFIM(; J=J, h=h), XXCorrelation{:static}(), OBC(N); beta=β, i=i, j=j
+                    TFIM(; J=J, h=h), SpinCorrelation(:x, :x), OBC(N); beta=β, i=i, j=j
                 )
                 @test qa_val ≈ ed_val atol=1e-10
             end
@@ -97,9 +99,9 @@ using QAtlas, Test, LinearAlgebra
         h, β, i, j = 0.7, 2.0, 40, 50
         model = TFIM(; J=1.0, h=h)
         v_inf = QAtlas.fetch(
-            model, XXCorrelation{:static}(), Infinite(); beta=β, i=i, j=j, N_proxy=80
+            model, SpinCorrelation(:x, :x), Infinite(); beta=β, i=i, j=j, N_proxy=80
         )
-        v_obc = QAtlas.fetch(model, XXCorrelation{:static}(), OBC(80); beta=β, i=i, j=j)
+        v_obc = QAtlas.fetch(model, SpinCorrelation(:x, :x), OBC(80); beta=β, i=i, j=j)
         @test v_inf == v_obc
     end
 end

--- a/test/models/quantum/TFIM/test_TFIM_yy.jl
+++ b/test/models/quantum/TFIM/test_TFIM_yy.jl
@@ -24,7 +24,7 @@ const _SY = ComplexF64[0 -im; im 0]
                     ed_val = real(tr(ρ * op))
                     qa_val = QAtlas.fetch(
                         TFIM(; J=1.0, h=h),
-                        YYCorrelation{:static}(),
+                        SpinCorrelation(:y, :y),
                         OBC(N);
                         beta=β,
                         i=i,
@@ -39,7 +39,7 @@ const _SY = ComplexF64[0 -im; im 0]
     @testset "i = j returns ⟨(σʸ)²⟩ = 1" begin
         for h in (0.5, 1.0, 1.5), β in (Inf, 1.0)
             v = QAtlas.fetch(
-                TFIM(; J=1.0, h=h), YYCorrelation{:static}(), OBC(8); beta=β, i=4, j=4
+                TFIM(; J=1.0, h=h), SpinCorrelation(:y, :y), OBC(8); beta=β, i=4, j=4
             )
             @test v ≈ 1.0 atol = 1e-12
         end
@@ -49,11 +49,11 @@ const _SY = ComplexF64[0 -im; im 0]
         for h in (0.5, 1.0, 1.5), β in (1.0, Inf)
             for i in 2:7, j in i:7
                 v_st = QAtlas.fetch(
-                    TFIM(; J=1.0, h=h), YYCorrelation{:static}(), OBC(8); beta=β, i=i, j=j
+                    TFIM(; J=1.0, h=h), SpinCorrelation(:y, :y), OBC(8); beta=β, i=i, j=j
                 )
                 v_cn = QAtlas.fetch(
                     TFIM(; J=1.0, h=h),
-                    YYCorrelation{:connected}(),
+                    ConnectedSpinCorrelation(:y, :y),
                     OBC(8);
                     beta=β,
                     i=i,
@@ -69,9 +69,9 @@ const _SY = ComplexF64[0 -im; im 0]
         model = TFIM(; J=1.0, h=h)
         for i in 2:(N - 1), j in i:(N - 1)
             c_dyn = QAtlas.fetch(
-                model, YYCorrelation{:dynamic}(), OBC(N); i=i, j=j, t=0.0, beta=β
+                model, DynamicalCorrelation(:y, :y), OBC(N); i=i, j=j, t=0.0, beta=β
             )
-            c_st = QAtlas.fetch(model, YYCorrelation{:static}(), OBC(N); i=i, j=j, beta=β)
+            c_st = QAtlas.fetch(model, SpinCorrelation(:y, :y), OBC(N); i=i, j=j, beta=β)
             @test imag(c_dyn) ≈ 0 atol = 1e-12
             @test real(c_dyn) ≈ c_st atol = 1e-10
         end
@@ -82,10 +82,10 @@ const _SY = ComplexF64[0 -im; im 0]
         model = TFIM(; J=1.0, h=h)
         for i in (3, 5), t in (0.4, 1.5)
             c_pos = QAtlas.fetch(
-                model, YYCorrelation{:dynamic}(), OBC(N); i=i, j=i, t=t, beta=β
+                model, DynamicalCorrelation(:y, :y), OBC(N); i=i, j=i, t=t, beta=β
             )
             c_neg = QAtlas.fetch(
-                model, YYCorrelation{:dynamic}(), OBC(N); i=i, j=i, t=(-t), beta=β
+                model, DynamicalCorrelation(:y, :y), OBC(N); i=i, j=i, t=(-t), beta=β
             )
             @test real(c_pos) ≈ real(c_neg) atol = 1e-10
             @test imag(c_pos) ≈ -imag(c_neg) atol = 1e-10

--- a/test/models/quantum/TFIM/test_TFIM_zaxis_closedform.jl
+++ b/test/models/quantum/TFIM/test_TFIM_zaxis_closedform.jl
@@ -53,13 +53,13 @@
     # ───────────────────────────────────────────────────────────────────────
     # Layer 3: ZZ connected correlator at OBC equals the static one (Z₂).
     # ───────────────────────────────────────────────────────────────────────
-    @testset "ZZCorrelation{:connected} = ZZCorrelation{:static} (Z₂)" begin
+    @testset "ConnectedSpinCorrelation{:z,:z} = SpinCorrelation{:z,:z} (Z₂)" begin
         for h in (0.5, 1.0, 1.5)
             for β in (Inf, 2.0, 0.5)
                 for r in 1:4
                     v_static = QAtlas.fetch(
                         TFIM(; J=1.0, h=h),
-                        ZZCorrelation{:static}(),
+                        SpinCorrelation(:z, :z),
                         OBC(; N=10);
                         beta=β,
                         i=2,
@@ -67,7 +67,7 @@
                     )
                     v_conn = QAtlas.fetch(
                         TFIM(; J=1.0, h=h),
-                        ZZCorrelation{:connected}(),
+                        ConnectedSpinCorrelation(:z, :z),
                         OBC(; N=10);
                         beta=β,
                         i=2,


### PR DESCRIPTION
## Proposed Changes

Complete migration of the **correlation family** (#734, 完全移行). QAtlas's `ZZ/XX/YYCorrelation{M}` were **parametric on a mode** `M ∈ {:static, :connected, :dynamic, :lightcone}` — one type, four distinct physical meanings. Split onto typed quantities:

| mode | → |
|---|---|
| `:static` | `SpinCorrelation{A,B}` (AbstractQAtlas) |
| `:connected` | `ConnectedSpinCorrelation{A,B}` (AbstractQAtlas #120 @ 0.3.31) |
| `:dynamic` | `DynamicalCorrelation{(A,B)}` (AbstractQAtlas — its n=1 retarded 2-point) |
| `:lightcone` | `LightconeSpinCorrelation{A,B}` — **new QAtlas-side** type (matrix-valued diagnostic, kept out of AbstractQAtlas's scalar vocabulary) |

- `ZZ/XX/YYCorrelation` are parametric so cannot be `const`-aliased → they become **deprecated constructor functions** mapping the old `mode` kwarg onto the new types; `ZZCorrelation(; mode=:dynamic)` still works, dispatch on `ZZCorrelation{:m}` is removed.
- ~26 fetch methods (incl. `@eval` generators), all 6 registry files, `axes.jl` (`dynamical_axis`/`component`), legacy shims, `INVENTORY.jsonl`, and 12 test files migrated. Registered type-set **==** dispatched type-set (verified).
- `version` 0.26.0 → **0.27.0**; `[compat]` `AbstractQAtlas = "0.3.31"`.

## Usage or Results

**Breaking**: `fetch(m, ZZCorrelation(mode=:X), …)` still works (deprecated constructor returns the mapped type); `::ZZCorrelation{:X}` dispatch / `ZZCorrelation{:X}()` construction are removed → use the target types. Verified: no fused dispatch/structs remain, format-clean, INVENTORY drift-guard consistent (2806 cards).

Part of #734. Next: the local/quench/mode cluster.