### PR TITLE
feat: derived-input transforms — GibbsHelmholtz + SpecificHeatFDT (~50 more hubs)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.28.6"
+version = "0.28.7"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -63,6 +63,8 @@ using AbstractQAtlas:
     AbstractRelation,
     EntropyResponse,
     SpecificHeatFromEntropy,
+    GibbsHelmholtz,
+    SpecificHeatFDT,
     slack,
     variable_slots,
     # the inequalities bound_registry.jl declares edges for

--- a/src/core/response.jl
+++ b/src/core/response.jl
@@ -268,7 +268,29 @@ function response_checks()
                                 fetch(m, _quantity_instance(d.quantity), bc; kw(x)...),
                                 x,
                             )
-                        val, _, trusted, why = derivative_agreement(g, x0; primary=backend)
+                        # A fetch can be non-differentiable by the chosen backend even
+                        # when its signature says `::Real`: some implementations narrow to
+                        # Float64 internally, and an AD dual then dies on a
+                        # `MethodError(Float64, Dual)`.  (Measured: AKLT2D and Cluster1D
+                        # do this for Energy{:per_site}.)  That is a fact about the
+                        # METHOD, exactly like a cross-check disagreement, so it becomes a
+                        # visible skip rather than an :error.
+                        #
+                        # Deliberately NOT a fallback to finite differences: this edge's
+                        # rtol was computed for `backend` before the run, so silently
+                        # substituting a lower-accuracy method would report an FD result
+                        # at an AD tolerance.  Scoped to the derivative alone — a throw
+                        # from the subject fetch or from `solve` is a real error and still
+                        # surfaces as one.
+                        local val, trusted, why
+                        try
+                            val, _, trusted, why = derivative_agreement(g, x0; primary=backend)
+                        catch err
+                            return _skip_outcome(
+                                "$(n): not differentiable by $(nameof(typeof(backend))) " *
+                                "— $(sprint(showerror, err))",
+                            )
+                        end
                         trusted || return _skip_outcome("$(n): $(why)")
                         args[n] = d.then(val)
                     end

--- a/src/core/response.jl
+++ b/src/core/response.jl
@@ -31,6 +31,19 @@
 A slot supplied by differentiating `fetch(model, quantity(), bc)` with respect
 to `wrt`, which is `:T` (temperature) or `:β` (inverse temperature).
 
+Two optional transforms cover the slots that are not simply `d⟨Q⟩/dx`:
+
+- `of(value, x)` — what to differentiate, as a function of the fetched value and
+  the axis variable.  `GibbsHelmholtz` wants `d(βF)/dβ`, not `dF/dβ`, so it
+  passes `of = (F, β) -> β * F`.
+- `then(derivative)` — post-processing.  `SpecificHeatFDT`'s energy variance is
+  `var_E = -∂U/∂β`, so it passes `then = d -> -d`.
+
+Both default to the identity, and both are deliberately plain functions rather
+than a symbolic mini-language: the whole point of this layer is that the algebra
+lives in AbstractQAtlas, so anything expressible here should stay small enough to
+read at the declaration site.
+
 Only the temperature axis is supported here.  A field derivative (`dF/dh`, for
 `MagnetizationResponse`) is deliberately absent: `h` is a MODEL parameter, not a
 fetch kwarg, so differentiating along it means reconstructing the model at each
@@ -41,7 +54,11 @@ leaving them uncovered.
 struct DerivedInput
     quantity::Type
     wrt::Symbol
-    function DerivedInput(quantity::Type, wrt::Symbol)
+    of::Function
+    then::Function
+    function DerivedInput(
+        quantity::Type, wrt::Symbol; of::Function=(v, x) -> v, then::Function=identity
+    )
         wrt in (:T, :β) || throw(
             ArgumentError(
                 "DerivedInput: `wrt` must be :T or :β (the temperature axis); got " *
@@ -49,7 +66,7 @@ struct DerivedInput
                 "does not exist yet — see the docstring.",
             ),
         )
-        return new(quantity, wrt)
+        return new(quantity, wrt, of, then)
     end
 end
 
@@ -58,7 +75,9 @@ end
 
 Terse constructor for [`DerivedInput`](@ref): `∂(FreeEnergy, :T)` is `dF/dT`.
 """
-∂(quantity::Type, wrt::Symbol) = DerivedInput(quantity, wrt)
+function ∂(quantity::Type, wrt::Symbol; of::Function=(v, x) -> v, then::Function=identity)
+    return DerivedInput(quantity, wrt; of=of, then=then)
+end
 
 """
     ResponseEdge
@@ -244,10 +263,14 @@ function response_checks()
                     # failed physical identity — so it becomes a visible skip.
                     for (n, d) in pairs(e.derived)
                         kw, x0 = _diff_axis(d.wrt, point)
-                        g = x -> fetch(m, _quantity_instance(d.quantity), bc; kw(x)...)
+                        g =
+                            x -> d.of(
+                                fetch(m, _quantity_instance(d.quantity), bc; kw(x)...),
+                                x,
+                            )
                         val, _, trusted, why = derivative_agreement(g, x0; primary=backend)
                         trusted || return _skip_outcome("$(n): $(why)")
-                        args[n] = val
+                        args[n] = d.then(val)
                     end
                     expected = solve(rel, Val(e.subject); args...)
                     actual = fetch(m, _quantity_instance(subject_T), bc; point...)

--- a/src/response_registry.jl
+++ b/src/response_registry.jl
@@ -34,6 +34,24 @@
     notes = "C = T ∂S/∂T — the caloric definition, independent of the C = β² Var(E) route.",
 )
 
+# Hubs whose `Energy{:per_site}` does not respond to the swept β.  Split out from
+# the list above because the reason is different and the affected edges are the
+# ones with an ENERGY subject or an energy derivative — a different hub set from
+# the entropy-subject edges, which is why they surfaced only when
+# :gibbs_helmholtz arrived.  The first three carry the wording
+# identity_registry.jl already uses for :gibbs.
+const _BETA_PINNED_ENERGY_MODELS = [
+    SSH => "Energy fetch returns T=0 ground-state energy (beta swallowed); thermal ε not implemented — the relation does not apply as stated (#508 kwargs-swallow audit)",
+    TightBinding1D => "Energy fetch returns T=0 ground-state energy (beta swallowed); thermal ε not implemented (#508 kwargs-swallow audit)",
+    TightBindingV1D => "Energy fetch returns T=0 ground-state energy (beta swallowed); thermal ε not implemented (#508 kwargs-swallow audit)",
+    # CIRCULAR, not merely β-pinned: SixVertex's Energy{:per_site} IS ∂(βF)/∂β,
+    # computed internally by a hard-coded central difference of f(a^β, b^β, c^β)
+    # at β = 1.  Checking Gibbs–Helmholtz against it would verify the model with
+    # the very relation it already assumes — the circularity the atlas's
+    # independence axis exists to prevent — and it ignores the swept β besides.
+    SixVertex => "Energy{:per_site} is itself computed as ∂(βF)/∂β by an internal finite difference pinned at β = 1; checking this relation against it would be circular",
+]
+
 # ── U = ∂(βF)/∂β ──────────────────────────────────────────────────────
 # The Gibbs–Helmholtz relation.  What is differentiated is the PRODUCT βF, not
 # F alone — that is what `of` is for.  Independent of :entropy_response despite
@@ -46,7 +64,7 @@
     derived = (dβF_dβ=∂(FreeEnergy, :β; of=(F, β) -> β * F),),
     sweep = (beta=[0.5, 1.0, 2.0],),
     finite_N = 6,
-    exclusions = _THERMO_DERIVATIVE_EXCLUSIONS,
+    exclusions = vcat(_THERMO_DERIVATIVE_EXCLUSIONS, _BETA_PINNED_ENERGY_MODELS),
     rtol_floor = 1e-4,
     notes = "U = ∂(βF)/∂β — Gibbs–Helmholtz; equivalently U = -∂ln Z/∂β.",
 )
@@ -66,7 +84,7 @@
     derived = (var_E=∂(Energy{:per_site}, :β; then=d -> -d),),
     sweep = (beta=[0.5, 1.0, 2.0],),
     finite_N = 6,
-    exclusions = _THERMO_DERIVATIVE_EXCLUSIONS,
+    exclusions = vcat(_THERMO_DERIVATIVE_EXCLUSIONS, _BETA_PINNED_ENERGY_MODELS),
     rtol_floor = 1e-4,
     notes = "C = β² Var(E), Var(E) = -∂⟨E⟩/∂β — the fluctuation route, independent of C = T ∂S/∂T.",
 )

--- a/src/response_registry.jl
+++ b/src/response_registry.jl
@@ -33,3 +33,40 @@
     rtol_floor = 1e-4,
     notes = "C = T ∂S/∂T — the caloric definition, independent of the C = β² Var(E) route.",
 )
+
+# ── U = ∂(βF)/∂β ──────────────────────────────────────────────────────
+# The Gibbs–Helmholtz relation.  What is differentiated is the PRODUCT βF, not
+# F alone — that is what `of` is for.  Independent of :entropy_response despite
+# relating the same two potentials: this is the β-derivative of βF, that one is
+# the T-derivative of F, and an implementation can satisfy one while breaking
+# the other.
+@response(
+    :gibbs_helmholtz,
+    relation = GibbsHelmholtz,
+    derived = (dβF_dβ=∂(FreeEnergy, :β; of=(F, β) -> β * F),),
+    sweep = (beta=[0.5, 1.0, 2.0],),
+    finite_N = 6,
+    exclusions = _THERMO_DERIVATIVE_EXCLUSIONS,
+    rtol_floor = 1e-4,
+    notes = "U = ∂(βF)/∂β — Gibbs–Helmholtz; equivalently U = -∂ln Z/∂β.",
+)
+
+# ── C = β² Var(E) ─────────────────────────────────────────────────────
+# The energy-fluctuation route to the specific heat.  `var_E` is not a fetchable
+# quantity, but it does not need to be: Var(E) = -∂⟨E⟩/∂β exactly, so `then`
+# supplies it by negating the derivative of the energy.  With `Energy{:per_site}`
+# the relation's `N` stays 1 — per-site C against per-site variance.
+#
+# This is a genuinely INDEPENDENT route to C: :specific_heat_from_entropy gets it
+# from the entropy, this one from the energy.  A model that computes C by one
+# formula and S or U by another is exactly what these two disagree on.
+@response(
+    :specific_heat_fdt,
+    relation = SpecificHeatFDT,
+    derived = (var_E=∂(Energy{:per_site}, :β; then=d -> -d),),
+    sweep = (beta=[0.5, 1.0, 2.0],),
+    finite_N = 6,
+    exclusions = _THERMO_DERIVATIVE_EXCLUSIONS,
+    rtol_floor = 1e-4,
+    notes = "C = β² Var(E), Var(E) = -∂⟨E⟩/∂β — the fluctuation route, independent of C = T ∂S/∂T.",
+)

--- a/test/generated/test_response_checks.jl
+++ b/test/generated/test_response_checks.jl
@@ -22,6 +22,8 @@ using QAtlas: generated_checks, RESPONSES, preferred_backend, ForwardDiffBackend
     ids = [c.id for c in checks]
     @test any(startswith("response/entropy_response/"), ids)
     @test any(startswith("response/specific_heat_from_entropy/"), ids)
+    @test any(startswith("response/gibbs_helmholtz/"), ids)
+    @test any(startswith("response/specific_heat_fdt/"), ids)
     @test length(unique(ids)) == length(ids)
 
     run_generated_suite(checks; label="generated response checks")
@@ -50,4 +52,30 @@ end
         relation=QAtlas.EntropyResponse,
         derived=(dF_dT=QAtlas.∂(QAtlas.FreeEnergy, :T),),
     )
+end
+
+@testset "derived-input transforms do what they say" begin
+    # `of` picks WHAT is differentiated: d(βF)/dβ, not dF/dβ.
+    dβF = QAtlas.∂(QAtlas.FreeEnergy, :β; of=(F, β) -> β * F)
+    @test dβF.of(2.0, 3.0) == 6.0
+    @test dβF.then(5.0) == 5.0
+    # `then` post-processes: Var(E) = -∂⟨E⟩/∂β.
+    var_E = QAtlas.∂(QAtlas.Energy{:per_site}, :β; then=d -> -d)
+    @test var_E.then(5.0) == -5.0
+    @test var_E.of(2.0, 3.0) == 2.0
+    # Defaults stay the identity, so an untransformed edge is unaffected.
+    plain = QAtlas.∂(QAtlas.FreeEnergy, :T)
+    @test plain.of(2.0, 3.0) == 2.0 && plain.then(5.0) == 5.0
+end
+
+@testset "the two specific-heat routes are independent" begin
+    # :specific_heat_from_entropy derives C from S, :specific_heat_fdt from U.
+    # A model computing C by one formula and S or U by another disagrees with
+    # exactly one of them — which is the point of running both.
+    ids = [c.id for c in generated_checks(; kinds=(:response,))]
+    hubs(pre) = Set(join(split(i, "/")[3:4], "/") for i in ids if startswith(i, pre))
+    from_S = hubs("response/specific_heat_from_entropy/")
+    from_U = hubs("response/specific_heat_fdt/")
+    @test !isempty(from_S) && !isempty(from_U)
+    @test !isempty(intersect(from_S, from_U))   # hubs covered by both routes
 end


### PR DESCRIPTION
## Proposed Changes

Two more AbstractQAtlas relations become live checks, from **one small mechanism**: `DerivedInput` grows `of` (what to differentiate) and `then` (what to do with the derivative), both defaulting to the identity.

| relation | | hubs | transform |
|---|---|---|---|
| `GibbsHelmholtz` | `U = ∂(βF)/∂β` | **26** | `of = (F, β) -> β * F` |
| `SpecificHeatFDT` | `C = β² Var(E)` | **24** | `then = d -> -d` |

### The second one is the interesting case

`var_E` is **not a fetchable quantity, and does not need to be**: `Var(E) = −∂⟨E⟩/∂β` exactly, so the derivative supplier from #757 produces it with a sign flip. With `Energy{:per_site}` the relation's `N` stays 1 — per-site `C` against per-site variance.

And it is an **independent route to the same quantity**: `:specific_heat_from_entropy` derives `C` from the entropy, `:specific_heat_fdt` from the energy. A model that computes `C` by one closed form and `S` or `U` by another satisfies exactly one of them. That is the reason to run both rather than pick the cheaper — and there is a test asserting the two routes actually overlap on some hubs, so the redundancy is real and not accidental.

## Usage or Results

```julia
∂(FreeEnergy, :β; of = (F, β) -> β * F)      # d(βF)/dβ
∂(Energy{:per_site}, :β; then = d -> -d)     # Var(E) = -∂U/∂β
```

Both transforms are plain functions, not a symbolic mini-language: the algebra belongs in AbstractQAtlas, so what is expressible at a QAtlas declaration site should stay small enough to read there.

`version` → **0.28.7**.

### Still blocked, and why

| relation | hubs | needs |
|---|---|---|
| `MagnetizationResponse` / `SusceptibilityResponse` | 9 each | field derivatives — `h` is a **model parameter**, not a fetch kwarg, so this needs a model-reconstruction mechanism |
| `MicrocanonicalTemperature` | 24 | `dS/dE` — a different parameterization |
| the entanglement inequalities | 8 each | region entropies `S_A` / `S_AB` |

> Verification is CI's. A local selection only covers the files I remember to pick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
