### PR TITLE
feat: model-axis derivatives + opt-in model lists (MagnetizationResponse, SusceptibilityResponse)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QAtlas"
 uuid = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
-version = "0.28.7"
+version = "0.28.8"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/QAtlas.jl
+++ b/src/QAtlas.jl
@@ -65,6 +65,8 @@ using AbstractQAtlas:
     SpecificHeatFromEntropy,
     GibbsHelmholtz,
     SpecificHeatFDT,
+    MagnetizationResponse,
+    SusceptibilityResponse,
     slack,
     variable_slots,
     # the inequalities bound_registry.jl declares edges for

--- a/src/core/response.jl
+++ b/src/core/response.jl
@@ -44,12 +44,24 @@ than a symbolic mini-language: the whole point of this layer is that the algebra
 lives in AbstractQAtlas, so anything expressible here should stay small enough to
 read at the declaration site.
 
-Only the temperature axis is supported here.  A field derivative (`dF/dh`, for
-`MagnetizationResponse`) is deliberately absent: `h` is a MODEL parameter, not a
-fetch kwarg, so differentiating along it means reconstructing the model at each
-step and every model spells its field differently.  That needs a model-parameter
-mechanism, and inventing one silently for two relations would be worse than
-leaving them uncovered.
+`wrt` is either a STATE axis or a MODEL axis, and the two differentiate
+differently:
+
+- `:T` / `:β` — the state point.  Varied through the `fetch` kwargs, so the
+  derivative can use whatever backend is loaded.
+- anything else — a model FIELD (`:h`, `:J`, `:Δ`, …), varied by rebuilding the
+  model with `_with_param`, the same reconstruction `@limits_to` already uses to
+  walk `param = :Δ`.  A field that does not exist is a declaration bug and
+  `_with_param` throws.
+
+!!! warning "A model axis is finite-difference only"
+    Model structs type their parameters concretely (`struct TFIM …; J::Float64;
+    h::Float64; end`), so rebuilding one with an AD dual runs it through
+    `Float64(...)` and destroys the derivative — silently.  A model axis is
+    therefore pinned to [`FiniteDifference`](@ref) and reported at its tolerance.
+    Making AD work here means parameterizing the model structs, which is a
+    breaking change to a type dispatched on in ~50 places; that belongs in its
+    own PR, not smuggled in here.
 """
 struct DerivedInput
     quantity::Type
@@ -59,13 +71,6 @@ struct DerivedInput
     function DerivedInput(
         quantity::Type, wrt::Symbol; of::Function=(v, x) -> v, then::Function=identity
     )
-        wrt in (:T, :β) || throw(
-            ArgumentError(
-                "DerivedInput: `wrt` must be :T or :β (the temperature axis); got " *
-                ":$(wrt). Field derivatives need a model-parameter mechanism that " *
-                "does not exist yet — see the docstring.",
-            ),
-        )
         return new(quantity, wrt, of, then)
     end
 end
@@ -102,6 +107,7 @@ struct ResponseEdge
     relation::AbstractRelation
     subject::Symbol
     derived::NamedTuple
+    models::Union{Nothing,Vector{Type}}
     rtol_floor::Float64
     sweep::NamedTuple
     finite_N::Int
@@ -137,6 +143,7 @@ function response!(
     name::Symbol;
     relation,
     derived::NamedTuple,
+    models::Union{Nothing,AbstractVector}=nothing,
     rtol_floor::Real=0.0,
     sweep::NamedTuple=NamedTuple(),
     finite_N::Int=8,
@@ -186,6 +193,7 @@ function response!(
             rel,
             first(qslots)[1],
             derived,
+            models === nothing ? nothing : Type[m for m in models],
             Float64(rtol_floor),
             sweep,
             finite_N,
@@ -211,25 +219,49 @@ end
 # Generator — the :response kind of generated_checks()
 # ──────────────────────────────────────────────────────────────────────
 
-# The fetch kwargs and evaluation point for differentiating along `wrt` at a
-# sweep point that carries `beta`.  β and T are one axis reparameterized, which
-# is why only these two are allowed.
-function _diff_axis(wrt::Symbol, point::NamedTuple)
+# What varying `wrt` means, as (build(x) -> (model, kwargs), x₀, backend).
+#
+# A STATE axis moves the fetch kwargs and leaves the model alone; a MODEL axis
+# rebuilds the model and leaves the state point alone.  The backend travels with
+# it because a model axis cannot use AD at all: model structs type their fields
+# `Float64`, so reconstructing one with a dual silently drops the derivative.
+# Returning the backend here — rather than choosing one per generator — keeps
+# that fact attached to the axis that causes it.
+function _diff_target(d::DerivedInput, m, point::NamedTuple, preferred)
     β = getfield(point, :beta)
-    wrt === :β && return (x -> merge(point, (; beta=x)), float(β))
-    return (x -> merge(point, (; beta=1 / x)), 1 / float(β))
+    d.wrt === :β && return (x -> (m, merge(point, (; beta=x))), float(β), preferred)
+    d.wrt === :T && return (x -> (m, merge(point, (; beta=1 / x))), 1 / float(β), preferred)
+    x0 = float(getfield(m, d.wrt))   # absent field ⇒ throws: a declaration bug
+    return (x -> (_with_param(m, d.wrt, x), point), x0, FiniteDifference())
 end
 
 function response_checks()
     out = GeneratedCheck[]
-    backend = preferred_backend()
+    preferred = preferred_backend()
     for e in RESPONSES
-        # The derivative's accuracy AND the fetched values' accuracy both bound
-        # what this check can assert; the looser of the two wins.
-        rtol = max(default_rtol(backend), e.rtol_floor)
+        # Three things bound what this check can assert: each derivative's
+        # backend, and the accuracy of the fetched values.  The loosest wins — a
+        # model axis pinned to finite differences drags the whole edge to the
+        # finite-difference tolerance, which is the honest report.
+        rtol = max(
+            e.rtol_floor,
+            maximum(
+                default_rtol(_axis_backend(d, preferred)) for d in values(e.derived);
+                init=0.0,
+            ),
+        )
         slots = variable_slots(e.relation)
         subject_T = only(T for (n, T) in slots if n === e.subject)
         for hub in _implemented_hubs(Type[subject_T])
+            # An allow-list marks a relation that is NOT universal over the atlas.
+            # `MagnetizationResponse` assumes the field conjugates to M_z, which is
+            # false for a transverse-field model — and both differentiation
+            # backends would agree on that wrong physics, so the cross-check
+            # cannot catch it.  Default (nothing) keeps generating on every hub
+            # implementing the subject; an explicit list is opt-IN, so a model
+            # added later is silently skipped rather than silently checked against
+            # physics that does not apply to it.
+            e.models === nothing || hub.model in e.models || continue
             hub_id = string(
                 "response/", e.name, "/", _kgshort(hub.model), "/", _kgshort(hub.bc)
             )
@@ -262,13 +294,15 @@ function response_checks()
                     # non-differentiable point) and must not be reported as a
                     # failed physical identity — so it becomes a visible skip.
                     for (n, d) in pairs(e.derived)
-                        kw, x0 = _diff_axis(d.wrt, point)
-                        g =
-                            x -> d.of(
-                                fetch(m, _quantity_instance(d.quantity), bc; kw(x)...),
+                        build, x0, b = _diff_target(d, m, point, preferred)
+                        g = function (x)
+                            mm, kw = build(x)
+                            return d.of(
+                                fetch(mm, _quantity_instance(d.quantity), bc; kw...),
                                 x,
                             )
-                        val, _, trusted, why = derivative_agreement(g, x0; primary=backend)
+                        end
+                        val, _, trusted, why = derivative_agreement(g, x0; primary=b)
                         trusted || return _skip_outcome("$(n): $(why)")
                         args[n] = d.then(val)
                     end
@@ -305,6 +339,13 @@ function response_checks()
         end
     end
     return out
+end
+
+# A model axis cannot use AD (see `_diff_target`); a state axis uses whatever is
+# loaded.  Kept beside the generator so the tolerance computation and the closure
+# construction cannot disagree about which backend an axis gets.
+function _axis_backend(d::DerivedInput, preferred)
+    return d.wrt in (:T, :β) ? preferred : FiniteDifference()
 end
 
 register_check_generator!(:response, response_checks)

--- a/src/response_registry.jl
+++ b/src/response_registry.jl
@@ -70,3 +70,46 @@
     rtol_floor = 1e-4,
     notes = "C = β² Var(E), Var(E) = -∂⟨E⟩/∂β — the fluctuation route, independent of C = T ∂S/∂T.",
 )
+
+# ── M = −∂F/∂h  and  χ = ∂M/∂h ────────────────────────────────────────
+# MODEL-axis derivatives: `h` is a field of the model, not a fetch kwarg, so
+# these rebuild the model at each step and are finite-difference only (see
+# `_diff_target`).  Reported at the finite-difference tolerance accordingly.
+#
+# WHY AN ALLOW-LIST AND NOT AN EXCLUSION LIST.  AbstractQAtlas types the subject
+# `Magnetization{:z}` / `Susceptibility{(:z,:z)}`, so these relations hold only
+# where `h` is the LONGITUDINAL field.  It is not, in this atlas:
+#
+#     -h Σ σᶻ  (longitudinal, valid)   IsingChain1D, CurieWeissIsing, LongRangeXY1D
+#     -h Σ σˣ  (TRANSVERSE, invalid)   TFIM, LongRangeIsing1D
+#
+# For a transverse-field model −∂F/∂h is ⟨σˣ⟩, not M_z. Both differentiation
+# backends would agree on that wrong number, so `derivative_agreement` cannot
+# save us — the cross-check catches a bad METHOD, never a relation applied to a
+# Hamiltonian it does not describe. Hence opt-in: a model added later is skipped
+# rather than checked against physics that does not apply to it.
+const _LONGITUDINAL_FIELD_MODELS = [IsingChain1D, CurieWeissIsing]
+
+@response(
+    :magnetization_response,
+    relation = MagnetizationResponse,
+    derived = (dF_dh=∂(FreeEnergy, :h; then=d -> -d),),
+    models = _LONGITUDINAL_FIELD_MODELS,
+    sweep = (beta=[0.5, 1.0, 2.0],),
+    finite_N = 6,
+    exclusions = _THERMO_DERIVATIVE_EXCLUSIONS,
+    rtol_floor = 1e-4,
+    notes = "M_z = -∂F/∂h — valid only where h is the longitudinal field.",
+)
+
+@response(
+    :susceptibility_response,
+    relation = SusceptibilityResponse,
+    derived = (dM_dh=∂(Magnetization{:z}, :h),),
+    models = _LONGITUDINAL_FIELD_MODELS,
+    sweep = (beta=[0.5, 1.0, 2.0],),
+    finite_N = 6,
+    exclusions = _THERMO_DERIVATIVE_EXCLUSIONS,
+    rtol_floor = 1e-4,
+    notes = "χ_zz = ∂M_z/∂h — the isothermal susceptibility as a field response.",
+)

--- a/test/generated/test_response_checks.jl
+++ b/test/generated/test_response_checks.jl
@@ -79,3 +79,25 @@ end
     @test !isempty(from_S) && !isempty(from_U)
     @test !isempty(intersect(from_S, from_U))   # hubs covered by both routes
 end
+
+@testset "model-axis derivatives are opt-in and finite-difference only" begin
+    # The allow-list is the defence the cross-check cannot provide: for a
+    # transverse-field model both backends agree on -∂F/∂h = ⟨σˣ⟩, which is not
+    # M_z, so nothing numerical would flag it.  TFIM must therefore be absent.
+    ids = [c.id for c in generated_checks(; kinds=(:response,))]
+    mag = filter(startswith("response/magnetization_response/"), ids)
+    @test !isempty(mag)
+    @test any(occursin("/CurieWeissIsing/"), mag)
+    @test !any(occursin("/TFIM/"), mag)          # transverse field — must not be checked
+    # An edge with no allow-list keeps generating everywhere.
+    @test any(occursin("/TFIM/"), filter(startswith("response/entropy_response/"), ids))
+
+    # A model axis is pinned to finite differences: rebuilding a struct whose
+    # fields are ::Float64 with an AD dual destroys the derivative silently.
+    fd_axis = QAtlas.∂(QAtlas.FreeEnergy, :h)
+    st_axis = QAtlas.∂(QAtlas.FreeEnergy, :T)
+    @test QAtlas._axis_backend(fd_axis, QAtlas.ForwardDiffBackend()) isa
+        QAtlas.FiniteDifference
+    @test QAtlas._axis_backend(st_axis, QAtlas.ForwardDiffBackend()) isa
+        QAtlas.ForwardDiffBackend
+end


### PR DESCRIPTION
## Proposed Changes

Derived inputs can now differentiate along a **model field**, not just the state point: `wrt` is `:T`/`:β` (vary the fetch kwargs) or any model field (rebuild the model). The rebuild is **`_with_param`, which already existed** for `@limits_to`'s `param = :Δ` walk — so this reuses the atlas's own parameter mechanism rather than inventing a second one.

Unlocks `MagnetizationResponse` (`M = −∂F/∂h`) and `SusceptibilityResponse` (`χ = ∂M/∂h`).

## Two constraints, both measured rather than assumed

### 1. A model axis is finite-difference only

Model structs type their parameters concretely:

```julia
struct TFIM <: AbstractQAtlasModel
    J::Float64
    h::Float64
end
```

so rebuilding one with an AD dual runs it through `Float64(...)` and **drops the derivative silently**. The axis therefore carries its own backend and its own tolerance, and the edge is reported at the loosest of them.

Making AD work here means parameterizing the model structs — a breaking change to a type dispatched on in ~50 places. That belongs in its own PR, not smuggled in.

### 2. These relations are not universal, so `models` is an ALLOW-list

AbstractQAtlas types the subject `Magnetization{:z}`, so `M = −∂F/∂h` holds only where `h` is the **longitudinal** field:

| coupling | models | valid? |
|---|---|---|
| `−h Σ σᶻ` | `IsingChain1D`, `CurieWeissIsing`, `LongRangeXY1D` | ✅ |
| `−h Σ σˣ` | `TFIM`, `LongRangeIsing1D` | ❌ — `−∂F/∂h` is `⟨σˣ⟩`, not `M_z` |

**`derivative_agreement` cannot catch this.** Both backends agree on the wrong number; the cross-check detects a bad *method*, never a relation applied to a Hamiltonian it does not describe. So the defence has to be structural.

Opt-**in** rather than exclusion means a model added later is silently *skipped* instead of silently *checked against physics that does not apply to it* — the same "do nothing rather than be wrong" default the rest of this layer uses. There is a test asserting `TFIM` is absent from these checks and present in the universal ones.

## Usage or Results

```julia
∂(FreeEnergy, :h; then = d -> -d)   # M = -∂F/∂h, model axis ⇒ finite differences
∂(Magnetization{:z}, :h)           # χ = ∂M/∂h
```

`version` → **0.28.8**.

> Stacked on #759 (base `main`). Verification is CI's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
