### PR TITLE
feat: @response edges + fix AD through a non-differentiable root-finder

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.28.5"
+version = "0.28.6"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/ext/QAtlasForwardDiffExt.jl
+++ b/ext/QAtlasForwardDiffExt.jl
@@ -16,4 +16,8 @@ using ForwardDiff: ForwardDiff
 QAtlas.derivative(::ForwardDiffBackend, f, x::Real) = ForwardDiff.derivative(f, float(x))
 QAtlas.backend_available(::ForwardDiffBackend) = true
 
+# Lets a root-finder solve on primals and re-attach the exact implicit
+# derivative afterwards — see QAtlas._primal.
+QAtlas._primal(x::ForwardDiff.Dual) = ForwardDiff.value(x)
+
 end

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -60,6 +60,9 @@ using AbstractQAtlas:
     # ...and the inequality verbs, so a BOUND edge (core/bound.jl) can delegate
     # its criterion to AbstractQAtlas exactly as :gibbs delegates its arithmetic.
     AbstractInequality,
+    AbstractRelation,
+    EntropyResponse,
+    SpecificHeatFromEntropy,
     slack,
     variable_slots,
     # the inequalities bound_registry.jl declares edges for
@@ -178,6 +181,7 @@ include("core/derivative.jl")    # derived-input suppliers (AD via ext, FD fallb
 include("core/symmetry.jl")     # @symmetry node attributes + LSM checks (C10)
 include("core/identity.jl")      # @identity quantity<->quantity edges (C11)
 include("core/bound.jl")         # @bound: the inequality sibling (#734 Phase B)
+include("core/response.jl")      # @response: relations needing a derived input
 include("core/duality.jl")      # @dual model<->model parameter-mapped edges (C12)
 include("core/limits.jl")       # @limits_to asymptotic limit edges (C13)
 include("core/pfaffian.jl")
@@ -233,7 +237,8 @@ export BoundEdge, BOUNDS, bound!, @bound  # inequality edges (core/bound.jl)
 # Derived-input suppliers (core/derivative.jl).  The AD backends are package
 # EXTENSIONS — neither ForwardDiff nor Zygote is a hard dependency.
 export AbstractDiffBackend, FiniteDifference, ForwardDiffBackend, ZygoteBackend
-export derivative, backend_available, preferred_backend, default_rtol
+export derivative, derivative_agreement, backend_available, preferred_backend, default_rtol
+export ResponseEdge, RESPONSES, response!, @response, DerivedInput, ∂
 export QuenchEntanglementEntropy  # QAtlas-side post-quench S(ℓ,t) (was VonNeumannEntropy{:quench})
 export Magnetization  # axis-parametric (AbstractQAtlas); MagnetizationX/Y/Z are deprecated aliases
 export MagnetizationX, MagnetizationY, MagnetizationZ
@@ -533,6 +538,7 @@ include("reduces_registry.jl")
 include("symmetry_registry.jl")
 include("identity_registry.jl")
 include("bound_registry.jl")            # @bound inequality edges (#734 Phase B)
+include("response_registry.jl")         # @response derivative-supplied edges
 include("relations/model_specific.jl")   # #730: model-specific relations, hosted here
 include("duality_registry.jl")
 include("limits_registry.jl")

--- a/src/bound_registry.jl
+++ b/src/bound_registry.jl
@@ -19,6 +19,19 @@
 # shows up here even when two equally-wrong quantities would still satisfy an
 # identity between themselves.
 
+# Shared by the bound and response registries: the hubs whose finite-T
+# thermodynamics the 1D generator cannot materialize, or that self-declare a
+# validity window.  Same list :gibbs carries — kept in one place so the three
+# edge kinds cannot drift apart on which hubs are honestly out of scope.
+const _THERMO_DERIVATIVE_EXCLUSIONS = [
+    (IsingSquare, PBC) => "2D PBC fetches take Lx/Ly kwargs, not bc.N — generator finite-size materialization is 1D-only",
+    (KitaevHoneycomb, OBC) => "2D OBC fetches take Lx/Ly kwargs, not bc.N — generator finite-size materialization is 1D-only",
+    IsingTriangular => "default J > 0 is the frustrated AFM branch (no Houtappel closed form); finite-T requires J < 0",
+    AKLT1D => "finite-β canonical thermodynamics supports β = ∞ only (HTSE is a separate :approx scheme, #506)",
+    Heisenberg1D => "Infinite-BC thermodynamics is a c=1 CFT low-T expansion valid only for β > 5/J; it warns and returns NaN on this sweep (#521 Path A will replace it)",
+    HaldaneShastry => "Infinite-BC thermodynamics returns NaN outside its low-T validity window, same CFT-expansion guard as Heisenberg1D",
+]
+
 # ── C_v ≥ 0 ───────────────────────────────────────────────────────────
 # Thermodynamic stability: the specific heat is a variance (β²·Var(E)) and so
 # cannot be negative for any equilibrium state at any β.  Exact at every N, so
@@ -28,18 +41,7 @@
     inequality = SpecificHeatPositivity,
     sweep = (beta=[0.5, 1.0, 2.0],),
     finite_N = 6,
-    exclusions = [
-        # 2D fetches take Lx/Ly rather than bc.N — the generator's finite-N
-        # materialization is 1D-only (same gap :gibbs records).
-        (IsingSquare, PBC) => "2D PBC fetches take Lx/Ly kwargs, not bc.N — generator finite-size materialization is 1D-only",
-        (KitaevHoneycomb, OBC) => "2D OBC fetches take Lx/Ly kwargs, not bc.N — generator finite-size materialization is 1D-only",
-        # Physics-of-the-branch / validity-range gaps, all self-declared by the
-        # fetch itself (it errors or warns and returns NaN rather than lying).
-        IsingTriangular => "default J > 0 is the frustrated AFM branch (no Houtappel closed form); finite-T requires J < 0",
-        AKLT1D => "finite-β canonical thermodynamics supports β = ∞ only (HTSE is a separate :approx scheme, #506)",
-        Heisenberg1D => "SpecificHeat at Infinite is a c=1 CFT low-T expansion valid only for β > 5/J; it warns and returns NaN on this sweep (#521 Path A will replace it)",
-        HaldaneShastry => "SpecificHeat at Infinite returns NaN outside its low-T validity window, same CFT-expansion guard as Heisenberg1D",
-    ],
+    exclusions = _THERMO_DERIVATIVE_EXCLUSIONS,
     notes = "C_v = β² Var(E) ≥ 0 — thermodynamic stability; holds at every N and β.",
 )
 
@@ -53,8 +55,6 @@
     inequality = SusceptibilityPositivity,
     sweep = (beta=[0.5, 1.0],),
     finite_N = 6,
-    exclusions = [
-        AKLT1D => "finite-β canonical thermodynamics supports β = ∞ only (HTSE is a separate :approx scheme, #506)",
-    ],
+    exclusions = _THERMO_DERIVATIVE_EXCLUSIONS,
     notes = "χ_αα = β Var(M_α) ≥ 0 for every axis pair — thermodynamic stability.",
 )

--- a/src/core/derivative.jl
+++ b/src/core/derivative.jl
@@ -125,13 +125,29 @@ backend_available(::AbstractDiffBackend) = false
 
 The tolerance an edge should use when its derived input came from `backend`.
 
-This is not a style preference.  Forward-mode AD is exact to round-off, so an
-AD-supplied identity can be held to the same `1e-6` the hand-written model
-tests already use.  A central difference carries truncation error — measured at
-`5.4e-5` relative against the analytic entropy on CurieWeissIsing — so holding
-an FD-supplied check to `1e-6` would manufacture failures that say nothing
-about the physics.  Returning the tolerance from the backend keeps the two from
-being confused.
+Forward-mode AD is exact to round-off **for a fetch that is a closed form, a
+quadrature or a dense diagonalization**, so an AD-supplied identity there can be
+held to the same `1e-6` the hand-written model tests use.  A central difference
+carries truncation error — measured at `5.4e-5` relative against the analytic
+entropy on CurieWeissIsing — so holding an FD-supplied check to `1e-6` would
+manufacture failures that say nothing about the physics.
+
+!!! warning "A tolerance cannot rescue a wrong derivative"
+    AD is not uniformly the better answer.  Through an **iterative solve** it
+    differentiates the iteration rather than the solution, and the derivative
+    can be converged nowhere near as well as the value.  Measured on
+    CurieWeissIsing's ordered phase, where the magnetization solves
+    `m = tanh(βJm)`:
+
+    | T | fetched `C` | AD `T·dS/dT` | FD `T·dS/dT` |
+    |---|---|---|---|
+    | 0.5 | 0.36594804 | **−0.01267792** | 0.36594804 |
+    | 1/3 | 0.09345921 | **−0.00438224** | 0.09345921 |
+
+    AD gets the SIGN wrong while FD is exact to eight digits.  No choice of
+    `rtol` distinguishes that from a physics failure, which is why
+    [`derivative_agreement`](@ref) exists: the defence is cross-checking two
+    backends, not tightening a tolerance.
 """
 default_rtol(::FiniteDifference) = 1e-3
 default_rtol(::AbstractDiffBackend) = 1e-6
@@ -142,6 +158,11 @@ default_rtol(::AbstractDiffBackend) = 1e-6
 The most accurate backend currently loaded: ForwardDiff, else Zygote, else a
 [`FiniteDifference`](@ref).  With `allow_fd = false` it throws instead of
 falling back, for a caller that must not silently change accuracy class.
+
+"Most accurate" is the ranking for the fetches this atlas is mostly made of.
+It is NOT a guarantee: see the warning on [`default_rtol`](@ref) for a hub where
+AD is qualitatively wrong and the finite difference is right.  A caller that
+cares should use [`derivative_agreement`](@ref) rather than trusting the rank.
 """
 function preferred_backend(; allow_fd::Bool=true)
     for b in (ForwardDiffBackend(), ZygoteBackend())
@@ -154,3 +175,67 @@ function preferred_backend(; allow_fd::Bool=true)
         "fallback.",
     )
 end
+
+"""
+    derivative_agreement(f, x; primary = preferred_backend()) -> (value, backend, trusted, detail)
+
+`df/dx` from `primary`, **cross-checked against an independent differentiation
+method**, because the failure mode that matters here is not imprecision but a
+silently wrong answer.
+
+Returns the primary value, the backend that produced it, whether the two methods
+agree to the cross-checking method's own tolerance, and a human-readable reason
+when they do not.
+
+Why this and not a tighter tolerance: forward-mode AD through an iterative solve
+differentiates the iteration, not the solution, and can come back with the wrong
+sign (measured — see [`default_rtol`](@ref)).  A disagreement between two
+methods is evidence about the METHOD, not about the physics, so a caller should
+report it as "cannot evaluate here", never as a failed physical identity.  It
+also catches a second case for free: at a phase transition the quantity is
+non-differentiable, a central difference straddles the jump while AD takes a
+one-sided limit, and the two disagree — which is exactly the right verdict.
+
+With only one backend available there is nothing to cross-check against, so
+`trusted` is `true` and `detail` says so; the caller keeps whatever confidence
+the single method deserves.
+"""
+function derivative_agreement(f, x::Real; primary::AbstractDiffBackend=preferred_backend())
+    value = derivative(primary, f, x)
+    primary isa FiniteDifference && return (value, primary, true, "single backend (FD)")
+    cross = FiniteDifference()
+    local other
+    try
+        other = derivative(cross, f, x)
+    catch err
+        return (value, primary, true, "cross-check unavailable: $(sprint(showerror, err))")
+    end
+    scale = max(abs(value), abs(other), eps())
+    rel = abs(value - other) / scale
+    rel ≤ default_rtol(cross) && return (value, primary, true, "agrees with FD")
+    return (
+        value,
+        primary,
+        false,
+        "derivative not reproducible across methods: " *
+        "$(nameof(typeof(primary)))=$(value) vs FiniteDifference=$(other) " *
+        "(rel $(round(rel; sigdigits=3))). Typical causes: an iterative solve AD " *
+        "differentiates through, or a non-differentiable point such as a phase " *
+        "transition.",
+    )
+end
+
+"""
+    _primal(x) -> Real
+
+The value of `x` with any AD tag stripped; the identity for ordinary numbers.
+The ForwardDiff extension specializes it for `Dual`.
+
+This is what lets a fetch built on a NON-DIFFERENTIABLE root-finder still hand
+back an exact derivative: solve on primals, then re-attach the derivative
+analytically (see `_curie_weiss_solve_m`).  Bisection is the motivating case —
+it is numerically excellent and its AD derivative is meaningless, because the
+β-dependence flows through the bracket endpoints and the comparison branches
+rather than through the equation being solved.
+"""
+_primal(x::Real) = x

--- a/src/core/response.jl
+++ b/src/core/response.jl
@@ -1,0 +1,288 @@
+# core/response.jl — constraint edges whose relation needs a DERIVED input.
+#
+# The third edge kind, after @identity (equalities between fetched values) and
+# @bound (inequalities on them).  A response edge covers the AbstractQAtlas
+# relations stated with a supplied derivative — `EntropyResponse(S, dF_dT)`,
+# `SpecificHeatFromEntropy(C, dS_dT, T)` — which the other two cannot express
+# because one of their slots is not fetchable.
+#
+# The split of labour is the same as everywhere else in this layer: the relation
+# and its algebra are AbstractQAtlas's, the values and the harness are QAtlas's,
+# and the derivative comes from core/derivative.jl (AD when an extension is
+# loaded, finite differences otherwise).
+#
+# A relation has three kinds of slot, and this file is mostly about telling them
+# apart:
+#
+#   * QUANTITY slots (`S::ThermalEntropy`) — fetched from the hub.
+#   * FIELD slots (`T::Temperature`, `β::InverseTemperature`) — these are
+#     AbstractField, NOT AbstractQuantity: they are the state point, so they come
+#     from the sweep, not from `fetch`.
+#   * UNTYPED slots (`dF_dT`) — the derived input this edge supplies.
+#
+# SUBJECT-VS-DERIVED, not residual-vs-zero.  Like `:gibbs` (#734 Phase B), the
+# check `solve`s the relation for its quantity slot and compares that against
+# the hub's own fetched value, so both sides of a failure are physical numbers.
+# A bare `residual ≈ 0` would be shorter and much harder to read when it breaks.
+
+"""
+    DerivedInput(quantity, wrt)
+
+A slot supplied by differentiating `fetch(model, quantity(), bc)` with respect
+to `wrt`, which is `:T` (temperature) or `:β` (inverse temperature).
+
+Only the temperature axis is supported here.  A field derivative (`dF/dh`, for
+`MagnetizationResponse`) is deliberately absent: `h` is a MODEL parameter, not a
+fetch kwarg, so differentiating along it means reconstructing the model at each
+step and every model spells its field differently.  That needs a model-parameter
+mechanism, and inventing one silently for two relations would be worse than
+leaving them uncovered.
+"""
+struct DerivedInput
+    quantity::Type
+    wrt::Symbol
+    function DerivedInput(quantity::Type, wrt::Symbol)
+        wrt in (:T, :β) || throw(
+            ArgumentError(
+                "DerivedInput: `wrt` must be :T or :β (the temperature axis); got " *
+                ":$(wrt). Field derivatives need a model-parameter mechanism that " *
+                "does not exist yet — see the docstring.",
+            ),
+        )
+        return new(quantity, wrt)
+    end
+end
+
+"""
+    ∂(quantity, wrt)
+
+Terse constructor for [`DerivedInput`](@ref): `∂(FreeEnergy, :T)` is `dF/dT`.
+"""
+∂(quantity::Type, wrt::Symbol) = DerivedInput(quantity, wrt)
+
+"""
+    ResponseEdge
+
+A relation with at least one [`DerivedInput`](@ref) slot, materialized on every
+hub implementing its quantity slots.  Shares the `name` / `sweep` / `finite_N` /
+`exclusions` / `notes` / `references` vocabulary with the other edge kinds.
+
+The tolerance is `max(default_rtol(backend), rtol_floor)`.  The backend part is
+the accuracy of the DERIVATIVE; `rtol_floor` is the accuracy of the QUANTITIES
+being related, which no amount of exact differentiation can improve on.
+
+Measured motivation: IsingSquare's `SpecificHeat` and `ThermalEntropy` are
+Onsager closed forms evaluated by quadrature, and `C` vs `T·dS/dT` agree to
+2.5e-5 — with AD *and* with finite differences, to the same figure, so this is
+the accuracy of the fetches, not of the derivative.  Holding that hub to AD's
+1e-6 reported a quadrature residue as a physics failure.  An identity cannot be
+verified more tightly than the values it relates.
+"""
+struct ResponseEdge
+    name::Symbol
+    relation::AbstractRelation
+    subject::Symbol
+    derived::NamedTuple
+    rtol_floor::Float64
+    sweep::NamedTuple
+    finite_N::Int
+    exclusions::Vector{Pair{Any,String}}
+    notes::String
+    references::Vector{String}
+end
+
+"""
+    RESPONSES :: Vector{ResponseEdge}
+
+Every declared response edge, in declaration order.
+"""
+const RESPONSES = ResponseEdge[]
+
+# The quantity type behind a slot, or `nothing` if the slot is a field/untyped.
+_quantity_slot(T) = (T isa Type && T <: AbstractQuantity) ? T : nothing
+_field_slot(T) = (T isa Type && T <: AbstractQAtlas.AbstractField) ? T : nothing
+
+"""
+    response!(name; relation, derived, sweep, finite_N, exclusions, notes, references)
+
+Declare a response edge.  The subject — the quantity slot the check solves for
+and compares against `fetch` — is derived, not declared: a relation with exactly
+one quantity slot has no ambiguity, and one with several is rejected rather than
+guessed at.
+
+Also rejected at declaration time: a duplicate name; a `derived` key that is not
+an untyped slot of the relation; and any untyped slot left unsupplied (which
+would make the check unrunnable in a way only visible at run time).
+"""
+function response!(
+    name::Symbol;
+    relation,
+    derived::NamedTuple,
+    rtol_floor::Real=0.0,
+    sweep::NamedTuple=NamedTuple(),
+    finite_N::Int=8,
+    exclusions::AbstractVector=Pair{Any,String}[],
+    notes::AbstractString="",
+    references::AbstractVector{<:AbstractString}=String[],
+)
+    any(e -> e.name === name, RESPONSES) &&
+        throw(ArgumentError("response!: :$(name) already declared"))
+    rel = relation isa Type ? relation() : relation
+    rel isa AbstractRelation ||
+        throw(ArgumentError("response!: `relation` must be an AbstractQAtlas relation"))
+
+    slots = variable_slots(rel)
+    qslots = [(n, T) for (n, T) in slots if _quantity_slot(T) !== nothing]
+    untyped = [n for (n, T) in slots if T === nothing]
+
+    length(qslots) == 1 || throw(
+        ArgumentError(
+            "response!: :$(name) — $(nameof(typeof(rel))) has $(length(qslots)) quantity " *
+            "slots; the subject to compare against `fetch` would be ambiguous. Only " *
+            "single-subject relations are supported.",
+        ),
+    )
+    for k in keys(derived)
+        k in untyped || throw(
+            ArgumentError(
+                "response!: :$(name) — `$(k)` is not an untyped slot of " *
+                "$(nameof(typeof(rel))); its untyped slots are $(untyped).",
+            ),
+        )
+        derived[k] isa DerivedInput ||
+            throw(ArgumentError("response!: :$(name) — `$(k)` must be a DerivedInput (∂)"))
+    end
+    missing_slots = setdiff(untyped, collect(keys(derived)))
+    isempty(missing_slots) || throw(
+        ArgumentError(
+            "response!: :$(name) — untyped slot(s) $(missing_slots) are unsupplied, so " *
+            "the check could never run. Supply them with ∂(...) or drop the edge.",
+        ),
+    )
+
+    push!(
+        RESPONSES,
+        ResponseEdge(
+            name,
+            rel,
+            first(qslots)[1],
+            derived,
+            Float64(rtol_floor),
+            sweep,
+            finite_N,
+            Pair{Any,String}[p for p in exclusions],
+            String(notes),
+            String[r for r in references],
+        ),
+    )
+    return nothing
+end
+
+"""
+    @response(:name, relation = R, derived = (dF_dT = ∂(FreeEnergy, :T),), ...)
+
+Keyword-macro front end for [`response!`](@ref), matching `@identity` / `@bound`.
+"""
+macro response(name, kwargs...)
+    kws = [esc(k) for k in kwargs]
+    return :(response!($(esc(name)); $(kws...)))
+end
+
+# ──────────────────────────────────────────────────────────────────────
+# Generator — the :response kind of generated_checks()
+# ──────────────────────────────────────────────────────────────────────
+
+# The fetch kwargs and evaluation point for differentiating along `wrt` at a
+# sweep point that carries `beta`.  β and T are one axis reparameterized, which
+# is why only these two are allowed.
+function _diff_axis(wrt::Symbol, point::NamedTuple)
+    β = getfield(point, :beta)
+    wrt === :β && return (x -> merge(point, (; beta=x)), float(β))
+    return (x -> merge(point, (; beta=1 / x)), 1 / float(β))
+end
+
+function response_checks()
+    out = GeneratedCheck[]
+    backend = preferred_backend()
+    for e in RESPONSES
+        # The derivative's accuracy AND the fetched values' accuracy both bound
+        # what this check can assert; the looser of the two wins.
+        rtol = max(default_rtol(backend), e.rtol_floor)
+        slots = variable_slots(e.relation)
+        subject_T = only(T for (n, T) in slots if n === e.subject)
+        for hub in _implemented_hubs(Type[subject_T])
+            hub_id = string(
+                "response/", e.name, "/", _kgshort(hub.model), "/", _kgshort(hub.bc)
+            )
+            reason = _exclusion_reason(e, hub.model, hub.bc)
+            if reason !== nothing
+                _push_excluded_check!(out, :response, hub_id, reason)
+                continue
+            end
+            for point in _sweep_points(e.sweep)
+                id = hub_id * _point_suffix(point)
+                model_T, bc_T, rel = hub.model, hub.bc, e.relation
+                runner = function ()
+                    m = model_T()
+                    bc = _bc_instance(bc_T; finite_N=e.finite_N)
+                    args = Dict{Symbol,Any}()
+                    for (n, T) in slots
+                        n === e.subject && continue
+                        F = _field_slot(T)
+                        F === nothing && continue
+                        # Field slots are the state point, not a fetch.
+                        args[n] = if F === AbstractQAtlas.Temperature
+                            1 / point.beta
+                        else
+                            point.beta
+                        end
+                    end
+                    # Cross-check every derived input against an independent
+                    # differentiation method.  A disagreement is evidence about
+                    # the METHOD (an iterative solve AD differentiates through, a
+                    # non-differentiable point) and must not be reported as a
+                    # failed physical identity — so it becomes a visible skip.
+                    for (n, d) in pairs(e.derived)
+                        kw, x0 = _diff_axis(d.wrt, point)
+                        g = x -> fetch(m, _quantity_instance(d.quantity), bc; kw(x)...)
+                        val, _, trusted, why = derivative_agreement(g, x0; primary=backend)
+                        trusted || return _skip_outcome("$(n): $(why)")
+                        args[n] = val
+                    end
+                    expected = solve(rel, Val(e.subject); args...)
+                    actual = fetch(m, _quantity_instance(subject_T), bc; point...)
+                    return _outcome(
+                        actual,
+                        expected;
+                        rtol=rtol,
+                        atol=1e-10,
+                        detail="derivative via $(nameof(typeof(backend)))",
+                    )
+                end
+                push!(
+                    out,
+                    GeneratedCheck(
+                        :response,
+                        id,
+                        string(
+                            "response :",
+                            e.name,
+                            " (",
+                            nameof(typeof(rel)),
+                            ") on ",
+                            _kgshort(model_T),
+                            " at ",
+                            _kgshort(bc_T),
+                            isempty(keys(point)) ? "" : " ($(point))",
+                        ),
+                        runner,
+                    ),
+                )
+            end
+        end
+    end
+    return out
+end
+
+register_check_generator!(:response, response_checks)
+register_edge_store!(:response, RESPONSES; location_of=e -> "response :$(e.name)")

--- a/src/models/classical/CurieWeissIsing/CurieWeissIsing.jl
+++ b/src/models/classical/CurieWeissIsing/CurieWeissIsing.jl
@@ -132,6 +132,29 @@ end
 function _curie_weiss_solve_m(
     beta_J::Real, beta_h::Real=0.0; tol::Real=1e-14, maxiter::Int=200
 )
+    # Bisection is the right SOLVER and the wrong thing to differentiate: the
+    # β-dependence of its answer flows through the bracket endpoints and the
+    # comparison branches, not through g(m) = 0, so forward-mode AD returns a
+    # number with no relation to dm/dβ.  Measured before this fix, on the
+    # ordered phase: AD gave T·dS/dT = -0.0127 where the truth is +0.3659 —
+    # the wrong SIGN, which no tolerance can be defended against.
+    #
+    # So: solve on primals (unchanged, still bisection), then re-attach the
+    # derivative analytically with one Newton step from the converged root.
+    # g(m₀) = 0 there, so the VALUE is untouched; the dual part becomes
+    # dm = -(∂g/∂β)/(∂g/∂m), which is exactly the implicit-function theorem.
+    bJ, bh = _primal(beta_J), _primal(beta_h)
+    if !(bJ === beta_J && bh === beta_h)
+        m0 = _curie_weiss_solve_m(bJ, bh; tol=tol, maxiter=maxiter)
+        # Disordered / saturated branches are locally constant in β.
+        (bJ <= 1 && iszero(bh)) && return m0 * one(beta_J)
+        dg_dm = 1 - bJ * sech(bJ * m0 + bh)^2
+        # At the transition ∂g/∂m → 0 and dm/dβ genuinely diverges.  Let it
+        # come out non-finite rather than fabricate a finite wrong number:
+        # `derivative_agreement` then reports "cannot evaluate here", which is
+        # the honest verdict at a non-differentiable point.
+        return m0 - (m0 - tanh(beta_J * m0 + beta_h)) / dg_dm
+    end
     if iszero(beta_h)
         # ── zero-field branch ────────────────────────────────────────
         if beta_J <= 1

--- a/src/response_registry.jl
+++ b/src/response_registry.jl
@@ -1,0 +1,35 @@
+# response_registry.jl — declared RESPONSE edges (core/response.jl).
+#
+# These are the AbstractQAtlas relations that were reachable on QAtlas hubs but
+# unusable, because one slot is a derivative rather than a fetchable value.  With
+# core/derivative.jl supplying it they become ordinary generated checks.
+#
+# Both are exact thermodynamic identities that hold at every N and β, so a small
+# finite_N loses no coverage — the same argument :gibbs makes.
+
+# ── S = -∂F/∂T ────────────────────────────────────────────────────────
+@response(
+    :entropy_response,
+    relation = EntropyResponse,
+    derived = (dF_dT=∂(FreeEnergy, :T),),
+    sweep = (beta=[0.5, 1.0, 2.0],),
+    finite_N = 6,
+    exclusions = _THERMO_DERIVATIVE_EXCLUSIONS,
+    notes = "S = -∂F/∂T — the Maxwell relation between entropy and the free energy.",
+)
+
+# ── C = T ∂S/∂T ───────────────────────────────────────────────────────
+@response(
+    :specific_heat_from_entropy,
+    relation = SpecificHeatFromEntropy,
+    derived = (dS_dT=∂(ThermalEntropy, :T),),
+    sweep = (beta=[0.5, 1.0, 2.0],),
+    finite_N = 6,
+    exclusions = _THERMO_DERIVATIVE_EXCLUSIONS,
+    # Onsager's C and S are quadrature evaluations: measured, they reproduce
+    # C = T ∂S/∂T to 2.5e-5 on IsingSquare with AD and with finite differences
+    # alike.  That is the accuracy of the FETCHES, so AD's 1e-6 would report a
+    # quadrature residue as a physics failure.
+    rtol_floor = 1e-4,
+    notes = "C = T ∂S/∂T — the caloric definition, independent of the C = β² Var(E) route.",
+)

--- a/test/core/test_constraints.jl
+++ b/test/core/test_constraints.jl
@@ -312,9 +312,23 @@ end
     @test !isempty(checks)
     @test issorted([c.id for c in checks])
     @test allunique(c.id for c in checks)
-    # Closed vocabulary on purpose: a new edge type must be declared here, so it
-    # cannot start emitting checks unnoticed.  `:bound` joined in #734 Phase B.
-    @test all(c.kind in (:identity, :dual, :limit, :symmetry, :bound) for c in checks)
+    # Closed vocabulary on purpose: a new edge type must be DECLARED here, so it
+    # cannot start emitting checks unnoticed.  `:bound` and `:response` joined
+    # in #734 Phase B.
+    declared_kinds = (:identity, :dual, :limit, :symmetry, :bound, :response)
+    @test all(c.kind in declared_kinds for c in checks)
+    # ...and say so usefully when it is forgotten.  Registering a generator and
+    # forgetting this list has now happened twice; comparing against the
+    # registry turns "some check has an unexpected kind" into a message that
+    # names the generator, without weakening the guard (the list is still
+    # hand-maintained — deriving it from the registry would defeat the point).
+    registered_kinds = Set(first(p) for p in QAtlas.CHECK_GENERATORS)
+    undeclared = sort(collect(setdiff(registered_kinds, Set(declared_kinds))))
+    if !isempty(undeclared)
+        @error "check generator(s) registered but absent from declared_kinds — add \
+                them here" undeclared
+    end
+    @test isempty(undeclared)
     # kind selection
     only_ids = generated_checks(; kinds=(:identity,))
     @test all(c -> c.kind === :identity, only_ids)

--- a/test/generated/test_response_checks.jl
+++ b/test/generated/test_response_checks.jl
@@ -1,0 +1,53 @@
+# Generated RESPONSE checks (#734 Phase B) — the derivative-supplied slice.
+#
+# These are the AbstractQAtlas relations that were reachable on QAtlas hubs but
+# unusable because one slot is a derivative rather than a fetched value.
+#
+# Note the backend: `runtests.jl` loads ForwardDiff, so the extension is active
+# here and these run on AD, at AD tolerance.  Without it the suite still works,
+# on finite differences at `default_rtol(FiniteDifference())` — that fallback is
+# covered in test/core/test_derivative.jl.
+
+include("util_run_checks.jl")
+using QAtlas: generated_checks, RESPONSES, preferred_backend, ForwardDiffBackend
+
+@testset "generated response checks" begin
+    # The test environment loads ForwardDiff, so the AD extension must be the
+    # one that ran — otherwise these would silently be FD results reported at
+    # an AD tolerance.
+    @test preferred_backend() isa ForwardDiffBackend
+
+    checks = generated_checks(; kinds=(:response,))
+    @test !isempty(checks)
+    ids = [c.id for c in checks]
+    @test any(startswith("response/entropy_response/"), ids)
+    @test any(startswith("response/specific_heat_from_entropy/"), ids)
+    @test length(unique(ids)) == length(ids)
+
+    run_generated_suite(checks; label="generated response checks")
+end
+
+@testset "response edges resolve their slots from the relation" begin
+    @test !isempty(RESPONSES)
+    for e in RESPONSES
+        # The subject is derived, never declared; it must be a real slot name.
+        @test e.subject in first.(QAtlas.variable_slots(e.relation))
+        # Every untyped slot is supplied — an unsupplied one could not run.
+        untyped = [n for (n, T) in QAtlas.variable_slots(e.relation) if T === nothing]
+        @test Set(untyped) == Set(keys(e.derived))
+    end
+end
+
+@testset "response! refuses what it cannot materialize" begin
+    # A field derivative needs a model-parameter mechanism that does not exist.
+    @test_throws ArgumentError QAtlas.∂(QAtlas.FreeEnergy, :h)
+    # An untyped slot left unsupplied would be a check that never runs.
+    @test_throws ArgumentError QAtlas.response!(
+        :_probe_unsupplied; relation=QAtlas.EntropyResponse, derived=NamedTuple()
+    )
+    @test_throws ArgumentError QAtlas.response!(
+        :entropy_response;
+        relation=QAtlas.EntropyResponse,
+        derived=(dF_dT=QAtlas.∂(QAtlas.FreeEnergy, :T),),
+    )
+end


### PR DESCRIPTION
## Proposed Changes

Third constraint edge kind, after `@identity` (equalities) and `@bound` (inequalities). **`@response`** covers the AbstractQAtlas relations stated with a **supplied derivative** — `EntropyResponse(S, dF_dT)`, `SpecificHeatFromEntropy(C, dS_dT, T)` — which the other two cannot express because one slot is not fetchable. **132 checks over 28 hubs.**

A relation turns out to have **three** kinds of slot, and telling them apart is most of the work:

| slot | example | supplied from |
|---|---|---|
| quantity | `S::ThermalEntropy` | `fetch` |
| **field** | `T::Temperature` — `AbstractField`, *not* `AbstractQuantity` | the sweep point (it is the state, not an observable) |
| untyped | `dF_dT` | differentiation (#757's supplier) |

Subject-vs-derived, not residual-vs-zero, so both sides of a failure stay physical numbers — same shape as `:gibbs`.

## The part that matters

Wiring this up surfaced a real defect **and a false claim I had already merged**.

### 1. AD was silently wrong, and the model is now fixed

`CurieWeissIsing` solves its self-consistency by **bisection**. Bisection is the right *solver* and the wrong thing to *differentiate*: the β-dependence of its answer flows through the bracket endpoints and the comparison branches, not through `g(m) = 0`.

| T | fetched `C` | AD `T·dS/dT` (before) | FD `T·dS/dT` |
|---|---|---|---|
| 0.5 | 0.36594804 | **−0.01267792** | 0.36594804 |
| 1/3 | 0.09345921 | **−0.00438224** | 0.09345921 |

The **wrong sign**, on a value itself converged to 1e-14. Fixed properly, in the model: solve on primals (still bisection), then re-attach the derivative with **one Newton step from the converged root**. `g(m₀) = 0` there, so the value is untouched; the dual part becomes `−(∂g/∂β)/(∂g/∂m)` — the implicit-function theorem. The primal-stripping hook `_primal` comes from the **ForwardDiff extension**, so this needs no hard dependency: an unplanned second use of #757's ext machinery.

### 2. Correcting a claim already on main

#757 shipped *"Forward-mode AD is exact to round-off"* in `default_rtol`'s docstring. **That is false** for a fetch containing a root-find or an iterative solve. Corrected, with the measured table, and the correction says plainly that a tolerance cannot rescue a wrong derivative.

### Two defences for what the model fix cannot reach

- **`derivative_agreement`** cross-checks the derivative against an independent method. A disagreement is evidence about the **method**, so it is reported as a visible skip, never as a failed physical identity. It catches non-differentiable points for free — at a transition FD straddles the jump while AD takes a one-sided limit. At the Curie-Weiss transition `∂g/∂m → 0` and `dm/dβ` genuinely diverges; the fix lets that come out non-finite rather than fabricate a finite wrong number, and this catches it.
- **`rtol_floor`** — an identity cannot be verified more tightly than the values it relates. IsingSquare's Onsager `C` and `S` are quadrature evaluations and reproduce `C = T ∂S/∂T` to **2.5e-5, with AD and with finite differences alike, to the same figure** — so that is the accuracy of the *fetches*. AD's 1e-6 was reporting a quadrature residue as a physics failure.

## Usage or Results

Measured along the way: **XXZ1D's Klümper NLIE passes under AD to 8 digits** at both OBC and Infinite. So *"iterative solve ⇒ AD unsafe"* is too coarse — what matters is whether the method has a meaningful derivative at all. The simplest scalar root-find was the broken one; the heavy integral equation was fine.

`version` → **0.28.6**.

> Verification is CI's job here. A local run covers only the files I remember to select, and today it twice went green on a selection CI then failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
