### PR TITLE
feat: delegate the :gibbs identity's arithmetic to AbstractQAtlas (#734 Phase B)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.28.1"
+version = "0.28.2"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.28.0"
+version = "0.28.1"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -46,7 +46,11 @@ using AbstractQAtlas:
     DynamicalSpinStructureFactor,
     SpinCorrelation,
     ConnectedSpinCorrelation,
-    DynamicalCorrelation
+    DynamicalCorrelation,
+    # Relations layer (#734 Phase B): the universal identities themselves, so an
+    # @identity edge can delegate its arithmetic instead of restating it.
+    FreeEnergyLegendre,
+    solve
 # `native_energy_granularity` is extended by bare `native_energy_granularity(::M, ::BC) = …`
 # methods in model files, which `using` forbids ("must be explicitly imported to be
 # extended"); it must therefore come in via `import` (#734).

--- a/src/identity_registry.jl
+++ b/src/identity_registry.jl
@@ -40,10 +40,20 @@
 # statement of the SAME finite system, exact at every N, so small N loses no
 # coverage — while N=8 put the spin-1 hubs at 3^8 = 6561-dimensional dense ED
 # per fetch and made the generated suite CI's long pole (52 min → seconds).
+# The ARITHMETIC is not restated here: it is AbstractQAtlas's `FreeEnergyLegendre`
+# (`F - (U - S/β)`, relations/fundamental.jl), and this edge asks it to derive `f`
+# from the hub's own `e` and `s`.  That makes the generated check the conformance
+# statement the split was for (#734): QAtlas's fetched FreeEnergy must equal what
+# the universal relation implies from QAtlas's fetched Energy and ThermalEntropy.
+# `solve` is generic over any variable the relation is affine in, so there is no
+# QAtlas-side rearrangement to drift out of sync.  Both sides stay physical
+# numbers (fetched f vs derived f), keeping failures diagnosable — a residual-vs-0
+# pair would not.  Granularity: the relation is type-keyed per-site, matching the
+# `Energy{:per_site}` participant below.
 @identity(
     :gibbs,
     quantities = (e=Energy{:per_site}, f=FreeEnergy, s=ThermalEntropy),
-    check = (v, p) -> (v.e, v.f + v.s / p.beta),
+    check = (v, p) -> (v.f, solve(FreeEnergyLegendre(), Val(:F); U=v.e, S=v.s, β=p.beta)),
     sweep = (beta=[0.5, 1.0, 2.0],),
     finite_N = 6,
     exclusions = [

--- a/test/generated/test_identity_gibbs.jl
+++ b/test/generated/test_identity_gibbs.jl
@@ -28,3 +28,22 @@ using QAtlas: generated_checks
 
     run_generated_suite(checks; label="generated gibbs checks")
 end
+
+# The edge no longer restates `f = ε − T·s`; it asks AbstractQAtlas's
+# `FreeEnergyLegendre` to derive `f` (#734 Phase B).  Pin that delegation against
+# the closed form it replaced, so an upstream convention change — sign, per-site
+# granularity, β-vs-T — fails HERE with a two-line diff instead of silently
+# redefining what ":gibbs" asserts for every hub in the atlas.
+@testset ":gibbs arithmetic is AbstractQAtlas's FreeEnergyLegendre" begin
+    for (e, s, beta) in ((-1.3, 0.42, 0.5), (-0.75, 0.1, 2.0), (0.0, 0.0, 1.0))
+        f_closed = e - s / beta   # the formula this edge used to carry inline
+        f_derived = QAtlas.solve(QAtlas.FreeEnergyLegendre(), Val(:F); U=e, S=s, β=beta)
+        @test f_derived ≈ f_closed atol = 1e-14
+    end
+    # β-or-T keyword convention must agree (T = 2 ⇔ β = 0.5).
+    @test QAtlas.solve(QAtlas.FreeEnergyLegendre(), Val(:F); U=-1.3, S=0.42, T=2.0) ≈
+        QAtlas.solve(QAtlas.FreeEnergyLegendre(), Val(:F); U=-1.3, S=0.42, β=0.5)
+    # Exact inputs stay exact — the relation is algebraic, not floating-point.
+    @test QAtlas.solve(QAtlas.FreeEnergyLegendre(), Val(:F); U=-1//2, S=1//4, β=1//2) ==
+        -1//2 - (1//4) / (1//2)
+end


### PR DESCRIPTION
## Proposed Changes

The `:gibbs` edge restated `f = ε − T·s` inline. AbstractQAtlas already owns that statement as **`FreeEnergyLegendre`** (`F − (U − S/β)`, `relations/fundamental.jl`), so QAtlas was carrying a second copy of a universal law it already depends on.

```julia
# before
check = (v, p) -> (v.e, v.f + v.s / p.beta)
# after
check = (v, p) -> (v.f, solve(FreeEnergyLegendre(), Val(:F); U=v.e, S=v.s, β=p.beta))
```

That turns every generated Gibbs check into the conformance statement the AbstractQAtlas split was for: **QAtlas's fetched `FreeEnergy` must equal what the universal relation implies from QAtlas's own fetched `Energy` and `ThermalEntropy`.**

Shape notes:

- Both sides stay **physical numbers** (fetched `f` vs derived `f`). A residual-vs-0 pair would be shorter but breaks `identity.jl`'s stated contract that `check` returns both sides so failures stay diagnosable.
- **No rearrangement is written here.** `solve` is generic over any variable the relation is affine in (three probes + a parabola test that *verifies* affinity), so there is no QAtlas-side algebra that can drift from ABQ's.
- Granularity lines up — the relation is type-keyed per-site, the participant is already `Energy{:per_site}`.
- No name collision: QAtlas has `solve_klumper_nlie` and friends, but no bare `solve`.

The harness stays QAtlas's: `sweep`, `finite_N`, the 7 per-model `exclusions`, and the isotropy edges' family expansion are untouched. **Only the arithmetic moved.**

## Usage or Results

Verified locally:

```
generated gibbs checks: 45 pass / 9 declared-skip / 0 fail / 0 error / 54 emitted
```

across TFIM, XXZ1D and the rest. Added a testset pinning the delegation against the closed form it replaced (sign, per-site granularity, β-vs-T convention, exact-rational input stays exact), so an upstream convention change fails *there* rather than silently redefining what `:gibbs` asserts atlas-wide.

`version` 0.28.0 → **0.28.1** (behaviour-preserving refactor → patch).

### Scope note

This is the **whole** of Phase B's math migration. `src/identity_registry.jl` declares exactly three `@identity` edges; the other two (`:su2_susceptibility_isotropy`, `:su2_magnetization_isotropy`) are family-level *symmetry* statements gated on the model's `@symmetry` profile — no AbstractQAtlas analogue, and the model-graph layer is QAtlas's by design, so they stay. Phase B was scoped as "the real design work"; measured against the source it is one identity, and its counterpart already existed upstream.

Part of #734.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
