### PR TITLE
feat: @bound — inequality constraint edges over AbstractQAtlas's @inequality

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.28.3"
+version = "0.28.4"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -57,6 +57,14 @@ using AbstractQAtlas:
     # carrier quantities ABQ kept.
     @relation,
     @inequality,
+    # ...and the inequality verbs, so a BOUND edge (core/bound.jl) can delegate
+    # its criterion to AbstractQAtlas exactly as :gibbs delegates its arithmetic.
+    AbstractInequality,
+    slack,
+    variable_slots,
+    # the inequalities bound_registry.jl declares edges for
+    SpecificHeatPositivity,
+    SusceptibilityPositivity,
     CarrierDensity,
     EffectiveMass,
     HallCoefficient,
@@ -167,7 +175,8 @@ include("core/about.jl")     # model description cards (summary + Hamiltonian)
 # generated-check protocol), then each edge type as a thin instantiation.
 include("core/constraints.jl")  # kernel: EDGE_STORES + GeneratedCheck protocol
 include("core/symmetry.jl")     # @symmetry node attributes + LSM checks (C10)
-include("core/identity.jl")     # @identity quantity<->quantity edges (C11)
+include("core/identity.jl")      # @identity quantity<->quantity edges (C11)
+include("core/bound.jl")         # @bound: the inequality sibling (#734 Phase B)
 include("core/duality.jl")      # @dual model<->model parameter-mapped edges (C12)
 include("core/limits.jl")       # @limits_to asymptotic limit edges (C13)
 include("core/pfaffian.jl")
@@ -219,6 +228,7 @@ export ChargeGap, SpinGap                                # Hubbard / correlated-
 export ThermalEntropy, VonNeumannEntropy, RenyiEntropy
 export ThermalEntropy, VonNeumannEntropy, RenyiEntropy, ResidualEntropy
 export EdwardsAndersonParameter, SpinGlassSusceptibility  # spin-glass order (#730)
+export BoundEdge, BOUNDS, bound!, @bound  # inequality edges (core/bound.jl)
 export QuenchEntanglementEntropy  # QAtlas-side post-quench S(ℓ,t) (was VonNeumannEntropy{:quench})
 export Magnetization  # axis-parametric (AbstractQAtlas); MagnetizationX/Y/Z are deprecated aliases
 export MagnetizationX, MagnetizationY, MagnetizationZ
@@ -517,6 +527,7 @@ include("reduces_registry.jl")
 # and quantity types; the identity family validation reads REGISTRY).
 include("symmetry_registry.jl")
 include("identity_registry.jl")
+include("bound_registry.jl")            # @bound inequality edges (#734 Phase B)
 include("relations/model_specific.jl")   # #730: model-specific relations, hosted here
 include("duality_registry.jl")
 include("limits_registry.jl")

--- a/src/bound_registry.jl
+++ b/src/bound_registry.jl
@@ -1,0 +1,60 @@
+# bound_registry.jl — declared BOUND edges (core/bound.jl), the inequality
+# sibling of identity_registry.jl.
+#
+# Each names an AbstractQAtlas `@inequality` and lets the generator materialize
+# it on every hub that implements the participants.  Nothing here restates the
+# criterion: the slack, its sign convention, and the physics all live upstream.
+#
+# WHY THESE FIRST.  Of AbstractQAtlas's 129 relations, 93 are type-keyed and 22
+# are reachable on some QAtlas hub — but only three of those need nothing beyond
+# what `fetch` already returns.  One is `FreeEnergyLegendre`, already covered by
+# the `:gibbs` identity.  The other two are these, and neither was checked
+# anywhere in the atlas before.  The rest of the reachable set waits on a
+# supplier for a derived input (`var_E`, `dS_dT`, the region entropies
+# `S_A`/`S_AB`/…), which is the same gap identity_registry.jl's deletion
+# criterion already names for the derivative-form identities.
+#
+# These are STABILITY bounds, and they fail differently from an equality: a
+# sign error, a bad analytic continuation, or a mis-normalized thermal state
+# shows up here even when two equally-wrong quantities would still satisfy an
+# identity between themselves.
+
+# ── C_v ≥ 0 ───────────────────────────────────────────────────────────
+# Thermodynamic stability: the specific heat is a variance (β²·Var(E)) and so
+# cannot be negative for any equilibrium state at any β.  Exact at every N, so
+# a small finite_N loses no coverage — same argument as :gibbs.
+@bound(
+    :specific_heat_positivity,
+    inequality = SpecificHeatPositivity,
+    sweep = (beta=[0.5, 1.0, 2.0],),
+    finite_N = 6,
+    exclusions = [
+        # 2D fetches take Lx/Ly rather than bc.N — the generator's finite-N
+        # materialization is 1D-only (same gap :gibbs records).
+        (IsingSquare, PBC) => "2D PBC fetches take Lx/Ly kwargs, not bc.N — generator finite-size materialization is 1D-only",
+        (KitaevHoneycomb, OBC) => "2D OBC fetches take Lx/Ly kwargs, not bc.N — generator finite-size materialization is 1D-only",
+        # Physics-of-the-branch / validity-range gaps, all self-declared by the
+        # fetch itself (it errors or warns and returns NaN rather than lying).
+        IsingTriangular => "default J > 0 is the frustrated AFM branch (no Houtappel closed form); finite-T requires J < 0",
+        AKLT1D => "finite-β canonical thermodynamics supports β = ∞ only (HTSE is a separate :approx scheme, #506)",
+        Heisenberg1D => "SpecificHeat at Infinite is a c=1 CFT low-T expansion valid only for β > 5/J; it warns and returns NaN on this sweep (#521 Path A will replace it)",
+        HaldaneShastry => "SpecificHeat at Infinite returns NaN outside its low-T validity window, same CFT-expansion guard as Heisenberg1D",
+    ],
+    notes = "C_v = β² Var(E) ≥ 0 — thermodynamic stability; holds at every N and β.",
+)
+
+# ── χ_T ≥ 0 ───────────────────────────────────────────────────────────
+# The isothermal susceptibility is likewise a variance (β·Var(M)), so it is
+# non-negative for every axis pair.  `SusceptibilityPositivity` types its slot
+# as the parametric FAMILY `Susceptibility`, so the generator expands it to one
+# check per concrete axis pair the hub implements.
+@bound(
+    :susceptibility_positivity,
+    inequality = SusceptibilityPositivity,
+    sweep = (beta=[0.5, 1.0],),
+    finite_N = 6,
+    exclusions = [
+        AKLT1D => "finite-β canonical thermodynamics supports β = ∞ only (HTSE is a separate :approx scheme, #506)",
+    ],
+    notes = "χ_αα = β Var(M_α) ≥ 0 for every axis pair — thermodynamic stability.",
+)

--- a/src/core/bound.jl
+++ b/src/core/bound.jl
@@ -1,0 +1,242 @@
+# core/bound.jl — quantity BOUND edges: the inequality sibling of core/identity.jl.
+#
+# An identity edge says N quantities must satisfy an exact equality.  A bound
+# edge says a quantity (or a tuple of them) must satisfy an INEQUALITY that no
+# implementation may violate: `C_v ≥ 0`, `χ_T ≥ 0`, entropy non-negativity, …
+# Physically these are stability and information-theoretic bounds, and they are
+# exactly the checks that catch a sign error, a bad analytic continuation, or a
+# thermal-state normalization mistake — failures an equality identity between
+# two equally-wrong quantities can miss.
+#
+# WHERE THE MATH LIVES.  Nowhere here.  AbstractQAtlas already states these as
+# `@inequality` relations with a `slack` verb whose sign IS the criterion, so a
+# bound edge names the AbstractQAtlas inequality and QAtlas supplies only the
+# values and the harness — the same split #734 Phase B established for `:gibbs`,
+# where the arithmetic moved to `FreeEnergyLegendre` and the sweep / finite_N /
+# exclusions stayed here.  The participants are DERIVED from the inequality's
+# typed slots (`variable_slots`), so a bound edge cannot drift from the relation
+# it claims to check: there is no second copy of the participant list to update.
+#
+# FAMILY SLOTS.  AbstractQAtlas types some slots as a parametric FAMILY rather
+# than a concrete leaf (`SusceptibilityPositivity(χT::Susceptibility)` covers
+# every axis pair).  Its own bag matching cannot bind those (its C4 note calls
+# such a relation permanently dead there), but a generator that fetches by
+# concrete type can: a family slot expands to one check per concrete member the
+# hub actually implements, the same way `IsotropyIdentityEdge` walks a family.
+# That is why these bounds are usable from here even though they are inert
+# upstream.
+
+"""
+    BoundEdge
+
+A one-sided constraint on a hub's fetched values: `slack(inequality; …) ≥ 0`.
+
+Fields mirror [`TupleIdentityEdge`](@ref) — `name`, `sweep` (fetch-kwargs grid),
+`finite_N` (OBC/PBC hub size), `atol`, `exclusions` (`Model` / `(Model, BC) =>
+reason`, emitted as visible `:skip` checks), `notes`, `references` — plus:
+
+- `inequality` — the AbstractQAtlas `AbstractInequality` instance that owns the
+  statement and computes the slack.
+- `quantities` — slot name => quantity type, **derived** from the inequality's
+  typed slots, not restated by the caller.
+
+Only `atol` is meaningful (no `rtol`): the criterion is `slack ≥ -atol`, a
+one-sided test against zero, where a relative tolerance has no reference scale.
+"""
+struct BoundEdge
+    name::Symbol
+    inequality::AbstractInequality
+    quantities::NamedTuple
+    sweep::NamedTuple
+    finite_N::Int
+    atol::Float64
+    exclusions::Vector{Pair{Any,String}}
+    notes::String
+    references::Vector{String}
+end
+
+"""
+    BOUNDS :: Vector{BoundEdge}
+
+Every declared bound edge, in declaration order.
+"""
+const BOUNDS = BoundEdge[]
+
+"""
+    bound!(name; inequality, sweep, finite_N, atol, exclusions, notes, references)
+
+Declare a bound edge.  `inequality` is an AbstractQAtlas `AbstractInequality`
+type or instance; its typed slots become the participants.
+
+Rejected at declaration time, loudly, because each would otherwise degrade into
+a silently-useless check:
+
+- a duplicate `name`;
+- a negative `atol`;
+- an inequality with **no** typed slots (nothing to fetch — it could never be
+  materialized on a hub);
+- an inequality with any **untyped** slot (a derived input such as `var_E` or
+  `S_AB` that the generator cannot obtain from `fetch`).  Those relations are
+  real and worth covering, but they need a supplier, not a silent skip.
+"""
+function bound!(
+    name::Symbol;
+    inequality,
+    sweep::NamedTuple=NamedTuple(),
+    finite_N::Int=8,
+    atol::Real=1e-10,
+    exclusions::AbstractVector=Pair{Any,String}[],
+    notes::AbstractString="",
+    references::AbstractVector{<:AbstractString}=String[],
+)
+    any(e -> e.name === name, BOUNDS) &&
+        throw(ArgumentError("bound!: :$(name) already declared"))
+    atol ≥ 0 || throw(ArgumentError("bound!: atol must be ≥ 0; got $(atol)"))
+    ineq = inequality isa Type ? inequality() : inequality
+    ineq isa AbstractInequality || throw(
+        ArgumentError(
+            "bound!: :$(name) — `inequality` must be an AbstractQAtlas " *
+            "AbstractInequality; got $(typeof(ineq))",
+        ),
+    )
+    slots = variable_slots(ineq)
+    # `variable_slots` yields (name, type-or-nothing) pairs directly — do NOT wrap
+    # it in `pairs()`, which would re-key them by integer index.
+    typed = [(n, T) for (n, T) in slots if T !== nothing]
+    untyped = [n for (n, T) in slots if T === nothing]
+    isempty(typed) && throw(
+        ArgumentError(
+            "bound!: :$(name) — $(nameof(typeof(ineq))) has no type-keyed slot, so " *
+            "there is nothing to fetch; it cannot be materialized on a hub",
+        ),
+    )
+    isempty(untyped) || throw(
+        ArgumentError(
+            "bound!: :$(name) — $(nameof(typeof(ineq))) needs the untyped slot(s) " *
+            "$(untyped), which the generator cannot obtain from `fetch`. Supply " *
+            "them via a dedicated edge rather than declaring a bound that would " *
+            "never run.",
+        ),
+    )
+    qs = NamedTuple{Tuple(first.(typed))}(Tuple(last.(typed)))
+    push!(
+        BOUNDS,
+        BoundEdge(
+            name,
+            ineq,
+            qs,
+            sweep,
+            finite_N,
+            Float64(atol),
+            Pair{Any,String}[p for p in exclusions],
+            String(notes),
+            String[r for r in references],
+        ),
+    )
+    return nothing
+end
+
+"""
+    @bound(:name, inequality = SomeInequality, sweep = (...,), ...)
+
+Keyword-macro front end for [`bound!`](@ref), matching [`@identity`](@ref)'s
+call shape so the two read alike at the declaration site.
+"""
+macro bound(name, kwargs...)
+    kws = [esc(k) for k in kwargs]
+    return :(bound!($(esc(name)); $(kws...)))
+end
+
+# ──────────────────────────────────────────────────────────────────────
+# Generator — the :bound kind of generated_checks()
+# ──────────────────────────────────────────────────────────────────────
+
+"""
+    _bound_outcome(slack; atol, detail="") -> CheckOutcome
+
+One-sided pass criterion: `slack ≥ -atol`.  Reported as `lhs = slack`,
+`rhs = 0`, so the recorded `abs_err` is the VIOLATION magnitude (zero for any
+satisfied bound, however slack), not a distance from a target — a bound that
+passes with room to spare is not "less accurate".
+"""
+function _bound_outcome(slack::Real; atol::Real, detail::String="")
+    s = Float64(slack)
+    status = s ≥ -atol ? :pass : :fail
+    violation = status === :pass ? 0.0 : abs(s)
+    return CheckOutcome(status, s, 0.0, violation, violation, detail)
+end
+
+# A family slot (`Susceptibility`) stands for every concrete member; a concrete
+# slot stands for itself.  Returns the per-slot candidate lists, in a
+# deterministic order, so the generated ids are stable across runs.
+function _bound_slot_candidates(e::BoundEdge)
+    return map(values(e.quantities)) do Q
+        return isconcretetype(Q) ? Type[Q] : sort!(_family_members(Q); by=string)
+    end
+end
+
+function bound_checks()
+    out = GeneratedCheck[]
+    for e in BOUNDS
+        names = keys(e.quantities)
+        for combo in Iterators.product(_bound_slot_candidates(e)...)
+            qtypes = collect(combo)
+            for hub in _implemented_hubs(qtypes)
+                tag =
+                    length(qtypes) == 1 ? _kgshort(qtypes[1]) : join(_kgshort.(qtypes), "-")
+                hub_id = string(
+                    "bound/",
+                    e.name,
+                    "/",
+                    _kgshort(hub.model),
+                    "/",
+                    _kgshort(hub.bc),
+                    "/",
+                    tag,
+                )
+                reason = _exclusion_reason(e, hub.model, hub.bc)
+                if reason !== nothing
+                    _push_excluded_check!(out, :bound, hub_id, reason)
+                    continue
+                end
+                for point in _sweep_points(e.sweep)
+                    id = hub_id * _point_suffix(point)
+                    model_T, bc_T, ineq = hub.model, hub.bc, e.inequality
+                    runner = function ()
+                        m = model_T()
+                        bc = _bc_instance(bc_T; finite_N=e.finite_N)
+                        vals = NamedTuple{names}(
+                            map(Q -> fetch(m, _quantity_instance(Q), bc; point...), qtypes),
+                        )
+                        return _bound_outcome(slack(ineq; vals...); atol=e.atol)
+                    end
+                    push!(
+                        out,
+                        GeneratedCheck(
+                            :bound,
+                            id,
+                            string(
+                                "bound :",
+                                e.name,
+                                " (",
+                                nameof(typeof(ineq)),
+                                ") on ",
+                                _kgshort(model_T),
+                                " at ",
+                                _kgshort(bc_T),
+                                " for ",
+                                tag,
+                                isempty(keys(point)) ? "" : " ($(point))",
+                            ),
+                            runner,
+                        ),
+                    )
+                end
+            end
+        end
+    end
+    return out
+end
+
+register_check_generator!(:bound, bound_checks)
+register_edge_store!(:bound, BOUNDS; location_of=e -> "bound :$(e.name)")

--- a/src/core/identity.jl
+++ b/src/core/identity.jl
@@ -221,7 +221,9 @@ end
 
 # The declared skip reason for a hub, if any: an exclusion keyed by the model
 # type covers every bc; a (model, bc) tuple covers that hub only.
-function _exclusion_reason(e::AbstractIdentityEdge, model_T::Type, bc_T::Type)
+# Untyped in `e`: this reads only `.exclusions`, so it serves the bound edges of
+# core/bound.jl as well — the exclusion vocabulary is shared, not identity-specific.
+function _exclusion_reason(e, model_T::Type, bc_T::Type)
     for (k, reason) in e.exclusions
         if k === model_T || (k isa Tuple && k[1] === model_T && k[2] === bc_T)
             return reason

--- a/test/core/test_constraints.jl
+++ b/test/core/test_constraints.jl
@@ -312,7 +312,9 @@ end
     @test !isempty(checks)
     @test issorted([c.id for c in checks])
     @test allunique(c.id for c in checks)
-    @test all(c.kind in (:identity, :dual, :limit, :symmetry) for c in checks)
+    # Closed vocabulary on purpose: a new edge type must be declared here, so it
+    # cannot start emitting checks unnoticed.  `:bound` joined in #734 Phase B.
+    @test all(c.kind in (:identity, :dual, :limit, :symmetry, :bound) for c in checks)
     # kind selection
     only_ids = generated_checks(; kinds=(:identity,))
     @test all(c -> c.kind === :identity, only_ids)

--- a/test/generated/test_bound_checks.jl
+++ b/test/generated/test_bound_checks.jl
@@ -1,0 +1,64 @@
+# Generated BOUND checks (#734 Phase B) — the inequality slice of the
+# generated-check protocol, materialized from the @bound edges of
+# src/bound_registry.jl.
+#
+# These are one-sided: `slack(inequality) ≥ -atol`, with the criterion and the
+# arithmetic owned by AbstractQAtlas.  Unlike an identity, a bound catches a
+# failure that two equally-wrong quantities could hide from each other — a sign
+# error, a bad analytic continuation, a mis-normalized thermal state.
+
+include("util_run_checks.jl")
+using QAtlas: generated_checks, BOUNDS
+
+@testset "generated bound checks" begin
+    checks = generated_checks(; kinds=(:bound,))
+    @test !isempty(checks)
+
+    ids = [c.id for c in checks]
+    # Both shipped bounds materialize, and on more than one model each — the
+    # "a new model gets constraint coverage for free" property, same as the
+    # identity slice.
+    @test any(startswith("bound/specific_heat_positivity/"), ids)
+    @test any(startswith("bound/susceptibility_positivity/"), ids)
+    @test any(startswith("bound/specific_heat_positivity/TFIM/"), ids)
+
+    # The susceptibility bound's slot is the parametric FAMILY `Susceptibility`,
+    # so the generator must have expanded it to concrete axis pairs rather than
+    # emitting one dead check against the UnionAll.
+    chi = filter(startswith("bound/susceptibility_positivity/"), ids)
+    @test !isempty(chi)
+    @test all(id -> occursin("Susceptibility{", id), chi)
+
+    # Ids are the sharding/reporting key: they must be unique and stable.
+    @test length(unique(ids)) == length(ids)
+
+    run_generated_suite(checks; label="generated bound checks")
+end
+
+@testset "bound edges derive their participants from the inequality" begin
+    @test !isempty(BOUNDS)
+    for e in BOUNDS
+        # Nothing restates the participant list: it comes from the relation's
+        # typed slots, so it cannot drift from what `slack` actually consumes.
+        @test !isempty(e.quantities)
+        @test Set(keys(e.quantities)) ⊆ Set(QAtlas.variable_slots(e.inequality) .|> first)
+        @test e.atol ≥ 0
+    end
+end
+
+@testset "bound! rejects inequalities it could never materialize" begin
+    # An untyped slot is a derived input (`var_E`, `S_AB`, …) the generator
+    # cannot obtain from `fetch`.  Declaring such a bound would produce a check
+    # that silently never runs, so it must fail loudly at declaration instead.
+    @test_throws ArgumentError QAtlas.bound!(
+        :_probe_untyped_slot; inequality=QAtlas.AbstractQAtlas.EntropyNonNegativity
+    )
+    # Duplicate names would collide the generated ids.
+    @test_throws ArgumentError QAtlas.bound!(
+        :specific_heat_positivity; inequality=QAtlas.SpecificHeatPositivity
+    )
+    # A negative tolerance is meaningless for a one-sided test.
+    @test_throws ArgumentError QAtlas.bound!(
+        :_probe_bad_atol; inequality=QAtlas.SpecificHeatPositivity, atol=-1.0
+    )
+end


### PR DESCRIPTION
## Proposed Changes

`@identity` says N quantities must satisfy an exact **equality**. Nothing said a quantity must satisfy an **inequality** — so the atlas had no `C_v ≥ 0` and no `χ ≥ 0` anywhere, even though AbstractQAtlas already states both and QAtlas implements the participants on 20 hubs.

`@bound` closes that on the split #734 Phase B established for `:gibbs` (#753): the inequality, its slack and its sign convention are **AbstractQAtlas's**; QAtlas supplies the **values and the harness** (`sweep` / `finite_N` / `exclusions`), reusing the existing generator protocol.

```julia
@bound(
    :specific_heat_positivity,
    inequality = SpecificHeatPositivity,
    sweep = (beta=[0.5, 1.0, 2.0],),
    finite_N = 6,
    exclusions = [...],
)
```

### Three design points worth the review

1. **Participants are derived, not declared.** `bound!` reads the relation's typed slots via `variable_slots`, so a bound edge *cannot* drift from what `slack` actually consumes — there is no second copy of the participant list. Same reason `:gibbs` stopped restating `f = ε − T·s`.
2. **Family slots expand.** `SusceptibilityPositivity` types its slot as the parametric family `Susceptibility`. AbstractQAtlas's own bag matching cannot bind that (its C4 note calls such a relation *permanently dead* there) — but a generator that fetches by concrete type can, so the family expands to one check per axis pair the hub implements. **A relation inert upstream is live here**; the asymmetry is documented at the top of `core/bound.jl`.
3. **Loud refusals.** `bound!` rejects an inequality with no typed slot, or with any *untyped* slot — a derived input (`var_E`, `S_AB`, `dS_dT`) the generator cannot fetch. Those bounds are real and worth covering, but they need a supplier, not a check that silently never runs. Covered by a negative test against `EntropyNonNegativity(S)`.

## Usage or Results

```
generated bound checks: 97 pass / 11 declared-skip / 0 fail / 0 error / 108 emitted
```

over **20 hubs** — checks that did not exist before, with no new physics and no vocabulary migration.

The 11 skips carry reasons and mirror `:gibbs`'s own exclusions (2D fetches taking `Lx`/`Ly`, `IsingTriangular`'s frustrated `J > 0` branch, `AKLT1D`'s `β = ∞`-only thermodynamics), plus two hubs whose `SpecificHeat` at `Infinite` is a c=1 CFT low-T expansion that **warns and returns `NaN`** outside `β > 5/J` — honest guards, not bugs, and recorded as such rather than papered over.

Verified by running the file under `Pkg.test`, not just `--project=.`.

`version` → **0.28.4** (additive → patch).

### Why these two bounds first

Of AbstractQAtlas's 129 relations, 93 are type-keyed and 22 are reachable on some QAtlas hub — but only three need nothing beyond what `fetch` already returns. One is `FreeEnergyLegendre`, already covered by `:gibbs`. **The other two are these, and neither was checked anywhere.** The rest of the reachable set waits on a supplier for a derived input, which is the same gap `identity_registry.jl`'s deletion criterion already names for the derivative-form identities.

Sweep points stay **fixed** here. Randomizing them is #755, and it belongs on `push:main` only with the seed recorded — otherwise PR CI turns flaky.

> **Stacked on #754** (base `main`, deliberately not the parent branch, so an auto-merge that deletes the parent cannot irrecoverably close this). Until #754 merges, this diff also shows its commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
