### PR TITLE
feat: derived-input suppliers via AD package extensions (ForwardDiff, Zygote)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.28.4"
+version = "0.28.5"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]
@@ -10,10 +10,19 @@ PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
+[weakdeps]
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+
+[extensions]
+QAtlasForwardDiffExt = "ForwardDiff"
+QAtlasZygoteExt = "Zygote"
+
 [compat]
 AbstractQAtlas = "0.3.31"
 Aqua = "0.8"
 ForwardDiff = "0.10, 1"
+Zygote = "0.6, 0.7"
 KrylovKit = "0.8, 0.9, 0.10"
 Lattice2D = "0.2.8, 0.3, 0.4"
 LatticeCore = "0.8, 0.10, 0.12"

--- a/ext/QAtlasForwardDiffExt.jl
+++ b/ext/QAtlasForwardDiffExt.jl
@@ -1,0 +1,19 @@
+# Forward-mode AD backend for QAtlas's derived inputs (core/derivative.jl).
+#
+# Loading ForwardDiff is all it takes to upgrade every derivative-supplied
+# constraint edge from the finite-difference fallback to machine precision —
+# and, via `default_rtol`, to the tighter tolerance that accuracy earns.
+#
+# Forward mode is the right mode here: the derived inputs are scalar → scalar
+# (`dF/dT`, `dβF/dβ`, `dM/dh`), and it needs nothing from a `fetch` beyond
+# being generic in its argument type, which 273 of the 304 `beta::` annotations
+# in src/ already are.
+module QAtlasForwardDiffExt
+
+using QAtlas: QAtlas, ForwardDiffBackend
+using ForwardDiff: ForwardDiff
+
+QAtlas.derivative(::ForwardDiffBackend, f, x::Real) = ForwardDiff.derivative(f, float(x))
+QAtlas.backend_available(::ForwardDiffBackend) = true
+
+end

--- a/ext/QAtlasZygoteExt.jl
+++ b/ext/QAtlasZygoteExt.jl
@@ -1,0 +1,29 @@
+# Reverse-mode AD backend for QAtlas's derived inputs (core/derivative.jl).
+#
+# Provided for cross-checking a ForwardDiff result with an independent
+# differentiation mode — the same "two routes must agree" discipline the atlas
+# applies to physical values.
+#
+# Expect a lower success rate than ForwardDiff on this atlas: reverse mode
+# needs an adjoint for everything it traverses (dense ED, quadrature, the NLIE
+# Newton solves), and for a scalar → scalar derivative it buys nothing that
+# forward mode does not already give.  `preferred_backend` therefore ranks it
+# BELOW ForwardDiff; a hub where Zygote throws is a Zygote coverage gap, not a
+# physics finding.
+module QAtlasZygoteExt
+
+using QAtlas: QAtlas, ZygoteBackend
+using Zygote: Zygote
+
+function QAtlas.derivative(::ZygoteBackend, f, x::Real)
+    g = only(Zygote.gradient(f, float(x)))
+    g === nothing && error(
+        "QAtlas.derivative(ZygoteBackend, …): Zygote returned no gradient at x = $x — " *
+        "the fetch is not reverse-differentiable (no adjoint along its path). Use " *
+        "ForwardDiffBackend() or FiniteDifference() for this hub.",
+    )
+    return g
+end
+QAtlas.backend_available(::ZygoteBackend) = true
+
+end

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -174,6 +174,7 @@ include("core/about.jl")     # model description cards (summary + Hamiltonian)
 # Constraint-edge layer (#697): one shared kernel (store registration +
 # generated-check protocol), then each edge type as a thin instantiation.
 include("core/constraints.jl")  # kernel: EDGE_STORES + GeneratedCheck protocol
+include("core/derivative.jl")    # derived-input suppliers (AD via ext, FD fallback)
 include("core/symmetry.jl")     # @symmetry node attributes + LSM checks (C10)
 include("core/identity.jl")      # @identity quantity<->quantity edges (C11)
 include("core/bound.jl")         # @bound: the inequality sibling (#734 Phase B)
@@ -229,6 +230,10 @@ export ThermalEntropy, VonNeumannEntropy, RenyiEntropy
 export ThermalEntropy, VonNeumannEntropy, RenyiEntropy, ResidualEntropy
 export EdwardsAndersonParameter, SpinGlassSusceptibility  # spin-glass order (#730)
 export BoundEdge, BOUNDS, bound!, @bound  # inequality edges (core/bound.jl)
+# Derived-input suppliers (core/derivative.jl).  The AD backends are package
+# EXTENSIONS — neither ForwardDiff nor Zygote is a hard dependency.
+export AbstractDiffBackend, FiniteDifference, ForwardDiffBackend, ZygoteBackend
+export derivative, backend_available, preferred_backend, default_rtol
 export QuenchEntanglementEntropy  # QAtlas-side post-quench S(ℓ,t) (was VonNeumannEntropy{:quench})
 export Magnetization  # axis-parametric (AbstractQAtlas); MagnetizationX/Y/Z are deprecated aliases
 export MagnetizationX, MagnetizationY, MagnetizationZ

--- a/src/core/derivative.jl
+++ b/src/core/derivative.jl
@@ -1,0 +1,156 @@
+# core/derivative.jl — supplying DERIVED inputs to a constraint edge.
+#
+# Most of AbstractQAtlas's relations that QAtlas could already reach are stated
+# with a supplied derivative: `EntropyResponse(S, dF_dT)`, `GibbsHelmholtz(U,
+# dβF_dβ)`, `SpecificHeatFromEntropy(C, dS_dT, T)`, `MagnetizationResponse(M,
+# dF_dh)`, … The quantity slots are fetchable; the derivative slot is not, so
+# the generator had nothing to put there and those relations stayed dead.  This
+# file supplies them.
+#
+# It is also the deletion criterion `identity_registry.jl` names for the
+# hand-written harness: "(a) the derivative-form identities (c_v, m_x = -∂f/∂h)
+# are generatable".  The same ForwardDiff-through-`fetch` pattern is currently
+# copy-pasted across at least four model test files (Kitaev1D, KitaevHoneycomb,
+# XXZ1D, S1Heisenberg1D) — one declarative supplier replaces all of them.
+#
+# ── BACKENDS ──────────────────────────────────────────────────────────
+# The differentiation method is a dispatchable choice, not a hard-wired one,
+# because none of them works everywhere:
+#
+#   * `ForwardDiffBackend` — forward-mode AD.  Exact to machine precision, and
+#     it only needs the fetch to be generic in its argument type; 273 of the
+#     304 `beta::` annotations in src/ are already `::Real`, and the existing
+#     hand-written tests prove it works through dense ED and quadrature.  This
+#     is the right tool here: the derivatives are all scalar → scalar.
+#   * `ZygoteBackend` — reverse-mode AD.  Offered because it is asked for, but
+#     expect it to fail on more hubs than ForwardDiff: it needs an adjoint for
+#     everything it traverses (dense ED, quadrature, the NLIE Newton solves),
+#     and for a scalar → scalar derivative reverse mode has no advantage over
+#     forward mode anyway.  Use it as a cross-check, not as the default.
+#   * `FiniteDifference` — always available, no dependency, works through code
+#     that is not differentiable at all.  The catch is TRUNCATION ERROR: a
+#     central difference agrees with the analytic entropy to ~1e-5 relative on
+#     CurieWeissIsing (measured), so an edge supplied this way must not be
+#     given an AD-grade tolerance or it becomes a false-failure generator.
+#     `default_rtol` below carries that difference so a caller cannot forget it.
+#
+# AD backends live in package EXTENSIONS (`ext/QAtlas*Ext.jl`), so neither
+# ForwardDiff nor Zygote is a hard dependency of the atlas — they light up only
+# when the user has loaded them.  With neither loaded, everything still works
+# through `FiniteDifference`.
+
+"""
+    AbstractDiffBackend
+
+How a derived input is obtained.  Concrete backends: [`FiniteDifference`](@ref)
+(always available), `ForwardDiffBackend` and `ZygoteBackend` (package
+extensions — see the file header for why they are not hard dependencies).
+"""
+abstract type AbstractDiffBackend end
+
+"""
+    FiniteDifference(; h = 1e-4)
+
+Central-difference backend, `(f(x+h) − f(x−h)) / 2h`.  Dependency-free and
+works through non-differentiable code, at the cost of truncation error — see
+[`default_rtol`](@ref).
+"""
+struct FiniteDifference <: AbstractDiffBackend
+    h::Float64
+    function FiniteDifference(; h::Real=1e-4)
+        return if h > 0
+            new(Float64(h))
+        else
+            throw(ArgumentError("FiniteDifference: h must be > 0"))
+        end
+    end
+end
+
+"""
+    ForwardDiffBackend()
+
+Forward-mode AD.  A no-op stub unless `ForwardDiff` is loaded, in which case
+`ext/QAtlasForwardDiffExt.jl` gives it a `derivative` method.
+"""
+struct ForwardDiffBackend <: AbstractDiffBackend end
+
+"""
+    ZygoteBackend()
+
+Reverse-mode AD.  A no-op stub unless `Zygote` is loaded
+(`ext/QAtlasZygoteExt.jl`).  Expect a lower success rate than
+[`ForwardDiffBackend`](@ref) on this atlas — see the file header.
+"""
+struct ZygoteBackend <: AbstractDiffBackend end
+
+"""
+    derivative(backend, f, x) -> Real
+
+`df/dx` at `x` by `backend`.
+
+An AD backend whose package is not loaded throws a message that names the
+`using` needed, rather than silently degrading to a finite difference: a check
+that quietly changed its accuracy class would be reported at the wrong
+tolerance.
+"""
+function derivative(b::AbstractDiffBackend, f, x::Real)
+    return error(
+        "QAtlas.derivative: no method for $(nameof(typeof(b))). It is provided by a " *
+        "package extension — add `using $(_backend_package(b))` to activate it, or " *
+        "pass `FiniteDifference()` to differentiate without any AD dependency.",
+    )
+end
+
+function derivative(b::FiniteDifference, f, x::Real)
+    h = b.h * max(one(Float64), abs(Float64(x)))   # scale-aware step
+    return (f(x + h) - f(x - h)) / (2h)
+end
+
+_backend_package(::ForwardDiffBackend) = "ForwardDiff"
+_backend_package(::ZygoteBackend) = "Zygote"
+_backend_package(b::AbstractDiffBackend) = string(nameof(typeof(b)))
+
+"""
+    backend_available(backend) -> Bool
+
+Whether `backend` can actually differentiate right now — i.e. its extension is
+loaded.  Lets a generator pick the best available backend instead of erroring,
+and lets a test skip an AD-only assertion honestly.
+"""
+backend_available(::FiniteDifference) = true
+backend_available(::AbstractDiffBackend) = false
+
+"""
+    default_rtol(backend) -> Float64
+
+The tolerance an edge should use when its derived input came from `backend`.
+
+This is not a style preference.  Forward-mode AD is exact to round-off, so an
+AD-supplied identity can be held to the same `1e-6` the hand-written model
+tests already use.  A central difference carries truncation error — measured at
+`5.4e-5` relative against the analytic entropy on CurieWeissIsing — so holding
+an FD-supplied check to `1e-6` would manufacture failures that say nothing
+about the physics.  Returning the tolerance from the backend keeps the two from
+being confused.
+"""
+default_rtol(::FiniteDifference) = 1e-3
+default_rtol(::AbstractDiffBackend) = 1e-6
+
+"""
+    preferred_backend(; allow_fd = true) -> AbstractDiffBackend
+
+The most accurate backend currently loaded: ForwardDiff, else Zygote, else a
+[`FiniteDifference`](@ref).  With `allow_fd = false` it throws instead of
+falling back, for a caller that must not silently change accuracy class.
+"""
+function preferred_backend(; allow_fd::Bool=true)
+    for b in (ForwardDiffBackend(), ZygoteBackend())
+        backend_available(b) && return b
+    end
+    allow_fd && return FiniteDifference()
+    return error(
+        "QAtlas.preferred_backend: no AD extension is loaded (add `using ForwardDiff` " *
+        "or `using Zygote`) and `allow_fd = false` forbids the finite-difference " *
+        "fallback.",
+    )
+end

--- a/test/core/test_derivative.jl
+++ b/test/core/test_derivative.jl
@@ -1,0 +1,67 @@
+# Derived-input suppliers (src/core/derivative.jl) + the AD package extensions.
+#
+# The point of this file is not that ForwardDiff can differentiate x^2.  It is
+# that a derivative taken THROUGH a real `fetch` reproduces a thermodynamic
+# identity the atlas does not otherwise check — `S = -∂F/∂T` — and that the
+# accuracy class of the answer is carried honestly by the backend rather than
+# assumed by the caller.
+
+using QAtlas, Test, ForwardDiff
+using QAtlas:
+    FiniteDifference,
+    ForwardDiffBackend,
+    ZygoteBackend,
+    derivative,
+    backend_available,
+    preferred_backend,
+    default_rtol
+
+@testset "backends: availability and the accuracy class they carry" begin
+    # FD needs nothing; ForwardDiff is live because this file loaded it.
+    @test backend_available(FiniteDifference())
+    @test backend_available(ForwardDiffBackend())
+    # Zygote is NOT in the test target, so its extension must stay dormant —
+    # and a dormant backend must refuse loudly rather than quietly degrade to a
+    # finite difference at a different accuracy class.
+    @test !backend_available(ZygoteBackend())
+    @test_throws ErrorException derivative(ZygoteBackend(), x -> x^2, 1.0)
+
+    # The tolerance travels with the method: AD earns the tight one, a central
+    # difference does not.  (Measured: FD reproduces the analytic entropy to
+    # ~5e-5 relative on CurieWeissIsing — 1e-6 there would be a false failure.)
+    @test default_rtol(ForwardDiffBackend()) < default_rtol(FiniteDifference())
+
+    # With ForwardDiff loaded it must win the preference order over FD.
+    @test preferred_backend() isa ForwardDiffBackend
+
+    @test_throws ArgumentError FiniteDifference(; h=0.0)
+end
+
+@testset "both backends agree on a closed form" begin
+    f = x -> sin(3x) * exp(-x / 2)
+    exact = 3cos(3.0) * exp(-0.5) - 0.5 * sin(3.0) * exp(-0.5)
+    @test derivative(ForwardDiffBackend(), f, 1.0) ≈ exact rtol = 1e-12
+    @test derivative(FiniteDifference(), f, 1.0) ≈ exact rtol = 1e-6
+end
+
+# ── The reason this machinery exists ──────────────────────────────────
+# S = -∂F/∂T through a real fetch.  TFIM at Infinite is the reference hub: it
+# implements both participants and has no validity-window guard on this sweep.
+@testset "S = -∂F/∂T through a real fetch (the derived input relations need)" begin
+    m = TFIM(; J=1.0, h=0.5)
+    bc = Infinite()
+    for T in (0.7, 1.0, 1.6)
+        F(t) = QAtlas.fetch(m, FreeEnergy(), bc; beta=1 / t)
+        S = QAtlas.fetch(m, ThermalEntropy(), bc; beta=1 / T)
+
+        ad = -derivative(ForwardDiffBackend(), F, T)
+        fd = -derivative(FiniteDifference(), F, T)
+
+        # AD is held to its own tolerance, FD to its own — the whole point of
+        # `default_rtol` being a property of the backend.
+        @test ad ≈ S rtol = default_rtol(ForwardDiffBackend())
+        @test fd ≈ S rtol = default_rtol(FiniteDifference())
+        # ...and AD is strictly the better estimate, which is why it is preferred.
+        @test abs(ad - S) ≤ abs(fd - S) + 1e-12
+    end
+end


### PR DESCRIPTION
## Proposed Changes

Most AbstractQAtlas relations QAtlas can already reach are stated with a **supplied derivative** — `EntropyResponse(S, dF_dT)`, `GibbsHelmholtz(U, dβF_dβ)`, `SpecificHeatFromEntropy(C, dS_dT, T)`, `MagnetizationResponse(M, dF_dh)`, `SusceptibilityResponse(χ, dM_dh)`. Their quantity slots are fetchable; the derivative slot is not, so the generator had nothing to put there and **those relations stayed dead** — ~100 hub-relation pairs across those five.

It is also the deletion criterion `identity_registry.jl` already names for the hand-written harness:

> *"(a) the derivative-form identities (c_v, m_x = −∂f/∂h) are generatable"*

and the same ForwardDiff-through-`fetch` snippet is currently copy-pasted across **four** model test files (Kitaev1D, KitaevHoneycomb, XXZ1D, S1Heisenberg1D).

### Not a hard dependency

Following the house pattern (ParaLinearAlgebra and the other lab repos all do this), the AD backends are package **extensions**:

```toml
[weakdeps]    ForwardDiff, Zygote
[extensions]  QAtlasForwardDiffExt, QAtlasZygoteExt
```

With neither loaded everything still works through `FiniteDifference`; `using ForwardDiff` upgrades the accuracy.

## Usage or Results

### Three points worth the review

1. **The tolerance travels with the backend.** `default_rtol(FiniteDifference()) = 1e-3` vs `1e-6` for AD. Not taste — a central difference reproduces the analytic entropy to only **~5.4e-5 relative on CurieWeissIsing** (measured), so holding an FD-supplied check to an AD-grade tolerance would manufacture failures that say nothing about the physics. Putting the tolerance *on the backend* means a caller cannot forget which one it earned.
2. **A dormant backend refuses; it does not degrade.** `derivative(ZygoteBackend(), …)` with Zygote unloaded throws and names the `using` required, rather than quietly falling back to a finite difference — that would silently change the accuracy class while the recorded tolerance stayed put, which is the symptomless failure mode this codebase keeps meeting.
3. **Zygote is ranked below ForwardDiff, on purpose and in writing.** These derivatives are scalar → scalar, where reverse mode buys nothing, and it needs an adjoint for everything it traverses (dense ED, quadrature, the NLIE Newton solves). Offered as an independent cross-check; a hub where Zygote throws is a *Zygote coverage gap, not a physics finding*.

### Measured before building

| | |
|---|---|
| `S = −dF/dT` via plain central differences | **19 of 28 hubs agree**; 1 "mismatch" is FD truncation at 5.4e-5; 8 are the usual known-gap hubs (AKLT1D finite-β, 2D `Lx`/`Ly`, IsingTriangular's `J>0` branch, the two NaN validity guards) |
| `beta::` annotations in `src/` | **273 of 304 are `::Real`** → forward-mode AD has the type genericity it needs |

Tests exercise the real path — `S = −∂F/∂T` **through `fetch`** on TFIM/Infinite, each backend held to its own tolerance — not just AD on a closed form. Verified under `Pkg.test`.

`version` → **0.28.5** (additive → patch).

### Next

This PR ships the **supplier**; wiring it into the edge declarations (so `EntropyResponse` & co. actually generate) is the follow-up, and is what finally satisfies `identity_registry.jl`'s deletion criterion (a).

> **Stacked on #756** (base `main`). Until that merges this diff also shows its commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
